### PR TITLE
fix(gateway): correct fault filtering for entities and complete type_info response

### DIFF
--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -81,7 +81,10 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
         ext.ros2_type(topic_type);
         try {
           auto type_info = type_introspection->get_type_info(topic_type);
-          ext.type_info(type_info.schema);
+          json type_info_obj;
+          type_info_obj["schema"] = type_info.schema;
+          type_info_obj["default_value"] = type_info.default_value;
+          ext.type_info(type_info_obj);
         } catch (const std::exception & e) {
           RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for topic '%s': %s", topic.name.c_str(),
                        e.what());
@@ -176,7 +179,10 @@ void DataHandlers::handle_get_data_item(const httplib::Request & req, httplib::R
       auto type_introspection = data_access_mgr->get_type_introspection();
       try {
         auto type_info = type_introspection->get_type_info(sample.message_type);
-        ext.type_info(type_info.schema);
+        json type_info_obj;
+        type_info_obj["schema"] = type_info.schema;
+        type_info_obj["default_value"] = type_info.default_value;
+        ext.type_info(type_info_obj);
       } catch (const std::exception & e) {
         RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for topic '%s': %s", full_topic_path.c_str(),
                      e.what());

--- a/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
@@ -101,8 +101,8 @@ EntityInfo HandlerContext::get_entity_info(const std::string & entity_id) const 
   // Search areas (O(1) lookup)
   if (auto area = cache.get_area(entity_id)) {
     info.type = EntityType::AREA;
-    info.namespace_path = "";  // Areas don't have namespace_path
-    info.fqn = "";
+    info.namespace_path = area->namespace_path;  // Use area's namespace for fault filtering
+    info.fqn = area->namespace_path;
     info.id_field = "area_id";
     info.error_name = "Area";
     return info;


### PR DESCRIPTION


# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

- Fix Component fault listing to filter by hosted App FQNs instead of namespace path (too broad)
- Fix Function fault listing to aggregate faults from host apps using their FQNs
- Fix Area entity info to use actual namespace_path for fault filtering instead of empty string
- Fix data endpoints to return complete type_info object with both 'schema' and 'default_value' fields
- Refactor NativeTopicSampler to use future.wait_for() instead of custom spin loop

---

## Issue

Link the related issue (required):

- closes #151 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
