### PR TITLE
fix(fault_manager): #155 use wall clock time instead of simulation time

### DIFF
--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/time_utils.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/time_utils.hpp
@@ -1,0 +1,36 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+
+#include "rclcpp/rclcpp.hpp"
+
+namespace ros2_medkit_fault_manager {
+
+/// Get current wall clock time in nanoseconds.
+/// This is not affected by use_sim_time parameter.
+inline int64_t get_wall_clock_ns() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count();
+}
+
+/// Get current wall clock time as rclcpp::Time.
+/// This is not affected by use_sim_time parameter.
+inline rclcpp::Time get_wall_clock_time() {
+  return rclcpp::Time(get_wall_clock_ns(), RCL_SYSTEM_TIME);
+}
+
+}  // namespace ros2_medkit_fault_manager


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

When running with use_sim_time=true, fault timestamps were recorded in simulation time (seconds since sim start) instead of wall clock time. This caused incorrect timestamps like "1970-01-01" when UI interpreted simulation time as Unix epoch.

Changes:
- Add get_wall_clock_time() helper using std::chrono::system_clock
- Replace node->now() with wall clock for fault timestamps in:
  - FaultManagerNode: report_fault_event, publish_fault_event, auto-confirm
  - SnapshotCapture: on-demand and background cache timestamps
  - RosbagCapture: message timestamps and bag metadata
- Add unit test to verify timestamps are valid wall clock values

---

## Issue

Link the related issue (required):

- closes #155 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
