### PR TITLE
Add unit tests for operation handlers

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -34,9 +34,7 @@ set(GATEWAY_VERSION "${CMAKE_MATCH_1}")
 # Find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
-find_package(example_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -311,6 +309,8 @@ if(BUILD_TESTING)
 
   # Add GTest
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(rclcpp_action REQUIRED)
+  find_package(example_interfaces REQUIRED)
 
   ament_add_gtest(test_gateway_node test/test_gateway_node.cpp)
   target_link_libraries(test_gateway_node gateway_lib)
@@ -467,7 +467,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_operation_handlers test/test_operation_handlers.cpp)
   target_link_libraries(test_operation_handlers gateway_lib)
   medkit_target_dependencies(test_operation_handlers rclcpp rclcpp_action std_srvs example_interfaces)
-  set_tests_properties(test_operation_handlers PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=69")
+  set_tests_properties(test_operation_handlers PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=72")
 
   # Demo update backend plugin (.so for integration tests)
   add_library(test_update_backend MODULE

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -36,6 +36,8 @@
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_clang_tidy</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>example_interfaces</test_depend>
+  <test_depend>rclcpp_action</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/ros2_medkit_gateway/test/test_operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_operation_handlers.cpp
@@ -37,6 +37,7 @@
 #include <vector>
 
 #include "ros2_medkit_gateway/gateway_node.hpp"
+#include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/http/handlers/operation_handlers.hpp"
 
 using json = nlohmann::json;
@@ -64,6 +65,7 @@ json parse_json(const httplib::Response & res) {
 int reserve_local_port() {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0) {
+    ADD_FAILURE() << "Failed to create socket for test port reservation: " << std::strerror(errno);
     return 0;
   }
 
@@ -73,12 +75,14 @@ int reserve_local_port() {
   addr.sin_port = 0;
 
   if (bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+    ADD_FAILURE() << "Failed to bind socket for test port reservation: " << std::strerror(errno);
     close(sock);
     return 0;
   }
 
   socklen_t addr_len = sizeof(addr);
   if (getsockname(sock, reinterpret_cast<sockaddr *>(&addr), &addr_len) != 0) {
+    ADD_FAILURE() << "Failed to inspect reserved test port: " << std::strerror(errno);
     close(sock);
     return 0;
   }
@@ -192,7 +196,7 @@ TEST_F(OperationHandlersValidationTest, ListOperationsMissingMatchesReturns400) 
 
   EXPECT_EQ(res.status, 400);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "invalid-request");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_INVALID_REQUEST);
 }
 
 TEST_F(OperationHandlersValidationTest, ListOperationsInvalidEntityReturns400) {
@@ -204,7 +208,7 @@ TEST_F(OperationHandlersValidationTest, ListOperationsInvalidEntityReturns400) {
 
   EXPECT_EQ(res.status, 400);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "invalid-parameter");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_INVALID_PARAMETER);
 }
 
 class OperationHandlersFixtureTest : public ::testing::Test {
@@ -370,7 +374,7 @@ TEST_F(OperationHandlersFixtureTest, ListOperationsUnknownEntityReturns404) {
 
   EXPECT_EQ(res.status, 404);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "entity-not-found");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_ENTITY_NOT_FOUND);
 }
 
 TEST_F(OperationHandlersFixtureTest, GetOperationReturnsActionMetadata) {
@@ -397,7 +401,7 @@ TEST_F(OperationHandlersFixtureTest, GetOperationUnknownOperationReturns404) {
 
   EXPECT_EQ(res.status, 404);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "operation-not-found");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_OPERATION_NOT_FOUND);
 }
 
 TEST_F(OperationHandlersFixtureTest, CreateExecutionOnServiceReturnsSynchronousResponse) {
@@ -458,7 +462,7 @@ TEST_F(OperationHandlersFixtureTest, CancelExecutionUnknownIdReturns404) {
 
   EXPECT_EQ(res.status, 404);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "resource-not-found");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_RESOURCE_NOT_FOUND);
 }
 
 TEST_F(OperationHandlersFixtureTest, UpdateExecutionStopReturnsAcceptedAndLocation) {
@@ -494,5 +498,5 @@ TEST_F(OperationHandlersFixtureTest, UpdateExecutionMissingCapabilityReturns400)
 
   EXPECT_EQ(res.status, 400);
   auto body = parse_json(res);
-  EXPECT_EQ(body["error_code"], "invalid-parameter");
+  EXPECT_EQ(body["error_code"], ros2_medkit_gateway::ERR_INVALID_PARAMETER);
 }


### PR DESCRIPTION
# Pull Request

## Summary

Add unit tests for `OperationHandlers` and register the new gateway test target/dependencies. The new coverage exercises service and action execution paths, validation failures, and not-found responses for issue #181.

---

## Issue

Link the related issue (required):

- closes #181

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Tested in Docker using `ros:jazzy-ros-base`.

- `colcon build --packages-up-to ros2_medkit_gateway --build-base /tmp/colcon/build --install-base /tmp/colcon/install --event-handlers console_direct+ --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select ros2_medkit_gateway --build-base /tmp/colcon/build --install-base /tmp/colcon/install --event-handlers console_direct+ --return-code-on-test-failure`
- `colcon test-result --test-result-base /tmp/colcon/build --verbose`

Result: `ros2_medkit_gateway` 57/57 passed, including `test_operation_handlers` 12/12.

Note: a workspace-wide `colcon build` attempt in the same image hit an unrelated GCC 13 internal compiler error while building `ros2_medkit_linux_introspection`.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed) - no breaking changes in this PR
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed - not needed for this test-only change
