### PR TITLE
refactor: standardize include guards to #pragma once

### DIFF
--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_enums.hpp
@@ -91,4 +91,3 @@ TopicOnlyPolicy parse_topic_only_policy(const std::string & str);
 std::string topic_only_policy_to_string(TopicOnlyPolicy policy);
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_manager.hpp
@@ -354,4 +354,3 @@ class DiscoveryManager {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_strategy.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_strategy.hpp
@@ -59,4 +59,3 @@ class DiscoveryStrategy {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/hybrid_discovery.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/hybrid_discovery.hpp
@@ -132,4 +132,3 @@ class HybridDiscoveryStrategy : public DiscoveryStrategy {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest.hpp
@@ -90,4 +90,3 @@ struct Manifest {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_manager.hpp
@@ -223,4 +223,3 @@ class ManifestManager {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_parser.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_parser.hpp
@@ -69,4 +69,3 @@ class ManifestParser {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_validator.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_validator.hpp
@@ -59,4 +59,3 @@ class ManifestValidator {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/runtime_linker.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/runtime_linker.hpp
@@ -177,4 +177,3 @@ class RuntimeLinker {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/validation_error.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/validation_error.hpp
@@ -86,4 +86,3 @@ struct ValidationResult {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/app.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/app.hpp
@@ -114,4 +114,3 @@ struct App {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
@@ -120,4 +120,3 @@ struct Area {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/common.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/common.hpp
@@ -135,4 +135,3 @@ struct ActionInfo {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
@@ -164,4 +164,3 @@ struct Component {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
@@ -69,4 +69,3 @@ struct Function {
 };
 
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/runtime_discovery.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/runtime_discovery.hpp
@@ -224,4 +224,3 @@ class RuntimeDiscoveryStrategy : public DiscoveryStrategy {
 
 }  // namespace discovery
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/auth_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/auth_handlers.hpp
@@ -59,4 +59,3 @@ class AuthHandlers {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/capability_builder.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/capability_builder.hpp
@@ -150,4 +150,3 @@ class LinksBuilder {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/config_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/config_handlers.hpp
@@ -69,4 +69,3 @@ class ConfigHandlers {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
@@ -92,4 +92,3 @@ class FaultHandlers {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handlers.hpp
@@ -36,4 +36,3 @@
 #include "ros2_medkit_gateway/http/handlers/health_handlers.hpp"
 #include "ros2_medkit_gateway/http/handlers/operation_handlers.hpp"
 #include "ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp"
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/operation_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/operation_handlers.hpp
@@ -85,4 +85,3 @@ class OperationHandlers {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -121,4 +121,3 @@ class SSEFaultHandler {
 
 }  // namespace handlers
 }  // namespace ros2_medkit_gateway
-


### PR DESCRIPTION
## Summary
Replace traditional `#ifndef`/`#define`/`#endif` include guards with `#pragma once` in 23 header files under `discovery/` and `http/handlers/` directories, aligning them with the existing convention used by the rest of the codebase.

Closes #174

## Changed files (23)

**`discovery/`** (15 files):
- `discovery_enums.hpp`, `discovery_manager.hpp`, `discovery_strategy.hpp`
- `hybrid_discovery.hpp`, `runtime_discovery.hpp`
- `models/`: `app.hpp`, `area.hpp`, `common.hpp`, `component.hpp`, `function.hpp`
- `manifest/`: `manifest.hpp`, `manifest_manager.hpp`, `manifest_parser.hpp`, `manifest_validator.hpp`, `runtime_linker.hpp`, `validation_error.hpp`

**`http/handlers/`** (7 files):
- `auth_handlers.hpp`, `capability_builder.hpp`, `config_handlers.hpp`
- `fault_handlers.hpp`, `handlers.hpp`, `operation_handlers.hpp`, `sse_fault_handler.hpp`

## Test plan
- [x] `colcon build` succeeds (6 packages)
- [x] All 1196 tests pass (0 errors, 0 failures) — verified in Docker (ubuntu:noble + ROS 2 Jazzy)
- [x] No `#ifndef` guards remain in gateway headers

Generated with [Claude Code](https://claude.com/claude-code)