### PR TITLE
[#44] feat: add /api/v1 prefix to all REST endpoints

### DIFF
--- a/postman/README.md
+++ b/postman/README.md
@@ -2,16 +2,20 @@
 
 This folder contains Postman collections for testing the ROS 2 Medkit Gateway REST API.
 
+## API Base Path
+
+All endpoints are prefixed with `/api/v1` for API versioning.
+
 ## Current Collection:
 
 **Collection:** `ros2-medkit-gateway.postman_collection.json`
 
 Includes below endpoints:
-- ✅ GET `/` - Gateway info
-- ✅ GET `/areas` - List all areas
-- ✅ GET `/components` - List all components
-- ✅ GET `/areas/{area_id}/components` - List components in specific area
-- ✅ GET `/components/{component_id}/data` - Read all topic data from a component
+- ✅ GET `/api/v1/` - Gateway info
+- ✅ GET `/api/v1/areas` - List all areas
+- ✅ GET `/api/v1/components` - List all components
+- ✅ GET `/api/v1/areas/{area_id}/components` - List components in specific area
+- ✅ GET `/api/v1/components/{component_id}/data` - Read all topic data from a component
 
 ## Quick Start
 

--- a/postman/environments/local.postman_environment.json
+++ b/postman/environments/local.postman_environment.json
@@ -3,7 +3,7 @@
   "values": [
     {
       "key": "base_url",
-      "value": "http://localhost:8080",
+      "value": "http://localhost:8080/api/v1",
       "type": "default",
       "enabled": true
     }

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -14,28 +14,30 @@ The ROS 2 Medkit Gateway exposes ROS 2 system information and data through a RES
 
 ## Endpoints
 
+All endpoints are prefixed with `/api/v1` for API versioning.
+
 ### Discovery Endpoints
 
-- `GET /health` - Health check endpoint (returns healthy status)
-- `GET /` - Gateway status and version information
-- `GET /areas` - List all discovered areas (powertrain, chassis, body, root)
-- `GET /components` - List all discovered components across all areas
-- `GET /areas/{area_id}/components` - List components within a specific area
+- `GET /api/v1/health` - Health check endpoint (returns healthy status)
+- `GET /api/v1/` - Gateway status and version information
+- `GET /api/v1/areas` - List all discovered areas (powertrain, chassis, body, root)
+- `GET /api/v1/components` - List all discovered components across all areas
+- `GET /api/v1/areas/{area_id}/components` - List components within a specific area
 
 ### Component Data Endpoints
 
-- `GET /components/{component_id}/data` - Read all topic data from a component
-- `GET /components/{component_id}/data/{topic_name}` - Read specific topic data from a component
+- `GET /api/v1/components/{component_id}/data` - Read all topic data from a component
+- `GET /api/v1/components/{component_id}/data/{topic_name}` - Read specific topic data from a component
 
 ### API Reference
 
-#### GET /areas
+#### GET /api/v1/areas
 
 Lists all discovered areas in the system.
 
 **Example:**
 ```bash
-curl http://localhost:8080/areas
+curl http://localhost:8080/api/v1/areas
 ```
 
 **Response:**
@@ -54,13 +56,13 @@ curl http://localhost:8080/areas
 ]
 ```
 
-#### GET /components
+#### GET /api/v1/components
 
 Lists all discovered components across all areas.
 
 **Example:**
 ```bash
-curl http://localhost:8080/components
+curl http://localhost:8080/api/v1/components
 ```
 
 **Response:**
@@ -90,13 +92,13 @@ curl http://localhost:8080/components
 - `type` - Always "Component"
 - `area` - Parent area this component belongs to
 
-#### GET /areas/{area_id}/components
+#### GET /api/v1/areas/{area_id}/components
 
 Lists all components within a specific area.
 
 **Example (Success):**
 ```bash
-curl http://localhost:8080/areas/powertrain/components
+curl http://localhost:8080/api/v1/areas/powertrain/components
 ```
 
 **Response (200 OK):**
@@ -121,7 +123,7 @@ curl http://localhost:8080/areas/powertrain/components
 
 **Example (Error - Area Not Found):**
 ```bash
-curl http://localhost:8080/areas/nonexistent/components
+curl http://localhost:8080/api/v1/areas/nonexistent/components
 ```
 
 **Response (404 Not Found):**
@@ -142,13 +144,13 @@ curl http://localhost:8080/areas/nonexistent/components
 
 ### Component Data Read Endpoints
 
-#### GET /components/{component_id}/data
+#### GET /api/v1/components/{component_id}/data
 
 Read all topic data from a specific component.
 
 **Example:**
 ```bash
-curl http://localhost:8080/components/temp_sensor/data
+curl http://localhost:8080/api/v1/components/temp_sensor/data
 ```
 
 **Response (200 OK):**
@@ -167,7 +169,7 @@ curl http://localhost:8080/components/temp_sensor/data
 
 **Example (Error - Component Not Found):**
 ```bash
-curl http://localhost:8080/components/nonexistent/data
+curl http://localhost:8080/api/v1/components/nonexistent/data
 ```
 
 **Response (404 Not Found):**
@@ -203,13 +205,13 @@ curl http://localhost:8080/components/nonexistent/data
 - Response time scales with batch count: `ceil(topics / batch_size) × timeout`
 - 3-second timeout per topic to accommodate slow-publishing topics
 
-#### GET /components/{component_id}/data/{topic_name}
+#### GET /api/v1/components/{component_id}/data/{topic_name}
 
 Read data from a specific topic within a component.
 
 **Example:**
 ```bash
-curl http://localhost:8080/components/temp_sensor/data/temperature
+curl http://localhost:8080/api/v1/components/temp_sensor/data/temperature
 ```
 
 **Response (200 OK):**
@@ -226,7 +228,7 @@ curl http://localhost:8080/components/temp_sensor/data/temperature
 
 **Example (Error - Topic Not Found):**
 ```bash
-curl http://localhost:8080/components/temp_sensor/data/nonexistent
+curl http://localhost:8080/api/v1/components/temp_sensor/data/nonexistent
 ```
 
 **Response (404 Not Found):**
@@ -240,7 +242,7 @@ curl http://localhost:8080/components/temp_sensor/data/nonexistent
 
 **Example (Error - Component Not Found):**
 ```bash
-curl http://localhost:8080/components/nonexistent/data/temperature
+curl http://localhost:8080/api/v1/components/nonexistent/data/temperature
 ```
 
 **Response (404 Not Found):**
@@ -253,7 +255,7 @@ curl http://localhost:8080/components/nonexistent/data/temperature
 
 **Example (Error - Invalid Topic Name):**
 ```bash
-curl http://localhost:8080/components/temp_sensor/data/invalid-name
+curl http://localhost:8080/api/v1/components/temp_sensor/data/invalid-name
 ```
 
 **Response (400 Bad Request):**
@@ -315,7 +317,7 @@ ros2 launch ros2_medkit_gateway demo_nodes.launch.py
 
 **Test the API:**
 ```bash
-curl http://localhost:8080/areas
+curl http://localhost:8080/api/v1/areas
 ```
 
 ## Configuration

--- a/src/ros2_medkit_gateway/test/test_cors.test.py
+++ b/src/ros2_medkit_gateway/test/test_cors.test.py
@@ -42,6 +42,8 @@ GATEWAY_PORT_WITH_CREDS = 8086  # CORS with credentials enabled
 ALLOWED_ORIGIN = 'http://localhost:5173'
 ALLOWED_ORIGIN_2 = 'http://localhost:3000'
 DISALLOWED_ORIGIN = 'http://evil.com'
+# API version prefix - must match rest_server.cpp
+API_BASE_PATH = '/api/v1'
 
 
 def generate_test_description():
@@ -96,8 +98,8 @@ def generate_test_description():
 class TestCorsIntegration(unittest.TestCase):
     """CORS integration tests."""
 
-    BASE_URL_NO_CREDS = f'http://{GATEWAY_HOST}:{GATEWAY_PORT_NO_CREDS}'
-    BASE_URL_WITH_CREDS = f'http://{GATEWAY_HOST}:{GATEWAY_PORT_WITH_CREDS}'
+    BASE_URL_NO_CREDS = f'http://{GATEWAY_HOST}:{GATEWAY_PORT_NO_CREDS}{API_BASE_PATH}'
+    BASE_URL_WITH_CREDS = f'http://{GATEWAY_HOST}:{GATEWAY_PORT_WITH_CREDS}{API_BASE_PATH}'
 
     @classmethod
     def setUpClass(cls):

--- a/src/ros2_medkit_gateway/test/test_gateway_node.cpp
+++ b/src/ros2_medkit_gateway/test/test_gateway_node.cpp
@@ -26,6 +26,9 @@
 using namespace std::chrono_literals;
 using httplib::StatusCode;
 
+// API version prefix - must match rest_server.cpp
+static constexpr const char * API_BASE_PATH = "/api/v1";
+
 class TestGatewayNode : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -55,9 +58,10 @@ class TestGatewayNode : public ::testing::Test {
     const auto start = std::chrono::steady_clock::now();
     const auto timeout = std::chrono::seconds(5);
     httplib::Client client(server_host_, server_port_);
+    const std::string health_endpoint = std::string(API_BASE_PATH) + "/health";
 
     while (std::chrono::steady_clock::now() - start < timeout) {
-      if (auto res = client.Get("/health")) {
+      if (auto res = client.Get(health_endpoint)) {
         if (res->status == StatusCode::OK_200) {
           return;
         }
@@ -79,7 +83,7 @@ class TestGatewayNode : public ::testing::Test {
 TEST_F(TestGatewayNode, test_health_endpoint) {
   auto client = create_client();
 
-  auto res = client.Get("/health");
+  auto res = client.Get(std::string(API_BASE_PATH) + "/health");
 
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, StatusCode::OK_200);
@@ -95,7 +99,7 @@ TEST_F(TestGatewayNode, test_root_endpoint) {
   // @verifies REQ_INTEROP_010
   auto client = create_client();
 
-  auto res = client.Get("/");
+  auto res = client.Get(std::string(API_BASE_PATH) + "/");
 
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, StatusCode::OK_200);
@@ -115,7 +119,7 @@ TEST_F(TestGatewayNode, test_version_info_endpoint) {
   // @verifies REQ_INTEROP_001
   auto client = create_client();
 
-  auto res = client.Get("/version-info");
+  auto res = client.Get(std::string(API_BASE_PATH) + "/version-info");
 
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, StatusCode::OK_200);
@@ -131,7 +135,7 @@ TEST_F(TestGatewayNode, test_list_areas_endpoint) {
   // @verifies REQ_INTEROP_003
   auto client = create_client();
 
-  auto res = client.Get("/areas");
+  auto res = client.Get(std::string(API_BASE_PATH) + "/areas");
 
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, StatusCode::OK_200);
@@ -145,7 +149,7 @@ TEST_F(TestGatewayNode, test_list_components_endpoint) {
   // @verifies REQ_INTEROP_003
   auto client = create_client();
 
-  auto res = client.Get("/components");
+  auto res = client.Get(std::string(API_BASE_PATH) + "/components");
 
   ASSERT_TRUE(res);
   EXPECT_EQ(res->status, StatusCode::OK_200);

--- a/src/ros2_medkit_gateway/test/test_integration.test.py
+++ b/src/ros2_medkit_gateway/test/test_integration.test.py
@@ -132,10 +132,14 @@ def generate_test_description():
     )
 
 
+# API version prefix - must match rest_server.cpp
+API_BASE_PATH = '/api/v1'
+
+
 class TestROS2MedkitGatewayIntegration(unittest.TestCase):
     """Integration tests for ROS 2 Medkit Gateway REST API and discovery."""
 
-    BASE_URL = 'http://localhost:8080'
+    BASE_URL = f'http://localhost:8080{API_BASE_PATH}'
     # Wait for cache refresh + safety margin
     # Must be kept in sync with gateway_params.yaml refresh_interval_ms (2000ms)
     # Need to wait for at least 2 refresh cycles to ensure all demo nodes are discovered
@@ -151,7 +155,7 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         max_retries = 5
         for i in range(max_retries):
             try:
-                response = requests.get(f'{cls.BASE_URL}/', timeout=1)
+                response = requests.get(f'{cls.BASE_URL}/health', timeout=1)
                 if response.status_code == 200:
                     return
             except requests.exceptions.RequestException:
@@ -182,11 +186,15 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
 
         # Verify endpoints list
         self.assertIsInstance(data['endpoints'], list)
-        self.assertIn('GET /health', data['endpoints'])
-        self.assertIn('GET /version-info', data['endpoints'])
-        self.assertIn('GET /areas', data['endpoints'])
-        self.assertIn('GET /components', data['endpoints'])
-        self.assertIn('PUT /components/{component_id}/data/{topic_name}', data['endpoints'])
+        self.assertIn('GET /api/v1/health', data['endpoints'])
+        self.assertIn('GET /api/v1/version-info', data['endpoints'])
+        self.assertIn('GET /api/v1/areas', data['endpoints'])
+        self.assertIn('GET /api/v1/components', data['endpoints'])
+        self.assertIn('PUT /api/v1/components/{component_id}/data/{topic_name}', data['endpoints'])
+
+        # Verify api_base field
+        self.assertIn('api_base', data)
+        self.assertEqual(data['api_base'], API_BASE_PATH)
 
         # Verify capabilities
         self.assertIn('discovery', data['capabilities'])


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Add API versioning by prefixing all REST endpoints with /api/v1/. This enables future backward-compatible API evolution when entity models change.

Changes:
- Add API_BASE_PATH constant and api_path() helper function
- Update all route registrations to use versioned paths
- Add api_base field to root endpoint response
- Update unit tests, integration tests, and CORS tests
- Update README and Postman collection/environment

Endpoints are now:
- GET /api/v1/health
- GET /api/v1/ (root)
- GET /api/v1/version-info
- GET /api/v1/areas
- GET /api/v1/components
- GET /api/v1/areas/{area_id}/components
- GET /api/v1/components/{component_id}/data
- GET /api/v1/components/{component_id}/data/{topic_name}
- PUT /api/v1/components/{component_id}/data/{topic_name}

---

## Issue

Link the related issue (required):

- closes #44

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [x] Breaking change
- [x] Documentation only

---

## Testing

colcon tests

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
