### PR TITLE
[#34] feat: add input validation for component_id and area_id parameters

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.8)
 project(ros2_medkit_gateway)
 
-# Compiler settings
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
@@ -16,6 +16,7 @@
 
 #include <httplib.h>
 
+#include <expected>
 #include <memory>
 #include <string>
 
@@ -45,7 +46,7 @@ private:
     void handle_component_data(const httplib::Request& req, httplib::Response& res);
 
     // Helper methods
-    bool validate_entity_id(const std::string& entity_id, std::string& error_message) const;
+    std::expected<void, std::string> validate_entity_id(const std::string& entity_id) const;
 
     GatewayNode* node_;
     std::string host_;

--- a/src/ros2_medkit_gateway/test/test_integration.test.py
+++ b/src/ros2_medkit_gateway/test/test_integration.test.py
@@ -220,7 +220,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         print(f'✓ Components test passed: {len(components)} components discovered')
 
     def test_04_automotive_areas_discovery(self):
-        """Test that automotive areas are properly discovered."""
+        """
+        Test that automotive areas are properly discovered.
+
+        @verifies REQ_INTEROP_003
+        """
         areas = self._get_json('/areas')
         area_ids = [area['id'] for area in areas]
 
@@ -257,7 +261,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         )
 
     def test_06_area_components_nonexistent_error(self):
-        """Test GET /areas/{area_id}/components returns 404 for nonexistent area."""
+        """
+        Test GET /areas/{area_id}/components returns 404 for nonexistent area.
+
+        @verifies REQ_INTEROP_006
+        """
         response = requests.get(
             f'{self.BASE_URL}/areas/nonexistent/components', timeout=5
         )
@@ -388,7 +396,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         print(f'✓ Component with no topics test passed: {len(data)} topics')
 
     def test_13_invalid_component_id_special_chars(self):
-        """Test GET /components/{component_id}/data rejects special characters."""
+        """
+        Test GET /components/{component_id}/data rejects special characters.
+
+        @verifies REQ_INTEROP_018
+        """
         # Test various invalid characters
         invalid_ids = [
             'component;drop',  # SQL injection attempt
@@ -419,7 +431,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         print('✓ Invalid component ID special characters test passed')
 
     def test_14_invalid_area_id_special_chars(self):
-        """Test GET /areas/{area_id}/components rejects special characters."""
+        """
+        Test GET /areas/{area_id}/components rejects special characters.
+
+        @verifies REQ_INTEROP_006
+        """
         # Test various invalid characters
         # Note: Forward slash is handled by URL routing, not validation
         invalid_ids = [
@@ -448,7 +464,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         print('✓ Invalid area ID special characters test passed')
 
     def test_15_valid_ids_with_underscores(self):
-        """Test that valid IDs with underscores are accepted (ROS 2 naming)."""
+        """
+        Test that valid IDs with underscores are accepted (ROS 2 naming).
+
+        @verifies REQ_INTEROP_018
+        """
         # While these IDs don't exist in the test environment,
         # they should pass validation and return 404 (not 400)
         valid_ids = [
@@ -473,7 +493,11 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         print('✓ Valid IDs with underscores test passed')
 
     def test_16_invalid_ids_with_hyphens(self):
-        """Test that IDs with hyphens are rejected (not allowed in ROS 2 names)."""
+        """
+        Test that IDs with hyphens are rejected (not allowed in ROS 2 names).
+
+        @verifies REQ_INTEROP_018
+        """
         invalid_ids = [
             'component-name',
             'component-name-123',


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Add validation to REST API endpoints enforcing ROS 2 naming conventions
(alphanumeric, underscore, forward slash). Rejects invalid input with
400 Bad Request and descriptive error messages. Improves security by
blocking special characters and preventing injection attempts.
---

## Issue

Link the related issue (required):

- closes #34 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
