### PR TITLE
chore: bump all packages to 0.3.0

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -33,7 +33,7 @@ All packages in the repository share the same version number.
 
 ### Version Stability [1.ii]
 
-The current version is **0.2.0** (initial rosdistro release).
+The current version is **0.3.0**.
 The package follows semver; the pre-1.0 version reflects that the public API may still evolve
 based on early adopter feedback, not a lack of quality infrastructure.
 The 1.0.0 release is planned after the API has been validated through pilot deployments.
@@ -225,7 +225,7 @@ Security issues can be reported via GitHub Security Advisories on the
 
 | Requirement | Status | Notes |
 |---|---|---|
-| Version policy | Met | Semver, all packages at 0.2.0 |
+| Version policy | Met | Semver, all packages at 0.3.0 |
 | Stable version (>=1.0.0) | Caveat | Pre-1.0; API versioned, 1.0.0 planned post-pilot |
 | Change requests | Met | All changes via PR |
 | CI | Met | Build + test + coverage on every PR |
@@ -237,6 +237,6 @@ Security issues can be reported via GitHub Security Advisories on the
 | Platform support | Met | Ubuntu Noble / ROS 2 Jazzy + Ubuntu Jammy / ROS 2 Humble + Rolling (best-effort) |
 | Security policy | Met | REP-2006 compliant |
 
-**Caveat:** Version is 0.2.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
+**Caveat:** Version is 0.3.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
 and the package meets all other Level 3 requirements. The 1.0.0 release is planned after
 API validation through pilot deployments.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ project = "ros2_medkit"
 project_copyright = f"{datetime.now().year}, selfpatch"
 author = "selfpatch Team"
 
-version = "0.1.0"
-release = "0.1.0"
+version = "0.3.0"
+release = "0.3.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ros2-medkit-docs"
-version = "0.1.0"
+version = "0.3.0"
 description = "Documentation for ROS 2 Medkit"
 authors = [{ name = "bburda", email = "bartoszburda93@gmail.com" }]
 requires-python = ">=3.12"
@@ -28,4 +28,3 @@ dev = ["sphinx-autobuild"]
 # This is a documentation-only package, no Python modules
 py-modules = []
 packages = []
-

--- a/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_diagnostic_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_diagnostic_bridge/package.xml
+++ b/src/ros2_medkit_diagnostic_bridge/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_diagnostic_bridge</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Bridge node converting ROS2 /diagnostics to FaultManager faults</description>
 
   <maintainer email="michal.faferek.coe@gmail.com">mfaferek93</maintainer>

--- a/src/ros2_medkit_fault_manager/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_manager/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package ros2_medkit_fault_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Accurate HIGHEST_SEVERITY reassignment and stale ``fault_to_cluster_`` cleanup (`#221 <https://github.com/selfpatch/ros2_medkit/pull/221>`_)
+* Clean up ``pending_clusters_`` when fault cleared before ``min_count`` (`#211 <https://github.com/selfpatch/ros2_medkit/pull/211>`_)
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda, @eclipse0922
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_manager</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Central fault manager node for ros2_medkit fault management system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_fault_reporter/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_reporter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_fault_reporter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_fault_reporter/package.xml
+++ b/src/ros2_medkit_fault_reporter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_reporter</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Client library for easy fault reporting with local filtering</description>
 
   <maintainer email="michal.faferek.coe@gmail.com">mfaferek93</maintainer>

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -2,6 +2,26 @@
 Changelog for package ros2_medkit_gateway
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Gateway plugin framework with dynamic C++ plugin loading (`#237 <https://github.com/selfpatch/ros2_medkit/pull/237>`_)
+* Software updates plugin with 8 SOVD-compliant endpoints (`#237 <https://github.com/selfpatch/ros2_medkit/pull/237>`_, `#231 <https://github.com/selfpatch/ros2_medkit/pull/231>`_)
+* SSE-based periodic data subscriptions for real-time streaming without polling (`#223 <https://github.com/selfpatch/ros2_medkit/pull/223>`_)
+* Global ``DELETE /api/v1/faults`` endpoint (`#228 <https://github.com/selfpatch/ros2_medkit/pull/228>`_)
+* Return HEALED/PREPASSED faults via status filter (`#218 <https://github.com/selfpatch/ros2_medkit/pull/218>`_)
+* Bulk data upload and delete endpoints (`#216 <https://github.com/selfpatch/ros2_medkit/pull/216>`_)
+* Token-bucket rate limiting middleware, configurable per-endpoint (`#220 <https://github.com/selfpatch/ros2_medkit/pull/220>`_)
+* Reduce lock contention in ConfigurationManager (`#194 <https://github.com/selfpatch/ros2_medkit/pull/194>`_)
+* Cache component topic map to avoid per-request graph rebuild (`#212 <https://github.com/selfpatch/ros2_medkit/pull/212>`_)
+* Require cpp-httplib >= 0.14 in pkg-config check (`#230 <https://github.com/selfpatch/ros2_medkit/pull/230>`_)
+* Add missing ``ament_index_cpp`` dependency to ``package.xml`` (`#191 <https://github.com/selfpatch/ros2_medkit/pull/191>`_)
+* Unit tests for HealthHandlers, DataHandlers, and AuthHandlers (`#232 <https://github.com/selfpatch/ros2_medkit/pull/232>`_, `#234 <https://github.com/selfpatch/ros2_medkit/pull/234>`_, `#233 <https://github.com/selfpatch/ros2_medkit/pull/233>`_)
+* Standardize include guards to ``#pragma once`` (`#192 <https://github.com/selfpatch/ros2_medkit/pull/192>`_)
+* Use ``foreach`` loop for CMake coverage flags (`#193 <https://github.com/selfpatch/ros2_medkit/pull/193>`_)
+* Migrate ``ament_target_dependencies`` to compat shim for Rolling (`#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda, @eclipse0922, @mfaferek93
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_gateway</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>HTTP gateway for ros2_medkit diagnostics system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_integration_tests/CHANGELOG.rst
+++ b/src/ros2_medkit_integration_tests/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros2_medkit_integration_tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.3.0 (2026-02-27)
+------------------
+* Refactored integration test suite into dedicated ``ros2_medkit_integration_tests`` package (`#227 <https://github.com/selfpatch/ros2_medkit/pull/227>`_)
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_integration_tests</name>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>Integration tests and demo nodes for ros2_medkit</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_msgs/CHANGELOG.rst
+++ b/src/ros2_medkit_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_msgs/package.xml
+++ b/src/ros2_medkit_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_msgs</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>ROS 2 message and service definitions for ros2_medkit fault management</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_serialization/CHANGELOG.rst
+++ b/src/ros2_medkit_serialization/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.3.0 (2026-02-27)
+------------------
+* Multi-distro CI support for ROS 2 Humble, Jazzy, and Rolling (`#219 <https://github.com/selfpatch/ros2_medkit/pull/219>`_, `#242 <https://github.com/selfpatch/ros2_medkit/pull/242>`_)
+* Contributors: @bburda
+
 0.2.0 (2026-02-07)
 ------------------
 * Initial rosdistro release

--- a/src/ros2_medkit_serialization/package.xml
+++ b/src/ros2_medkit_serialization/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_serialization</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Runtime JSON to ROS 2 message serialization library</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
# Pull Request

## Summary

Bump all ros2_medkit packages from 0.2.0 (and 0.1.0 for integration_tests/docs) to **0.3.0**. Add CHANGELOG.rst entries for each package summarizing all changes since 0.2.0.

### Files changed

- **7x `package.xml`** - version bump to 0.3.0
- **7x `CHANGELOG.rst`** - new 0.3.0 section (created for `ros2_medkit_integration_tests`)
- **`docs/conf.py`** - version + release to 0.3.0
- **`docs/pyproject.toml`** - version to 0.3.0
- **`QUALITY_DECLARATION.md`** - version references updated

---

## Issue

- closes

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Version-only change - no functional impact. CI build will validate package.xml schema and CHANGELOG.rst formatting.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed