### PR TITLE
[#107] feat(cpp): downgrade C++ standard from C++23 to C++17

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,6 +16,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
     locales \
     build-essential \
     cmake \
+    doxygen \
     python3-pip \
     python3-venv \
     python3-dev \

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@
 
 **ros2_medkit** is a ROS 2 diagnostics gateway that exposes ROS 2 system information via a RESTful HTTP API. It models robots as a **diagnostic entity tree** (Area → Component → Function → App) aligned with the SOVD (Service-Oriented Vehicle Diagnostics) specification.
 
-**Tech Stack**: C++23, ROS 2 Jazzy, Ubuntu 24.04
+**Tech Stack**: C++17, ROS 2 Jazzy, Ubuntu 24.04
 
 ## Architecture
 
@@ -24,7 +24,7 @@ GatewayNode (src/ros2_medkit_gateway/src/gateway_node.cpp)
 
 ## Code Style & Conventions
 
-- **C++ Standard**: C++23 with `-Wall -Wextra -Wpedantic -Wshadow -Wconversion`
+- **C++ Standard**: C++17 with `-Wall -Wextra -Wpedantic -Wshadow -Wconversion`
 - **ROS 2 Distribution**: Jazzy (Ubuntu 24.04)
 - **Formatting**: Google-based clang-format with 120 column limit, 2-space indent
 - **Pointer style**: Middle alignment (`Type * ptr`) per ROS 2 conventions

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ so the same concepts can be used across robots, vehicles, and other embedded sys
 
 - **OS:** Ubuntu 24.04 LTS
 - **ROS 2:** Jazzy Jalisco
-- **Compiler:** GCC 13+ (C++23 support)
+- **Compiler:** GCC 13+ (C++17 support)
 - **Build System:** colcon + ament_cmake
 
 ## 🚀 Quick Start

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -17,7 +17,7 @@ System Requirements
    * - ROS 2 Distribution
      - Jazzy Jalisco
    * - C++ Compiler
-     - GCC 13+ (C++23 support required)
+     - GCC 13+ (C++17 support required)
    * - CMake
      - 3.22+
    * - Python
@@ -161,7 +161,7 @@ Troubleshooting
       sudo rosdep init  # Only needed once
       rosdep update
 
-**Build fails with C++23 errors**
+**Build fails with C++17 errors**
 
    Ensure you have GCC 13 or newer:
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -23,7 +23,7 @@ Solution: Initialize and update rosdep:
    sudo rosdep init  # Only needed once
    rosdep update
 
-**Build fails with C++23 errors**
+**Build fails with C++17 errors**
 
 .. code-block:: text
 

--- a/docs/tutorials/devcontainer.rst
+++ b/docs/tutorials/devcontainer.rst
@@ -15,7 +15,7 @@ The devcontainer provides:
 
 - **Ubuntu 24.04** base image
 - **ROS 2 Jazzy** desktop-full installation
-- **C++23** toolchain (GCC 13)
+- **C++17** toolchain (GCC 13)
 - **Development tools**: CMake, colcon, rosdep, clang-format, clang-tidy
 - **Documentation tools**: Doxygen, Sphinx, PlantUML
 - **Code coverage**: lcov

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(ros2_medkit_fault_manager)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/src/ros2_medkit_fault_reporter/CMakeLists.txt
+++ b/src/ros2_medkit_fault_reporter/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.8)
 project(ros2_medkit_fault_reporter)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Downgrade C++ standard from c++23 to c++17

- Update CMAKE_CXX_STANDARD from 23 to 17 in fault_manager and fault_reporter CMakeLists.txt
- Update all documentation references from C++23 to C++17:
  - README.md requirements section
  - installation.rst system requirements and troubleshooting
  - troubleshooting.rst build error messages
  - devcontainer.rst toolchain description
  - copilot-instructions.md tech stack and code style
- Add doxygen to devcontainer Dockerfile dependencies

---

## Issue

Link the related issue (required):

- closes #107 
---

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [x] Breaking change
- [ ] Documentation only

---

## Testing

using colcon tests and generating docs

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
