### PR TITLE
[#128] fix(clang-format): reformat fault_handlers.cpp

### DIFF
--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -113,12 +113,9 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
                                         filter.include_cleared, include_muted, include_clusters);
 
     if (result.success) {
-      json response = {{entity_info.id_field, entity_id},
-                       {"source_id", namespace_path},
-                       {"faults", result.data["faults"]},
-                       {"count", result.data["count"]},
-                       {"muted_count", result.data["muted_count"]},
-                       {"cluster_count", result.data["cluster_count"]}};
+      json response = {{entity_info.id_field, entity_id},           {"source_id", namespace_path},
+                       {"faults", result.data["faults"]},           {"count", result.data["count"]},
+                       {"muted_count", result.data["muted_count"]}, {"cluster_count", result.data["cluster_count"]}};
 
       // Include detailed correlation data if requested and present
       if (result.data.contains("muted_faults")) {


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Reformat fault_handlers.cpp to fix clang-format error.

---

## Issue

Link the related issue (required):

- closes #128 
---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?
colcon test
---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
