### PR TITLE
perf: cache component topic map to avoid per-request graph rebuild

### DIFF
--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/native_topic_sampler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/native_topic_sampler.hpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
@@ -290,6 +291,12 @@ class NativeTopicSampler {
 
   /// Native JSON serializer for topic deserialization
   std::shared_ptr<ros2_medkit_serialization::JsonSerializer> serializer_;
+
+  /// Cached component topic map, updated by build_component_topic_map()
+  std::map<std::string, ComponentTopics> topic_map_cache_;
+
+  /// Protects topic_map_cache_ for concurrent access from HTTP and refresh threads
+  mutable std::mutex topic_map_mutex_;
 };
 
 }  // namespace ros2_medkit_gateway


### PR DESCRIPTION
## Summary

Closes #184

- Add thread-safe cache (`topic_map_cache_` + `topic_map_mutex_`) to `NativeTopicSampler`
- `build_component_topic_map()` now populates the cache after each rebuild (called every 10s by refresh timer)
- `get_component_topics()` reads from cache instead of calling `build_component_topic_map()` on every REST API request

Previously, each HTTP request to endpoints using `get_component_topics()` triggered a full ROS 2 graph rebuild. On systems with hundreds of topics (e.g., multi-sensor robots), this caused unnecessary CPU overhead on resource-constrained onboard computers.

## Test plan

- [ ] Verify `colcon build` succeeds
- [ ] Verify `colcon test --packages-select ros2_medkit_gateway` passes
- [ ] Verify `clang-format` and `ament_copyright` checks pass
- [ ] Manual test: confirm API responses remain identical with cached path

🤖 Generated with [Claude Code](https://claude.com/claude-code)