### PR TITLE
fix(deps): use correct rosdep key for SQLite3

### DIFF
--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -13,7 +13,7 @@
   <depend>rclcpp</depend>
   <depend>ros2_medkit_msgs</depend>
   <depend>ros2_medkit_serialization</depend>
-  <depend>sqlite3</depend>
+  <depend>libsqlite3-dev</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>


### PR DESCRIPTION
## Summary

- Fix `sqlite3` → `libsqlite3-dev` rosdep key in `ros2_medkit_fault_manager/package.xml`

Buildfarm job `Jdev__ros2_medkit__ubuntu_noble_amd64` fails because `sqlite3` rosdep key installs the CLI tool, not the dev headers/library needed for `find_package(SQLite3 REQUIRED)`.

Build log: https://build.ros2.org/job/Jdev__ros2_medkit__ubuntu_noble_amd64/1/display/redirect

## Test plan

- [ ] Verify buildfarm rebuild passes after merge

Fixes #249