### PR TITLE
docs: fix deprecated needs_extra_links in sphinx conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,20 +111,18 @@ needs_types = [
     ),
 ]
 
-needs_links = [
-    {
-        "option": "links",
+needs_links = {
+    "links": {
         "incoming": "is linked by",
         "outgoing": "links to",
     },
-    {
-        "option": "verifies",
+    "verifies": {
         "incoming": "is verified by",
         "outgoing": "verifies",
-        "copy_link": False,
+        "copy": False,
         "allow_dead_links": False,
     },
-]
+}
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output


### PR DESCRIPTION
## Summary
- fix deprecated Sphinx config key usage in docs/conf.py
- split out from #232 so this can be merged first

## Why
- the docs config fix is cross-cutting and benefits #232, #233, and #234
- separating this keeps test PRs focused on their handler test scope