### PR TITLE
fix(fault_manager): allow CLEARED faults to be reactivated by FAILED …

### DIFF
--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -110,7 +110,8 @@ class FaultStorage {
   /// @param description Human-readable description (only used for FAILED events)
   /// @param source_id Reporting source identifier
   /// @param timestamp Current time for tracking
-  /// @return true if this created a new fault entry, false if existing fault was updated
+  /// @return true if this is a new occurrence (new fault or reactivated CLEARED fault),
+  ///         false if existing active fault was updated
   virtual bool report_fault_event(const std::string & fault_code, uint8_t event_type, uint8_t severity,
                                   const std::string & description, const std::string & source_id,
                                   const rclcpp::Time & timestamp) = 0;

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -343,8 +343,65 @@ TEST_F(FaultStorageTest, CriticalBypassCanBeDisabled) {
   EXPECT_EQ(fault->status, Fault::STATUS_PREFAILED);
 }
 
-TEST_F(FaultStorageTest, ClearedFaultNotReconfirmed) {
+TEST_F(FaultStorageTest, ClearedFaultCanBeReactivated) {
   rclcpp::Clock clock;
+
+  // Report to confirm (with default threshold=-1, single report confirms)
+  bool is_new = storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
+                                            "Initial", "/node1", clock.now());
+  EXPECT_TRUE(is_new);
+
+  auto fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
+  EXPECT_EQ(fault->occurrence_count, 1u);
+
+  // Clear the fault
+  storage_.clear_fault("FAULT_1");
+  fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CLEARED);
+
+  // Report again - should reactivate
+  is_new = storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
+                                       "Reactivated", "/node2", clock.now());
+  EXPECT_TRUE(is_new);  // Should return true like a new fault
+
+  fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // Should be reconfirmed
+  EXPECT_EQ(fault->occurrence_count, 2u);             // Should increment
+  EXPECT_EQ(fault->reporting_sources.size(), 2u);     // Both sources
+  EXPECT_EQ(fault->description, "Reactivated");       // Updated description
+}
+
+TEST_F(FaultStorageTest, PassedEventForClearedFaultIgnored) {
+  rclcpp::Clock clock;
+
+  // Report and confirm
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                              clock.now());
+
+  // Clear the fault
+  storage_.clear_fault("FAULT_1");
+
+  // PASSED event should be ignored for CLEARED fault
+  bool result =
+      storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now());
+  EXPECT_FALSE(result);
+
+  auto fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CLEARED);  // Should stay cleared
+}
+
+TEST_F(FaultStorageTest, ClearedFaultReactivationRestartsDebounce) {
+  rclcpp::Clock clock;
+
+  // Set threshold to -3 to test debounce behavior
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  storage_.set_debounce_config(config);
 
   // Report 3 times to confirm
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
@@ -354,16 +411,30 @@ TEST_F(FaultStorageTest, ClearedFaultNotReconfirmed) {
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node3",
                               clock.now());
 
+  auto fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
+
   // Clear the fault
   storage_.clear_fault("FAULT_1");
 
-  // Report again
+  // Reactivate - should start in PREFAILED with counter=-1
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node4",
                               clock.now());
 
-  auto fault = storage_.get_fault("FAULT_1");
+  fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->status, Fault::STATUS_CLEARED);  // Should stay cleared
+  EXPECT_EQ(fault->status, Fault::STATUS_PREFAILED);  // Not yet confirmed, needs 2 more FAILED
+
+  // Report 2 more times to re-confirm
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node5",
+                              clock.now());
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node6",
+                              clock.now());
+
+  fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // Now confirmed
 }
 
 TEST_F(FaultStorageTest, PassedEventIncrementsCounter) {


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

allow CLEARED faults to be reactivated by FAILED events                                                                                                                
                                                                                                                                                                                             
Previously, report_fault_event() had an early return that silently                                                                                                                         
ignored all events for CLEARED faults. This caused faults to remain                                                                                                                        
CLEARED forever even when the underlying issue recurred.                                                                                                                                   
                                                                                                                                                                                             
Changes:                                                                                                                                                                                   
- FAILED events now reactivate CLEARED faults with debounce counter                                                                                                                        
  reset to -1 (fresh start)                                                                                                                                                                
- PASSED events for CLEARED faults are still ignored (expected)                                                                                                                            
- occurrence_count increments on reactivation                                                                                                                                              
- Return true to trigger EVENT_CONFIRMED and snapshot capture                                                                                                                              
                                                                                                                                                                                             
Updated tests to reflect new behavior and added integration test.

---

## Issue

Link the related issue (required):

- closes #144 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
