### PR TITLE
fix(gateway): use timed_mutex with 3s timeout to prevent permanent thread pool exhaustion

### DIFF
--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/configuration_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/configuration_manager.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <rclcpp/rclcpp.hpp>
 #include <shared_mutex>
 #include <string>
@@ -163,7 +164,7 @@ class ConfigurationManager {
   /// cache lookups or JSON building. With negative cache + self-guard,
   /// most requests never touch this mutex.
   /// Declared BEFORE param_node_ so it outlives the node during destruction.
-  mutable std::mutex spin_mutex_;
+  mutable std::timed_mutex spin_mutex_;
 
   /// Internal node for parameter client operations.
   /// Created once in constructor - must be in DDS graph early for fast service discovery.
@@ -176,6 +177,17 @@ class ConfigurationManager {
 
   /// Maximum entries in negative cache before hard eviction
   static constexpr size_t kMaxNegativeCacheSize = 500;
+
+  /// Margin added to service_timeout_sec_ for spin_mutex acquisition timeout.
+  /// Must exceed parameter_service_timeout_sec to avoid spurious TIMEOUT errors.
+  static constexpr double kSpinLockMarginSec{1.0};
+
+  /// Timeout for shutdown to wait for in-flight IPC
+  static constexpr std::chrono::seconds kShutdownTimeout{10};
+
+  /// Try to acquire spin_mutex_ with timeout.
+  /// Returns unique_lock on success, nullopt on timeout (result populated with error).
+  std::optional<std::unique_lock<std::timed_mutex>> try_acquire_spin_lock(ParameterResult & result);
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/configuration_manager.cpp
+++ b/src/ros2_medkit_gateway/src/configuration_manager.cpp
@@ -61,8 +61,12 @@ void ConfigurationManager::shutdown() {
   if (shutdown_.exchange(true)) {
     return;  // Already shut down
   }
-  // Acquire spin_mutex_ first to wait for any in-flight IPC to complete
-  std::lock_guard<std::mutex> spin_lock(spin_mutex_);
+  // Hold lock through cleanup to prevent race with in-flight requests
+  std::unique_lock<std::timed_mutex> spin_lock(spin_mutex_, std::defer_lock);
+  if (!spin_lock.try_lock_for(kShutdownTimeout)) {
+    RCLCPP_WARN(node_->get_logger(),
+                "ConfigurationManager shutdown: spin_mutex_ not released within timeout, proceeding with cleanup");
+  }
   std::lock_guard<std::mutex> lock(clients_mutex_);
   param_clients_.clear();
   param_node_.reset();
@@ -70,6 +74,23 @@ void ConfigurationManager::shutdown() {
 
 ParameterResult ConfigurationManager::shut_down_result() {
   return {false, {}, "ConfigurationManager is shut down", ParameterErrorCode::SHUT_DOWN};
+}
+
+std::optional<std::unique_lock<std::timed_mutex>>
+ConfigurationManager::try_acquire_spin_lock(ParameterResult & result) {
+  auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::duration<double>(service_timeout_sec_ + kSpinLockMarginSec));
+  std::unique_lock<std::timed_mutex> lock(spin_mutex_, std::defer_lock);
+  if (!lock.try_lock_for(timeout)) {
+    result.success = false;
+    result.error_message = "Parameter service temporarily unavailable - timed out after " +
+                           std::to_string(static_cast<int>(service_timeout_sec_ + kSpinLockMarginSec)) + "s";
+    result.error_code = ParameterErrorCode::TIMEOUT;
+    RCLCPP_WARN(node_->get_logger(), "Parameter service spin lock timeout (%.1fs) - another operation may be blocking",
+                service_timeout_sec_ + kSpinLockMarginSec);
+    return std::nullopt;
+  }
+  return lock;
 }
 
 std::chrono::duration<double> ConfigurationManager::get_service_timeout() const {
@@ -226,7 +247,10 @@ ParameterResult ConfigurationManager::list_parameters(const std::string & node_n
     // "Node already added to executor" errors from concurrent spin.
     std::vector<rclcpp::Parameter> parameters;
     {
-      std::lock_guard<std::mutex> spin_lock(spin_mutex_);
+      auto spin_lock = try_acquire_spin_lock(result);
+      if (!spin_lock) {
+        return result;
+      }
 
       // Cache default values first (gives node extra time for DDS service discovery)
       cache_default_values(node_name);
@@ -303,7 +327,10 @@ ParameterResult ConfigurationManager::get_parameter(const std::string & node_nam
     std::vector<rcl_interfaces::msg::ParameterDescriptor> descriptors;
 
     {
-      std::lock_guard<std::mutex> spin_lock(spin_mutex_);
+      auto spin_lock = try_acquire_spin_lock(result);
+      if (!spin_lock) {
+        return result;
+      }
       auto client = get_param_client(node_name);
 
       if (!client->wait_for_service(get_service_timeout())) {
@@ -402,8 +429,12 @@ ParameterResult ConfigurationManager::set_parameter(const std::string & node_nam
     return result;
   }
 
-  std::lock_guard<std::mutex> spin_lock(spin_mutex_);
   ParameterResult result;
+
+  auto spin_lock = try_acquire_spin_lock(result);
+  if (!spin_lock) {
+    return result;
+  }
 
   try {
     auto client = get_param_client(node_name);
@@ -724,8 +755,12 @@ ParameterResult ConfigurationManager::reset_parameter(const std::string & node_n
     return result;
   }
 
-  std::lock_guard<std::mutex> spin_lock(spin_mutex_);
   ParameterResult result;
+
+  auto spin_lock = try_acquire_spin_lock(result);
+  if (!spin_lock) {
+    return result;
+  }
 
   try {
     cache_default_values(node_name);
@@ -847,8 +882,12 @@ ParameterResult ConfigurationManager::reset_all_parameters(const std::string & n
     return result;
   }
 
-  std::lock_guard<std::mutex> spin_lock(spin_mutex_);
   ParameterResult result;
+
+  auto spin_lock = try_acquire_spin_lock(result);
+  if (!spin_lock) {
+    return result;
+  }
 
   try {
     cache_default_values(node_name);

--- a/src/ros2_medkit_gateway/test/test_configuration_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_configuration_manager.cpp
@@ -361,6 +361,42 @@ TEST_F(TestConfigurationManager, test_concurrent_queries_no_crash) {
   }
 }
 
+TEST_F(TestConfigurationManager, test_spin_lock_timeout_returns_error) {
+  // Hold spin_mutex_ from a background thread, verify public method returns TIMEOUT
+  // Access the mutex via a configurations call that blocks on a nonexistent node
+  std::atomic<bool> holding{false};
+  std::atomic<bool> done{false};
+
+  // Background thread: acquire spin_mutex_ and hold it
+  std::thread blocker([this, &holding, &done]() {
+    auto result = config_manager_->list_parameters("/blocking_node_timeout_test");
+    holding = true;
+    // list_parameters already released the lock, but by the time it returns
+    // the test thread should have observed the TIMEOUT. Spin briefly to keep
+    // the test deterministic.
+    while (!done.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  });
+
+  // Wait for blocker to start (it will hold spin_mutex_ during wait_for_service)
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  // This call should timeout on spin_mutex_ if blocker is still holding it,
+  // OR succeed if blocker already released. Either way, no hang.
+  auto start = std::chrono::steady_clock::now();
+  auto result = config_manager_->list_parameters("/timeout_test_node");
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  // Should complete within reasonable time (not hang forever)
+  EXPECT_LT(elapsed, std::chrono::seconds(10));
+  // Result is either TIMEOUT or SERVICE_UNAVAILABLE - both are acceptable
+  EXPECT_FALSE(result.success);
+
+  done = true;
+  blocker.join();
+}
+
 TEST_F(TestConfigurationManager, test_negative_cache_cross_method) {
   // list_parameters marks node unavailable, get_parameter should return cached
   auto list_result = config_manager_->list_parameters("/cross_method_cached_node");


### PR DESCRIPTION
## Summary

spin_mutex_ in ConfigurationManager blocked indefinitely when a node accepted parameter service but never responded. One hung thread held the mutex forever, all subsequent configurations requests queued on it, exhausting httplib's 8-thread pool. Gateway became permanently unresponsive.

Replace std::mutex with std::timed_mutex. All public methods use try_lock_for(3s) - if mutex unavailable, return TIMEOUT error instead of blocking forever.

## Test plan

- [x] 22/22 unit tests pass
- [x] 58/58 integration tests pass (100%)
- [x] Tested on Jetson Orin Nano with SSE enabled + web UI: stable after fix
- [x] Confirmed via gdb: before fix, 7 threads blocked on spin_mutex_; after fix, threads return with TIMEOUT

Fixes #332