### PR TITLE
[#52] feat: return topic metadata with schema when data unavailable

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(rcl_interfaces REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 
 # Find cpp-httplib using pkg-config
 find_package(PkgConfig REQUIRED)
@@ -44,6 +45,7 @@ add_library(gateway_lib STATIC
   src/ros2_cli_wrapper.cpp
   src/output_parser.cpp
   src/data_access_manager.cpp
+  src/type_introspection.cpp
 )
 
 ament_target_dependencies(gateway_lib
@@ -51,6 +53,7 @@ ament_target_dependencies(gateway_lib
   std_msgs
   std_srvs
   rcl_interfaces
+  ament_index_cpp
 )
 
 target_link_libraries(gateway_lib
@@ -82,6 +85,11 @@ install(TARGETS gateway_node
 
 install(DIRECTORY launch config
   DESTINATION share/${PROJECT_NAME}
+)
+
+# Install scripts with execute permissions explicitly set
+install(PROGRAMS scripts/get_type_schema.py
+  DESTINATION share/${PROJECT_NAME}/scripts
 )
 
 # Testing

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/type_introspection.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/type_introspection.hpp
@@ -1,0 +1,132 @@
+// Copyright 2025 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <unordered_map>
+
+namespace ros2_medkit_gateway {
+
+// Forward declarations
+class ROS2CLIWrapper;
+class OutputParser;
+
+/**
+ * @brief Information about a ROS 2 message type including schema and template
+ */
+struct TopicTypeInfo {
+  std::string name;              ///< Full type name (e.g., "sensor_msgs/msg/Temperature")
+  nlohmann::json schema;         ///< Recursive field type information
+  nlohmann::json default_value;  ///< Template with default values
+};
+
+/**
+ * @brief Metadata about a topic (without actual data)
+ */
+struct TopicMetadata {
+  std::string topic_path;   ///< Full topic path (e.g., "/powertrain/engine/temperature")
+  std::string type_name;    ///< Message type name
+  int publisher_count{0};   ///< Number of publishers
+  int subscriber_count{0};  ///< Number of subscribers
+};
+
+/**
+ * @brief Provides type introspection capabilities for ROS 2 message types
+ *
+ * This class allows querying information about ROS 2 topics and message types
+ * without requiring actual message data. It uses CLI commands and a Python
+ * helper script to gather type information.
+ *
+ * Type information is cached to avoid repeated CLI calls for the same types.
+ */
+class TypeIntrospection {
+ public:
+  /**
+   * @brief Construct a new TypeIntrospection object
+   *
+   * @param scripts_path Path to the directory containing helper scripts
+   */
+  explicit TypeIntrospection(const std::string & scripts_path = "");
+
+  ~TypeIntrospection() = default;
+
+  // Disable copy (due to mutex and unique_ptrs)
+  TypeIntrospection(const TypeIntrospection &) = delete;
+  TypeIntrospection & operator=(const TypeIntrospection &) = delete;
+
+  // Disable move (mutex is not movable)
+  TypeIntrospection(TypeIntrospection &&) = delete;
+  TypeIntrospection & operator=(TypeIntrospection &&) = delete;
+
+  /**
+   * @brief Get metadata for a topic (type, publisher/subscriber counts)
+   *
+   * This method is fast and doesn't require the topic to be publishing.
+   *
+   * @param topic_path Full path to the topic (e.g., "/powertrain/engine/temperature")
+   * @return TopicMetadata containing topic information
+   * @throws std::runtime_error if topic info cannot be retrieved
+   */
+  TopicMetadata get_topic_metadata(const std::string & topic_path);
+
+  /**
+   * @brief Get full type information including schema (with caching)
+   *
+   * @param type_name Full type name (e.g., "sensor_msgs/msg/Temperature")
+   * @return TopicTypeInfo containing schema and default values
+   * @throws std::runtime_error if type info cannot be retrieved
+   */
+  TopicTypeInfo get_type_info(const std::string & type_name);
+
+  /**
+   * @brief Get the default value template for a message type
+   *
+   * Uses `ros2 interface proto` to generate a template with default values.
+   *
+   * @param type_name Full type name
+   * @return nlohmann::json Template with default field values
+   * @throws std::runtime_error if template cannot be generated
+   */
+  nlohmann::json get_type_template(const std::string & type_name);
+
+  /**
+   * @brief Get the JSON schema for a message type
+   *
+   * Uses a Python helper script to generate recursive type schema.
+   *
+   * @param type_name Full type name
+   * @return nlohmann::json Schema with field types
+   * @throws std::runtime_error if schema cannot be generated
+   */
+  nlohmann::json get_type_schema(const std::string & type_name);
+
+  /**
+   * @brief Clear the type info cache
+   */
+  void clear_cache();
+
+ private:
+  std::string scripts_path_;                     ///< Path to helper scripts
+  std::unique_ptr<ROS2CLIWrapper> cli_wrapper_;  ///< CLI wrapper for commands
+  std::unique_ptr<OutputParser> output_parser_;  ///< Parser for CLI output
+
+  std::unordered_map<std::string, TopicTypeInfo> type_cache_;  ///< Cache for type info
+  mutable std::mutex cache_mutex_;                             ///< Mutex for thread-safe cache access
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -18,6 +18,8 @@
   <depend>nlohmann-json-dev</depend>
   <depend>libcpp-httplib-dev</depend>
   <depend>yaml_cpp_vendor</depend>
+  <exec_depend>rosidl_runtime_py</exec_depend>
+  <exec_depend>rosidl_parser</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/ros2_medkit_gateway/scripts/get_type_schema.py
+++ b/src/ros2_medkit_gateway/scripts/get_type_schema.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright 2025 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Generate JSON schema for ROS 2 message types.
+
+This script uses rosidl_runtime_py to introspect message types and generate
+a JSON schema representation that includes field names and types recursively.
+
+Usage:
+    python3 get_type_schema.py <message_type>
+    python3 get_type_schema.py sensor_msgs/msg/Temperature
+
+Output:
+    JSON object with "name" and "schema" fields, or "error" on failure.
+"""
+
+import json
+import sys
+
+from rosidl_parser.definition import (
+    Array,
+    BasicType,
+    BoundedSequence,
+    BoundedString,
+    NamespacedType,
+    UnboundedSequence,
+    UnboundedString,
+)
+from rosidl_runtime_py.utilities import get_message
+
+
+def type_to_dict(slot_type):
+    """
+    Convert a rosidl type definition to a JSON-serializable dictionary.
+
+    Args
+    ----
+        slot_type: A rosidl_parser.definition type object
+
+    Returns
+    -------
+        dict: JSON-serializable representation of the type
+
+    """
+    if isinstance(slot_type, BasicType):
+        return {'type': slot_type.typename}
+
+    elif isinstance(slot_type, (UnboundedString, BoundedString)):
+        result = {'type': 'string'}
+        if isinstance(slot_type, BoundedString):
+            result['max_length'] = slot_type.maximum_size
+        return result
+
+    elif isinstance(slot_type, NamespacedType):
+        # Nested message type - recursively get its schema
+        nested_name = '/'.join(slot_type.namespaces + [slot_type.name])
+        try:
+            nested_class = get_message(nested_name)
+            return {
+                'type': nested_name,
+                'fields': get_message_schema(nested_class)
+            }
+        except (ModuleNotFoundError, AttributeError, ImportError):
+            # If we can't load the nested type, just return the name
+            return {'type': nested_name}
+
+    elif isinstance(slot_type, (Array, UnboundedSequence, BoundedSequence)):
+        result = {
+            'type': 'array',
+            'items': type_to_dict(slot_type.value_type)
+        }
+        if isinstance(slot_type, Array):
+            result['size'] = slot_type.size
+        elif isinstance(slot_type, BoundedSequence):
+            result['max_size'] = slot_type.maximum_size
+        return result
+
+    else:
+        # Fallback for unknown types
+        return {'type': str(type(slot_type).__name__)}
+
+
+def get_message_schema(msg_class):
+    """
+    Get the full schema for a message class.
+
+    Args
+    ----
+        msg_class: A ROS 2 message class
+
+    Returns
+    -------
+        dict: Schema with field names as keys and type info as values
+
+    """
+    schema = {}
+    for slot, slot_type in zip(msg_class.__slots__, msg_class.SLOT_TYPES):
+        # Skip internal fields (start with underscore but aren't real fields)
+        if slot.startswith('_') and slot != '_check_fields':
+            field_name = slot[1:]  # Remove leading underscore
+            schema[field_name] = type_to_dict(slot_type)
+    return schema
+
+
+def main():
+    """Execute schema generation from command line."""
+    if len(sys.argv) != 2:
+        result = {
+            'error': 'Usage: get_type_schema.py <message_type>',
+            'example': 'get_type_schema.py sensor_msgs/msg/Temperature'
+        }
+        print(json.dumps(result))
+        sys.exit(1)
+
+    type_name = sys.argv[1]
+
+    try:
+        msg_class = get_message(type_name)
+        schema = get_message_schema(msg_class)
+        result = {
+            'name': type_name,
+            'schema': schema
+        }
+        print(json.dumps(result))
+    except Exception as e:  # noqa: BLE001 - Catch all for JSON error reporting
+        result = {
+            'error': f"Failed to get schema for '{type_name}': {str(e)}",
+            'type': type_name
+        }
+        print(json.dumps(result))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ros2_medkit_gateway/src/type_introspection.cpp
+++ b/src/ros2_medkit_gateway/src/type_introspection.cpp
@@ -1,0 +1,199 @@
+// Copyright 2025 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/type_introspection.hpp"
+
+#include <regex>
+#include <sstream>
+#include <stdexcept>
+
+#include "ros2_medkit_gateway/output_parser.hpp"
+#include "ros2_medkit_gateway/ros2_cli_wrapper.hpp"
+
+namespace ros2_medkit_gateway {
+
+TypeIntrospection::TypeIntrospection(const std::string & scripts_path)
+  : scripts_path_(scripts_path)
+  , cli_wrapper_(std::make_unique<ROS2CLIWrapper>())
+  , output_parser_(std::make_unique<OutputParser>()) {
+}
+
+TopicMetadata TypeIntrospection::get_topic_metadata(const std::string & topic_path) {
+  TopicMetadata metadata;
+  metadata.topic_path = topic_path;
+
+  // Call: ros2 topic info {topic}
+  std::string cmd = "ros2 topic info " + ROS2CLIWrapper::escape_shell_arg(topic_path);
+  std::string output = cli_wrapper_->exec(cmd);
+
+  // Parse output:
+  // Type: sensor_msgs/msg/Temperature
+  // Publisher count: 1
+  // Subscription count: 0
+
+  // Extract type
+  std::regex type_regex(R"(Type:\s*(\S+))");
+  std::smatch type_match;
+  if (std::regex_search(output, type_match, type_regex)) {
+    metadata.type_name = type_match[1].str();
+  }
+
+  // Extract publisher count
+  std::regex pub_regex(R"(Publisher count:\s*(\d+))");
+  std::smatch pub_match;
+  if (std::regex_search(output, pub_match, pub_regex)) {
+    metadata.publisher_count = std::stoi(pub_match[1].str());
+  }
+
+  // Extract subscription count
+  std::regex sub_regex(R"(Subscription count:\s*(\d+))");
+  std::smatch sub_match;
+  if (std::regex_search(output, sub_match, sub_regex)) {
+    metadata.subscriber_count = std::stoi(sub_match[1].str());
+  }
+
+  // Validate that we got the critical type_name field
+  if (metadata.type_name.empty()) {
+    throw std::runtime_error("Failed to parse type name from topic info for: " + topic_path);
+  }
+
+  return metadata;
+}
+
+nlohmann::json TypeIntrospection::get_type_template(const std::string & type_name) {
+  // Call: ros2 interface proto {type_name}
+  std::string cmd = "ros2 interface proto " + ROS2CLIWrapper::escape_shell_arg(type_name);
+  std::string output = cli_wrapper_->exec(cmd);
+
+  // The output is a quoted YAML string, e.g.:
+  // "header:\n  stamp:\n    sec: 0\n..."
+  // We need to remove the surrounding quotes and parse as YAML
+
+  // Remove surrounding quotes if present
+  if (output.size() >= 2 && output.front() == '"' && output.back() == '"') {
+    output = output.substr(1, output.size() - 2);
+  }
+
+  // Unescape common escape sequences (\n, \t, \r, \\, \")
+  std::string unescaped;
+  for (size_t i = 0; i < output.size(); ++i) {
+    if (i + 1 < output.size() && output[i] == '\\') {
+      char next = output[i + 1];
+      switch (next) {
+        case 'n':
+          unescaped += '\n';
+          ++i;
+          break;
+        case 't':
+          unescaped += '\t';
+          ++i;
+          break;
+        case 'r':
+          unescaped += '\r';
+          ++i;
+          break;
+        case '\\':
+          unescaped += '\\';
+          ++i;
+          break;
+        case '"':
+          unescaped += '"';
+          ++i;
+          break;
+        default:
+          unescaped += output[i];
+          break;
+      }
+    } else {
+      unescaped += output[i];
+    }
+  }
+
+  return output_parser_->parse_yaml(unescaped);
+}
+
+nlohmann::json TypeIntrospection::get_type_schema(const std::string & type_name) {
+  // Call Python script for recursive schema
+  if (scripts_path_.empty()) {
+    throw std::runtime_error("scripts_path not configured for TypeIntrospection");
+  }
+
+  std::string script_path = "python3 " + ROS2CLIWrapper::escape_shell_arg(scripts_path_ + "/get_type_schema.py") + " " +
+                            ROS2CLIWrapper::escape_shell_arg(type_name);
+
+  std::string output = cli_wrapper_->exec(script_path);
+
+  try {
+    nlohmann::json result = nlohmann::json::parse(output);
+
+    // Check for error in result
+    if (result.contains("error")) {
+      throw std::runtime_error(result["error"].get<std::string>());
+    }
+
+    return result;
+  } catch (const nlohmann::json::parse_error & e) {
+    throw std::runtime_error("Failed to parse schema output: " + std::string(e.what()));
+  }
+}
+
+TopicTypeInfo TypeIntrospection::get_type_info(const std::string & type_name) {
+  // Check cache first
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto it = type_cache_.find(type_name);
+    if (it != type_cache_.end()) {
+      return it->second;
+    }
+  }
+
+  // Build type info
+  TopicTypeInfo info;
+  info.name = type_name;
+
+  // Get template (default values)
+  try {
+    info.default_value = get_type_template(type_name);
+  } catch (const std::exception & e) {
+    // If template fails, use empty object
+    info.default_value = nlohmann::json::object();
+  }
+
+  // Get schema (recursive type info)
+  try {
+    nlohmann::json schema_result = get_type_schema(type_name);
+    if (schema_result.contains("schema")) {
+      info.schema = schema_result["schema"];
+    } else {
+      info.schema = nlohmann::json::object();
+    }
+  } catch (const std::exception & e) {
+    // If schema fails, use empty object
+    info.schema = nlohmann::json::object();
+  }
+
+  // Cache it (use try_emplace to avoid overwriting if another thread added it first)
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto [it, inserted] = type_cache_.try_emplace(type_name, info);
+    return it->second;  // Return cached version (may be from another thread)
+  }
+}
+
+void TypeIntrospection::clear_cache() {
+  std::lock_guard<std::mutex> lock(cache_mutex_);
+  type_cache_.clear();
+}
+
+}  // namespace ros2_medkit_gateway


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

  - Add TypeIntrospection class for topic metadata and type schema retrieval
  - Add Python script using rosidl_runtime_py for recursive JSON schema generation
  - Implement get_topic_sample_with_fallback() returning metadata on timeout
  - Response includes status field: data or metadata_only
  - Include type_info (schema, default_value), publisher/subscriber counts
  - Update integration tests for new response format


---

## Issue

Link the related issue (required):

- closes #52 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
