### PR TITLE
fix(gateway): return HEALED/PREPASSED faults via status filter

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -359,8 +359,30 @@ Query and manage faults.
    Faults are reported by ROS 2 nodes via the FaultReporter library, not via REST API.
    The gateway queries faults from the ros2_medkit_fault_manager node.
 
+``GET /api/v1/faults``
+   List all faults across the system.
+
 ``GET /api/v1/components/{id}/faults``
    List all faults for an entity.
+
+   Both endpoints accept an optional ``?status=`` query parameter:
+
+   +-----------------+--------------------------------------------------+
+   | Value           | Returns                                          |
+   +=================+==================================================+
+   | *(default)*     | ``PREFAILED`` + ``CONFIRMED`` (active faults)    |
+   +-----------------+--------------------------------------------------+
+   | ``pending``     | ``PREFAILED`` only                               |
+   +-----------------+--------------------------------------------------+
+   | ``confirmed``   | ``CONFIRMED`` only                               |
+   +-----------------+--------------------------------------------------+
+   | ``cleared``     | ``CLEARED`` + ``HEALED`` + ``PREPASSED``         |
+   |                 | (SOVD "cleared" semantics)                       |
+   +-----------------+--------------------------------------------------+
+   | ``healed``      | ``HEALED`` + ``PREPASSED`` only                  |
+   +-----------------+--------------------------------------------------+
+   | ``all``         | All statuses                                     |
+   +-----------------+--------------------------------------------------+
 
    **Example Response:**
 

--- a/postman/collections/ros2-medkit-gateway.postman_collection.json
+++ b/postman/collections/ros2-medkit-gateway.postman_collection.json
@@ -1122,7 +1122,7 @@
                 }
               ]
             },
-            "description": "List all faults across the system including cleared ones. Use status=pending, status=confirmed, status=cleared, or status=all to filter."
+            "description": "List all faults across the system including cleared ones. Use status=pending, status=confirmed, status=cleared, status=healed, or status=all to filter."
           },
           "response": []
         },
@@ -1168,7 +1168,7 @@
                 }
               ]
             },
-            "description": "List all faults including cleared ones. Use status=prefailed, status=confirmed, status=cleared, or status=all to filter."
+            "description": "List all faults including cleared ones. Use status=prefailed, status=confirmed, status=cleared, status=healed, or status=all to filter."
           },
           "response": []
         },

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/fault_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/fault_manager.hpp
@@ -70,12 +70,13 @@ class FaultManager {
   /// @param include_prefailed Include PREFAILED status faults (debounce not yet confirmed)
   /// @param include_confirmed Include CONFIRMED status faults
   /// @param include_cleared Include CLEARED status faults
+  /// @param include_healed Include HEALED and PREPASSED status faults
   /// @param include_muted Include muted faults (correlation symptoms) in response
   /// @param include_clusters Include cluster info in response
   /// @return FaultResult with array of faults (and optionally muted_faults and clusters)
   FaultResult list_faults(const std::string & source_id = "", bool include_prefailed = true,
-                          bool include_confirmed = true, bool include_cleared = false, bool include_muted = false,
-                          bool include_clusters = false);
+                          bool include_confirmed = true, bool include_cleared = false, bool include_healed = false,
+                          bool include_muted = false, bool include_clusters = false);
 
   /// Get a specific fault by code with environment data
   /// @param fault_code Fault identifier

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/http_utils.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/http_utils.hpp
@@ -90,6 +90,7 @@ struct FaultStatusFilter {
   bool include_pending = true;
   bool include_confirmed = true;
   bool include_cleared = false;
+  bool include_healed = false;
   bool is_valid = true;
 };
 
@@ -107,6 +108,7 @@ inline FaultStatusFilter parse_fault_status_param(const httplib::Request & req) 
     filter.include_pending = false;
     filter.include_confirmed = false;
     filter.include_cleared = false;
+    filter.include_healed = false;
 
     if (status == "pending") {
       filter.include_pending = true;
@@ -114,10 +116,14 @@ inline FaultStatusFilter parse_fault_status_param(const httplib::Request & req) 
       filter.include_confirmed = true;
     } else if (status == "cleared") {
       filter.include_cleared = true;
+      filter.include_healed = true;  // SOVD maps both CLEARED and HEALED to "cleared"
+    } else if (status == "healed") {
+      filter.include_healed = true;
     } else if (status == "all") {
       filter.include_pending = true;
       filter.include_confirmed = true;
       filter.include_cleared = true;
+      filter.include_healed = true;
     } else {
       filter.is_valid = false;
     }

--- a/src/ros2_medkit_gateway/src/fault_manager.cpp
+++ b/src/ros2_medkit_gateway/src/fault_manager.cpp
@@ -127,7 +127,8 @@ FaultResult FaultManager::report_fault(const std::string & fault_code, uint8_t s
 }
 
 FaultResult FaultManager::list_faults(const std::string & source_id, bool include_prefailed, bool include_confirmed,
-                                      bool include_cleared, bool include_muted, bool include_clusters) {
+                                      bool include_cleared, bool include_healed, bool include_muted,
+                                      bool include_clusters) {
   std::lock_guard<std::mutex> lock(list_mutex_);
   FaultResult result;
 
@@ -151,6 +152,10 @@ FaultResult FaultManager::list_faults(const std::string & source_id, bool includ
   }
   if (include_cleared) {
     request->statuses.push_back(ros2_medkit_msgs::msg::Fault::STATUS_CLEARED);
+  }
+  if (include_healed) {
+    request->statuses.push_back(ros2_medkit_msgs::msg::Fault::STATUS_HEALED);
+    request->statuses.push_back(ros2_medkit_msgs::msg::Fault::STATUS_PREPASSED);
   }
 
   // Correlation options

--- a/src/ros2_medkit_gateway/test/test_integration.test.py
+++ b/src/ros2_medkit_gateway/test/test_integration.test.py
@@ -2337,8 +2337,8 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         self.assertIn('x-medkit', data)
         self.assertIn('count', data['x-medkit'])
 
-        # Test other valid status values
-        for status in ['pending', 'confirmed', 'cleared']:
+        # Test other valid status values (including healed)
+        for status in ['pending', 'confirmed', 'cleared', 'healed']:
             response = requests.get(
                 f'{self.BASE_URL}/faults?status={status}',
                 timeout=10
@@ -2364,6 +2364,7 @@ class TestROS2MedkitGatewayIntegration(unittest.TestCase):
         params = data['parameters']
         self.assertIn('allowed_values', params)
         self.assertIn('pending', params['allowed_values'])  # Should mention valid values
+        self.assertIn('healed', params['allowed_values'])  # Must include healed
         self.assertIn('parameter', params)
         self.assertEqual(params.get('parameter'), 'status')
         self.assertIn('value', params)


### PR DESCRIPTION
## Summary

`list_faults` API never returned faults in HEALED or PREPASSED status — they disappeared from the API after healing. Even `?status=all` only queried PREFAILED, CONFIRMED, and CLEARED.

Adds `include_healed` flag through the full filter chain: HTTP parser → FaultStatusFilter → FaultManager::list_faults() → ListFaults service request. Also fixes `handle_clear_all_faults` passing empty strings for bool parameters.

---

## Issue

- closes #217

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

1. Report a fault, let it heal (CONFIRMED → PREPASSED → HEALED)
2. `GET /api/v1/faults` — healed fault should NOT appear (default unchanged)
3. `GET /api/v1/faults?status=all` — healed fault appears
4. `GET /api/v1/faults?status=healed` — only healed/prepassed faults
5. `GET /api/v1/faults?status=cleared` — both CLEARED and HEALED faults (SOVD semantics)
6. `GET /api/v1/faults?status=invalid` — 400 with updated allowed_values

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed