### PR TITLE
[#48] feat: add Codecov integration with code coverage reporting

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,6 +36,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     clang-tidy \
     graphviz \
     plantuml \
+    lcov \
     && locale-gen en_US.UTF-8 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-format clang-tidy
+          source /opt/ros/jazzy/setup.bash
           rosdep update
           rosdep install --from-paths src --ignore-src -r -y
 
@@ -63,3 +64,93 @@ jobs:
           path: |
             log/
             build/*/test_results/
+
+  coverage:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up ROS 2 Jazzy
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lcov
+          source /opt/ros/jazzy/setup.bash
+          rosdep update
+          rosdep install --from-paths src --ignore-src -r -y
+
+      - name: Build packages with coverage
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          colcon build --symlink-install \
+            --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON \
+            --event-handlers console_direct+
+
+      - name: Run unit tests only
+        # Run only unit tests for coverage:
+        # -LE linter: exclude linters by label
+        # -E integration: exclude integration tests by name regex
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          source install/setup.bash
+          colcon test \
+            --ctest-args -LE linter -E integration \
+            --event-handlers console_direct+
+
+      - name: Generate coverage report
+        run: |
+          # Capture coverage data with error tolerance
+          lcov --capture --directory build --output-file coverage.raw.info \
+            --ignore-errors mismatch,negative,empty || true
+
+          # Check if we have valid coverage data
+          if [ -s coverage.raw.info ] && grep -q 'SF:' coverage.raw.info; then
+            # Extract only our source code (exclude gtest_vendor and other ROS dependencies)
+            lcov --extract coverage.raw.info \
+              '*/ros2_medkit/src/*/src/*' \
+              '*/ros2_medkit/src/*/include/*' \
+              --output-file coverage.info \
+              --ignore-errors unused,empty || true
+
+            if [ -s coverage.info ]; then
+              lcov --list coverage.info
+              # Generate HTML report
+              genhtml coverage.info --output-directory coverage_html \
+                --ignore-errors source || true
+            else
+              echo "Filtered coverage.info is empty, using raw coverage"
+              cp coverage.raw.info coverage.info
+              lcov --list coverage.info || true
+              genhtml coverage.info --output-directory coverage_html \
+                --ignore-errors source || true
+            fi
+          else
+            echo "No valid coverage data found in coverage.raw.info"
+            echo "Creating empty coverage file to prevent upload failure"
+            touch coverage.info
+            mkdir -p coverage_html
+          fi
+
+      - name: Upload coverage HTML report as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage_html/
+
+      - name: Upload coverage to Codecov
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.info
+          flags: unittests
+          name: ros2_medkit-coverage
+          fail_ci_if_error: true
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,13 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# C++ coverage artifacts (lcov/gcov)
+*.gcda
+*.gcno
+*.gcov
+coverage.info
+coverage_html/
+
 # Translations
 *.mo
 *.pot

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ros2_medkit
 
 [![CI](https://github.com/selfpatch/ros2_medkit/actions/workflows/ci.yml/badge.svg)](https://github.com/selfpatch/ros2_medkit/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/selfpatch/ros2_medkit/branch/main/graph/badge.svg)](https://codecov.io/gh/selfpatch/ros2_medkit)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://selfpatch.github.io/ros2_medkit/)
 
 Modern, SOVD-compatible diagnostics for ROS 2 robots, built around an entity tree
@@ -86,16 +87,57 @@ colcon test --ctest-args -R test_integration
 colcon test-result --verbose
 ```
 
+### Code Coverage
+
+To generate code coverage reports locally:
+
+1. Build with coverage flags enabled:
+
+```bash
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+```
+
+2. Run tests:
+
+```bash
+source install/setup.bash
+colcon test --ctest-args -LE linter
+```
+
+3. Generate coverage report:
+
+```bash
+lcov --capture --directory build --output-file coverage.raw.info --ignore-errors mismatch,negative
+lcov --extract coverage.raw.info '*/ros2_medkit/src/*/src/*' '*/ros2_medkit/src/*/include/*' --output-file coverage.info --ignore-errors unused
+lcov --list coverage.info
+```
+
+4. (Optional) Generate HTML report:
+
+```bash
+genhtml coverage.info --output-directory coverage_html
+```
+
+Then open `coverage_html/index.html` in your browser.
+
 ### CI/CD
 
 All pull requests and pushes to main are automatically built and tested using GitHub Actions.
-The CI workflow runs on Ubuntu 24.04 with ROS 2 Jazzy, executes a single `colcon test` to cover:
+The CI workflow runs on Ubuntu 24.04 with ROS 2 Jazzy and consists of two parallel jobs:
 
-- Code linting and formatting checks
-- Unit tests
-- Integration tests with demo automotive nodes
+**build-and-test:**
 
-After every run the workflow always calls `colcon test-result --verbose` and uploads the generated logs/results as artifacts for debugging.
+- Code linting and formatting checks (clang-format, clang-tidy)
+- Unit tests and integration tests with demo automotive nodes
+
+**coverage:**
+
+- Builds with coverage instrumentation (Debug mode)
+- Runs unit tests only (for stable coverage metrics)
+- Generates lcov coverage report (available as artifact)
+- Uploads coverage to Codecov (only on push to main)
+
+After every run the workflow uploads test results and coverage reports as artifacts for debugging and review.
 
 ## Contributing
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,43 @@
+# Codecov configuration for ros2_medkit
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+
+# Ignore paths from coverage reporting
+ignore:
+  - "test/**/*"                    # Test files
+
+  - "**/test_*.cpp"                # Test source files
+  - "build/**/*"                   # Build artifacts
+  - "install/**/*"                 # Install artifacts
+  - "log/**/*"                     # Log files
+  - "docs/**/*"                    # Documentation
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: true
+  require_base: false
+  require_head: true
+
+# Flag management for different test types
+flags:
+  unittests:
+    paths:
+      - src/
+    carryforward: true

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -9,6 +9,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+# Code coverage option
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+if(ENABLE_COVERAGE)
+  message(STATUS "Code coverage enabled")
+  add_compile_options(--coverage -O0 -g)
+  add_link_options(--coverage)
+endif()
+
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -27,9 +35,8 @@ pkg_check_modules(cpp_httplib REQUIRED IMPORTED_TARGET cpp-httplib)
 # Include directories
 include_directories(include)
 
-# Gateway node executable
-add_executable(gateway_node
-  src/main.cpp
+# Gateway library (shared between executable and tests for coverage)
+add_library(gateway_lib STATIC
   src/config.cpp
   src/gateway_node.cpp
   src/rest_server.cpp
@@ -39,18 +46,34 @@ add_executable(gateway_node
   src/data_access_manager.cpp
 )
 
-ament_target_dependencies(gateway_node
+ament_target_dependencies(gateway_lib
   rclcpp
   std_msgs
   std_srvs
   rcl_interfaces
 )
 
-target_link_libraries(gateway_node
+target_link_libraries(gateway_lib
   PkgConfig::cpp_httplib
   nlohmann_json::nlohmann_json
   yaml-cpp::yaml-cpp
 )
+
+# Apply coverage flags to library
+if(ENABLE_COVERAGE)
+  target_compile_options(gateway_lib PRIVATE --coverage -O0 -g)
+  target_link_options(gateway_lib PRIVATE --coverage)
+endif()
+
+# Gateway node executable
+add_executable(gateway_node src/main.cpp)
+target_link_libraries(gateway_node gateway_lib)
+
+# Apply coverage flags to gateway_node target
+if(ENABLE_COVERAGE)
+  target_compile_options(gateway_node PRIVATE --coverage -O0 -g)
+  target_link_options(gateway_node PRIVATE --coverage)
+endif()
 
 # Install
 install(TARGETS gateway_node
@@ -78,8 +101,13 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   ament_add_gtest(test_gateway_node test/test_gateway_node.cpp)
-  target_link_libraries(test_gateway_node PkgConfig::cpp_httplib nlohmann_json::nlohmann_json)
-  ament_target_dependencies(test_gateway_node rclcpp)
+  target_link_libraries(test_gateway_node gateway_lib)
+
+  # Apply coverage flags to test target
+  if(ENABLE_COVERAGE)
+    target_compile_options(test_gateway_node PRIVATE --coverage -O0 -g)
+    target_link_options(test_gateway_node PRIVATE --coverage)
+  endif()
 
   # Integration testing
   find_package(ament_cmake_pytest REQUIRED)


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

 add Codecov integration with code coverage reporting

- Add ENABLE_COVERAGE CMake option with gcov flags (-fprofile-arcs, -ftest-coverage) for coverage instrumentation
- Update CI workflow to always build with coverage and generate lcov reports, uploading coverage.info as artifact on every run
- Upload coverage to Codecov only on push to main branch
- Add codecov.yml configuration with path filters (ignore test/, build/, install/, docs/) and coverage thresholds
- Add Codecov badge to README.md
- Add "Code Coverage" section to README with local usage instructions
- Update CI/CD section in README to reflect new coverage workflow
- Add lcov to devcontainer Dockerfile
- Update .gitignore with coverage artifacts (*.gcda, *.gcno, *.gcov, coverage.info, coverage_html/)

---

## Issue

- closes #48 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

colcon test

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
