### PR TITLE
fix(discovery): #146  prevent duplicate components for root namespace…

### DIFF
--- a/src/ros2_medkit_gateway/src/discovery/runtime_discovery.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/runtime_discovery.cpp
@@ -473,10 +473,16 @@ std::set<std::string> RuntimeDiscoveryStrategy::get_node_namespaces() {
   auto names_and_namespaces = node_graph->get_node_names_and_namespaces();
 
   for (const auto & name_and_ns : names_and_namespaces) {
+    std::string node_name = name_and_ns.first;
     std::string ns = name_and_ns.second;
     std::string area = extract_area_from_namespace(ns);
     if (area != "root") {
       namespaces.insert(area);
+    } else {
+      // For root namespace nodes, add the node name to prevent
+      // topic-based discovery from creating duplicate components
+      // e.g., node /fault_manager publishes /fault_manager/events
+      namespaces.insert(node_name);
     }
   }
 

--- a/src/ros2_medkit_gateway/test/test_discovery_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_discovery_manager.cpp
@@ -237,3 +237,22 @@ TEST_F(DiscoveryManagerWithPublishersTest, DiscoverTopicComponents_DoesNotDuplic
     EXPECT_FALSE(comp.id.empty());
   }
 }
+
+TEST_F(DiscoveryManagerWithPublishersTest, DiscoverTopicComponents_DoesNotDuplicateRootNamespaceNodeTopics) {
+  // Root namespace nodes publishing topics with matching prefix
+  // should not create duplicate topic-based components.
+  //
+  // Create a publisher with topic prefix matching the test node's name.
+  // The test node is named "test_discovery_node" and in root namespace.
+  auto pub = node_->create_publisher<std_msgs::msg::String>("/test_discovery_node/status", 10);
+
+  rclcpp::spin_some(node_);
+
+  auto topic_components = discovery_manager_->discover_topic_components();
+
+  // Should NOT create a topic-based component for "test_discovery_node"
+  // because there's already a node with that name in root namespace
+  for (const auto & comp : topic_components) {
+    EXPECT_NE(comp.id, "test_discovery_node") << "Should not create duplicate component for root namespace node";
+  }
+}


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

prevent duplicate components for root namespace nodes                                                                                                                 
                                                                                                                                                                                        
Nodes in root namespace (e.g., /fault_manager) publishing topics with                                                                                                                 
matching prefix (e.g., /fault_manager/events) were incorrectly creating                                                                                                               
both a node-based app and a duplicate topic-based component.                                                                                                                          
                                                                                                                                                                                        
Add node names to namespace set in get_node_namespaces() for root                                                                                                                     
namespace nodes, so discover_topic_components() skips creating                                                                                                                        
redundant topic-based components.

---

## Issue

Link the related issue (required):

- closes #146 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
