### PR TITLE
fix: align discovery plugin package versions to 0.3.0

### DIFF
--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_beacon_common</name>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>Shared library for ros2_medkit beacon discovery plugins</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_linux_introspection</name>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>Linux introspection plugins for ros2_medkit gateway - procfs, systemd, and container</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_param_beacon</name>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>Parameter-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_topic_beacon</name>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <description>Topic-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>


### PR DESCRIPTION
## Summary

Bumps 4 discovery plugin packages from 0.1.0 to 0.3.0 to match the rest of the repo.

`bloom-release` requires all packages to share the same version and fails with:
```
RuntimeError: Two packages have different version numbers (0.1.0 != 0.3.0)
```

## Changes

- `ros2_medkit_beacon_common/package.xml`: 0.1.0 -> 0.3.0
- `ros2_medkit_linux_introspection/package.xml`: 0.1.0 -> 0.3.0
- `ros2_medkit_param_beacon/package.xml`: 0.1.0 -> 0.3.0
- `ros2_medkit_topic_beacon/package.xml`: 0.1.0 -> 0.3.0

## Issue

Closes #291

Blocks first bloom-release to rosdistro (ros2-gbp/ros2-gbp-github-org#977).