### PR TITLE
fix(ci): match Jenkins build farm dependency isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,6 @@ jobs:
         timeout-minutes: 15
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          source install/setup.bash
           colcon test --return-code-on-test-failure \
             --ctest-args -LE linter \
             --event-handlers console_direct+
@@ -218,7 +217,6 @@ jobs:
       - name: Run linters
         run: |
           source /opt/ros/jazzy/setup.bash
-          source install/setup.bash
           colcon test --return-code-on-test-failure \
             --ctest-args -L linter \
             --event-handlers console_direct+
@@ -279,7 +277,6 @@ jobs:
       - name: Run unit and integration tests
         run: |
           source /opt/ros/jazzy/setup.bash
-          source install/setup.bash
           colcon test --return-code-on-test-failure \
             --ctest-args -LE linter \
             --event-handlers console_direct+
@@ -354,7 +351,6 @@ jobs:
       - name: Run unit and integration tests for coverage
         run: |
           source /opt/ros/jazzy/setup.bash
-          source install/setup.bash
           colcon test \
             --ctest-args -LE linter \
             --event-handlers console_direct+

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -698,9 +698,9 @@ GatewayNode::GatewayNode() : Node("ros2_medkit_gateway") {
           return tl::make_unexpected(std::string("ConfigurationManager not available"));
         }
         const auto & cache = get_thread_safe_cache();
-        auto configs = cache.get_entity_configurations(entity_id);
+        auto entity_configs = cache.get_entity_configurations(entity_id);
         nlohmann::json items = nlohmann::json::array();
-        for (const auto & node : configs.nodes) {
+        for (const auto & node : entity_configs.nodes) {
           auto result = config_mgr->list_parameters(node.node_fqn);
           if (result.success && result.data.is_array()) {
             for (auto & param : result.data) {

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -29,6 +29,7 @@
   <test_depend>python3-requests</test_depend>
   <test_depend>ros2_medkit_gateway</test_depend>
   <test_depend>ros2_medkit_fault_manager</test_depend>
+  <test_depend>ros2_medkit_linux_introspection</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary

Fix 2 test failures and a GCC warning reported by the ROS 2 Jenkins build farm (Jazzy, build #9 UNSTABLE):

- Add missing `<test_depend>ros2_medkit_linux_introspection</test_depend>` to `ros2_medkit_integration_tests/package.xml` - caused `test_combined_introspection` and `test_procfs_introspection` to fail
- Remove `source install/setup.bash` from all CI test steps so colcon manages per-package `AMENT_PREFIX_PATH` from declared dependencies only - matching Jenkins build farm behavior and catching undeclared deps early
- Rename shadowed variable `configs` to `entity_configs` in `gateway_node.cpp:701` to fix `-Wshadow` warning

---

## Issue

- closes #279

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- CI will validate the changes by running `colcon test` without pre-sourcing `install/setup.bash` - if any other undeclared dependencies exist, they will be caught
- The `-Wshadow` fix is a safe rename with no behavioral change

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed