### PR TITLE
fix: allow add_layer() after pipeline execute for plugin registration

### DIFF
--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/merge_pipeline.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/merge_pipeline.hpp
@@ -101,7 +101,6 @@ class MergePipeline {
   std::unique_ptr<RuntimeLinker> linker_;
   ManifestConfig manifest_config_;
   LinkingResult linking_result_;
-  bool executed_{false};
 };
 
 }  // namespace discovery

--- a/src/ros2_medkit_gateway/src/discovery/hybrid_discovery.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/hybrid_discovery.cpp
@@ -47,8 +47,8 @@ std::vector<Function> HybridDiscoveryStrategy::discover_functions() {
 
 void HybridDiscoveryStrategy::refresh() {
   // Execute pipeline WITHOUT lock - safe because:
-  // 1. add_layer() is construction-only (called in DiscoveryManager::initialize()
-  //    before EntityCache timer starts refresh cycles)
+  // 1. add_layer() is called during initialization (from DiscoveryManager::initialize()
+  //    and gateway_node plugin setup) before the EntityCache timer starts
   // 2. refresh() is only called from the ROS executor timer callback (single-threaded)
   //    - concurrent refresh() calls cannot occur under the default executor model
   auto new_result = pipeline_.execute();

--- a/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
@@ -297,7 +297,6 @@ MergePipeline::MergePipeline(rclcpp::Logger logger) : logger_(std::move(logger))
 }
 
 void MergePipeline::add_layer(std::unique_ptr<DiscoveryLayer> layer) {
-  assert(!executed_ && "add_layer() must only be called before first refresh()");
   layers_.push_back(std::move(layer));
 }
 
@@ -376,8 +375,6 @@ std::vector<Entity> MergePipeline::merge_entities(std::vector<std::pair<size_t, 
 }
 
 MergeResult MergePipeline::execute() {
-  executed_ = true;
-
   MergeReport report;
   for (const auto & layer : layers_) {
     report.layers.push_back(layer->name());

--- a/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
@@ -1645,3 +1645,27 @@ TEST_F(MergePipelineTest, SuppressDoesNotAffectRootNamespaceEntities) {
   }
   EXPECT_TRUE(found_root_comp) << "Runtime component in root namespace should not be suppressed";
 }
+
+// Regression test: add_layer() after execute() must not crash.
+// Plugins are loaded after the initial pipeline execution in gateway_node.cpp,
+// so add_layer() must be callable after execute().
+TEST_F(MergePipelineTest, AddLayerAfterExecuteDoesNotCrash) {
+  // First layer with one app
+  LayerOutput manifest_output;
+  manifest_output.apps.push_back(make_app("app-one", ""));
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_output));
+
+  // Execute pipeline
+  auto result1 = pipeline_.execute();
+  EXPECT_EQ(result1.apps.size(), 1u);
+
+  // Add another layer AFTER execute - simulates plugin registration
+  // in gateway_node.cpp where plugins are loaded after initial discovery
+  LayerOutput plugin_output;
+  plugin_output.apps.push_back(make_app("plugin-app", ""));
+  pipeline_.add_layer(std::make_unique<TestLayer>("plugin", plugin_output));
+
+  // Re-execute should include the new layer's entities
+  auto result2 = pipeline_.execute();
+  EXPECT_EQ(result2.apps.size(), 2u);
+}


### PR DESCRIPTION
# Pull Request

## Summary

Remove the `!executed_` assertion in `MergePipeline::add_layer()` that caused SIGABRT on gateway startup when using hybrid mode with plugins.

The `HybridDiscoveryStrategy` constructor calls `refresh()` (which calls `pipeline_.execute()`, setting `executed_ = true`). Plugin layers are registered later during gateway initialization, after plugins are loaded and configured. The assertion made `add_layer()` crash for any hybrid-mode gateway with plugins - affecting all 3 selfpatch_demos.

## Issue

- closes #307 (regression from initial fix)

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

## Testing

- Unit test added: `MergePipelineTest.AddLayerAfterExecuteDoesNotCrash` verifies add_layer() works after execute() and re-execution includes the new layer
- Full merge pipeline test suite: 69/69 pass
- Pre-commit hooks pass (clang-format, ament-copyright, trim whitespace)

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed