### PR TITLE
fix: add controller to REQUIRED_APPS in entity model test

### DIFF
--- a/src/ros2_medkit_integration_tests/test/features/test_entity_model_runtime.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_entity_model_runtime.test.py
@@ -46,7 +46,7 @@ def generate_test_description():
 class TestEntityModelRuntime(GatewayTestCase):
     """Verify the SOVD entity model in runtime_only discovery mode."""
 
-    MIN_EXPECTED_APPS = 9
+    MIN_EXPECTED_APPS = len(ALL_DEMO_NODES)
     REQUIRED_FUNCTIONS = {'powertrain', 'chassis', 'body', 'perception'}
     REQUIRED_APPS = {'temp_sensor', 'rpm_sensor', 'actuator', 'lidar_sensor', 'controller'}
 


### PR DESCRIPTION
## Summary

- Add `controller` to `REQUIRED_APPS` so discovery wait gates on it before tests run
- Bump `MIN_EXPECTED_APPS` from 8 to 9 to match actual demo node count

---

## Issue

- closes #339

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- CI on Rolling should now pass consistently - the discovery wait will ensure `controller` app is discovered before `test_multiple_apps_same_component` runs
- No behavioral change to the gateway itself

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed