### PR TITLE
fix: add missing ament_index_cpp dependency to package.xml

### DIFF
--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -22,6 +22,7 @@
   <!-- OpenSSL is found via CMake find_package (system package) -->
   <depend>libssl-dev</depend>
   <depend>yaml_cpp_vendor</depend>
+  <depend>ament_index_cpp</depend>
   <depend>ros2_medkit_msgs</depend>
   <depend>ros2_medkit_serialization</depend>
   <exec_depend>rosidl_runtime_py</exec_depend>


### PR DESCRIPTION
## Summary
- Add `ament_index_cpp` as `<depend>` in `ros2_medkit_gateway/package.xml`

## Problem
`CMakeLists.txt` declares `find_package(ament_index_cpp REQUIRED)` (line 30) and links against it (line 128), but `package.xml` does not declare this dependency. This means `rosdep install` won't resolve it, which can cause build failures in clean environments.

## Fix
Added `<depend>ament_index_cpp</depend>` to `package.xml`.

Closes #173

## Test plan
- [x] `rosdep install --from-paths src --ignore-src -r -y` resolves `ament_index_cpp`
- [x] `colcon build --packages-select ros2_medkit_gateway` succeeds in clean workspace
- [x] All 1196 tests pass (0 errors, 0 failures) — verified in Docker (ubuntu:noble + ROS 2 Jazzy)

Generated with [Claude Code](https://claude.com/claude-code)