### PR TITLE
[#40] fix: return server capabilities at GET / and add GET /version-info

### DIFF
--- a/postman/collections/ros2-medkit-gateway.postman_collection.json
+++ b/postman/collections/ros2-medkit-gateway.postman_collection.json
@@ -9,7 +9,7 @@
       "name": "Discovery",
       "item": [
         {
-          "name": "GET Gateway Info",
+          "name": "GET Server Capabilities",
           "request": {
             "method": "GET",
             "header": [],
@@ -22,7 +22,25 @@
                 ""
               ]
             },
-            "description": "Get gateway status and version information"
+            "description": "Get server capabilities and entry points (REQ_INTEROP_010). Returns server name, version, available endpoints, and capabilities."
+          },
+          "response": []
+        },
+        {
+          "name": "GET Version Info",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/version-info",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "version-info"
+              ]
+            },
+            "description": "Get gateway status and version information (REQ_INTEROP_001). Returns status, version, and timestamp."
           },
           "response": []
         },

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/rest_server.hpp
@@ -40,6 +40,7 @@ private:
     // Route handlers
     void handle_health(const httplib::Request& req, httplib::Response& res);
     void handle_root(const httplib::Request& req, httplib::Response& res);
+    void handle_version_info(const httplib::Request& req, httplib::Response& res);
     void handle_list_areas(const httplib::Request& req, httplib::Response& res);
     void handle_list_components(const httplib::Request& req, httplib::Response& res);
     void handle_area_components(const httplib::Request& req, httplib::Response& res);

--- a/src/ros2_medkit_gateway/test/test_gateway_node.cpp
+++ b/src/ros2_medkit_gateway/test/test_gateway_node.cpp
@@ -92,9 +92,22 @@ private:
           (void)req;
 
           nlohmann::json info_json = {
-              {"service", "ros2_medkit_gateway"},
+              {"name", "ROS 2 Medkit Gateway"},
               {"version", VERSION},
-              {"endpoints", nlohmann::json::array({"/health", "/"})}};
+              {"endpoints", nlohmann::json::array({
+                  "/health",
+                  "/version-info",
+                  "/areas",
+                  "/components",
+                  "/areas/{area_id}/components",
+                  "/components/{component_id}/data",
+                  "/components/{component_id}/data/{topic_name}"
+              })},
+              {"capabilities", {
+                  {"discovery", true},
+                  {"data_access", true}
+              }}
+          };
 
           res.set_content(info_json.dump(), "application/json");
           res.status = 200;
@@ -155,11 +168,14 @@ TEST_F(TestGatewayNode, test_root_endpoint) {
 
   // Parse and verify JSON
   auto json_response = nlohmann::json::parse(res->body);
-  EXPECT_EQ(json_response["service"], "ros2_medkit_gateway");
+  EXPECT_EQ(json_response["name"], "ROS 2 Medkit Gateway");
   EXPECT_EQ(json_response["version"], "0.1.0");
   EXPECT_TRUE(json_response.contains("endpoints"));
   EXPECT_TRUE(json_response["endpoints"].is_array());
-  EXPECT_EQ(json_response["endpoints"].size(), 2);
+  EXPECT_EQ(json_response["endpoints"].size(), 7);
+  EXPECT_TRUE(json_response.contains("capabilities"));
+  EXPECT_TRUE(json_response["capabilities"]["discovery"]);
+  EXPECT_TRUE(json_response["capabilities"]["data_access"]);
 }
 
 int main(int argc, char **argv) {

--- a/src/ros2_medkit_gateway/test/test_integration.test.py
+++ b/src/ros2_medkit_gateway/test/test_integration.test.py
@@ -167,16 +167,47 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
 
     def test_01_root_endpoint(self):
         """
-        Test GET / returns gateway status and version.
+        Test GET / returns server capabilities and entry points.
 
         @verifies REQ_INTEROP_010
         """
         data = self._get_json('/')
+        self.assertIn('name', data)
+        self.assertIn('version', data)
+        self.assertIn('endpoints', data)
+        self.assertIn('capabilities', data)
+
+        self.assertEqual(data['name'], 'ROS 2 Medkit Gateway')
+        self.assertEqual(data['version'], '0.1.0')
+
+        # Verify endpoints list
+        self.assertIsInstance(data['endpoints'], list)
+        self.assertIn('/health', data['endpoints'])
+        self.assertIn('/version-info', data['endpoints'])
+        self.assertIn('/areas', data['endpoints'])
+        self.assertIn('/components', data['endpoints'])
+
+        # Verify capabilities
+        self.assertIn('discovery', data['capabilities'])
+        self.assertIn('data_access', data['capabilities'])
+        self.assertTrue(data['capabilities']['discovery'])
+        self.assertTrue(data['capabilities']['data_access'])
+        print('✓ Root endpoint test passed')
+
+    def test_01b_version_info_endpoint(self):
+        """
+        Test GET /version-info returns gateway status and version.
+
+        @verifies REQ_INTEROP_001
+        """
+        data = self._get_json('/version-info')
         self.assertIn('status', data)
         self.assertIn('version', data)
+        self.assertIn('timestamp', data)
         self.assertEqual(data['status'], 'ROS 2 Medkit Gateway running')
         self.assertEqual(data['version'], '0.1.0')
-        print('✓ Root endpoint test passed')
+        self.assertIsInstance(data['timestamp'], int)
+        print('✓ Version info endpoint test passed')
 
     def test_02_list_areas(self):
         """


### PR DESCRIPTION
  - GET / now returns server capabilities and entry points per REQ_INTEROP_010 (name, version, endpoints list, capabilities object)
  - Add GET /version-info for version information per REQ_INTEROP_001 (status, version, timestamp)
  - Update test_01_root_endpoint to verify capabilities response
  - Add test_01b_version_info_endpoint for new endpoint
  - Update Postman collection with new requests

# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Briefly describe what changed and why.

---

## Issue

Link the related issue (required):

- closes #40 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
