### PR TITLE
19/get/components/component id/data/topic name

### DIFF
--- a/postman/collections/ros2-medkit-gateway.postman_collection.json
+++ b/postman/collections/ros2-medkit-gateway.postman_collection.json
@@ -88,7 +88,7 @@
       "name": "Component Data",
       "item": [
         {
-          "name": "GET Component Data",
+          "name": "GET Component Data (All Topics)",
           "request": {
             "method": "GET",
             "header": [],
@@ -104,6 +104,69 @@
               ]
             },
             "description": "Read all topic data from a specific component. Returns array of topic samples with metadata (topic, timestamp, data). Change 'temp_sensor' to other component IDs like 'rpm_sensor', 'pressure_sensor', etc."
+          },
+          "response": []
+        },
+        {
+          "name": "GET Component Topic Data (Temperature)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/components/temp_sensor/data/temperature",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "components",
+                "temp_sensor",
+                "data",
+                "temperature"
+              ]
+            },
+            "description": "Read specific topic data from a component. Returns single topic sample with topic path, timestamp, and data. The topic_name is relative to the component's namespace."
+          },
+          "response": []
+        },
+        {
+          "name": "GET Component Topic Data (RPM)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/components/rpm_sensor/data/rpm",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "components",
+                "rpm_sensor",
+                "data",
+                "rpm"
+              ]
+            },
+            "description": "Read RPM topic data from the rpm_sensor component."
+          },
+          "response": []
+        },
+        {
+          "name": "GET Component Topic Data (Pressure)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/components/pressure_sensor/data/pressure",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "components",
+                "pressure_sensor",
+                "data",
+                "pressure"
+              ]
+            },
+            "description": "Read brake pressure topic data from the pressure_sensor component."
           },
           "response": []
         }

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/exceptions.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/exceptions.hpp
@@ -1,0 +1,46 @@
+// Copyright 2025 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace ros2_medkit_gateway {
+
+/// Exception thrown when a topic is not available or times out
+class TopicNotAvailableException : public std::runtime_error {
+public:
+    explicit TopicNotAvailableException(const std::string& topic)
+        : std::runtime_error("Topic not available: " + topic), topic_(topic) {}
+
+    const std::string& topic() const noexcept { return topic_; }
+
+private:
+    std::string topic_;
+};
+
+/// Exception thrown when a required command (e.g., ros2 CLI) is not available
+class CommandNotAvailableException : public std::runtime_error {
+public:
+    explicit CommandNotAvailableException(const std::string& command)
+        : std::runtime_error("Command not available: " + command), command_(command) {}
+
+    const std::string& command() const noexcept { return command_; }
+
+private:
+    std::string command_;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
@@ -44,6 +44,7 @@ private:
     void handle_list_components(const httplib::Request& req, httplib::Response& res);
     void handle_area_components(const httplib::Request& req, httplib::Response& res);
     void handle_component_data(const httplib::Request& req, httplib::Response& res);
+    void handle_component_topic_data(const httplib::Request& req, httplib::Response& res);
 
     // Helper methods
     std::expected<void, std::string> validate_entity_id(const std::string& entity_id) const;


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

add GET /components/{component_id}/data/{topic_name} endpoint

Add endpoint to read specific topic data from a component. Includes
input validation for topic_name parameter following ROS 2 naming
conventions (alphanumeric and underscore only). Returns 404 for
nonexistent component/topic, 400 for invalid input.

---

## Issue

Link the related issue (required):

- closes #19 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
