### PR TITLE
fix(linux_introspection): declare pkg-config as buildtool_depend

### DIFF
--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ros2_medkit_cmake</buildtool_depend>
+  <buildtool_depend>pkg-config</buildtool_depend>
 
   <depend>ros2_medkit_gateway</depend>
   <depend>nlohmann-json-dev</depend>


### PR DESCRIPTION
# Pull Request

## Summary

The `ros2_medkit_linux_introspection` package fails to configure on the ROS buildfarm because `pkg-config` is not installed on clean agents. `CMakeLists.txt` uses `find_package(PkgConfig REQUIRED)` to locate `libsystemd` via `pkg_check_modules`, but `package.xml` did not declare `pkg-config` as a build tool dependency. `rosdep` only installs declared dependencies, so the binary was missing on the buildfarm while local dev environments have it system-wide, masking the issue.

This PR adds `<buildtool_depend>pkg-config</buildtool_depend>` to the package manifest so `rosdep install` pulls it in on clean agents.

---

## Issue

- closes #352

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- Verified locally that `package.xml` still validates against `package_format3.xsd`.
- Buildfarm job `Hdev__ros2_medkit__ubuntu_jammy_amd64` (Humble / Jammy) previously failed with `Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)` at `CMakeLists.txt:44`. With the new buildtool dep, `rosdep install` will install `pkg-config` before CMake runs.

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed