### PR TITLE
ci: trigger selfpatch_demos CI on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,8 +407,14 @@ jobs:
 
   notify-demos:
     needs: [jazzy-lint, jazzy-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.jazzy-lint.result == 'success' &&
+      needs.jazzy-test.result == 'success'
     runs-on: ubuntu-latest
+    # Only Jazzy gates the dispatch. Humble failures do not block demos CI - intentional tradeoff.
+    permissions: {}
     steps:
       - name: Trigger selfpatch_demos CI
         uses: peter-evans/repository-dispatch@v4
@@ -416,6 +422,4 @@ jobs:
           token: ${{ secrets.DEMOS_DISPATCH_TOKEN }}
           repository: selfpatch/selfpatch_demos
           event-type: ros2_medkit_updated
-          client-payload: >-
-            {"sha": "${{ github.sha }}",
-             "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}
+          client-payload: '{"sha":"${{ github.sha }}","run_url":"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"}'


### PR DESCRIPTION
# Pull Request

## Summary

Adds a `notify-demos` job to the CI workflow that dispatches a `repository_dispatch` event to `selfpatch/selfpatch_demos` after both `jazzy-lint` and `jazzy-test` pass on pushes to main. This keeps the integration demo suite in sync with every gateway merge.

- Fires only on `push` to `main` (skipped on PRs via the `if:` condition)
- Waits for `jazzy-lint` and `jazzy-test` to both succeed before dispatching
- Sends `client-payload` with `sha` and `run_url` so the selfpatch_demos job summary can link back to the triggering gateway CI run
- Uses `peter-evans/repository-dispatch@v4` with the `DEMOS_DISPATCH_TOKEN` secret (fine-grained PAT with `contents:write` on `selfpatch/selfpatch_demos`)

---

## Issue

- closes #224

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

The `notify-demos` job will be skipped on this PR (the `if:` condition evaluates to false for `pull_request` events). End-to-end validation will happen after both this PR and selfpatch/selfpatch_demos#36 are merged: the next push to main will dispatch `ros2_medkit_updated` to selfpatch_demos and trigger its CI.

Pre-conditions:
- `DEMOS_DISPATCH_TOKEN` secret is already configured in this repo (confirmed via `gh secret list`)
- selfpatch/selfpatch_demos#36 (which registers the `ros2_medkit_updated` trigger on the selfpatch_demos side) must be merged before this PR lands

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed