### PR TITLE
fix(gateway): prevent duplicate node from internal parameter client

### DIFF
--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -33,8 +33,8 @@ ros2_medkit_gateway:
       # List of allowed origins
       # Examples: ["http://localhost:5173", "https://example.com"]
       # Use ["*"] to allow all origins (not recommended for production)
-      # Empty list = CORS disabled
-      allowed_origins: []
+      # Empty list = CORS disabled (use [""] for ROS 2 YAML compatibility)
+      allowed_origins: [""]
 
       # Allowed HTTP methods for CORS requests
       # Default: ["GET", "PUT", "OPTIONS"]

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/data_access_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/data_access_manager.hpp
@@ -95,8 +95,24 @@ class DataAccessManager {
    * @param component_namespace Component's namespace (e.g., "/powertrain/engine")
    * @param timeout_sec Timeout per topic for topics that have publishers
    * @return JSON array with topic data/metadata
+   * @deprecated Use get_component_data_by_fqn instead for accurate topic discovery
    */
   json get_component_data_native(const std::string & component_namespace, double timeout_sec = 1.0);
+
+  /**
+   * @brief Get component data by fully qualified name using topic map
+   *
+   * This method finds all topics that the component publishes or subscribes to
+   * by building a component-topic map from the ROS graph. This is more accurate
+   * than namespace-based filtering because:
+   * - A node can publish/subscribe to topics outside its namespace
+   * - Topics like /clock, /tf, /diagnostics are in root namespace but used by many nodes
+   *
+   * @param component_fqn Component's fully qualified name (e.g., "/ros2_medkit_gateway")
+   * @param timeout_sec Timeout per topic for topics that have publishers
+   * @return JSON array with topic data/metadata for all topics this component interacts with
+   */
+  json get_component_data_by_fqn(const std::string & component_fqn, double timeout_sec = 1.0);
 
   /**
    * @brief Get single topic sample using native rclcpp APIs
@@ -108,6 +124,14 @@ class DataAccessManager {
    * @return JSON with topic data or metadata
    */
   json get_topic_sample_native(const std::string & topic_name, double timeout_sec = 1.0);
+
+  /**
+   * @brief Get the configured topic sample timeout
+   * @return Timeout in seconds for topic sampling
+   */
+  double get_topic_sample_timeout() const {
+    return topic_sample_timeout_sec_;
+  }
 
  private:
   /**

--- a/src/ros2_medkit_gateway/src/configuration_manager.cpp
+++ b/src/ros2_medkit_gateway/src/configuration_manager.cpp
@@ -27,6 +27,9 @@ ConfigurationManager::ConfigurationManager(rclcpp::Node * node) : node_(node) {
   rclcpp::NodeOptions options;
   options.start_parameter_services(false);
   options.start_parameter_event_publisher(false);
+  // Don't inherit node name/namespace from global arguments (--ros-args -r __node:=...)
+  // Without this, the internal node would have the same name as the main gateway node
+  options.use_global_arguments(false);
   param_node_ = std::make_shared<rclcpp::Node>("_param_client_node", options);
   RCLCPP_INFO(node_->get_logger(), "ConfigurationManager initialized");
 }


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

The ConfigurationManager creates an internal rclcpp::Node for SyncParametersClient operations. Without use_global_arguments(false), this node inherited the --ros-args -r __node:= remapping from the launch system, causing it to appear with the same name as the main gateway node.

Also includes:
- Fix YAML empty array parsing (use [""] instead of [])
- Use component topic map for /data endpoint instead of namespace filter
- Filter "A message was lost" warnings from ros2 topic echo output

---

## Issue

Link the related issue (required):

- closes #64 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

colcon test 

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
