### PR TITLE
[#36] docs: Add project roadmap and restructure compliance section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ros2_medkit
 
-[![CI](https://github.com/bburda/ros2_medkit/actions/workflows/ci.yml/badge.svg)](https://github.com/bburda/ros2_medkit/actions/workflows/ci.yml)
+[![CI](https://github.com/selfpatch/ros2_medkit/actions/workflows/ci.yml/badge.svg)](https://github.com/selfpatch/ros2_medkit/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://selfpatch.github.io/ros2_medkit/)
 
 Modern, SOVD-compatible diagnostics for ROS 2 robots, built around an entity tree
 (Area / Component / Function / App) for runtime discovery, health modeling, and troubleshooting.
@@ -24,8 +25,12 @@ so the same concepts can be used across robots, vehicles, and other embedded sys
 
 > **Early prototype / work in progress**
 >
-> This is a personal open source project to explore diagnostic patterns for ROS 2.
-> APIs, architecture, and naming may change at any time.
+> This is an open source project exploring diagnostic patterns for ROS 2.
+> APIs, architecture, and naming may change as the project evolves.
+
+See the [Roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html) for planned
+milestones, or check [GitHub Milestones](https://github.com/selfpatch/ros2_medkit/milestones)
+for current progress.
 
 ## Target Use Cases
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,11 +13,12 @@ Welcome to the documentation for **ros2_medkit**.
    :caption: General
 
    introduction
+   roadmap
    design/index
 
 .. toctree::
    :maxdepth: 4
-   :caption: Requirements Engineering
+   :caption: Standard Compliance
 
    requirements/index
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -28,8 +28,11 @@ Status
 
 **Early prototype / work in progress**
 
-This is a personal open source project to explore diagnostic patterns for ROS 2.
-APIs, architecture, and naming may change at any time.
+This is an open source project exploring diagnostic patterns for ROS 2.
+APIs, architecture, and naming may change as the project evolves.
+
+The current focus is on covering the SOVD API surface to enable early integration
+and compliance validation. See the :doc:`roadmap` for planned milestones and priorities.
 
 Target Use Cases
 ----------------

--- a/docs/requirements/index.rst
+++ b/docs/requirements/index.rst
@@ -1,7 +1,17 @@
-Requirements Engineering
-========================
+Standard Compliance
+===================
 
-This section contains the requirements specification, verification tests, and coverage reports for the ros2_medkit project.
+This section tracks ros2_medkit's compliance with diagnostic industry standards.
+
+.. note::
+
+   These are **not project requirements** in the traditional V-Model sense.
+
+   The items listed here represent standard API endpoints that ros2_medkit
+   implements for interoperability with diagnostic tools and systems.
+   The project may also include **extensions beyond the standard**
+   (e.g., exposing ROS 2 Topics as diagnostic entities) which are documented
+   separately.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/requirements/specs/index.rst
+++ b/docs/requirements/specs/index.rst
@@ -1,7 +1,8 @@
-Specifications
-==============
+API Specification
+=================
 
-This section details the functional requirements for each subsystem of ros2_medkit.
+This section details the standard API endpoints that ros2_medkit implements
+for diagnostic interoperability.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/roadmap.rst
+++ b/docs/roadmap.rst
@@ -1,0 +1,128 @@
+Roadmap
+=======
+
+This document outlines the proposed development roadmap for ros2_medkit.
+The plan is subject to change based on community feedback and project priorities.
+
+For the latest status, see the `GitHub Milestones <https://github.com/selfpatch/ros2_medkit/milestones>`_.
+
+Strategy
+--------
+
+**Developer-first, then system-wide.**
+
+The project follows a phased approach that prioritizes developer experience:
+
+1. **Start with Apps (ROS 2 nodes)** — The level closest to developers. Provide tooling
+   that makes their daily work easier: discovering nodes, reading data, checking faults.
+
+2. **Expand to full system** — Once app-level features are solid, extend coverage to
+   Components, Areas, and system-wide operations.
+
+3. **API coverage first, quality later** — The initial goal is to cover the entire
+   standard API surface using available ROS 2 capabilities. This enables early integration
+   with real projects and compliance validation. Code hardening and production-ready
+   implementations will follow in later phases.
+
+Milestones
+----------
+
+MS1: Full Discovery & Data Access
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Goal:** Provide a complete view of the ROS 2 system and enable basic data operations.
+
+Developers can discover all running nodes, explore the entity hierarchy, and read/write
+diagnostic data. This milestone establishes the foundation for all subsequent features.
+
+**Standard API coverage:**
+
+- Discovery (11 endpoints) — version info, entity collections, hierarchy navigation
+- Data (5 endpoints) — data categories, groups, read/write operations
+
+`MS1 on GitHub <https://github.com/selfpatch/ros2_medkit/milestone/1>`_
+
+MS2: App Observability
+~~~~~~~~~~~~~~~~~~~~~~
+
+**Goal:** Enable developers to monitor application health and diagnose issues.
+
+With observability features, developers can check fault codes, browse logs, and monitor
+the lifecycle state of their nodes — essential for debugging and troubleshooting.
+
+**Standard API coverage:**
+
+- Faults (4 endpoints) — list, inspect, and clear diagnostic faults
+- Logs (5 endpoints) — browse and configure application logs
+- Lifecycle (6 endpoints) — status, start, restart, shutdown operations
+
+`MS2 on GitHub <https://github.com/selfpatch/ros2_medkit/milestone/2>`_
+
+MS3: Configuration & Control
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Goal:** Allow developers to configure and control running applications.
+
+This milestone brings configuration management (backed by ROS 2 parameters) and
+operation execution, giving developers runtime control over their nodes.
+
+**Standard API coverage:**
+
+- Configuration (5 endpoints) — read/write configuration values
+- Operations (7 endpoints) — define, execute, and monitor operations
+- Modes (3 endpoints) — entity operating modes
+
+`MS3 on GitHub <https://github.com/selfpatch/ros2_medkit/milestone/3>`_
+
+MS4: Automation & Subscriptions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Goal:** Enable automated workflows and reactive data collection.
+
+Developers can set up scripts for automated diagnostics, subscribe to data changes,
+and define triggers for event-driven workflows.
+
+**Standard API coverage:**
+
+- Scripts (8 endpoints) — upload, execute, and manage diagnostic scripts
+- Subscriptions (8 endpoints) — cyclic data subscriptions and triggers
+- Datasets (4 endpoints) — dynamic data lists for subscription
+
+`MS4 on GitHub <https://github.com/selfpatch/ros2_medkit/milestone/4>`_
+
+MS5: Fleet & Advanced Features
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Goal:** Complete SOVD API coverage with fleet-oriented and advanced features.
+
+The final milestone adds capabilities for fleet management, bulk data transfer,
+software updates, and authentication — completing the standard specification coverage.
+
+**Standard API coverage:**
+
+- Bulk Data (5 endpoints) — large data transfers
+- Communication Logs (5 endpoints) — protocol-level logging
+- Clear Data (5 endpoints) — cache and learned data management
+- Updates (4 endpoints) — software update management
+- Auth (2 endpoints) — authorization and token management
+
+`MS5 on GitHub <https://github.com/selfpatch/ros2_medkit/milestone/5>`_
+
+Future Directions
+-----------------
+
+After achieving full standard API coverage, the project will focus on:
+
+**Code Hardening**
+   Replace initial implementations with production-ready code. Remove workarounds
+   and refactor into smaller, well-tested packages.
+
+**Additional Diagnostic Protocols**
+   Extend support to other diagnostic standards relevant to robotics and embedded
+   systems.
+
+**Transport Protocols**
+   Add support for alternative transport mechanisms beyond HTTP/REST.
+
+We welcome community input on prioritization. Feel free to open an issue or
+join the discussion on GitHub!


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Add a 5-phase development roadmap with "developer-first" strategy:
- MS1: Full Discovery & Data Access
- MS2: App Observability
- MS3: Configuration & Control
- MS4: Automation & Subscriptions
- MS5: Fleet & Advanced Features

Restructure requirements section as "Standard Compliance" to clarify that tracked items represent standard API endpoints for interoperability, not traditional V-Model project requirements. The project may include extensions beyond the standard (e.g., ROS 2 Topics as entities).

Other changes:
- Add documentation badge linking to GitHub Pages
- Fix CI badge to point to correct repository (selfpatch/ros2_medkit)
- Update status section with links to roadmap and milestones
- Add cross-references between introduction and roadmap


---

## Issue

Link the related issue (required):

- closes #36

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [x] Documentation only

---

## Testing

Documentation will be built on CI

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
