### PR TITLE
fix(ci): resolve graph provider test deadlock and clang-tidy timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-    timeout-minutes: 60
+    timeout-minutes: 75
     defaults:
       run:
         shell: bash

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -277,7 +277,7 @@ if(BUILD_TESTING)
 
   ros2_medkit_clang_tidy(
     HEADER_FILTER "^${CMAKE_CURRENT_SOURCE_DIR}/(include|src|test)/"
-    TIMEOUT 1500
+    TIMEOUT 3000
   )
 
   # Add GTest

--- a/src/ros2_medkit_gateway/test/test_graph_provider_plugin.cpp
+++ b/src/ros2_medkit_gateway/test/test_graph_provider_plugin.cpp
@@ -721,9 +721,16 @@ TEST_F(GraphProviderPluginRosTest, IntrospectDoesNotQueryFaultManagerServiceOnGa
       });
 
   auto gateway_node = std::make_shared<GatewayNode>();
+
+  // Only spin service_node - gateway_node must NOT be added to the executor.
+  // GatewayNode creates wall timers (refresh_cache, cleanup, subscription_cleanup)
+  // that fire on the executor thread. refresh_cache() calls ROS 2 graph APIs
+  // (get_node_names_and_namespaces, get_topic_names_and_types) which can stall
+  // on CI runners, causing executor.cancel() + join() to deadlock.
+  // Service discovery (is_available/service_is_ready) works via DDS without
+  // the node spinning in an executor.
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(service_node);
-  executor.add_node(gateway_node);
   std::thread spin_thread([&executor]() {
     executor.spin();
   });
@@ -755,7 +762,6 @@ TEST_F(GraphProviderPluginRosTest, IntrospectDoesNotQueryFaultManagerServiceOnGa
 
   executor.cancel();
   spin_thread.join();
-  executor.remove_node(gateway_node);
   executor.remove_node(service_node);
   gateway_node.reset();
   clear_fault_service.reset();
@@ -794,9 +800,11 @@ TEST_F(GraphProviderPluginRosTest, HttpGraphRequestDoesNotQueryFaultManagerServi
       });
 
   auto gateway_node = std::make_shared<GatewayNode>();
+
+  // Only spin service_node - see IntrospectDoesNotQueryFaultManagerServiceOnGatewayThread
+  // for rationale. gateway_node's wall timers can deadlock executor shutdown.
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(service_node);
-  executor.add_node(gateway_node);
   std::thread spin_thread([&executor]() {
     executor.spin();
   });
@@ -827,7 +835,6 @@ TEST_F(GraphProviderPluginRosTest, HttpGraphRequestDoesNotQueryFaultManagerServi
 
   executor.cancel();
   spin_thread.join();
-  executor.remove_node(gateway_node);
   executor.remove_node(service_node);
   gateway_node.reset();
   clear_fault_service.reset();


### PR DESCRIPTION
# Pull Request

## Summary

Two CI timeout fixes that caused the latest main CI run to fail:

- **Graph provider test deadlock**: Removed `gateway_node` from the `SingleThreadedExecutor` in `IntrospectDoesNotQueryFaultManagerServiceOnGatewayThread` and `HttpGraphRequestDoesNotQueryFaultManagerService` tests. The gateway's wall timers (`refresh_cache`, etc.) fired on the executor thread and called ROS 2 graph APIs that can stall on CI runners, deadlocking `executor.cancel()` + `spin_thread.join()` during teardown. The tests only need `service_node` spinning for mock fault manager services.

- **clang-tidy timeout**: Increased CTest timeout from 1500s to 3000s (50min) and jazzy-lint job timeout from 60 to 75 minutes. The gateway codebase has grown beyond the previous 25-minute limit.

---

## Issue

- closes #282

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- Graph provider test fix verified by analyzing the executor architecture - `FaultManager::is_available()` uses `service_is_ready()` which queries DDS discovery directly without requiring the node to spin in an executor.
- clang-tidy timeout is a configuration change - will be validated by the CI run on this PR.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed