### PR TITLE
fix(test): resolve buildfarm executor shutdown deadlock in graph provider tests

### DIFF
--- a/src/ros2_medkit_gateway/test/test_graph_provider_plugin.cpp
+++ b/src/ros2_medkit_gateway/test/test_graph_provider_plugin.cpp
@@ -234,6 +234,20 @@ class LocalHttpServer {
   int port_{-1};
 };
 
+/// RAII guard that joins a spin_some loop thread on all exit paths (including
+/// early returns from ASSERT_* macros) so we never hit std::terminate from a
+/// joinable std::thread destructor.
+struct SpinGuard {
+  std::atomic<bool> & flag;
+  std::thread & thread;
+  ~SpinGuard() {
+    flag.store(true, std::memory_order_relaxed);
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+};
+
 class GraphProviderPluginRosTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
@@ -729,11 +743,19 @@ TEST_F(GraphProviderPluginRosTest, IntrospectDoesNotQueryFaultManagerServiceOnGa
   // on CI runners, causing executor.cancel() + join() to deadlock.
   // Service discovery (is_available/service_is_ready) works via DDS without
   // the node spinning in an executor.
+  //
+  // Use spin_some() in a loop instead of spin() so shutdown doesn't depend on
+  // DDS guard conditions waking rmw_wait() - those are unreliable on loaded CI
+  // runners and caused recurring buildfarm timeouts.
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(service_node);
-  std::thread spin_thread([&executor]() {
-    executor.spin();
+  std::atomic<bool> stop_spinning{false};
+  std::thread spin_thread([&executor, &stop_spinning]() {
+    while (!stop_spinning.load(std::memory_order_relaxed)) {
+      executor.spin_some(100ms);
+    }
   });
+  SpinGuard spin_guard{stop_spinning, spin_thread};
 
   auto * plugin = [&]() -> GraphProviderPlugin * {
     for (auto * provider : gateway_node->get_plugin_manager()->get_introspection_providers()) {
@@ -760,7 +782,8 @@ TEST_F(GraphProviderPluginRosTest, IntrospectDoesNotQueryFaultManagerServiceOnGa
 
   EXPECT_EQ(list_fault_calls.load(), 0);
 
-  executor.cancel();
+  // Explicit shutdown (SpinGuard is a safety net for early ASSERT returns)
+  stop_spinning.store(true, std::memory_order_relaxed);
   spin_thread.join();
   executor.remove_node(service_node);
   gateway_node.reset();
@@ -803,11 +826,16 @@ TEST_F(GraphProviderPluginRosTest, HttpGraphRequestDoesNotQueryFaultManagerServi
 
   // Only spin service_node - see IntrospectDoesNotQueryFaultManagerServiceOnGatewayThread
   // for rationale. gateway_node's wall timers can deadlock executor shutdown.
+  // Use spin_some() loop to avoid guard condition unreliability on CI runners.
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(service_node);
-  std::thread spin_thread([&executor]() {
-    executor.spin();
+  std::atomic<bool> stop_spinning{false};
+  std::thread spin_thread([&executor, &stop_spinning]() {
+    while (!stop_spinning.load(std::memory_order_relaxed)) {
+      executor.spin_some(100ms);
+    }
   });
+  SpinGuard spin_guard{stop_spinning, spin_thread};
 
   const auto deadline = std::chrono::steady_clock::now() + 3s;
   while (std::chrono::steady_clock::now() < deadline && !gateway_node->get_fault_manager()->is_available()) {
@@ -833,7 +861,8 @@ TEST_F(GraphProviderPluginRosTest, HttpGraphRequestDoesNotQueryFaultManagerServi
   ASSERT_EQ(res->status, 200);
   EXPECT_EQ(list_fault_calls.load(), 0);
 
-  executor.cancel();
+  // Explicit shutdown (SpinGuard is a safety net for early ASSERT returns)
+  stop_spinning.store(true, std::memory_order_relaxed);
   spin_thread.join();
   executor.remove_node(service_node);
   gateway_node.reset();


### PR DESCRIPTION
# Pull Request

## Summary

Replace `executor.spin()` with `spin_some(100ms)` in a polled loop in 2 graph provider ROS tests to fix recurring Jenkins Buildfarm timeouts.

`executor.cancel()` relies on DDS guard conditions to wake `rmw_wait()`, which is unreliable on loaded CI runners (CycloneDDS). `spin_thread.join()` deadlocks when the guard condition fails to unblock the executor. The `spin_some()` loop checks an `atomic<bool>` flag every iteration and exits within one timeout period - no dependency on guard conditions.

---

## Issue

- closes #284

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- All 26 tests in `test_graph_provider_plugin` pass locally
- Stress tested: 50/50 iterations pass under 4-core CPU stress load with 15s timeout per run (simulating loaded CI runner)

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed