### PR TITLE
Add pre-commit hooks for clang-format, flake8, cmake-lint, shellcheck and copyright

### DIFF
--- a/.devcontainer/setup-env.sh
+++ b/.devcontainer/setup-env.sh
@@ -8,9 +8,11 @@ grep -Fxq "source /opt/ros/jazzy/setup.zsh" ~/.zshrc || echo "source /opt/ros/ja
 # Source the current shell to apply changes immediately
 if [ -n "$ZSH_VERSION" ]; then
     # Running in zsh
+    # shellcheck source=/dev/null
     source ~/.zshrc 2>/dev/null || true
 elif [ -n "$BASH_VERSION" ]; then
     # Running in bash
+    # shellcheck source=/dev/null
     source ~/.bashrc 2>/dev/null || true
 fi
 

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+# Match ament_flake8 defaults (ROS 2 Jazzy)
+extend-ignore = B902,C816,D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404,I202
+import-order-style = google
+max-line-length = 99
+show-source = true
+statistics = true
+
+per-file-ignores =
+    # Sphinx conf.py requires matplotlib backend setup before stdlib imports
+    docs/conf.py: E402, F401, I100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,62 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  # ── C / C++ ────────────────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.8
+    hooks:
+      - id: clang-format
+        name: clang-format
+        types_or: [c, c++]
+        exclude: /vendored/
+        # Uses the project's .clang-format automatically
+
+  # ── CMake ──────────────────────────────────────────────────────────────
+  - repo: https://github.com/cmake-lint/cmake-lint
+    rev: 1.4.3
+    hooks:
+      - id: cmakelint
+        name: cmake-lint
+        args: [--filter=-linelength]
+
+  # ── Shell ──────────────────────────────────────────────────────────────
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        name: shellcheck
+
+  # ── Python (matches ament_lint_common: flake8 + pep257) ─────────────
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        name: flake8
+        additional_dependencies:
+          - flake8-blind-except
+          - flake8-class-newline
+          - flake8-docstrings
+          - flake8-import-order
+        # Config read from .flake8 (matches ament_flake8 defaults)
+
+  # ── General ────────────────────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-xml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+
+  # ── Copyright / License (matches ament_cmake_copyright) ────────────
+  - repo: local
+    hooks:
+      - id: ament-copyright
+        name: ament-copyright
+        entry: ament_copyright
+        language: system
+        types_or: [c, c++, python, cmake]
+        exclude: /vendored/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,15 +30,21 @@ Thanks for your interest in contributing to ros2_medkit! This guide explains how
 ### Development Workflow
 
 1. **Fork the repository** and clone your fork locally
-2. **Create a branch** from `main` with a descriptive name:
+2. **Install pre-commit hooks** (one-time setup):
+   ```bash
+   pip install pre-commit
+   pre-commit install
+   ```
+3. **Create a branch** from `main` with a descriptive name:
    - `feature/short-description` for new features
    - `fix/short-description` for bug fixes
    - `docs/short-description` for documentation changes
-3. **Make your changes** following the project's coding standards
-4. **Test your changes** locally (see Build and Test section below)
-5. **Commit your changes** with clear, descriptive commit messages
-6. **Push your branch** to your fork
-7. **Open a Pull Request** against the `main` branch of this repository
+4. **Make your changes** following the project's coding standards
+5. **Test your changes** locally (see Build and Test section below)
+6. **Commit your changes** with clear, descriptive commit messages
+   - Pre-commit hooks will automatically check formatting
+7. **Push your branch** to your fork
+8. **Open a Pull Request** against the `main` branch of this repository
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ We'd love to have you join our community!
 
 This section is for contributors and developers who want to build and test ros2_medkit locally.
 
+### Pre-commit Hooks
+
+This project uses [pre-commit](https://pre-commit.com/) to automatically run
+`clang-format`, `flake8`, and other checks on staged files before each commit.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+To run all hooks against every file (useful after first setup):
+
+```bash
+pre-commit run --all-files
+```
+
 ### Installing Dependencies
 
 ```bash

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,17 @@
+# Copyright 2025 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Configuration file for the Sphinx documentation builder.
 #
 # For the full list of built-in configuration values, see the documentation:

--- a/scripts/generate_verification.py
+++ b/scripts/generate_verification.py
@@ -1,3 +1,17 @@
+# Copyright 2025 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Generate verification.rst from test files with @verifies tags."""
 
 import os
@@ -29,7 +43,7 @@ def parse_cpp_file(file_path):
         start_index = match.end()
 
         # Extract a chunk of text after the match to search for comments
-        search_window = content[start_index : start_index + 2000]
+        search_window = content[start_index:start_index + 2000]
         lines = search_window.split("\n")
 
         # Auto-generate ID and Title
@@ -99,7 +113,7 @@ def parse_py_file(file_path):
         start_index = match.end()
 
         # Extract a chunk of text after the match to search for docstrings/comments
-        search_window = content[start_index : start_index + 2000]
+        search_window = content[start_index:start_index + 2000]
         lines = search_window.split("\n")
 
         # Auto-generate ID and Title
@@ -231,7 +245,7 @@ def generate_rst(tests):
 
 
 def update_requirement_status(verified_reqs):
-    """Update status in requirement spec files from 'open' to 'verified' for verified requirements."""
+    """Update requirement spec file statuses from open to verified."""
     if not REQUIREMENTS_SPECS_DIR.exists():
         print(f"Requirements specs directory {REQUIREMENTS_SPECS_DIR} does not exist.")
         return
@@ -264,7 +278,10 @@ def update_requirement_status(verified_reqs):
                 while i < len(lines):
                     next_line = lines[i]
                     # Check if line is indented (part of directive) or empty
-                    if re.match(r'^\s+:', next_line) or (next_line.strip() == '' and i + 1 < len(lines) and re.match(r'^\s+:', lines[i + 1])):
+                    if (re.match(r'^\s+:', next_line)
+                            or (next_line.strip() == ''
+                                and i + 1 < len(lines)
+                                and re.match(r'^\s+:', lines[i + 1]))):
                         req_block_lines.append(next_line)
                         i += 1
                     elif next_line.strip() == '':
@@ -289,7 +306,9 @@ def update_requirement_status(verified_reqs):
                         current_status = status_match.group(2)
 
                 # If we found a verified requirement with open status, update it
-                if req_id and req_id in verified_reqs and status_line_idx is not None and current_status == 'open':
+                if (req_id and req_id in verified_reqs
+                        and status_line_idx is not None
+                        and current_status == 'open'):
                     indent = re.match(r'(\s*)', req_block_lines[status_line_idx]).group(1)
                     req_block_lines[status_line_idx] = f"{indent}:status: verified"
                     modified = True
@@ -306,7 +325,10 @@ def update_requirement_status(verified_reqs):
             updated_files.append(spec_file.name)
 
     if updated_files:
-        print(f"Updated {total_updated_reqs} requirement(s) to 'verified' status in {len(updated_files)} file(s):")
+        print(
+            f"Updated {total_updated_reqs} requirement(s)"
+            f" to 'verified' status in {len(updated_files)} file(s):"
+        )
         for filename in updated_files:
             print(f"  - {filename}")
     else:


### PR DESCRIPTION


# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Add pre-commit hooks for clang-format, flake8, cmake-lint, shellcheck and copyright
- Add .pre-commit-config.yaml with hooks matching ament_lint tooling
- Add .flake8 config matching ament_flake8 defaults (ROS 2 Jazzy)
- Add missing Apache 2.0 headers to docs/conf.py and generate_verification.py
- Fix shellcheck warnings in setup-env.sh
- Fix flake8 violations in generate_verification.py (E203, E501)
- Document pre-commit setup in README.md and CONTRIBUTING.md

---

## Issue

Link the related issue (required):

- closes #148 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?
precommit run all fixes

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
