### PR TITLE
[#33] feat: implement parallel topic sampling with configurable concu…

### DIFF
--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -24,3 +24,9 @@ ros2_medkit_gateway:
     # How often to discover ROS 2 nodes and update the cache
     # Valid range: 100-60000 (0.1s to 60s)
     refresh_interval_ms: 2000
+
+    # Data Access Configuration
+    # Maximum number of concurrent topic samples when fetching component data
+    # Higher values improve response time but use more system resources
+    # Valid range: 1-50
+    max_parallel_topic_samples: 10

--- a/src/ros2_medkit_gateway/design/index.rst
+++ b/src/ros2_medkit_gateway/design/index.rst
@@ -152,7 +152,8 @@ Main Components
    - Handles timeout and error cases gracefully
    - Returns topic data as JSON with metadata (topic name, timestamp, data)
    - Configurable timeout per topic (default: 3 seconds for slow publishers)
-   - Sequential topic sampling with planned parallel sampling improvement
+   - Parallel topic sampling with configurable concurrency limit (``max_parallel_topic_samples``, default: 10)
+   - Batched processing to bound resource usage while improving performance
 
 5. **ROS2CLIWrapper** - Executes ROS 2 CLI commands safely
    - Wraps ``popen()`` with RAII for exception safety during command execution

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/data_access_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/data_access_manager.hpp
@@ -59,6 +59,7 @@ private:
     rclcpp::Node* node_;
     std::unique_ptr<ROS2CLIWrapper> cli_wrapper_;
     std::unique_ptr<OutputParser> output_parser_;
+    int max_parallel_samples_;
 };
 
 }  // namespace ros2_medkit_gateway


### PR DESCRIPTION
…rrency



# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

  Implement batched parallel topic sampling to significantly improve performance
  when fetching component data from multiple ROS 2 topics. Previously, topics
  were sampled sequentially (N × timeout), now they are sampled in parallel
  batches (≈timeout regardless of N).

---

## Issue

Link the related issue (required):

- closes #33

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
