### PR TITLE
feat: add per-entity provider interfaces (DataProvider, OperationProvider, FaultProvider)

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2077,6 +2077,9 @@ Common Error Codes
    * - ``ERR_FORBIDDEN``
      - 403
      - Insufficient permissions for this operation
+   * - ``x-medkit-plugin-error``
+     - 400-599
+     - Plugin provider returned an error. Status varies by plugin. Message truncated to 512 chars.
 
 URL Encoding
 ------------

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2081,6 +2081,17 @@ Common Error Codes
      - 400-599
      - Plugin provider returned an error. Status varies by plugin. Message truncated to 512 chars.
 
+Plugin Entity Delegation
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Entities created by gateway plugins (via ``IntrospectionProvider``) have their
+data, operations, and faults requests transparently routed to the owning plugin's
+``DataProvider``, ``OperationProvider``, or ``FaultProvider``. The response format
+is determined by the plugin. If the plugin returns an error, the response uses the
+``x-medkit-plugin-error`` vendor code with an ``entity_id`` parameter identifying
+the affected entity. See :doc:`/tutorials/plugin-system` for details on per-entity
+provider routing.
+
 URL Encoding
 ------------
 

--- a/docs/design/index.rst
+++ b/docs/design/index.rst
@@ -18,4 +18,5 @@ This section contains design documentation for the ros2_medkit project packages.
    ros2_medkit_msgs/index
    ros2_medkit_param_beacon/index
    ros2_medkit_serialization/index
+   ros2_medkit_sovd_service_interface/index
    ros2_medkit_topic_beacon/index

--- a/docs/design/ros2_medkit_sovd_service_interface
+++ b/docs/design/ros2_medkit_sovd_service_interface
@@ -1,0 +1,1 @@
+../../src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design

--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -20,6 +20,13 @@ Plugins implement the ``GatewayPlugin`` C++ base class plus one or more typed pr
 - **ScriptProvider** - replaces or augments the default filesystem-based script backend.
   Plugins can provide script listings, create custom scripts, and execute them using
   alternative runtimes. See the ``/scripts`` endpoints in :doc:`/api/rest`.
+- **DataProvider** - per-entity data resource backend (list, read, write data). Plugins
+  that create entities via IntrospectionProvider can serve data for those entities.
+  Entity requests are routed to the owning plugin automatically.
+- **OperationProvider** - per-entity operation backend (list operations, execute). Uses
+  the same per-entity routing model as DataProvider.
+- **FaultProvider** - per-entity fault backend (list faults, get fault details, clear
+  faults). Uses the same per-entity routing model as DataProvider.
 
 A single plugin can implement multiple provider interfaces. For example, a "systemd" plugin
 could provide both introspection (discover systemd units) and updates (manage service restarts).
@@ -224,7 +231,7 @@ Plugin Lifecycle
 1. ``dlopen`` loads the ``.so`` with ``RTLD_NOW | RTLD_LOCAL``
 2. ``plugin_api_version()`` is checked against the gateway's ``PLUGIN_API_VERSION``
 3. ``create_plugin()`` factory function creates the plugin instance
-4. Provider interfaces are queried via ``get_update_provider()`` / ``get_introspection_provider()`` / ``get_log_provider()`` / ``get_script_provider()``
+4. Provider interfaces are queried via ``get_update_provider()`` / ``get_introspection_provider()`` / ``get_log_provider()`` / ``get_script_provider()`` / ``get_data_provider()`` / ``get_operation_provider()`` / ``get_fault_provider()``
 5. ``configure()`` is called with per-plugin JSON config
 6. ``set_context()`` provides ``PluginContext`` with ROS 2 node, entity cache, faults, and HTTP utilities
 7. ``get_routes()`` returns custom REST endpoint definitions as ``vector<PluginRoute>``
@@ -665,7 +672,30 @@ Multiple plugins can be loaded simultaneously:
 - **LogProvider**: Only the first plugin's LogProvider is used for queries (same as UpdateProvider).
   All LogProvider plugins receive ``on_log_entry()`` calls as observers.
 - **ScriptProvider**: Only the first plugin's ScriptProvider is used (same as UpdateProvider).
+- **DataProvider / OperationProvider / FaultProvider**: These use per-entity routing based
+  on entity ownership. Entities created by a plugin's IntrospectionProvider are automatically
+  routed to that same plugin's DataProvider, OperationProvider, and FaultProvider. Multiple
+  plugins can each serve different entities concurrently - there is no "first wins" conflict
+  because each plugin only handles requests for its own entities.
 - **Custom routes**: All plugins can register endpoints (use unique path prefixes)
+
+Entity Ownership
+~~~~~~~~~~~~~~~~
+
+DataProvider, OperationProvider, and FaultProvider use an entity ownership model to
+route requests to the correct plugin.
+
+- ``IntrospectionProvider::introspect()`` determines ownership: entities returned in a
+  plugin's ``IntrospectionResult::new_entities`` are owned by that plugin.
+- Entity ownership is refreshed periodically during cache updates (each discovery cycle
+  re-evaluates ``introspect()`` results from all plugins).
+- The gateway maintains an internal map from entity ID to the plugin that created it.
+- When a data, operation, or fault request arrives for an entity, the handler looks up
+  the owning plugin and delegates to its corresponding provider. Entities not owned by
+  any plugin fall through to the default gateway behavior.
+
+This model allows multiple plugins to coexist without conflict - each plugin manages
+its own entities independently.
 
 Graph Provider Plugin (ros2_medkit_graph_provider)
 ---------------------------------------------------

--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -658,6 +658,66 @@ The ``scripts.scripts_dir`` parameter must be set for the scripts subsystem to
 initialize, even when using a plugin backend. The plugin replaces how scripts are
 stored and executed, but the subsystem must be enabled first.
 
+Per-Entity Provider Example (DataProvider)
+-------------------------------------------
+
+A plugin that creates entities via ``IntrospectionProvider`` and serves data for them
+via ``DataProvider``. OperationProvider and FaultProvider follow the same pattern.
+
+.. code-block:: cpp
+
+   #include "ros2_medkit_gateway/plugins/gateway_plugin.hpp"
+   #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
+   #include "ros2_medkit_gateway/providers/data_provider.hpp"
+
+   class MyDataPlugin : public GatewayPlugin, public IntrospectionProvider, public DataProvider {
+    public:
+     std::string name() const override { return "my_data_plugin"; }
+     void configure(const nlohmann::json &) override {}
+     void shutdown() override {}
+
+     // IntrospectionProvider: create entities owned by this plugin
+     IntrospectionResult introspect(const IntrospectionInput &) override {
+       IntrospectionResult result;
+       App ecu;
+       ecu.id = "my_ecu";
+       ecu.name = "My ECU";
+       result.new_entities.apps.push_back(std::move(ecu));
+       return result;
+     }
+
+     // DataProvider: serve data for owned entities
+     tl::expected<nlohmann::json, DataProviderErrorInfo> list_data(const std::string & entity_id) override {
+       return nlohmann::json{{"items", {{{"id", "temperature"}, {"name", "Temperature"}}}}};
+     }
+     tl::expected<nlohmann::json, DataProviderErrorInfo> read_data(
+         const std::string &, const std::string & resource_name) override {
+       if (resource_name == "temperature") {
+         return nlohmann::json{{"value", 42.5}};
+       }
+       return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::ResourceNotFound, "Unknown resource", 404});
+     }
+     tl::expected<nlohmann::json, DataProviderErrorInfo> write_data(
+         const std::string &, const std::string &, const nlohmann::json &) override {
+       return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::ReadOnly, "Read-only data", 403});
+     }
+   };
+
+   // Plugin exports - both providers must be exported via extern "C"
+   extern "C" GATEWAY_PLUGIN_EXPORT GatewayPlugin* create_plugin() { return new MyDataPlugin(); }
+   extern "C" GATEWAY_PLUGIN_EXPORT int plugin_api_version() { return PLUGIN_API_VERSION; }
+   extern "C" GATEWAY_PLUGIN_EXPORT IntrospectionProvider* get_introspection_provider(GatewayPlugin* p) {
+     return static_cast<MyDataPlugin*>(p);
+   }
+   extern "C" GATEWAY_PLUGIN_EXPORT DataProvider* get_data_provider(GatewayPlugin* p) {
+     return static_cast<MyDataPlugin*>(p);
+   }
+
+The gateway automatically adds ``data`` capability to entities owned by a plugin that
+registers a ``DataProvider``. Similarly for ``operations`` (OperationProvider) and ``faults``
+(FaultProvider). There is no need to call ``register_entity_capability()`` for these
+standard resource collections.
+
 Multiple Plugins
 ----------------
 

--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -136,7 +136,7 @@ Writing a Plugin
      return static_cast<MyPlugin*>(p);
    }
 
-The ``get_update_provider`` (and ``get_introspection_provider``, ``get_log_provider``, ``get_script_provider``) functions use ``extern "C"``
+The ``get_update_provider`` (and ``get_introspection_provider``, ``get_log_provider``, ``get_script_provider``, ``get_data_provider``, ``get_operation_provider``, ``get_fault_provider``) functions use ``extern "C"``
 to avoid RTTI issues across shared library boundaries. The ``static_cast`` is safe because
 these functions execute inside the plugin's own ``.so`` where the type hierarchy is known.
 

--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -667,8 +667,11 @@ via ``DataProvider``. OperationProvider and FaultProvider follow the same patter
 .. code-block:: cpp
 
    #include "ros2_medkit_gateway/plugins/gateway_plugin.hpp"
+   #include "ros2_medkit_gateway/plugins/plugin_types.hpp"
    #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
    #include "ros2_medkit_gateway/providers/data_provider.hpp"
+
+   using namespace ros2_medkit_gateway;
 
    class MyDataPlugin : public GatewayPlugin, public IntrospectionProvider, public DataProvider {
     public:
@@ -693,7 +696,7 @@ via ``DataProvider``. OperationProvider and FaultProvider follow the same patter
      tl::expected<nlohmann::json, DataProviderErrorInfo> read_data(
          const std::string &, const std::string & resource_name) override {
        if (resource_name == "temperature") {
-         return nlohmann::json{{"value", 42.5}};
+         return nlohmann::json{{"id", resource_name}, {"data", {{"temperature", 42.5}}}};
        }
        return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::ResourceNotFound, "Unknown resource", 404});
      }
@@ -717,6 +720,14 @@ The gateway automatically adds ``data`` capability to entities owned by a plugin
 registers a ``DataProvider``. Similarly for ``operations`` (OperationProvider) and ``faults``
 (FaultProvider). There is no need to call ``register_entity_capability()`` for these
 standard resource collections.
+
+.. warning::
+
+   All provider methods may be called concurrently from multiple HTTP handler
+   threads. Implementations that access shared state must provide their own
+   synchronization (e.g., ``std::mutex``). Plugin responses are passed through
+   verbatim to the API consumer - match the SOVD response format for consistency
+   with native entities.
 
 Multiple Plugins
 ----------------

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -595,6 +595,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_plugin_manager test/test_plugin_manager.cpp)
   target_link_libraries(test_plugin_manager gateway_lib)
 
+  # Plugin entity routing tests
+  ament_add_gtest(test_plugin_entity_routing test/test_plugin_entity_routing.cpp)
+  target_link_libraries(test_plugin_entity_routing gateway_lib)
+
   # Plugin HTTP types tests
   ament_add_gtest(test_plugin_http_types test/test_plugin_http_types.cpp)
   target_link_libraries(test_plugin_http_types gateway_lib)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -85,6 +85,7 @@ include_directories(include)
 # Gateway library (shared between executable and tests for coverage)
 add_library(gateway_lib STATIC
   src/config.cpp
+  src/entity_validation.cpp
   src/gateway_node.cpp
   src/data_access_manager.cpp
   src/type_introspection.cpp

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_validation.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_validation.hpp
@@ -1,4 +1,4 @@
-// Copyright 2026 mfaferek93
+// Copyright 2026 bburda
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ros2_medkit_gateway/plugins/plugin_types.hpp"
-#include "sovd_service_interface.hpp"
+#pragma once
 
-using namespace ros2_medkit_gateway;
+#include <string>
 
-extern "C" GATEWAY_PLUGIN_EXPORT int plugin_api_version() {
-  return PLUGIN_API_VERSION;  // Must match PLUGIN_API_VERSION (exact match required)
-}
+#include <tl/expected.hpp>
 
-extern "C" GATEWAY_PLUGIN_EXPORT GatewayPlugin * create_plugin() {
-  return new SovdServiceInterface();
-}
+namespace ros2_medkit_gateway {
+
+/// Validate an entity ID against naming conventions.
+/// Allow: alphanumeric (a-z, A-Z, 0-9), underscore (_), hyphen (-).
+/// Max 256 characters.
+/// @return void on success, error message string on failure.
+tl::expected<void, std::string> validate_entity_id(const std::string & entity_id);
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/error_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/error_codes.hpp
@@ -140,6 +140,9 @@ constexpr const char * ERR_SCRIPT_NOT_RUNNING = "x-medkit-script-not-running";
 constexpr const char * ERR_SCRIPT_CONCURRENCY_LIMIT = "x-medkit-concurrency-limit";
 constexpr const char * ERR_SCRIPT_FILE_TOO_LARGE = "x-medkit-script-too-large";
 
+/// Plugin provider returned an error (used for DataProvider/OperationProvider/FaultProvider errors)
+constexpr const char * ERR_PLUGIN_ERROR = "x-medkit-plugin-error";
+
 /**
  * @brief Check if an error code is a vendor-specific code
  * @param error_code Error code to check

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
@@ -76,6 +76,10 @@ struct EntityInfo {
   std::string peer_url;   ///< Base URL of the peer (e.g., "http://localhost:8081")
   std::string peer_name;  ///< Peer name for metadata (e.g., "subsystem_b")
 
+  // Plugin routing fields
+  bool is_plugin{false};    ///< True if entity is owned by a plugin
+  std::string plugin_name;  ///< Plugin name (empty if not plugin-owned)
+
   /**
    * @brief Get SovdEntityType equivalent
    */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
@@ -300,6 +300,10 @@ class HandlerContext {
   static void send_error(httplib::Response & res, int status, const std::string & error_code,
                          const std::string & message, const nlohmann::json & parameters = {});
 
+  /// Sanitize and send a plugin provider error (clamp status 400-599, truncate message 512 chars)
+  static void send_plugin_error(httplib::Response & res, int http_status, const std::string & message,
+                                const nlohmann::json & extra_params = {});
+
   /**
    * @brief Send JSON success response
    */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_http_types.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_http_types.hpp
@@ -40,6 +40,9 @@ class PluginRequest {
   /// Request body (by reference - avoids copying large payloads).
   const std::string & body() const;
 
+  /// Get a query parameter value by name. Returns empty string if not present.
+  std::string query_param(const std::string & name) const;
+
  private:
   const void * impl_;
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_loader.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_loader.hpp
@@ -27,6 +27,8 @@ class UpdateProvider;
 class IntrospectionProvider;
 class LogProvider;
 class ScriptProvider;
+class DataProvider;
+class OperationProvider;
 
 /**
  * @brief Result of loading a gateway plugin.
@@ -63,6 +65,13 @@ struct GatewayPluginLoadResult {
   /// Lifetime tied to plugin - do not use after plugin is destroyed.
   ScriptProvider * script_provider = nullptr;
 
+  /// Non-owning pointer to DataProvider interface (null if not provided).
+  /// Unlike LogProvider/ScriptProvider, multiple plugins can each provide data for different entities.
+  DataProvider * data_provider = nullptr;
+
+  /// Non-owning pointer to OperationProvider interface (null if not provided).
+  OperationProvider * operation_provider = nullptr;
+
   /// Get the dlopen handle (for dlsym queries by PluginManager)
   void * dl_handle() const {
     return handle_;
@@ -85,6 +94,8 @@ struct GatewayPluginLoadResult {
  *   extern "C" IntrospectionProvider* get_introspection_provider(GatewayPlugin* plugin);
  *   extern "C" LogProvider* get_log_provider(GatewayPlugin* plugin);
  *   extern "C" ScriptProvider* get_script_provider(GatewayPlugin* plugin);
+ *   extern "C" DataProvider* get_data_provider(GatewayPlugin* plugin);
+ *   extern "C" OperationProvider* get_operation_provider(GatewayPlugin* plugin);
  *
  * Path requirements: must be absolute, have .so extension, and resolve to a real file.
  */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_loader.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_loader.hpp
@@ -28,6 +28,7 @@ class IntrospectionProvider;
 class LogProvider;
 class ScriptProvider;
 class DataProvider;
+class FaultProvider;
 class OperationProvider;
 
 /**
@@ -72,6 +73,9 @@ struct GatewayPluginLoadResult {
   /// Non-owning pointer to OperationProvider interface (null if not provided).
   OperationProvider * operation_provider = nullptr;
 
+  /// Non-owning pointer to FaultProvider interface (null if not provided).
+  FaultProvider * fault_provider = nullptr;
+
   /// Get the dlopen handle (for dlsym queries by PluginManager)
   void * dl_handle() const {
     return handle_;
@@ -96,6 +100,7 @@ struct GatewayPluginLoadResult {
  *   extern "C" ScriptProvider* get_script_provider(GatewayPlugin* plugin);
  *   extern "C" DataProvider* get_data_provider(GatewayPlugin* plugin);
  *   extern "C" OperationProvider* get_operation_provider(GatewayPlugin* plugin);
+ *   extern "C" FaultProvider* get_fault_provider(GatewayPlugin* plugin);
  *
  * Path requirements: must be absolute, have .so extension, and resolve to a real file.
  */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
@@ -30,8 +30,10 @@
 
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <shared_mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace httplib {
@@ -167,6 +169,28 @@ class PluginManager {
     return context_;
   }
 
+  // ---- Entity ownership (per-entity provider routing) ----
+
+  /// Register entity ownership for a plugin.
+  /// Called after IntrospectionProvider::introspect() returns new entities.
+  /// Maps entity IDs to the plugin that created them, enabling per-entity
+  /// provider routing in handlers.
+  void register_entity_ownership(const std::string & plugin_name, const std::vector<std::string> & entity_ids);
+
+  /// Get DataProvider for a specific entity (if plugin-owned)
+  /// @return Non-owning pointer, or nullptr if entity is not plugin-owned
+  ///         or owning plugin doesn't implement DataProvider
+  DataProvider * get_data_provider_for_entity(const std::string & entity_id) const;
+
+  /// Get OperationProvider for a specific entity (if plugin-owned)
+  /// @return Non-owning pointer, or nullptr if entity is not plugin-owned
+  ///         or owning plugin doesn't implement OperationProvider
+  OperationProvider * get_operation_provider_for_entity(const std::string & entity_id) const;
+
+  /// Check if an entity is owned by a plugin
+  /// @return Plugin name if owned, nullopt otherwise
+  std::optional<std::string> get_entity_owner(const std::string & entity_id) const;
+
   // ---- Info ----
   bool has_plugins() const;
   std::vector<std::string> plugin_names() const;
@@ -196,6 +220,8 @@ class PluginManager {
   ScriptProvider * first_script_provider_ = nullptr;
   ResourceSamplerRegistry * sampler_registry_ = nullptr;
   TransportRegistry * transport_registry_ = nullptr;
+  /// Entity ID -> plugin name mapping (populated from IntrospectionProvider results)
+  std::unordered_map<std::string, std::string> entity_ownership_;
   bool shutdown_called_ = false;
   mutable std::shared_mutex plugins_mutex_;
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
@@ -19,8 +19,10 @@
 #include "ros2_medkit_gateway/plugins/plugin_context.hpp"
 #include "ros2_medkit_gateway/plugins/plugin_loader.hpp"
 #include "ros2_medkit_gateway/plugins/plugin_types.hpp"
+#include "ros2_medkit_gateway/providers/data_provider.hpp"
 #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
 #include "ros2_medkit_gateway/providers/log_provider.hpp"
+#include "ros2_medkit_gateway/providers/operation_provider.hpp"
 #include "ros2_medkit_gateway/providers/script_provider.hpp"
 #include "ros2_medkit_gateway/providers/update_provider.hpp"
 #include "ros2_medkit_gateway/resource_sampler.hpp"
@@ -179,6 +181,8 @@ class PluginManager {
     IntrospectionProvider * introspection_provider = nullptr;
     LogProvider * log_provider = nullptr;
     ScriptProvider * script_provider = nullptr;
+    DataProvider * data_provider = nullptr;
+    OperationProvider * operation_provider = nullptr;
   };
 
   /// Disable a plugin after a lifecycle error (nulls providers, resets plugin).

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
@@ -20,6 +20,7 @@
 #include "ros2_medkit_gateway/plugins/plugin_loader.hpp"
 #include "ros2_medkit_gateway/plugins/plugin_types.hpp"
 #include "ros2_medkit_gateway/providers/data_provider.hpp"
+#include "ros2_medkit_gateway/providers/fault_provider.hpp"
 #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
 #include "ros2_medkit_gateway/providers/log_provider.hpp"
 #include "ros2_medkit_gateway/providers/operation_provider.hpp"
@@ -187,6 +188,9 @@ class PluginManager {
   ///         or owning plugin doesn't implement OperationProvider
   OperationProvider * get_operation_provider_for_entity(const std::string & entity_id) const;
 
+  /// Get FaultProvider for a specific entity (if plugin-owned)
+  FaultProvider * get_fault_provider_for_entity(const std::string & entity_id) const;
+
   /// Check if an entity is owned by a plugin
   /// @return Plugin name if owned, nullopt otherwise
   std::optional<std::string> get_entity_owner(const std::string & entity_id) const;
@@ -207,6 +211,7 @@ class PluginManager {
     ScriptProvider * script_provider = nullptr;
     DataProvider * data_provider = nullptr;
     OperationProvider * operation_provider = nullptr;
+    FaultProvider * fault_provider = nullptr;
   };
 
   /// Disable a plugin after a lifecycle error (nulls providers, resets plugin).

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
@@ -178,6 +178,10 @@ class PluginManager {
   /// provider routing in handlers.
   void register_entity_ownership(const std::string & plugin_name, const std::vector<std::string> & entity_ids);
 
+  /// Clear all entity ownership entries for a given plugin.
+  /// Called before re-registering during refresh to remove stale entries.
+  void clear_entity_ownership(const std::string & plugin_name);
+
   /// Get DataProvider for a specific entity (if plugin-owned)
   /// @return Non-owning pointer, or nullptr if entity is not plugin-owned
   ///         or owning plugin doesn't implement DataProvider

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_manager.hpp
@@ -222,6 +222,7 @@ class PluginManager {
   /// Also clears provider pointers in load_result to prevent dangling references.
   void disable_plugin(LoadedPlugin & lp);
 
+  mutable std::shared_mutex plugins_mutex_;
   std::vector<LoadedPlugin> plugins_;
   PluginContext * context_ = nullptr;
   UpdateProvider * first_update_provider_ = nullptr;
@@ -232,7 +233,6 @@ class PluginManager {
   /// Entity ID -> plugin name mapping (populated from IntrospectionProvider results)
   std::unordered_map<std::string, std::string> entity_ownership_;
   bool shutdown_called_ = false;
-  mutable std::shared_mutex plugins_mutex_;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_types.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/plugins/plugin_types.hpp
@@ -28,7 +28,7 @@
 namespace ros2_medkit_gateway {
 
 /// Current plugin API version. Plugins must export this value from plugin_api_version().
-constexpr int PLUGIN_API_VERSION = 5;
+constexpr int PLUGIN_API_VERSION = 6;
 
 /// Log severity levels for plugin logging callback
 enum class PluginLogLevel { kInfo, kWarn, kError };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/data_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/data_provider.hpp
@@ -1,0 +1,84 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <tl/expected.hpp>
+
+namespace ros2_medkit_gateway {
+
+enum class DataProviderError {
+  EntityNotFound,
+  ResourceNotFound,
+  ReadOnly,
+  WriteOnly,
+  TransportError,
+  Timeout,
+  InvalidValue,
+  Internal
+};
+
+struct DataProviderErrorInfo {
+  DataProviderError code;
+  std::string message;
+  int http_status{500};  ///< Suggested HTTP status code
+};
+
+/**
+ * @brief Provider interface for entity data resources
+ *
+ * Typed provider interface for plugins that serve SOVD data resources
+ * (GET /{entity_type}/{id}/data, GET /{entity_type}/{id}/data/{name}).
+ * Unlike LogProvider/ScriptProvider (singletons), multiple DataProvider
+ * plugins can coexist - each handles its own set of entities.
+ *
+ * Entity ownership is determined by IntrospectionProvider: entities
+ * created by a plugin's introspect() are routed to that plugin's
+ * DataProvider.
+ *
+ * @par Thread safety
+ * All methods may be called from multiple HTTP handler threads concurrently.
+ * Implementations must provide their own synchronization.
+ *
+ * @see GatewayPlugin for the base class all plugins must also implement
+ * @see OperationProvider for the operations counterpart
+ */
+class DataProvider {
+ public:
+  virtual ~DataProvider() = default;
+
+  /// List available data resources for an entity
+  /// @param entity_id SOVD entity ID (e.g., "openbsw_demo_ecu")
+  /// @return JSON with {"items": [...]} array of data resource descriptors
+  virtual tl::expected<nlohmann::json, DataProviderErrorInfo> list_data(const std::string & entity_id) = 0;
+
+  /// Read a specific data resource
+  /// @param entity_id SOVD entity ID
+  /// @param resource_name Data resource name (e.g., "hardcoded_data")
+  /// @return JSON response body for the data resource
+  virtual tl::expected<nlohmann::json, DataProviderErrorInfo> read_data(const std::string & entity_id,
+                                                                        const std::string & resource_name) = 0;
+
+  /// Write a data resource value
+  /// @param entity_id SOVD entity ID
+  /// @param resource_name Data resource name
+  /// @param value JSON value to write
+  /// @return JSON response body confirming the write
+  virtual tl::expected<nlohmann::json, DataProviderErrorInfo>
+  write_data(const std::string & entity_id, const std::string & resource_name, const nlohmann::json & value) = 0;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/fault_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/fault_provider.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <tl/expected.hpp>
+
+namespace ros2_medkit_gateway {
+
+enum class FaultProviderError { EntityNotFound, FaultNotFound, TransportError, Timeout, Internal };
+
+struct FaultProviderErrorInfo {
+  FaultProviderError code;
+  std::string message;
+  int http_status{500};  ///< Suggested HTTP status code
+};
+
+/**
+ * @brief Provider interface for entity fault/DTC resources
+ *
+ * Typed provider interface for plugins that serve SOVD faults
+ * (GET /{entity_type}/{id}/faults, GET /{entity_type}/{id}/faults/{code}).
+ * Per-entity routing like DataProvider.
+ *
+ * Plugins implementing this interface query their backend (e.g., UDS
+ * ReadDTCInformation 0x19) on demand and return faults in SOVD format.
+ *
+ * @par Thread safety
+ * All methods may be called concurrently. Implementations must synchronize.
+ *
+ * @see GatewayPlugin for the base class all plugins must also implement
+ * @see DataProvider for the data counterpart
+ */
+class FaultProvider {
+ public:
+  virtual ~FaultProvider() = default;
+
+  /// List faults for an entity
+  /// @param entity_id SOVD entity ID
+  /// @return JSON with {"items": [...]} array of fault descriptors
+  virtual tl::expected<nlohmann::json, FaultProviderErrorInfo> list_faults(const std::string & entity_id) = 0;
+
+  /// Get a specific fault with environment data
+  /// @param entity_id SOVD entity ID
+  /// @param fault_code Fault code (e.g., DTC identifier)
+  /// @return JSON response with fault detail + environment data
+  virtual tl::expected<nlohmann::json, FaultProviderErrorInfo> get_fault(const std::string & entity_id,
+                                                                         const std::string & fault_code) = 0;
+
+  /// Clear a fault
+  /// @param entity_id SOVD entity ID
+  /// @param fault_code Fault code to clear
+  /// @return JSON response confirming the clear
+  virtual tl::expected<nlohmann::json, FaultProviderErrorInfo> clear_fault(const std::string & entity_id,
+                                                                           const std::string & fault_code) = 0;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <string>
+#include <tl/expected.hpp>
+
+namespace ros2_medkit_gateway {
+
+enum class OperationProviderError {
+  EntityNotFound,
+  OperationNotFound,
+  InvalidParameters,
+  TransportError,
+  Timeout,
+  Rejected,
+  Internal
+};
+
+struct OperationProviderErrorInfo {
+  OperationProviderError code;
+  std::string message;
+  int http_status{500};  ///< Suggested HTTP status code
+};
+
+/**
+ * @brief Provider interface for entity operations
+ *
+ * Typed provider interface for plugins that serve SOVD operations
+ * (GET /{entity_type}/{id}/operations, POST /{entity_type}/{id}/operations/{name}).
+ * Per-entity routing like DataProvider.
+ *
+ * @par Thread safety
+ * All methods may be called concurrently. Implementations must synchronize.
+ *
+ * @see GatewayPlugin for the base class all plugins must also implement
+ * @see DataProvider for the data counterpart
+ */
+class OperationProvider {
+ public:
+  virtual ~OperationProvider() = default;
+
+  /// List available operations for an entity
+  /// @param entity_id SOVD entity ID
+  /// @return JSON with {"items": [...]} array of operation descriptors
+  virtual tl::expected<nlohmann::json, OperationProviderErrorInfo> list_operations(const std::string & entity_id) = 0;
+
+  /// Execute an operation
+  /// @param entity_id SOVD entity ID
+  /// @param operation_name Operation name (e.g., "session_control")
+  /// @param parameters JSON parameters from request body
+  /// @return JSON response body with operation result
+  virtual tl::expected<nlohmann::json, OperationProviderErrorInfo>
+  execute_operation(const std::string & entity_id, const std::string & operation_name,
+                    const nlohmann::json & parameters) = 0;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
@@ -58,6 +58,29 @@ class OperationProvider {
   /// @return JSON with {"items": [...]} array of operation descriptors
   virtual tl::expected<nlohmann::json, OperationProviderErrorInfo> list_operations(const std::string & entity_id) = 0;
 
+  /// Get a specific operation by name
+  /// @param entity_id SOVD entity ID
+  /// @param operation_name Operation name
+  /// @return JSON with operation detail, or OperationNotFound error
+  /// @note Default implementation calls list_operations + linear scan.
+  ///       Override for O(1) lookup in plugins with many operations.
+  virtual tl::expected<nlohmann::json, OperationProviderErrorInfo> get_operation(const std::string & entity_id,
+                                                                                 const std::string & operation_name) {
+    auto result = list_operations(entity_id);
+    if (!result) {
+      return tl::make_unexpected(result.error());
+    }
+    if (result->contains("items") && (*result)["items"].is_array()) {
+      for (const auto & item : (*result)["items"]) {
+        if (item.value("id", "") == operation_name) {
+          return item;
+        }
+      }
+    }
+    return tl::make_unexpected(
+        OperationProviderErrorInfo{OperationProviderError::OperationNotFound, "Operation not found", 404});
+  }
+
   /// Execute an operation
   /// @param entity_id SOVD entity ID
   /// @param operation_name Operation name (e.g., "session_control")

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/providers/operation_provider.hpp
@@ -73,7 +73,7 @@ class OperationProvider {
     if (result->contains("items") && (*result)["items"].is_array()) {
       for (const auto & item : (*result)["items"]) {
         if (item.value("id", "") == operation_name) {
-          return item;
+          return tl::expected<nlohmann::json, OperationProviderErrorInfo>{item};
         }
       }
     }

--- a/src/ros2_medkit_gateway/src/discovery/layers/plugin_layer.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/layers/plugin_layer.cpp
@@ -69,6 +69,20 @@ LayerOutput PluginLayer::discover() {
   output.apps = std::move(result.new_entities.apps);
   output.functions = std::move(result.new_entities.functions);
 
+  // Tag all plugin-created entities with source="plugin"
+  for (auto & area : output.areas) {
+    area.source = "plugin";
+  }
+  for (auto & comp : output.components) {
+    comp.source = "plugin";
+  }
+  for (auto & app : output.apps) {
+    app.source = "plugin";
+  }
+  for (auto & func : output.functions) {
+    func.source = "plugin";
+  }
+
   // Validate entity IDs from plugin
   validate_entities(output.areas, name_, logger_);
   validate_entities(output.components, name_, logger_);

--- a/src/ros2_medkit_gateway/src/entity_validation.cpp
+++ b/src/ros2_medkit_gateway/src/entity_validation.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/entity_validation.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+namespace ros2_medkit_gateway {
+
+tl::expected<void, std::string> validate_entity_id(const std::string & entity_id) {
+  if (entity_id.empty()) {
+    return tl::unexpected("Entity ID cannot be empty");
+  }
+
+  if (entity_id.length() > 256) {
+    return tl::unexpected("Entity ID too long (max 256 characters)");
+  }
+
+  // Allow: alphanumeric (a-z, A-Z, 0-9), underscore (_), hyphen (-)
+  // Reject: forward slash (conflicts with URL routing), special characters, escape sequences
+  // Note: Hyphens are allowed in manifest entity IDs (e.g., "engine-ecu", "front-left-door")
+  for (char c : entity_id) {
+    bool is_alphanumeric = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+    bool is_allowed_special = (c == '_' || c == '-');
+
+    if (!is_alphanumeric && !is_allowed_special) {
+      std::string char_repr;
+      if (c < 32 || c > 126) {
+        std::ostringstream oss;
+        oss << "0x" << std::hex << std::setfill('0') << std::setw(2)
+            << static_cast<unsigned int>(static_cast<unsigned char>(c));
+        char_repr = oss.str();
+      } else {
+        char_repr = std::string(1, c);
+      }
+      return tl::unexpected("Entity ID contains invalid character: '" + char_repr +
+                            "'. Only alphanumeric, underscore and hyphen are allowed");
+    }
+  }
+
+  return {};
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -648,8 +648,16 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     // Register entity ownership for per-entity provider routing
     for (auto & [name, provider] : introspection_providers) {
       IntrospectionInput input;
-      auto result = provider->introspect(input);
+      IntrospectionResult result;
+      try {
+        result = provider->introspect(input);
+      } catch (const std::exception & e) {
+        RCLCPP_ERROR(get_logger(), "Plugin '%s' introspect() threw during init: %s", name.c_str(), e.what());
+        continue;
+      }
       std::vector<std::string> entity_ids;
+      entity_ids.reserve(result.new_entities.areas.size() + result.new_entities.components.size() +
+                         result.new_entities.apps.size() + result.new_entities.functions.size());
       for (const auto & area : result.new_entities.areas) {
         entity_ids.push_back(area.id);
       }
@@ -1559,41 +1567,23 @@ void GatewayNode::refresh_cache() {
       aggregation_mgr_->update_routing_table(peer_routing_table);
     }
 
-    // Inject plugin entities for non-hybrid modes.
-    // In hybrid mode, plugin entities are merged via the pipeline (PluginLayer).
-    // In runtime_only/manifest_only modes, we append them directly.
-    if (discovery_mgr_->get_mode() != DiscoveryMode::HYBRID && plugin_mgr_ && plugin_mgr_->has_plugins()) {
-      auto providers = plugin_mgr_->get_named_introspection_providers();
-      for (auto & [name, provider] : providers) {
-        IntrospectionInput input;
-        auto result = provider->introspect(input);
-        for (auto & area : result.new_entities.areas) {
-          area.source = "plugin";
-          areas.push_back(std::move(area));
-        }
-        for (auto & comp : result.new_entities.components) {
-          comp.source = "plugin";
-          all_components.push_back(std::move(comp));
-        }
-        for (auto & app : result.new_entities.apps) {
-          app.source = "plugin";
-          apps.push_back(std::move(app));
-        }
-        for (auto & func : result.new_entities.functions) {
-          func.source = "plugin";
-          functions.push_back(std::move(func));
-        }
-      }
-    }
-
-    // Refresh entity ownership for per-entity provider routing.
-    // Re-register ownership each cycle to pick up dynamically discovered entities
-    // and remove stale entries for entities that are no longer reported.
+    // Inject plugin entities (non-hybrid) and refresh entity ownership (all modes).
+    // Single introspect() call per plugin handles both concerns.
     if (plugin_mgr_ && plugin_mgr_->has_plugins()) {
+      bool inject_entities = (discovery_mgr_->get_mode() != DiscoveryMode::HYBRID);
       auto providers = plugin_mgr_->get_named_introspection_providers();
       for (auto & [name, provider] : providers) {
         IntrospectionInput input;
-        auto result = provider->introspect(input);
+        IntrospectionResult result;
+        try {
+          result = provider->introspect(input);
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(get_logger(), "Plugin '%s' introspect() threw during refresh: %s", name.c_str(), e.what());
+          plugin_mgr_->clear_entity_ownership(name);
+          continue;
+        }
+
+        // Collect entity IDs for ownership before any move
         std::vector<std::string> entity_ids;
         entity_ids.reserve(result.new_entities.areas.size() + result.new_entities.components.size() +
                            result.new_entities.apps.size() + result.new_entities.functions.size());
@@ -1609,6 +1599,28 @@ void GatewayNode::refresh_cache() {
         for (const auto & func : result.new_entities.functions) {
           entity_ids.push_back(func.id);
         }
+
+        // In non-hybrid modes, inject plugin entities directly
+        if (inject_entities) {
+          for (auto & area : result.new_entities.areas) {
+            area.source = "plugin";
+            areas.push_back(std::move(area));
+          }
+          for (auto & comp : result.new_entities.components) {
+            comp.source = "plugin";
+            all_components.push_back(std::move(comp));
+          }
+          for (auto & app : result.new_entities.apps) {
+            app.source = "plugin";
+            apps.push_back(std::move(app));
+          }
+          for (auto & func : result.new_entities.functions) {
+            func.source = "plugin";
+            functions.push_back(std::move(func));
+          }
+        }
+
+        // Refresh ownership (IDs collected before move)
         plugin_mgr_->clear_entity_ownership(name);
         plugin_mgr_->register_entity_ownership(name, entity_ids);
       }

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1586,6 +1586,34 @@ void GatewayNode::refresh_cache() {
       }
     }
 
+    // Refresh entity ownership for per-entity provider routing.
+    // Re-register ownership each cycle to pick up dynamically discovered entities
+    // and remove stale entries for entities that are no longer reported.
+    if (plugin_mgr_ && plugin_mgr_->has_plugins()) {
+      auto providers = plugin_mgr_->get_named_introspection_providers();
+      for (auto & [name, provider] : providers) {
+        IntrospectionInput input;
+        auto result = provider->introspect(input);
+        std::vector<std::string> entity_ids;
+        entity_ids.reserve(result.new_entities.areas.size() + result.new_entities.components.size() +
+                           result.new_entities.apps.size() + result.new_entities.functions.size());
+        for (const auto & area : result.new_entities.areas) {
+          entity_ids.push_back(area.id);
+        }
+        for (const auto & comp : result.new_entities.components) {
+          entity_ids.push_back(comp.id);
+        }
+        for (const auto & app : result.new_entities.apps) {
+          entity_ids.push_back(app.id);
+        }
+        for (const auto & func : result.new_entities.functions) {
+          entity_ids.push_back(func.id);
+        }
+        plugin_mgr_->clear_entity_ownership(name);
+        plugin_mgr_->register_entity_ownership(name, entity_ids);
+      }
+    }
+
     // Filter ROS 2 internal nodes (underscore prefix convention).
     // Controlled by discovery.runtime.filter_internal_nodes parameter (default: true).
     // Covers local heuristic apps (which bypass the merge pipeline orphan filter

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1559,24 +1559,9 @@ void GatewayNode::refresh_cache() {
           continue;
         }
 
-        // Collect entity IDs for ownership before any move
+        // In non-hybrid modes, inject plugin entities directly (with validation).
+        // Collect validated entity IDs for ownership registration.
         std::vector<std::string> entity_ids;
-        entity_ids.reserve(result.new_entities.areas.size() + result.new_entities.components.size() +
-                           result.new_entities.apps.size() + result.new_entities.functions.size());
-        for (const auto & area : result.new_entities.areas) {
-          entity_ids.push_back(area.id);
-        }
-        for (const auto & comp : result.new_entities.components) {
-          entity_ids.push_back(comp.id);
-        }
-        for (const auto & app : result.new_entities.apps) {
-          entity_ids.push_back(app.id);
-        }
-        for (const auto & func : result.new_entities.functions) {
-          entity_ids.push_back(func.id);
-        }
-
-        // In non-hybrid modes, inject plugin entities directly (with validation)
         if (inject_entities) {
           for (auto & area : result.new_entities.areas) {
             if (!validate_entity_id(area.id)) {
@@ -1584,6 +1569,7 @@ void GatewayNode::refresh_cache() {
                           area.id.c_str());
               continue;
             }
+            entity_ids.push_back(area.id);
             area.source = "plugin";
             areas.push_back(std::move(area));
           }
@@ -1593,6 +1579,7 @@ void GatewayNode::refresh_cache() {
                           comp.id.c_str());
               continue;
             }
+            entity_ids.push_back(comp.id);
             comp.source = "plugin";
             all_components.push_back(std::move(comp));
           }
@@ -1601,6 +1588,7 @@ void GatewayNode::refresh_cache() {
               RCLCPP_WARN(get_logger(), "Plugin '%s': dropping app with invalid ID '%s'", name.c_str(), app.id.c_str());
               continue;
             }
+            entity_ids.push_back(app.id);
             app.source = "plugin";
             apps.push_back(std::move(app));
           }
@@ -1610,12 +1598,36 @@ void GatewayNode::refresh_cache() {
                           func.id.c_str());
               continue;
             }
+            entity_ids.push_back(func.id);
             func.source = "plugin";
             functions.push_back(std::move(func));
           }
+        } else {
+          // Hybrid mode: PluginLayer validates in discover(). Collect IDs
+          // with validation for ownership (entities are not injected here).
+          for (const auto & area : result.new_entities.areas) {
+            if (validate_entity_id(area.id)) {
+              entity_ids.push_back(area.id);
+            }
+          }
+          for (const auto & comp : result.new_entities.components) {
+            if (validate_entity_id(comp.id)) {
+              entity_ids.push_back(comp.id);
+            }
+          }
+          for (const auto & app : result.new_entities.apps) {
+            if (validate_entity_id(app.id)) {
+              entity_ids.push_back(app.id);
+            }
+          }
+          for (const auto & func : result.new_entities.functions) {
+            if (validate_entity_id(func.id)) {
+              entity_ids.push_back(func.id);
+            }
+          }
         }
 
-        // Refresh ownership (IDs collected before move)
+        // Refresh ownership with validated IDs only
         plugin_mgr_->clear_entity_ownership(name);
         plugin_mgr_->register_entity_ownership(name, entity_ids);
       }

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -23,6 +23,7 @@
 #include <unordered_set>
 
 #include "ros2_medkit_gateway/aggregation/network_utils.hpp"
+#include "ros2_medkit_gateway/entity_validation.hpp"
 #include "ros2_medkit_gateway/param_utils.hpp"
 
 #include "ros2_medkit_gateway/http/handlers/sse_transport_provider.hpp"
@@ -643,35 +644,10 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
       }
       discovery_mgr_->refresh_pipeline();
     }
-    // Non-hybrid modes: plugin entities are injected during refresh_cache()
-
-    // Register entity ownership for per-entity provider routing
-    for (auto & [name, provider] : introspection_providers) {
-      IntrospectionInput input;
-      IntrospectionResult result;
-      try {
-        result = provider->introspect(input);
-      } catch (const std::exception & e) {
-        RCLCPP_ERROR(get_logger(), "Plugin '%s' introspect() threw during init: %s", name.c_str(), e.what());
-        continue;
-      }
-      std::vector<std::string> entity_ids;
-      entity_ids.reserve(result.new_entities.areas.size() + result.new_entities.components.size() +
-                         result.new_entities.apps.size() + result.new_entities.functions.size());
-      for (const auto & area : result.new_entities.areas) {
-        entity_ids.push_back(area.id);
-      }
-      for (const auto & comp : result.new_entities.components) {
-        entity_ids.push_back(comp.id);
-      }
-      for (const auto & app : result.new_entities.apps) {
-        entity_ids.push_back(app.id);
-      }
-      for (const auto & func : result.new_entities.functions) {
-        entity_ids.push_back(func.id);
-      }
-      plugin_mgr_->register_entity_ownership(name, entity_ids);
-    }
+    // Non-hybrid modes: plugin entities are injected during refresh_cache().
+    // Entity ownership is also registered during refresh_cache() (single introspect() call
+    // per plugin handles both injection and ownership). No separate init-time registration
+    // needed because refresh_cache() runs before the HTTP server accepts requests.
   }
 
   // Initialize log manager (subscribes to /rosout, delegates to plugin if available)
@@ -1600,21 +1576,40 @@ void GatewayNode::refresh_cache() {
           entity_ids.push_back(func.id);
         }
 
-        // In non-hybrid modes, inject plugin entities directly
+        // In non-hybrid modes, inject plugin entities directly (with validation)
         if (inject_entities) {
           for (auto & area : result.new_entities.areas) {
+            if (!validate_entity_id(area.id)) {
+              RCLCPP_WARN(get_logger(), "Plugin '%s': dropping area with invalid ID '%s'", name.c_str(),
+                          area.id.c_str());
+              continue;
+            }
             area.source = "plugin";
             areas.push_back(std::move(area));
           }
           for (auto & comp : result.new_entities.components) {
+            if (!validate_entity_id(comp.id)) {
+              RCLCPP_WARN(get_logger(), "Plugin '%s': dropping component with invalid ID '%s'", name.c_str(),
+                          comp.id.c_str());
+              continue;
+            }
             comp.source = "plugin";
             all_components.push_back(std::move(comp));
           }
           for (auto & app : result.new_entities.apps) {
+            if (!validate_entity_id(app.id)) {
+              RCLCPP_WARN(get_logger(), "Plugin '%s': dropping app with invalid ID '%s'", name.c_str(), app.id.c_str());
+              continue;
+            }
             app.source = "plugin";
             apps.push_back(std::move(app));
           }
           for (auto & func : result.new_entities.functions) {
+            if (!validate_entity_id(func.id)) {
+              RCLCPP_WARN(get_logger(), "Plugin '%s': dropping function with invalid ID '%s'", name.c_str(),
+                          func.id.c_str());
+              continue;
+            }
             func.source = "plugin";
             functions.push_back(std::move(func));
           }

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -88,7 +88,9 @@ nlohmann::json extract_plugin_config(rclcpp::Node * node, const std::string & pl
   // Source 2: global YAML overrides from --params-file
   declare_plugin_params_from_yaml(node, prefix, path_key);
 
-  auto result = node->list_parameters({prefix}, 10);
+  // list_parameters uses "." as hierarchy separator - prefix must NOT have trailing dot.
+  std::string list_prefix = "plugins." + plugin_name;
+  auto result = node->list_parameters({list_prefix}, 10);
   for (const auto & name : result.names) {
     if (name != path_key) {
       config[name.substr(prefix.size())] = parameter_to_json(node->get_parameter(name));

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -633,14 +633,36 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   plugin_mgr_->set_context(*plugin_ctx_);
   RCLCPP_INFO(get_logger(), "Loaded %zu plugin(s)", loaded);
 
-  // Register IntrospectionProvider plugins as pipeline layers (hybrid mode only)
-  if (discovery_mgr_->get_mode() == DiscoveryMode::HYBRID) {
-    auto providers = plugin_mgr_->get_named_introspection_providers();
-    for (auto & [name, provider] : providers) {
-      discovery_mgr_->add_plugin_layer(name, provider);
-    }
-    if (!providers.empty()) {
+  // Register IntrospectionProvider plugins
+  auto introspection_providers = plugin_mgr_->get_named_introspection_providers();
+  if (!introspection_providers.empty()) {
+    if (discovery_mgr_->get_mode() == DiscoveryMode::HYBRID) {
+      // Hybrid: add as pipeline layers for merge
+      for (auto & [name, provider] : introspection_providers) {
+        discovery_mgr_->add_plugin_layer(name, provider);
+      }
       discovery_mgr_->refresh_pipeline();
+    }
+    // Non-hybrid modes: plugin entities are injected during refresh_cache()
+
+    // Register entity ownership for per-entity provider routing
+    for (auto & [name, provider] : introspection_providers) {
+      IntrospectionInput input;
+      auto result = provider->introspect(input);
+      std::vector<std::string> entity_ids;
+      for (const auto & area : result.new_entities.areas) {
+        entity_ids.push_back(area.id);
+      }
+      for (const auto & comp : result.new_entities.components) {
+        entity_ids.push_back(comp.id);
+      }
+      for (const auto & app : result.new_entities.apps) {
+        entity_ids.push_back(app.id);
+      }
+      for (const auto & func : result.new_entities.functions) {
+        entity_ids.push_back(func.id);
+      }
+      plugin_mgr_->register_entity_ownership(name, entity_ids);
     }
   }
 
@@ -1535,6 +1557,33 @@ void GatewayNode::refresh_cache() {
       functions = std::move(merged.functions);
       peer_routing_table = std::move(merged.routing_table);
       aggregation_mgr_->update_routing_table(peer_routing_table);
+    }
+
+    // Inject plugin entities for non-hybrid modes.
+    // In hybrid mode, plugin entities are merged via the pipeline (PluginLayer).
+    // In runtime_only/manifest_only modes, we append them directly.
+    if (discovery_mgr_->get_mode() != DiscoveryMode::HYBRID && plugin_mgr_ && plugin_mgr_->has_plugins()) {
+      auto providers = plugin_mgr_->get_named_introspection_providers();
+      for (auto & [name, provider] : providers) {
+        IntrospectionInput input;
+        auto result = provider->introspect(input);
+        for (auto & area : result.new_entities.areas) {
+          area.source = "plugin";
+          areas.push_back(std::move(area));
+        }
+        for (auto & comp : result.new_entities.components) {
+          comp.source = "plugin";
+          all_components.push_back(std::move(comp));
+        }
+        for (auto & app : result.new_entities.apps) {
+          app.source = "plugin";
+          apps.push_back(std::move(app));
+        }
+        for (auto & func : result.new_entities.functions) {
+          func.source = "plugin";
+          functions.push_back(std::move(func));
+        }
+      }
     }
 
     // Filter ROS 2 internal nodes (underscore prefix convention).

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -63,6 +63,10 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -170,6 +174,10 @@ void DataHandlers::handle_get_data_item(const httplib::Request & req, httplib::R
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -289,6 +297,10 @@ void DataHandlers::handle_put_data_item(const httplib::Request & req, httplib::R
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -70,7 +70,8 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
         }
         return;
       }
-      HandlerContext::send_json(res, json{{"items", json::array()}});
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No data provider for plugin entity '" + entity_id + "'");
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -55,7 +55,10 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
@@ -155,7 +158,10 @@ void DataHandlers::handle_get_data_item(const httplib::Request & req, httplib::R
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
@@ -245,6 +251,11 @@ void DataHandlers::handle_put_data_item(const httplib::Request & req, httplib::R
       return;  // Response already sent (error or forwarded to peer)
     }
 
+    // Check lock access for data (before plugin delegation - locks apply to all entities)
+    if (ctx_.validate_lock_access(req, res, *entity_opt, "data")) {
+      return;
+    }
+
     // Delegate to plugin DataProvider if entity is plugin-owned
     if (entity_opt->is_plugin) {
       auto * pmgr = ctx_.node()->get_plugin_manager();
@@ -262,17 +273,15 @@ void DataHandlers::handle_put_data_item(const httplib::Request & req, httplib::R
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
       HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
                                  "No data provider for plugin entity '" + entity_id + "'");
-      return;
-    }
-
-    // Check lock access for data
-    if (ctx_.validate_lock_access(req, res, *entity_opt, "data")) {
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -21,6 +21,8 @@
 #include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/http/http_utils.hpp"
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
+#include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/providers/data_provider.hpp"
 
 using json = nlohmann::json;
 
@@ -43,6 +45,23 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
       return;  // Response already sent (error or forwarded to peer)
     }
     auto entity_info = *entity_opt;
+
+    // Delegate to plugin DataProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
+      if (data_prov) {
+        auto result = data_prov->list_data(entity_id);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_json(res, json{{"items", json::array()}});
+      return;
+    }
 
     // Use unified cache method to get aggregated data
     const auto & cache = ctx_.node()->get_thread_safe_cache();
@@ -127,6 +146,24 @@ void DataHandlers::handle_get_data_item(const httplib::Request & req, httplib::R
       return;  // Response already sent (error or forwarded to peer)
     }
 
+    // Delegate to plugin DataProvider if entity is plugin-owned
+    if (entity_opt->is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
+      if (data_prov) {
+        auto result = data_prov->read_data(entity_id, topic_name);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No data provider for plugin entity '" + entity_id + "'");
+      return;
+    }
+
     // Determine the full ROS topic path
     std::string full_topic_path;
     if (topic_name.empty() || topic_name[0] == '/') {
@@ -206,6 +243,32 @@ void DataHandlers::handle_put_data_item(const httplib::Request & req, httplib::R
     auto entity_opt = ctx_.validate_entity_for_route(req, res, entity_id);
     if (!entity_opt) {
       return;  // Response already sent (error or forwarded to peer)
+    }
+
+    // Delegate to plugin DataProvider if entity is plugin-owned
+    if (entity_opt->is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
+      if (data_prov) {
+        json value;
+        if (!req.body.empty()) {
+          value = json::parse(req.body, nullptr, false);
+          if (value.is_discarded()) {
+            HandlerContext::send_error(res, 400, ERR_INVALID_REQUEST, "Invalid JSON body");
+            return;
+          }
+        }
+        auto result = data_prov->write_data(entity_id, topic_name, value);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No data provider for plugin entity '" + entity_id + "'");
+      return;
     }
 
     // Check lock access for data

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -51,14 +51,18 @@ void DataHandlers::handle_list_data(const httplib::Request & req, httplib::Respo
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
       if (data_prov) {
-        auto result = data_prov->list_data(entity_id);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = data_prov->list_data(entity_id);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -154,14 +158,18 @@ void DataHandlers::handle_get_data_item(const httplib::Request & req, httplib::R
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
       if (data_prov) {
-        auto result = data_prov->read_data(entity_id, topic_name);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = data_prov->read_data(entity_id, topic_name);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -269,14 +277,18 @@ void DataHandlers::handle_put_data_item(const httplib::Request & req, httplib::R
             return;
           }
         }
-        auto result = data_prov->write_data(entity_id, topic_name, value);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = data_prov->write_data(entity_id, topic_name, value);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin DataProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -60,6 +60,9 @@ void append_plugin_capabilities(json & capabilities, const std::string & entity_
   if (pmgr->get_operation_provider_for_entity(entity_id) && !has_capability(capabilities, "operations")) {
     capabilities.push_back({{"name", "operations"}, {"href", href_prefix + "operations"}});
   }
+  if (pmgr->get_fault_provider_for_entity(entity_id) && !has_capability(capabilities, "faults")) {
+    capabilities.push_back({{"name", "faults"}, {"href", href_prefix + "faults"}});
+  }
 
   // Plugin-registered custom capabilities (via PluginContext)
   auto * ctx = pmgr->get_context();

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -72,12 +72,16 @@ void append_plugin_capabilities(json & capabilities, const std::string & entity_
 
   // Type-level capabilities (registered for all entities of this type)
   for (const auto & cap_name : ctx->get_type_capabilities(entity_type)) {
-    capabilities.push_back({{"name", cap_name}, {"href", href_prefix + cap_name}});
+    if (!has_capability(capabilities, cap_name)) {
+      capabilities.push_back({{"name", cap_name}, {"href", href_prefix + cap_name}});
+    }
   }
 
   // Entity-specific capabilities
   for (const auto & cap_name : ctx->get_entity_capabilities(entity_id)) {
-    capabilities.push_back({{"name", cap_name}, {"href", href_prefix + cap_name}});
+    if (!has_capability(capabilities, cap_name)) {
+      capabilities.push_back({{"name", cap_name}, {"href", href_prefix + cap_name}});
+    }
   }
 }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -22,6 +22,7 @@
 #include "ros2_medkit_gateway/http/handlers/capability_builder.hpp"
 #include "ros2_medkit_gateway/http/http_utils.hpp"
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
+#include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
 
 using json = nlohmann::json;
 
@@ -30,17 +31,41 @@ namespace handlers {
 
 namespace {
 
+/// Check if a capability name is already present in the capabilities array
+bool has_capability(const json & capabilities, const std::string & name) {
+  for (const auto & cap : capabilities) {
+    if (cap.contains("name") && cap["name"] == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Append plugin-registered capabilities to a capabilities JSON array
 void append_plugin_capabilities(json & capabilities, const std::string & entity_type_path,
                                 const std::string & entity_id, SovdEntityType entity_type, const GatewayNode * node) {
   auto * pmgr = node->get_plugin_manager();
-  if (!pmgr || !pmgr->get_context()) {
+  if (!pmgr) {
     return;
   }
-  auto * ctx = pmgr->get_context();
+
   std::string href_prefix;
   href_prefix.reserve(64);
   href_prefix.append("/api/v1/").append(entity_type_path).append("/").append(entity_id).append("/");
+
+  // Auto-add standard capabilities based on registered providers
+  if (pmgr->get_data_provider_for_entity(entity_id) && !has_capability(capabilities, "data")) {
+    capabilities.push_back({{"name", "data"}, {"href", href_prefix + "data"}});
+  }
+  if (pmgr->get_operation_provider_for_entity(entity_id) && !has_capability(capabilities, "operations")) {
+    capabilities.push_back({{"name", "operations"}, {"href", href_prefix + "operations"}});
+  }
+
+  // Plugin-registered custom capabilities (via PluginContext)
+  auto * ctx = pmgr->get_context();
+  if (!ctx) {
+    return;
+  }
 
   // Type-level capabilities (registered for all entities of this type)
   for (const auto & cap_name : ctx->get_type_capabilities(entity_type)) {

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -332,6 +332,10 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -599,6 +603,10 @@ void FaultHandlers::handle_get_fault(const httplib::Request & req, httplib::Resp
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -688,6 +696,10 @@ void FaultHandlers::handle_clear_fault(const httplib::Request & req, httplib::Re
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
                        e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -324,7 +324,10 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
@@ -584,7 +587,10 @@ void FaultHandlers::handle_get_fault(const httplib::Request & req, httplib::Resp
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
@@ -652,6 +658,11 @@ void FaultHandlers::handle_clear_fault(const httplib::Request & req, httplib::Re
     }
     auto entity_info = *entity_opt;
 
+    // Check lock access for faults (before plugin delegation - locks apply to all entities)
+    if (ctx_.validate_lock_access(req, res, entity_info, "faults")) {
+      return;
+    }
+
     // Delegate to plugin FaultProvider if entity is plugin-owned
     if (entity_info.is_plugin) {
       auto * pmgr = ctx_.node()->get_plugin_manager();
@@ -661,17 +672,15 @@ void FaultHandlers::handle_clear_fault(const httplib::Request & req, httplib::Re
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
       HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
                                  "No fault provider for plugin entity '" + entity_id + "'");
-      return;
-    }
-
-    // Check lock access for faults
-    if (ctx_.validate_lock_access(req, res, entity_info, "faults")) {
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -320,14 +320,18 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
       if (fault_prov) {
-        auto result = fault_prov->list_faults(entity_id);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = fault_prov->list_faults(entity_id);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -583,14 +587,18 @@ void FaultHandlers::handle_get_fault(const httplib::Request & req, httplib::Resp
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
       if (fault_prov) {
-        auto result = fault_prov->get_fault(entity_id, fault_code);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = fault_prov->get_fault(entity_id, fault_code);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -668,14 +676,18 @@ void FaultHandlers::handle_clear_fault(const httplib::Request & req, httplib::Re
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
       if (fault_prov) {
-        auto result = fault_prov->clear_fault(entity_id, fault_code);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = fault_prov->clear_fault(entity_id, fault_code);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -339,7 +339,8 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
         }
         return;
       }
-      HandlerContext::send_json(res, json{{"items", json::array()}});
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No fault provider for plugin entity '" + entity_id + "'");
       return;
     }
 
@@ -772,11 +773,21 @@ void FaultHandlers::handle_clear_all_faults(const httplib::Request & req, httpli
         try {
           auto list_result = fault_prov->list_faults(entity_id);
           if (list_result && list_result->contains("items") && (*list_result)["items"].is_array()) {
+            std::vector<std::string> failed_codes;
             for (const auto & fault : (*list_result)["items"]) {
               auto code = fault.value("code", "");
               if (!code.empty()) {
-                (void)fault_prov->clear_fault(entity_id, code);
+                auto clear_result = fault_prov->clear_fault(entity_id, code);
+                if (!clear_result) {
+                  failed_codes.push_back(code);
+                }
               }
+            }
+            if (!failed_codes.empty()) {
+              HandlerContext::send_plugin_error(res, 500,
+                                                "Failed to clear " + std::to_string(failed_codes.size()) + " fault(s)",
+                                                {{"entity_id", entity_id}, {"failed_codes", failed_codes}});
+              return;
             }
           } else if (!list_result) {
             HandlerContext::send_plugin_error(res, list_result.error().http_status, list_result.error().message,
@@ -794,8 +805,11 @@ void FaultHandlers::handle_clear_all_faults(const httplib::Request & req, httpli
           HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
           return;
         }
+        res.status = 204;
+        return;
       }
-      res.status = 204;
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No fault provider for plugin entity '" + entity_id + "'");
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -29,6 +29,8 @@
 #include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/http/http_utils.hpp"
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
+#include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/providers/fault_provider.hpp"
 
 using json = nlohmann::json;
 
@@ -313,6 +315,23 @@ void FaultHandlers::handle_list_faults(const httplib::Request & req, httplib::Re
     }
     auto entity_info = *entity_opt;
 
+    // Delegate to plugin FaultProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
+      if (fault_prov) {
+        auto result = fault_prov->list_faults(entity_id);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_json(res, json{{"items", json::array()}});
+      return;
+    }
+
     // Validate entity type supports faults collection (SOVD Table 8)
     if (auto err = HandlerContext::validate_collection_access(entity_info, ResourceCollection::FAULTS)) {
       HandlerContext::send_error(res, 400, ERR_COLLECTION_NOT_SUPPORTED, *err);
@@ -556,6 +575,24 @@ void FaultHandlers::handle_get_fault(const httplib::Request & req, httplib::Resp
     }
     auto entity_info = *entity_opt;
 
+    // Delegate to plugin FaultProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
+      if (fault_prov) {
+        auto result = fault_prov->get_fault(entity_id, fault_code);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No fault provider for plugin entity '" + entity_id + "'");
+      return;
+    }
+
     // Fault codes may contain dots and underscores, validate basic constraints
     if (fault_code.empty() || fault_code.length() > 256) {
       HandlerContext::send_error(res, 400, ERR_INVALID_PARAMETER, "Invalid fault code",
@@ -614,6 +651,24 @@ void FaultHandlers::handle_clear_fault(const httplib::Request & req, httplib::Re
       return;  // Response already sent (error or forwarded to peer)
     }
     auto entity_info = *entity_opt;
+
+    // Delegate to plugin FaultProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
+      if (fault_prov) {
+        auto result = fault_prov->clear_fault(entity_id, fault_code);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No fault provider for plugin entity '" + entity_id + "'");
+      return;
+    }
 
     // Check lock access for faults
     if (ctx_.validate_lock_access(req, res, entity_info, "faults")) {

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -759,8 +759,43 @@ void FaultHandlers::handle_clear_all_faults(const httplib::Request & req, httpli
     }
     auto entity_info = *entity_opt;
 
-    // Check lock access for faults
+    // Check lock access for faults (before plugin delegation - locks apply to all entities)
     if (ctx_.validate_lock_access(req, res, entity_info, "faults")) {
+      return;
+    }
+
+    // Delegate to plugin FaultProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * fault_prov = pmgr ? pmgr->get_fault_provider_for_entity(entity_id) : nullptr;
+      if (fault_prov) {
+        try {
+          auto list_result = fault_prov->list_faults(entity_id);
+          if (list_result && list_result->contains("items") && (*list_result)["items"].is_array()) {
+            for (const auto & fault : (*list_result)["items"]) {
+              auto code = fault.value("code", "");
+              if (!code.empty()) {
+                (void)fault_prov->clear_fault(entity_id, code);
+              }
+            }
+          } else if (!list_result) {
+            HandlerContext::send_plugin_error(res, list_result.error().http_status, list_result.error().message,
+                                              {{"entity_id", entity_id}});
+            return;
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
+                       e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+          return;
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
+          return;
+        }
+      }
+      res.status = 204;
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
@@ -89,6 +89,17 @@ EntityInfo HandlerContext::get_entity_info(const std::string & entity_id, SovdEn
         ei.peer_url = aggregation_mgr_->get_peer_url(*peer);
       }
     }
+    // Check plugin ownership (only if not already a remote entity)
+    if (!ei.is_remote) {
+      auto * pmgr = node_->get_plugin_manager();
+      if (pmgr) {
+        auto owner = pmgr->get_entity_owner(ei.id);
+        if (owner) {
+          ei.is_plugin = true;
+          ei.plugin_name = *owner;
+        }
+      }
+    }
   };
 
   // If expected_type is specified, search ONLY in that collection

--- a/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
@@ -14,6 +14,8 @@
 
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
 
+#include <algorithm>
+
 #include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
 #include "ros2_medkit_gateway/entity_validation.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -330,6 +332,14 @@ void HandlerContext::send_error(httplib::Response & res, int status, const std::
   }
 
   res.set_content(error_json.dump(2), "application/json");
+}
+
+void HandlerContext::send_plugin_error(httplib::Response & res, int http_status, const std::string & message,
+                                       const json & extra_params) {
+  static constexpr size_t kMaxMessageLength = 512;
+  int status = std::clamp(http_status, 400, 599);
+  std::string msg = message.size() > kMaxMessageLength ? message.substr(0, kMaxMessageLength) + "..." : message;
+  send_error(res, status, ERR_PLUGIN_ERROR, msg, extra_params);
 }
 
 void HandlerContext::send_json(httplib::Response & res, const json & data) {

--- a/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
@@ -15,6 +15,7 @@
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
 
 #include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
+#include "ros2_medkit_gateway/entity_validation.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/lock_manager.hpp"
@@ -27,41 +28,7 @@ namespace ros2_medkit_gateway {
 namespace handlers {
 
 tl::expected<void, std::string> HandlerContext::validate_entity_id(const std::string & entity_id) const {
-  // Check for empty string
-  if (entity_id.empty()) {
-    return tl::unexpected("Entity ID cannot be empty");
-  }
-
-  // Check length (reasonable limit to prevent abuse)
-  if (entity_id.length() > 256) {
-    return tl::unexpected("Entity ID too long (max 256 characters)");
-  }
-
-  // Validate characters according to naming conventions
-  // Allow: alphanumeric (a-z, A-Z, 0-9), underscore (_), hyphen (-)
-  // Reject: forward slash (conflicts with URL routing), special characters, escape sequences
-  // Note: Hyphens are allowed in manifest entity IDs (e.g., "engine-ecu", "front-left-door")
-  for (char c : entity_id) {
-    bool is_alphanumeric = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
-    bool is_allowed_special = (c == '_' || c == '-');
-
-    if (!is_alphanumeric && !is_allowed_special) {
-      // For non-printable characters, show the character code
-      std::string char_repr;
-      if (c < 32 || c > 126) {
-        std::ostringstream oss;
-        oss << "0x" << std::hex << std::setfill('0') << std::setw(2)
-            << static_cast<unsigned int>(static_cast<unsigned char>(c));
-        char_repr = oss.str();
-      } else {
-        char_repr = std::string(1, c);
-      }
-      return tl::unexpected("Entity ID contains invalid character: '" + char_repr +
-                            "'. Only alphanumeric, underscore and hyphen are allowed");
-    }
-  }
-
-  return {};
+  return ::ros2_medkit_gateway::validate_entity_id(entity_id);
 }
 
 tl::expected<std::string, std::string>

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -70,7 +70,8 @@ void OperationHandlers::handle_list_operations(const httplib::Request & req, htt
         }
         return;
       }
-      HandlerContext::send_json(res, json{{"items", json::array()}});
+      HandlerContext::send_error(res, 404, ERR_RESOURCE_NOT_FOUND,
+                                 "No operation provider for plugin entity '" + entity_id + "'");
       return;
     }
 
@@ -216,22 +217,12 @@ void OperationHandlers::handle_get_operation(const httplib::Request & req, httpl
       auto * op_prov = pmgr ? pmgr->get_operation_provider_for_entity(entity_id) : nullptr;
       if (op_prov) {
         try {
-          auto result = op_prov->list_operations(entity_id);
+          auto result = op_prov->get_operation(entity_id, operation_id);
           if (result) {
-            // Find matching operation in the items array
-            if (result->contains("items") && (*result)["items"].is_array()) {
-              for (const auto & item : (*result)["items"]) {
-                if (item.value("id", "") == operation_id) {
-                  HandlerContext::send_json(res, json{{"item", item}});
-                  return;
-                }
-              }
-            }
-            HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND, "Operation not found",
-                                       {{"entity_id", entity_id}, {"operation_id", operation_id}});
+            HandlerContext::send_json(res, json{{"item", *result}});
           } else {
             HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
-                                              {{"entity_id", entity_id}});
+                                              {{"entity_id", entity_id}, {"operation_id", operation_id}});
           }
         } catch (const std::exception & e) {
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -14,7 +14,6 @@
 
 #include "ros2_medkit_gateway/http/handlers/operation_handlers.hpp"
 
-#include <algorithm>
 #include <unordered_set>
 
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -64,6 +63,10 @@ void OperationHandlers::handle_list_operations(const httplib::Request & req, htt
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
                        entity_id.c_str(), e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -227,15 +230,17 @@ void OperationHandlers::handle_get_operation(const httplib::Request & req, httpl
             HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND, "Operation not found",
                                        {{"entity_id", entity_id}, {"operation_id", operation_id}});
           } else {
-            auto status = std::clamp(result.error().http_status, 400, 599);
-            auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                           : result.error().message;
-            HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg, {{"entity_id", entity_id}});
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
           }
         } catch (const std::exception & e) {
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
                        entity_id.c_str(), e.what());
-          HandlerContext::send_error(res, 500, ERR_PLUGIN_ERROR, "Plugin threw exception", {{"entity_id", entity_id}});
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -443,6 +448,10 @@ void OperationHandlers::handle_create_execution(const httplib::Request & req, ht
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
                        entity_id.c_str(), e.what());
           HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
+        } catch (...) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw unknown exception for entity '%s'",
+                       entity_id.c_str());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw unknown exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -21,6 +21,8 @@
 #include "ros2_medkit_gateway/http/http_utils.hpp"
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
 #include "ros2_medkit_gateway/operation_manager.hpp"
+#include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/providers/operation_provider.hpp"
 
 using json = nlohmann::json;
 
@@ -43,6 +45,23 @@ void OperationHandlers::handle_list_operations(const httplib::Request & req, htt
       return;  // Response already sent (error or forwarded to peer)
     }
     auto entity_info = *entity_opt;
+
+    // Delegate to plugin OperationProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * op_prov = pmgr ? pmgr->get_operation_provider_for_entity(entity_id) : nullptr;
+      if (op_prov) {
+        auto result = op_prov->list_operations(entity_id);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_json(res, json{{"items", json::array()}});
+      return;
+    }
 
     // Use ThreadSafeEntityCache for O(1) entity lookup and aggregated operations
     const auto & cache = ctx_.node()->get_thread_safe_cache();
@@ -348,6 +367,32 @@ void OperationHandlers::handle_create_execution(const httplib::Request & req, ht
       return;  // Response already sent (error or forwarded to peer)
     }
     auto entity_info = *entity_opt;
+
+    // Delegate to plugin OperationProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * op_prov = pmgr ? pmgr->get_operation_provider_for_entity(entity_id) : nullptr;
+      if (op_prov) {
+        json params = json::object();
+        if (!req.body.empty()) {
+          params = json::parse(req.body, nullptr, false);
+          if (params.is_discarded()) {
+            HandlerContext::send_error(res, 400, ERR_INVALID_REQUEST, "Invalid JSON body");
+            return;
+          }
+        }
+        auto result = op_prov->execute_operation(entity_id, operation_id, params);
+        if (result) {
+          HandlerContext::send_json(res, *result);
+        } else {
+          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND,
+                                 "No operation provider for plugin entity '" + entity_id + "'");
+      return;
+    }
 
     // Check lock access for operations
     if (ctx_.validate_lock_access(req, res, entity_info, "operations")) {

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -14,6 +14,7 @@
 
 #include "ros2_medkit_gateway/http/handlers/operation_handlers.hpp"
 
+#include <algorithm>
 #include <unordered_set>
 
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -55,7 +56,10 @@ void OperationHandlers::handle_list_operations(const httplib::Request & req, htt
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
@@ -368,6 +372,11 @@ void OperationHandlers::handle_create_execution(const httplib::Request & req, ht
     }
     auto entity_info = *entity_opt;
 
+    // Check lock access for operations (before plugin delegation - locks apply to all entities)
+    if (ctx_.validate_lock_access(req, res, entity_info, "operations")) {
+      return;
+    }
+
     // Delegate to plugin OperationProvider if entity is plugin-owned
     if (entity_info.is_plugin) {
       auto * pmgr = ctx_.node()->get_plugin_manager();
@@ -385,17 +394,15 @@ void OperationHandlers::handle_create_execution(const httplib::Request & req, ht
         if (result) {
           HandlerContext::send_json(res, *result);
         } else {
-          HandlerContext::send_error(res, result.error().http_status, "x-plugin-error", result.error().message);
+          auto status = std::clamp(result.error().http_status, 400, 599);
+          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                         : result.error().message;
+          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
         }
         return;
       }
       HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND,
                                  "No operation provider for plugin entity '" + entity_id + "'");
-      return;
-    }
-
-    // Check lock access for operations
-    if (ctx_.validate_lock_access(req, res, entity_info, "operations")) {
       return;
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -52,14 +52,18 @@ void OperationHandlers::handle_list_operations(const httplib::Request & req, htt
       auto * pmgr = ctx_.node()->get_plugin_manager();
       auto * op_prov = pmgr ? pmgr->get_operation_provider_for_entity(entity_id) : nullptr;
       if (op_prov) {
-        auto result = op_prov->list_operations(entity_id);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = op_prov->list_operations(entity_id);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
+                       entity_id.c_str(), e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }
@@ -202,6 +206,43 @@ void OperationHandlers::handle_get_operation(const httplib::Request & req, httpl
       return;  // Response already sent (error or forwarded to peer)
     }
     auto entity_info = *entity_opt;
+
+    // Delegate to plugin OperationProvider if entity is plugin-owned
+    if (entity_info.is_plugin) {
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto * op_prov = pmgr ? pmgr->get_operation_provider_for_entity(entity_id) : nullptr;
+      if (op_prov) {
+        try {
+          auto result = op_prov->list_operations(entity_id);
+          if (result) {
+            // Find matching operation in the items array
+            if (result->contains("items") && (*result)["items"].is_array()) {
+              for (const auto & item : (*result)["items"]) {
+                if (item.value("id", "") == operation_id) {
+                  HandlerContext::send_json(res, json{{"item", item}});
+                  return;
+                }
+              }
+            }
+            HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND, "Operation not found",
+                                       {{"entity_id", entity_id}, {"operation_id", operation_id}});
+          } else {
+            auto status = std::clamp(result.error().http_status, 400, 599);
+            auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
+                                                           : result.error().message;
+            HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg, {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
+                       entity_id.c_str(), e.what());
+          HandlerContext::send_error(res, 500, ERR_PLUGIN_ERROR, "Plugin threw exception", {{"entity_id", entity_id}});
+        }
+        return;
+      }
+      HandlerContext::send_error(res, 404, ERR_OPERATION_NOT_FOUND,
+                                 "No operation provider for plugin entity '" + entity_id + "'");
+      return;
+    }
 
     // Use ThreadSafeEntityCache for O(1) entity lookup
     const auto & cache = ctx_.node()->get_thread_safe_cache();
@@ -390,14 +431,18 @@ void OperationHandlers::handle_create_execution(const httplib::Request & req, ht
             return;
           }
         }
-        auto result = op_prov->execute_operation(entity_id, operation_id, params);
-        if (result) {
-          HandlerContext::send_json(res, *result);
-        } else {
-          auto status = std::clamp(result.error().http_status, 400, 599);
-          auto msg = result.error().message.size() > 512 ? result.error().message.substr(0, 512) + "..."
-                                                         : result.error().message;
-          HandlerContext::send_error(res, status, ERR_PLUGIN_ERROR, msg);
+        try {
+          auto result = op_prov->execute_operation(entity_id, operation_id, params);
+          if (result) {
+            HandlerContext::send_json(res, *result);
+          } else {
+            HandlerContext::send_plugin_error(res, result.error().http_status, result.error().message,
+                                              {{"entity_id", entity_id}});
+          }
+        } catch (const std::exception & e) {
+          RCLCPP_ERROR(HandlerContext::logger(), "Plugin OperationProvider threw for entity '%s': %s",
+                       entity_id.c_str(), e.what());
+          HandlerContext::send_plugin_error(res, 500, "Plugin threw exception", {{"entity_id", entity_id}});
         }
         return;
       }

--- a/src/ros2_medkit_gateway/src/plugins/plugin_context.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_context.cpp
@@ -18,6 +18,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <vector>
 
+#include "ros2_medkit_gateway/entity_validation.hpp"
+
 #include "ros2_medkit_gateway/condition_evaluator.hpp"
 #include "ros2_medkit_gateway/fault_manager.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -100,9 +102,9 @@ class GatewayPluginContext : public PluginContext {
 
   std::optional<PluginEntityInfo> validate_entity_for_route(const PluginRequest & req, PluginResponse & res,
                                                             const std::string & entity_id) const override {
-    // Validate entity ID format
-    if (entity_id.empty() || entity_id.size() > 256) {
-      res.send_error(400, ERR_INVALID_PARAMETER, "Invalid entity ID");
+    // Validate entity ID format (shared validation with HandlerContext)
+    if (auto err = validate_entity_id(entity_id); !err) {
+      res.send_error(400, ERR_INVALID_PARAMETER, err.error());
       return std::nullopt;
     }
 

--- a/src/ros2_medkit_gateway/src/plugins/plugin_http_types.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_http_types.cpp
@@ -14,6 +14,8 @@
 
 #include "ros2_medkit_gateway/plugins/plugin_http_types.hpp"
 
+#include <algorithm>
+
 #include <httplib.h>
 
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
@@ -61,7 +63,8 @@ void PluginResponse::send_json(const nlohmann::json & data) {
 
 void PluginResponse::send_error(int status, const std::string & error_code, const std::string & message,
                                 const nlohmann::json & parameters) {
-  handlers::HandlerContext::send_error(*static_cast<httplib::Response *>(impl_), status, error_code, message,
+  int clamped = std::clamp(status, 400, 599);
+  handlers::HandlerContext::send_error(*static_cast<httplib::Response *>(impl_), clamped, error_code, message,
                                        parameters);
 }
 

--- a/src/ros2_medkit_gateway/src/plugins/plugin_http_types.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_http_types.cpp
@@ -46,6 +46,10 @@ const std::string & PluginRequest::body() const {
   return static_cast<const httplib::Request *>(impl_)->body;
 }
 
+std::string PluginRequest::query_param(const std::string & name) const {
+  return static_cast<const httplib::Request *>(impl_)->get_param_value(name);
+}
+
 // --- PluginResponse ---
 
 PluginResponse::PluginResponse(void * impl) : impl_(impl) {

--- a/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
@@ -36,6 +36,9 @@ GatewayPluginLoadResult::~GatewayPluginLoadResult() {
   introspection_provider = nullptr;
   log_provider = nullptr;
   script_provider = nullptr;
+  data_provider = nullptr;
+  operation_provider = nullptr;
+  fault_provider = nullptr;
   plugin.reset();
   if (handle_) {
     dlclose(handle_);

--- a/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
@@ -16,6 +16,7 @@
 
 #include "ros2_medkit_gateway/plugins/plugin_types.hpp"
 #include "ros2_medkit_gateway/providers/data_provider.hpp"
+#include "ros2_medkit_gateway/providers/fault_provider.hpp"
 #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
 #include "ros2_medkit_gateway/providers/operation_provider.hpp"
 #include "ros2_medkit_gateway/providers/script_provider.hpp"
@@ -49,6 +50,7 @@ GatewayPluginLoadResult::GatewayPluginLoadResult(GatewayPluginLoadResult && othe
   , script_provider(other.script_provider)
   , data_provider(other.data_provider)
   , operation_provider(other.operation_provider)
+  , fault_provider(other.fault_provider)
   , handle_(other.handle_) {
   other.update_provider = nullptr;
   other.introspection_provider = nullptr;
@@ -56,6 +58,7 @@ GatewayPluginLoadResult::GatewayPluginLoadResult(GatewayPluginLoadResult && othe
   other.script_provider = nullptr;
   other.data_provider = nullptr;
   other.operation_provider = nullptr;
+  other.fault_provider = nullptr;
   other.handle_ = nullptr;
 }
 
@@ -68,6 +71,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     script_provider = nullptr;
     data_provider = nullptr;
     operation_provider = nullptr;
+    fault_provider = nullptr;
     plugin.reset();
     if (handle_) {
       dlclose(handle_);
@@ -81,6 +85,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     script_provider = other.script_provider;
     data_provider = other.data_provider;
     operation_provider = other.operation_provider;
+    fault_provider = other.fault_provider;
     handle_ = other.handle_;
 
     other.update_provider = nullptr;
@@ -89,6 +94,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     other.script_provider = nullptr;
     other.data_provider = nullptr;
     other.operation_provider = nullptr;
+    other.fault_provider = nullptr;
     other.handle_ = nullptr;
   }
   return *this;
@@ -263,6 +269,20 @@ tl::expected<GatewayPluginLoadResult, std::string> PluginLoader::load(const std:
                   e.what());
     } catch (...) {
       RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_operation_provider threw unknown exception in %s",
+                  plugin_path.c_str());
+    }
+  }
+
+  using FaultProviderFn = FaultProvider * (*)(GatewayPlugin *);
+  auto fault_fn = reinterpret_cast<FaultProviderFn>(dlsym(handle, "get_fault_provider"));
+  if (fault_fn) {
+    try {
+      result.fault_provider = fault_fn(raw_plugin);
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_fault_provider threw in %s: %s", plugin_path.c_str(),
+                  e.what());
+    } catch (...) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_fault_provider threw unknown exception in %s",
                   plugin_path.c_str());
     }
   }

--- a/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
@@ -47,11 +47,15 @@ GatewayPluginLoadResult::GatewayPluginLoadResult(GatewayPluginLoadResult && othe
   , introspection_provider(other.introspection_provider)
   , log_provider(other.log_provider)
   , script_provider(other.script_provider)
+  , data_provider(other.data_provider)
+  , operation_provider(other.operation_provider)
   , handle_(other.handle_) {
   other.update_provider = nullptr;
   other.introspection_provider = nullptr;
   other.log_provider = nullptr;
   other.script_provider = nullptr;
+  other.data_provider = nullptr;
+  other.operation_provider = nullptr;
   other.handle_ = nullptr;
 }
 
@@ -62,6 +66,8 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     introspection_provider = nullptr;
     log_provider = nullptr;
     script_provider = nullptr;
+    data_provider = nullptr;
+    operation_provider = nullptr;
     plugin.reset();
     if (handle_) {
       dlclose(handle_);
@@ -73,12 +79,16 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     introspection_provider = other.introspection_provider;
     log_provider = other.log_provider;
     script_provider = other.script_provider;
+    data_provider = other.data_provider;
+    operation_provider = other.operation_provider;
     handle_ = other.handle_;
 
     other.update_provider = nullptr;
     other.introspection_provider = nullptr;
     other.log_provider = nullptr;
     other.script_provider = nullptr;
+    other.data_provider = nullptr;
+    other.operation_provider = nullptr;
     other.handle_ = nullptr;
   }
   return *this;

--- a/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
@@ -15,7 +15,9 @@
 #include "ros2_medkit_gateway/plugins/plugin_loader.hpp"
 
 #include "ros2_medkit_gateway/plugins/plugin_types.hpp"
+#include "ros2_medkit_gateway/providers/data_provider.hpp"
 #include "ros2_medkit_gateway/providers/introspection_provider.hpp"
+#include "ros2_medkit_gateway/providers/operation_provider.hpp"
 #include "ros2_medkit_gateway/providers/script_provider.hpp"
 #include "ros2_medkit_gateway/providers/update_provider.hpp"
 
@@ -223,6 +225,34 @@ tl::expected<GatewayPluginLoadResult, std::string> PluginLoader::load(const std:
                   e.what());
     } catch (...) {
       RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_script_provider threw unknown exception in %s",
+                  plugin_path.c_str());
+    }
+  }
+
+  using DataProviderFn = DataProvider * (*)(GatewayPlugin *);
+  auto data_fn = reinterpret_cast<DataProviderFn>(dlsym(handle, "get_data_provider"));
+  if (data_fn) {
+    try {
+      result.data_provider = data_fn(raw_plugin);
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_data_provider threw in %s: %s", plugin_path.c_str(),
+                  e.what());
+    } catch (...) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_data_provider threw unknown exception in %s",
+                  plugin_path.c_str());
+    }
+  }
+
+  using OperationProviderFn = OperationProvider * (*)(GatewayPlugin *);
+  auto operation_fn = reinterpret_cast<OperationProviderFn>(dlsym(handle, "get_operation_provider"));
+  if (operation_fn) {
+    try {
+      result.operation_provider = operation_fn(raw_plugin);
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_operation_provider threw in %s: %s", plugin_path.c_str(),
+                  e.what());
+    } catch (...) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_operation_provider threw unknown exception in %s",
                   plugin_path.c_str());
     }
   }

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -19,6 +19,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/plugins/plugin_http_types.hpp"
 
 namespace ros2_medkit_gateway {
@@ -297,12 +298,12 @@ void PluginManager::register_routes(httplib::Server & server, const std::string 
             RCLCPP_ERROR(rclcpp::get_logger("plugin_manager"), "Plugin '%s' handler threw on %s: %s",
                          plugin_name.c_str(), full_pattern.c_str(), e.what());
             PluginResponse plugin_res(&res);
-            plugin_res.send_error(500, "x-medkit-plugin-error", "Internal plugin error");
+            plugin_res.send_error(500, ERR_PLUGIN_ERROR, "Internal plugin error");
           } catch (...) {
             RCLCPP_ERROR(rclcpp::get_logger("plugin_manager"), "Plugin '%s' handler threw unknown exception on %s",
                          plugin_name.c_str(), full_pattern.c_str());
             PluginResponse plugin_res(&res);
-            plugin_res.send_error(500, "x-medkit-plugin-error", "Internal plugin error");
+            plugin_res.send_error(500, ERR_PLUGIN_ERROR, "Internal plugin error");
           }
         };
 
@@ -431,7 +432,23 @@ void PluginManager::register_entity_ownership(const std::string & plugin_name,
                                               const std::vector<std::string> & entity_ids) {
   std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
   for (const auto & eid : entity_ids) {
+    auto it = entity_ownership_.find(eid);
+    if (it != entity_ownership_.end() && it->second != plugin_name) {
+      RCLCPP_WARN(logger(), "Entity '%s' ownership transferred from plugin '%s' to '%s'", eid.c_str(),
+                  it->second.c_str(), plugin_name.c_str());
+    }
     entity_ownership_[eid] = plugin_name;
+  }
+}
+
+void PluginManager::clear_entity_ownership(const std::string & plugin_name) {
+  std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
+  for (auto it = entity_ownership_.begin(); it != entity_ownership_.end();) {
+    if (it->second == plugin_name) {
+      it = entity_ownership_.erase(it);
+    } else {
+      ++it;
+    }
   }
 }
 

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -54,6 +54,7 @@ PluginManager::~PluginManager() {
   plugins_.clear();
 }
 
+// Called during init only (before HTTP server starts). No lock needed.
 void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   LoadedPlugin lp;
   lp.config = nlohmann::json::object();
@@ -99,6 +100,7 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   plugins_.push_back(std::move(lp));
 }
 
+// Called during init only (before HTTP server starts). No lock needed.
 size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
   size_t loaded = 0;
   for (const auto & cfg : configs) {

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -64,6 +64,7 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   lp.script_provider = dynamic_cast<ScriptProvider *>(plugin.get());
   lp.data_provider = dynamic_cast<DataProvider *>(plugin.get());
   lp.operation_provider = dynamic_cast<OperationProvider *>(plugin.get());
+  lp.fault_provider = dynamic_cast<FaultProvider *>(plugin.get());
 
   // Cache first UpdateProvider, warn on duplicates
   if (lp.update_provider) {
@@ -116,6 +117,7 @@ size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
       lp.script_provider = result->script_provider;
       lp.data_provider = result->data_provider;
       lp.operation_provider = result->operation_provider;
+      lp.fault_provider = result->fault_provider;
 
       // Cache first UpdateProvider, warn on duplicates
       if (lp.update_provider) {
@@ -202,12 +204,14 @@ void PluginManager::disable_plugin(LoadedPlugin & lp) {
   lp.script_provider = nullptr;
   lp.data_provider = nullptr;
   lp.operation_provider = nullptr;
+  lp.fault_provider = nullptr;
   lp.load_result.update_provider = nullptr;
   lp.load_result.introspection_provider = nullptr;
   lp.load_result.log_provider = nullptr;
   lp.load_result.script_provider = nullptr;
   lp.load_result.data_provider = nullptr;
   lp.load_result.operation_provider = nullptr;
+  lp.load_result.fault_provider = nullptr;
   lp.load_result.plugin.reset();
 }
 
@@ -454,6 +458,20 @@ OperationProvider * PluginManager::get_operation_provider_for_entity(const std::
   for (const auto & lp : plugins_) {
     if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
       return lp.operation_provider;
+    }
+  }
+  return nullptr;
+}
+
+FaultProvider * PluginManager::get_fault_provider_for_entity(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto own_it = entity_ownership_.find(entity_id);
+  if (own_it == entity_ownership_.end()) {
+    return nullptr;
+  }
+  for (const auto & lp : plugins_) {
+    if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
+      return lp.fault_provider;
     }
   }
   return nullptr;

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -423,6 +423,51 @@ std::vector<std::string> PluginManager::plugin_names() const {
   return names;
 }
 
+void PluginManager::register_entity_ownership(const std::string & plugin_name,
+                                              const std::vector<std::string> & entity_ids) {
+  std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
+  for (const auto & eid : entity_ids) {
+    entity_ownership_[eid] = plugin_name;
+  }
+}
+
+DataProvider * PluginManager::get_data_provider_for_entity(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto own_it = entity_ownership_.find(entity_id);
+  if (own_it == entity_ownership_.end()) {
+    return nullptr;
+  }
+  for (const auto & lp : plugins_) {
+    if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
+      return lp.data_provider;
+    }
+  }
+  return nullptr;
+}
+
+OperationProvider * PluginManager::get_operation_provider_for_entity(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto own_it = entity_ownership_.find(entity_id);
+  if (own_it == entity_ownership_.end()) {
+    return nullptr;
+  }
+  for (const auto & lp : plugins_) {
+    if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
+      return lp.operation_provider;
+    }
+  }
+  return nullptr;
+}
+
+std::optional<std::string> PluginManager::get_entity_owner(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto it = entity_ownership_.find(entity_id);
+  if (it != entity_ownership_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
 std::vector<openapi::RouteDescriptions> PluginManager::collect_route_descriptions() const {
   std::vector<openapi::RouteDescriptions> all_descriptions;
   std::shared_lock<std::shared_mutex> lock(plugins_mutex_);

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -62,6 +62,8 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   lp.introspection_provider = dynamic_cast<IntrospectionProvider *>(plugin.get());
   lp.log_provider = dynamic_cast<LogProvider *>(plugin.get());
   lp.script_provider = dynamic_cast<ScriptProvider *>(plugin.get());
+  lp.data_provider = dynamic_cast<DataProvider *>(plugin.get());
+  lp.operation_provider = dynamic_cast<OperationProvider *>(plugin.get());
 
   // Cache first UpdateProvider, warn on duplicates
   if (lp.update_provider) {
@@ -112,6 +114,8 @@ size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
       // IntrospectionProvider mechanism - safe across the dlopen boundary).
       lp.log_provider = result->log_provider;
       lp.script_provider = result->script_provider;
+      lp.data_provider = result->data_provider;
+      lp.operation_provider = result->operation_provider;
 
       // Cache first UpdateProvider, warn on duplicates
       if (lp.update_provider) {
@@ -196,10 +200,14 @@ void PluginManager::disable_plugin(LoadedPlugin & lp) {
   lp.introspection_provider = nullptr;
   lp.log_provider = nullptr;
   lp.script_provider = nullptr;
+  lp.data_provider = nullptr;
+  lp.operation_provider = nullptr;
   lp.load_result.update_provider = nullptr;
   lp.load_result.introspection_provider = nullptr;
   lp.load_result.log_provider = nullptr;
   lp.load_result.script_provider = nullptr;
+  lp.load_result.data_provider = nullptr;
+  lp.load_result.operation_provider = nullptr;
   lp.load_result.plugin.reset();
 }
 

--- a/src/ros2_medkit_gateway/test/test_plugin_config.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_config.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @verifies REQ_INTEROP_098
 /// Tests that plugin config from --params-file YAML reaches the gateway plugin framework.
 ///
 /// The bug: extract_plugin_config() read from get_node_options().parameter_overrides(),

--- a/src/ros2_medkit_gateway/test/test_plugin_config.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_config.cpp
@@ -83,6 +83,16 @@ TEST(PluginConfig, YamlPluginParamsReachGateway) {
   ASSERT_TRUE(node->has_parameter("plugins.my_plugin.threshold"));
   EXPECT_DOUBLE_EQ(node->get_parameter("plugins.my_plugin.threshold").as_double(), 3.14);
 
+  // Verify list_parameters finds declared params with the correct prefix.
+  // ROS 2 list_parameters uses "." as hierarchy separator.
+  // Prefix WITHOUT trailing dot works; prefix WITH trailing dot returns nothing.
+  auto result_no_dot = node->list_parameters({"plugins.my_plugin"}, 10);
+  EXPECT_GE(result_no_dot.names.size(), 5u) << "list_parameters with prefix (no trailing dot) should find params";
+
+  auto result_with_dot = node->list_parameters({"plugins.my_plugin."}, 10);
+  EXPECT_EQ(result_with_dot.names.size(), 0u) << "list_parameters with trailing dot returns nothing - "
+                                              << "extract_plugin_config must use prefix without trailing dot";
+
   node.reset();
   rclcpp::shutdown();
   std::remove(yaml_path.c_str());

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -335,6 +335,45 @@ TEST(PluginEntityRouting, ClearEntityOwnership) {
   EXPECT_EQ(*mgr.get_entity_owner("ent3"), "plugin_b");
 }
 
+// =============================================================================
+// OperationProvider list+filter contract (used by handle_get_operation)
+// =============================================================================
+
+TEST(PluginEntityRouting, OperationListFilterFindsMatchingItem) {
+  // Verifies the contract that handle_get_operation depends on:
+  // list_operations returns {"items": [...]}, handler scans for matching "id"
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockDataOpPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("test_plugin", {"my_ecu"});
+
+  auto * op = mgr.get_operation_provider_for_entity("my_ecu");
+  ASSERT_NE(op, nullptr);
+  auto result = op->list_operations("my_ecu");
+  ASSERT_TRUE(result.has_value());
+  ASSERT_TRUE(result->contains("items"));
+  ASSERT_TRUE((*result)["items"].is_array());
+
+  // Simulate handler's filter logic: find item with matching "id"
+  bool found = false;
+  for (const auto & item : (*result)["items"]) {
+    if (item.value("id", "") == "test_op") {
+      found = true;
+      EXPECT_EQ(item["entity"], "my_ecu");
+    }
+  }
+  EXPECT_TRUE(found);
+
+  // Non-matching ID should not be found
+  bool found_nonexistent = false;
+  for (const auto & item : (*result)["items"]) {
+    if (item.value("id", "") == "nonexistent_op") {
+      found_nonexistent = true;
+    }
+  }
+  EXPECT_FALSE(found_nonexistent);
+}
+
 TEST(PluginEntityRouting, ClearAndReregisterOwnership) {
   PluginManager mgr;
   mgr.register_entity_ownership("plugin_a", {"ent1", "ent2"});

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -339,9 +339,54 @@ TEST(PluginEntityRouting, ClearEntityOwnership) {
 // OperationProvider list+filter contract (used by handle_get_operation)
 // =============================================================================
 
-TEST(PluginEntityRouting, OperationListFilterFindsMatchingItem) {
-  // Verifies the contract that handle_get_operation depends on:
-  // list_operations returns {"items": [...]}, handler scans for matching "id"
+// =============================================================================
+// OperationProvider Error Propagation Tests
+// =============================================================================
+
+class MockErrorOpPlugin : public GatewayPlugin, public OperationProvider {
+ public:
+  std::string name() const override {
+    return "error_op_plugin";
+  }
+  void configure(const json &) override {
+  }
+  void shutdown() override {
+  }
+
+  tl::expected<json, OperationProviderErrorInfo> list_operations(const std::string &) override {
+    return tl::make_unexpected(OperationProviderErrorInfo{OperationProviderError::TransportError, "unreachable", 503});
+  }
+  tl::expected<json, OperationProviderErrorInfo> execute_operation(const std::string &, const std::string &,
+                                                                   const json &) override {
+    return tl::make_unexpected(OperationProviderErrorInfo{OperationProviderError::Rejected, "rejected", 409});
+  }
+};
+
+TEST(PluginEntityRouting, OperationProviderErrorPropagation) {
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockErrorOpPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("error_op_plugin", {"bad_ecu"});
+
+  auto * op = mgr.get_operation_provider_for_entity("bad_ecu");
+  ASSERT_NE(op, nullptr);
+
+  auto list_result = op->list_operations("bad_ecu");
+  ASSERT_FALSE(list_result.has_value());
+  EXPECT_EQ(list_result.error().http_status, 503);
+  EXPECT_EQ(list_result.error().code, OperationProviderError::TransportError);
+
+  auto exec_result = op->execute_operation("bad_ecu", "reset", json::object());
+  ASSERT_FALSE(exec_result.has_value());
+  EXPECT_EQ(exec_result.error().http_status, 409);
+  EXPECT_EQ(exec_result.error().code, OperationProviderError::Rejected);
+}
+
+// =============================================================================
+// get_operation() default implementation tests
+// =============================================================================
+
+TEST(PluginEntityRouting, GetOperationDefaultFindsMatch) {
   PluginManager mgr;
   auto plugin = std::make_unique<MockDataOpPlugin>();
   mgr.add_plugin(std::move(plugin));
@@ -349,29 +394,40 @@ TEST(PluginEntityRouting, OperationListFilterFindsMatchingItem) {
 
   auto * op = mgr.get_operation_provider_for_entity("my_ecu");
   ASSERT_NE(op, nullptr);
-  auto result = op->list_operations("my_ecu");
+
+  auto result = op->get_operation("my_ecu", "test_op");
   ASSERT_TRUE(result.has_value());
-  ASSERT_TRUE(result->contains("items"));
-  ASSERT_TRUE((*result)["items"].is_array());
+  EXPECT_EQ((*result)["id"], "test_op");
+  EXPECT_EQ((*result)["entity"], "my_ecu");
+}
 
-  // Simulate handler's filter logic: find item with matching "id"
-  bool found = false;
-  for (const auto & item : (*result)["items"]) {
-    if (item.value("id", "") == "test_op") {
-      found = true;
-      EXPECT_EQ(item["entity"], "my_ecu");
-    }
-  }
-  EXPECT_TRUE(found);
+TEST(PluginEntityRouting, GetOperationDefaultReturnsNotFound) {
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockDataOpPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("test_plugin", {"my_ecu"});
 
-  // Non-matching ID should not be found
-  bool found_nonexistent = false;
-  for (const auto & item : (*result)["items"]) {
-    if (item.value("id", "") == "nonexistent_op") {
-      found_nonexistent = true;
-    }
-  }
-  EXPECT_FALSE(found_nonexistent);
+  auto * op = mgr.get_operation_provider_for_entity("my_ecu");
+  ASSERT_NE(op, nullptr);
+
+  auto result = op->get_operation("my_ecu", "nonexistent_op");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 404);
+  EXPECT_EQ(result.error().code, OperationProviderError::OperationNotFound);
+}
+
+TEST(PluginEntityRouting, GetOperationPropagatesListError) {
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockErrorOpPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("error_op_plugin", {"bad_ecu"});
+
+  auto * op = mgr.get_operation_provider_for_entity("bad_ecu");
+  ASSERT_NE(op, nullptr);
+
+  auto result = op->get_operation("bad_ecu", "any_op");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 503);
 }
 
 TEST(PluginEntityRouting, OwnershipForNonLoadedPluginReturnsNullProviders) {

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -16,6 +16,7 @@
 
 #include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
 #include "ros2_medkit_gateway/providers/data_provider.hpp"
+#include "ros2_medkit_gateway/providers/fault_provider.hpp"
 #include "ros2_medkit_gateway/providers/operation_provider.hpp"
 
 using namespace ros2_medkit_gateway;
@@ -174,4 +175,175 @@ TEST(PluginEntityRouting, UnownedEntityReturnsNullProviders) {
   // Don't register ownership - entity is not owned by any plugin
   EXPECT_EQ(mgr.get_data_provider_for_entity("unowned"), nullptr);
   EXPECT_EQ(mgr.get_operation_provider_for_entity("unowned"), nullptr);
+}
+
+// =============================================================================
+// FaultProvider Routing Tests
+// =============================================================================
+
+class MockFaultPlugin : public GatewayPlugin, public FaultProvider {
+ public:
+  std::string name() const override {
+    return "fault_plugin";
+  }
+  void configure(const json &) override {
+  }
+  void shutdown() override {
+  }
+
+  tl::expected<json, FaultProviderErrorInfo> list_faults(const std::string & entity_id) override {
+    return json{{"items", json::array({{{"code", "DTC_001"}, {"entity", entity_id}}})}};
+  }
+  tl::expected<json, FaultProviderErrorInfo> get_fault(const std::string &, const std::string & code) override {
+    return json{{"code", code}, {"status", "pending"}};
+  }
+  tl::expected<json, FaultProviderErrorInfo> clear_fault(const std::string &, const std::string & code) override {
+    return json{{"code", code}, {"cleared", true}};
+  }
+};
+
+TEST(PluginEntityRouting, FaultProviderResolvedForOwnedEntity) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockFaultPlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("fault_plugin", {"my_ecu"});
+
+  auto * fp = mgr.get_fault_provider_for_entity("my_ecu");
+  ASSERT_NE(fp, nullptr);
+  EXPECT_EQ(fp, static_cast<FaultProvider *>(raw));
+
+  auto result = fp->list_faults("my_ecu");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ((*result)["items"][0]["code"], "DTC_001");
+}
+
+TEST(PluginEntityRouting, BarePluginReturnsNullFaultProvider) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockBarePlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("bare_plugin", {"entity1"});
+  EXPECT_EQ(mgr.get_fault_provider_for_entity("entity1"), nullptr);
+}
+
+TEST(PluginEntityRouting, UnownedEntityReturnsNullFaultProvider) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockFaultPlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  EXPECT_EQ(mgr.get_fault_provider_for_entity("unowned"), nullptr);
+}
+
+// =============================================================================
+// Error Propagation Tests
+// =============================================================================
+
+class MockErrorPlugin : public GatewayPlugin, public DataProvider, public FaultProvider {
+ public:
+  std::string name() const override {
+    return "error_plugin";
+  }
+  void configure(const json &) override {
+  }
+  void shutdown() override {
+  }
+
+  tl::expected<json, DataProviderErrorInfo> list_data(const std::string &) override {
+    return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::TransportError, "backend unavailable", 503});
+  }
+  tl::expected<json, DataProviderErrorInfo> read_data(const std::string &, const std::string &) override {
+    return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::ResourceNotFound, "no such resource", 404});
+  }
+  tl::expected<json, DataProviderErrorInfo> write_data(const std::string &, const std::string &,
+                                                       const json &) override {
+    return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::ReadOnly, "read-only entity", 403});
+  }
+
+  tl::expected<json, FaultProviderErrorInfo> list_faults(const std::string &) override {
+    return tl::make_unexpected(FaultProviderErrorInfo{FaultProviderError::TransportError, "not reachable", 503});
+  }
+  tl::expected<json, FaultProviderErrorInfo> get_fault(const std::string &, const std::string &) override {
+    return tl::make_unexpected(FaultProviderErrorInfo{FaultProviderError::FaultNotFound, "unknown fault", 404});
+  }
+  tl::expected<json, FaultProviderErrorInfo> clear_fault(const std::string &, const std::string &) override {
+    return tl::make_unexpected(FaultProviderErrorInfo{FaultProviderError::Internal, "cannot clear", 409});
+  }
+};
+
+TEST(PluginEntityRouting, DataProviderErrorPropagation) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockErrorPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("error_plugin", {"bad_ecu"});
+
+  auto * dp = mgr.get_data_provider_for_entity("bad_ecu");
+  ASSERT_NE(dp, nullptr);
+
+  auto result = dp->list_data("bad_ecu");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 503);
+  EXPECT_EQ(result.error().message, "backend unavailable");
+  EXPECT_EQ(result.error().code, DataProviderError::TransportError);
+}
+
+TEST(PluginEntityRouting, FaultProviderErrorPropagation) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockErrorPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("error_plugin", {"bad_ecu"});
+
+  auto * fp = mgr.get_fault_provider_for_entity("bad_ecu");
+  ASSERT_NE(fp, nullptr);
+
+  auto result = fp->get_fault("bad_ecu", "DTC_999");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 404);
+  EXPECT_EQ(result.error().message, "unknown fault");
+}
+
+// =============================================================================
+// Entity Ownership Conflict Tests
+// =============================================================================
+
+TEST(PluginEntityRouting, OwnershipConflictLastWins) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("plugin_a", {"shared_entity"});
+  mgr.register_entity_ownership("plugin_b", {"shared_entity"});
+
+  auto owner = mgr.get_entity_owner("shared_entity");
+  ASSERT_TRUE(owner.has_value());
+  EXPECT_EQ(*owner, "plugin_b");
+}
+
+TEST(PluginEntityRouting, ClearEntityOwnership) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("plugin_a", {"ent1", "ent2"});
+  mgr.register_entity_ownership("plugin_b", {"ent3"});
+
+  mgr.clear_entity_ownership("plugin_a");
+
+  EXPECT_FALSE(mgr.get_entity_owner("ent1").has_value());
+  EXPECT_FALSE(mgr.get_entity_owner("ent2").has_value());
+  // plugin_b's entity should be unaffected
+  EXPECT_EQ(*mgr.get_entity_owner("ent3"), "plugin_b");
+}
+
+TEST(PluginEntityRouting, ClearAndReregisterOwnership) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("plugin_a", {"ent1", "ent2"});
+
+  // Simulate refresh: entity2 disappeared, entity3 appeared
+  mgr.clear_entity_ownership("plugin_a");
+  mgr.register_entity_ownership("plugin_a", {"ent1", "ent3"});
+
+  EXPECT_TRUE(mgr.get_entity_owner("ent1").has_value());
+  EXPECT_FALSE(mgr.get_entity_owner("ent2").has_value());  // removed
+  EXPECT_TRUE(mgr.get_entity_owner("ent3").has_value());   // added
 }

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_gateway/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/providers/data_provider.hpp"
+#include "ros2_medkit_gateway/providers/operation_provider.hpp"
+
+using namespace ros2_medkit_gateway;
+using json = nlohmann::json;
+
+// --- Mock plugin implementing DataProvider + OperationProvider ---
+
+class MockDataOpPlugin : public GatewayPlugin, public DataProvider, public OperationProvider {
+ public:
+  std::string name() const override {
+    return name_;
+  }
+  void configure(const json &) override {
+  }
+  void shutdown() override {
+  }
+
+  // DataProvider
+  tl::expected<json, DataProviderErrorInfo> list_data(const std::string & entity_id) override {
+    return json{{"items", json::array({{{"id", "test_data"}, {"entity", entity_id}}})}};
+  }
+  tl::expected<json, DataProviderErrorInfo> read_data(const std::string &, const std::string & resource) override {
+    return json{{"value", resource}};
+  }
+  tl::expected<json, DataProviderErrorInfo> write_data(const std::string &, const std::string &,
+                                                       const json &) override {
+    return json{{"status", "ok"}};
+  }
+
+  // OperationProvider
+  tl::expected<json, OperationProviderErrorInfo> list_operations(const std::string & entity_id) override {
+    return json{{"items", json::array({{{"id", "test_op"}, {"entity", entity_id}}})}};
+  }
+  tl::expected<json, OperationProviderErrorInfo> execute_operation(const std::string &, const std::string & op,
+                                                                   const json &) override {
+    return json{{"executed", op}};
+  }
+
+  std::string name_ = "test_plugin";
+};
+
+// --- Mock plugin without providers ---
+
+class MockBarePlugin : public GatewayPlugin {
+ public:
+  std::string name() const override {
+    return "bare_plugin";
+  }
+  void configure(const json &) override {
+  }
+  void shutdown() override {
+  }
+};
+
+// =============================================================================
+// Entity Ownership Tests
+// =============================================================================
+
+TEST(PluginEntityRouting, UnknownEntityReturnsNullopt) {
+  PluginManager mgr;
+  EXPECT_FALSE(mgr.get_entity_owner("nonexistent").has_value());
+  EXPECT_EQ(mgr.get_data_provider_for_entity("nonexistent"), nullptr);
+  EXPECT_EQ(mgr.get_operation_provider_for_entity("nonexistent"), nullptr);
+}
+
+TEST(PluginEntityRouting, RegisteredEntityReturnsOwner) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("uds_gateway", {"ecu1", "ecu2"});
+
+  auto owner1 = mgr.get_entity_owner("ecu1");
+  ASSERT_TRUE(owner1.has_value());
+  EXPECT_EQ(*owner1, "uds_gateway");
+
+  auto owner2 = mgr.get_entity_owner("ecu2");
+  ASSERT_TRUE(owner2.has_value());
+  EXPECT_EQ(*owner2, "uds_gateway");
+
+  EXPECT_FALSE(mgr.get_entity_owner("ecu3").has_value());
+}
+
+TEST(PluginEntityRouting, MultiplePluginsOwnDifferentEntities) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("uds_gateway", {"ecu1"});
+  mgr.register_entity_ownership("opcua_gateway", {"plc1"});
+
+  EXPECT_EQ(*mgr.get_entity_owner("ecu1"), "uds_gateway");
+  EXPECT_EQ(*mgr.get_entity_owner("plc1"), "opcua_gateway");
+}
+
+// =============================================================================
+// Provider Routing Tests (with in-process plugins via add_plugin)
+// =============================================================================
+
+TEST(PluginEntityRouting, DataProviderResolvedForOwnedEntity) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockDataOpPlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+
+  // Register ownership
+  mgr.register_entity_ownership("test_plugin", {"my_ecu"});
+
+  // Should resolve to the plugin's DataProvider
+  auto * dp = mgr.get_data_provider_for_entity("my_ecu");
+  ASSERT_NE(dp, nullptr);
+  EXPECT_EQ(dp, static_cast<DataProvider *>(raw));
+
+  // Verify it actually works
+  auto result = dp->list_data("my_ecu");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ((*result)["items"][0]["entity"], "my_ecu");
+}
+
+TEST(PluginEntityRouting, OperationProviderResolvedForOwnedEntity) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockDataOpPlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("test_plugin", {"my_ecu"});
+
+  auto * op = mgr.get_operation_provider_for_entity("my_ecu");
+  ASSERT_NE(op, nullptr);
+  EXPECT_EQ(op, static_cast<OperationProvider *>(raw));
+
+  auto result = op->execute_operation("my_ecu", "reset", json::object());
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ((*result)["executed"], "reset");
+}
+
+TEST(PluginEntityRouting, BarePluginReturnsNullProviders) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockBarePlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("bare_plugin", {"entity1"});
+
+  // Entity is owned, but plugin doesn't implement providers
+  auto owner = mgr.get_entity_owner("entity1");
+  ASSERT_TRUE(owner.has_value());
+  EXPECT_EQ(*owner, "bare_plugin");
+
+  EXPECT_EQ(mgr.get_data_provider_for_entity("entity1"), nullptr);
+  EXPECT_EQ(mgr.get_operation_provider_for_entity("entity1"), nullptr);
+}
+
+TEST(PluginEntityRouting, UnownedEntityReturnsNullProviders) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockDataOpPlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  // Don't register ownership - entity is not owned by any plugin
+  EXPECT_EQ(mgr.get_data_provider_for_entity("unowned"), nullptr);
+  EXPECT_EQ(mgr.get_operation_provider_for_entity("unowned"), nullptr);
+}

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -20,7 +20,7 @@
 #include "ros2_medkit_gateway/providers/operation_provider.hpp"
 
 using namespace ros2_medkit_gateway;
-using json = nlohmann::json;
+// json alias already available via ros2_medkit_gateway namespace headers
 
 // --- Mock plugin implementing DataProvider + OperationProvider ---
 
@@ -372,6 +372,19 @@ TEST(PluginEntityRouting, OperationListFilterFindsMatchingItem) {
     }
   }
   EXPECT_FALSE(found_nonexistent);
+}
+
+TEST(PluginEntityRouting, OwnershipForNonLoadedPluginReturnsNullProviders) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("ghost_plugin", {"entity1"});
+
+  auto owner = mgr.get_entity_owner("entity1");
+  ASSERT_TRUE(owner.has_value());
+  EXPECT_EQ(*owner, "ghost_plugin");
+
+  EXPECT_EQ(mgr.get_data_provider_for_entity("entity1"), nullptr);
+  EXPECT_EQ(mgr.get_operation_provider_for_entity("entity1"), nullptr);
+  EXPECT_EQ(mgr.get_fault_provider_for_entity("entity1"), nullptr);
 }
 
 TEST(PluginEntityRouting, ClearAndReregisterOwnership) {

--- a/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
@@ -63,6 +63,17 @@ TEST(PluginRequestTest, Body) {
   EXPECT_EQ(preq.body(), R"({"key": "value"})");
 }
 
+TEST(PluginRequestTest, QueryParam) {
+  httplib::Request req;
+  req.params.emplace("filter", "active");
+  req.params.emplace("limit", "10");
+
+  PluginRequest preq(&req);
+  EXPECT_EQ(preq.query_param("filter"), "active");
+  EXPECT_EQ(preq.query_param("limit"), "10");
+  EXPECT_EQ(preq.query_param("nonexistent"), "");
+}
+
 TEST(PluginResponseTest, SendJson) {
   httplib::Response res;
 

--- a/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
@@ -141,6 +141,8 @@ TEST(SendPluginErrorTest, PassesThroughValidStatus) {
   EXPECT_EQ(res.status, 503);
   auto body = nlohmann::json::parse(res.body);
   EXPECT_EQ(body["message"], "service unavailable");
+  EXPECT_EQ(body["error_code"], "vendor-error");
+  EXPECT_EQ(body["vendor_code"], "x-medkit-plugin-error");
 }
 
 TEST(SendPluginErrorTest, TruncatesLongMessage) {

--- a/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_http_types.cpp
@@ -16,7 +16,9 @@
 #include <httplib.h>
 
 #include <regex>
+#include <string>
 
+#include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
 #include "ros2_medkit_gateway/plugins/plugin_http_types.hpp"
 
 using namespace ros2_medkit_gateway;
@@ -94,4 +96,66 @@ TEST(PluginResponseTest, SendError) {
   auto body = nlohmann::json::parse(res.body);
   EXPECT_EQ(body["error_code"], "not-found");
   EXPECT_EQ(body["message"], "Entity not found");
+}
+
+TEST(PluginResponseTest, SendErrorClampsLowStatus) {
+  httplib::Response res;
+  PluginResponse pres(&res);
+  pres.send_error(200, "bad-status", "Should clamp to 400");
+  EXPECT_EQ(res.status, 400);
+}
+
+TEST(PluginResponseTest, SendErrorClampsHighStatus) {
+  httplib::Response res;
+  PluginResponse pres(&res);
+  pres.send_error(999, "bad-status", "Should clamp to 599");
+  EXPECT_EQ(res.status, 599);
+}
+
+TEST(PluginResponseTest, SendErrorClampsNegativeStatus) {
+  httplib::Response res;
+  PluginResponse pres(&res);
+  pres.send_error(-1, "bad-status", "Should clamp to 400");
+  EXPECT_EQ(res.status, 400);
+}
+
+// =============================================================================
+// send_plugin_error tests (HandlerContext static method)
+// =============================================================================
+
+TEST(SendPluginErrorTest, ClampsLowStatus) {
+  httplib::Response res;
+  handlers::HandlerContext::send_plugin_error(res, 200, "test error");
+  EXPECT_EQ(res.status, 400);
+}
+
+TEST(SendPluginErrorTest, ClampsHighStatus) {
+  httplib::Response res;
+  handlers::HandlerContext::send_plugin_error(res, 999, "test error");
+  EXPECT_EQ(res.status, 599);
+}
+
+TEST(SendPluginErrorTest, PassesThroughValidStatus) {
+  httplib::Response res;
+  handlers::HandlerContext::send_plugin_error(res, 503, "service unavailable");
+  EXPECT_EQ(res.status, 503);
+  auto body = nlohmann::json::parse(res.body);
+  EXPECT_EQ(body["message"], "service unavailable");
+}
+
+TEST(SendPluginErrorTest, TruncatesLongMessage) {
+  httplib::Response res;
+  std::string long_msg(600, 'x');
+  handlers::HandlerContext::send_plugin_error(res, 500, long_msg);
+  auto body = nlohmann::json::parse(res.body);
+  std::string msg = body["message"];
+  EXPECT_LE(msg.size(), 516u);  // 512 + "..."
+  EXPECT_TRUE(msg.find("...") != std::string::npos);
+}
+
+TEST(SendPluginErrorTest, IncludesExtraParams) {
+  httplib::Response res;
+  handlers::HandlerContext::send_plugin_error(res, 500, "fail", {{"entity_id", "ecu1"}});
+  auto body = nlohmann::json::parse(res.body);
+  EXPECT_EQ(body["parameters"]["entity_id"], "ecu1");
 }

--- a/src/ros2_medkit_msgs/design/index.rst
+++ b/src/ros2_medkit_msgs/design/index.rst
@@ -35,6 +35,8 @@ Message Definitions
      - Muted fault tracking (code, entity, mute reason, expiry)
    * - ``MedkitDiscoveryHint.msg``
      - Beacon discovery hint published by nodes for the topic beacon plugin
+   * - ``EntityInfo.msg``
+     - SOVD entity representation for service interface: ID, type, capabilities, metadata
 
 Service Definitions
 -------------------
@@ -61,6 +63,12 @@ Service Definitions
      - Retrieve rosbag file path for download
    * - ``ListRosbags.srv``
      - List all available rosbag snapshots
+   * - ``ListEntities.srv``
+     - List entities with optional type filtering (for SOVD service interface)
+   * - ``GetEntityData.srv``
+     - Get data items for a specific entity (for SOVD service interface)
+   * - ``GetCapabilities.srv``
+     - Get capabilities/resource collections for a specific entity (for SOVD service interface)
 
 Design Decisions
 ----------------

--- a/src/ros2_medkit_msgs/design/index.rst
+++ b/src/ros2_medkit_msgs/design/index.rst
@@ -36,7 +36,7 @@ Message Definitions
    * - ``MedkitDiscoveryHint.msg``
      - Beacon discovery hint published by nodes for the topic beacon plugin
    * - ``EntityInfo.msg``
-     - SOVD entity representation for service interface: ID, type, capabilities, metadata
+     - SOVD entity representation for service interface: ID, type, name, parent, FQN, capabilities
 
 Service Definitions
 -------------------

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CMakeLists.txt
@@ -31,16 +31,6 @@ find_package(ros2_medkit_gateway REQUIRED)
 find_package(ros2_medkit_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
-find_package(OpenSSL REQUIRED)
-
-# cpp-httplib via multi-distro compatibility macro.
-# On Humble the system package is too old (0.10.x); fall back to gateway's
-# vendored copy which is installed alongside the gateway package.
-set(_gw_vendored "${ros2_medkit_gateway_DIR}/../vendored/cpp_httplib")
-medkit_find_cpp_httplib(VENDORED_DIR "${_gw_vendored}")
-
-# Enable OpenSSL support for cpp-httplib
-add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
 
 # MODULE target: loaded via dlopen at runtime by PluginManager.
 # Symbols from gateway_lib are resolved from the host process at runtime.
@@ -66,8 +56,6 @@ target_link_options(sovd_service_interface PRIVATE
 
 target_link_libraries(sovd_service_interface
   nlohmann_json::nlohmann_json
-  cpp_httplib_target
-  OpenSSL::SSL OpenSSL::Crypto
 )
 
 install(TARGETS sovd_service_interface
@@ -110,8 +98,6 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_sovd_service_interface
     nlohmann_json::nlohmann_json
-    cpp_httplib_target
-    OpenSSL::SSL OpenSSL::Crypto
   )
   medkit_set_test_domain(test_sovd_service_interface)
 endif()

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
@@ -8,11 +8,12 @@ The ``ros2_medkit_sovd_service_interface`` package implements a gateway plugin t
 exposes the medkit entity tree and fault data via standard ROS 2 services. This enables
 other ROS 2 nodes to query gateway entities and faults without going through the HTTP API.
 
-The plugin creates three ROS 2 services:
+The plugin creates four ROS 2 services:
 
 - ``~/list_entities`` - lists entities by type (areas, components, apps, functions)
 - ``~/get_entity_data`` - returns data items for a specific entity
 - ``~/get_capabilities`` - returns the capability set for a specific entity
+- ``~/list_entity_faults`` - lists faults for a specific entity
 
 Architecture
 ------------
@@ -32,6 +33,7 @@ existing managers and exposes it via ROS 2 service interfaces.
    |   |           |-- ~/list_entities service             |
    |   |           |-- ~/get_entity_data service           |
    |   |           |-- ~/get_capabilities service          |
+   |   |           |-- ~/list_entity_faults service        |
    |   |           +-- PluginContext (read-only access)     |
    |   +-- EntityCache <---+                               |
    |   +-- FaultManager <--+                               |
@@ -58,6 +60,7 @@ The plugin uses custom message types from ``ros2_medkit_msgs``:
 - ``ListEntities.srv`` - request/response for entity listing with type filter
 - ``GetEntityData.srv`` - request/response for entity data retrieval
 - ``GetCapabilities.srv`` - request/response for entity capability queries
+- ``ListFaultsForEntity.srv`` - request/response for entity fault listing
 
 Design Decisions
 ----------------
@@ -79,5 +82,6 @@ This keeps it simple and avoids circular dependencies.
 PluginContext Read-Only Access
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The plugin only uses read-only ``PluginContext`` methods (``list_entities()``,
-``get_entity()``, ``get_entity_data()``). It never mutates gateway state.
+The plugin only uses read-only ``PluginContext`` methods (``get_entity_snapshot()``,
+``get_entity()``, ``list_entity_faults()``, ``get_entity_capabilities()``,
+``get_type_capabilities()``). It never mutates gateway state.

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
@@ -48,8 +48,7 @@ Key Components
   the ``PluginContext`` entity cache for data.
 
 **Service Exports** (``src/service_exports.cpp``)
-  Standard plugin C API: ``plugin_api_version()``, ``create_plugin()``,
-  ``destroy_plugin()``.
+  Standard plugin C API: ``plugin_api_version()``, ``create_plugin()``.
 
 Message Types
 -------------

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/design/index.rst
@@ -1,0 +1,83 @@
+ros2_medkit_sovd_service_interface
+====================================
+
+Overview
+--------
+
+The ``ros2_medkit_sovd_service_interface`` package implements a gateway plugin that
+exposes the medkit entity tree and fault data via standard ROS 2 services. This enables
+other ROS 2 nodes to query gateway entities and faults without going through the HTTP API.
+
+The plugin creates three ROS 2 services:
+
+- ``~/list_entities`` - lists entities by type (areas, components, apps, functions)
+- ``~/get_entity_data`` - returns data items for a specific entity
+- ``~/get_capabilities`` - returns the capability set for a specific entity
+
+Architecture
+------------
+
+The plugin runs as a gateway MODULE (loaded via dlopen) and uses ``PluginContext`` to
+access the entity cache and fault manager. It does not implement any provider interfaces
+(DataProvider, OperationProvider, etc.) - instead it reads data from the gateway's
+existing managers and exposes it via ROS 2 service interfaces.
+
+.. code-block:: text
+
+   Gateway Process
+   +------------------------------------------------------+
+   | GatewayNode                                          |
+   |   +-- PluginManager                                  |
+   |   |     +-- SovdServiceInterface (MODULE .so)        |
+   |   |           |-- ~/list_entities service             |
+   |   |           |-- ~/get_entity_data service           |
+   |   |           |-- ~/get_capabilities service          |
+   |   |           +-- PluginContext (read-only access)     |
+   |   +-- EntityCache <---+                               |
+   |   +-- FaultManager <--+                               |
+   +------------------------------------------------------+
+
+Key Components
+--------------
+
+**SovdServiceInterface** (``src/sovd_service_interface.cpp``)
+  Main plugin class inheriting ``GatewayPlugin``. Creates ROS 2 services during
+  ``configure()`` and destroys them during ``shutdown()``. Service callbacks query
+  the ``PluginContext`` entity cache for data.
+
+**Service Exports** (``src/service_exports.cpp``)
+  Standard plugin C API: ``plugin_api_version()``, ``create_plugin()``,
+  ``destroy_plugin()``.
+
+Message Types
+-------------
+
+The plugin uses custom message types from ``ros2_medkit_msgs``:
+
+- ``EntityInfo.msg`` - entity representation with ID, type, name, capabilities
+- ``ListEntities.srv`` - request/response for entity listing with type filter
+- ``GetEntityData.srv`` - request/response for entity data retrieval
+- ``GetCapabilities.srv`` - request/response for entity capability queries
+
+Design Decisions
+----------------
+
+ROS 2 Services over Topics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Services were chosen over topics because entity queries are inherently request-response.
+Topics would require a pub/sub pattern that adds complexity without benefit for
+point-in-time queries.
+
+No Provider Interfaces
+~~~~~~~~~~~~~~~~~~~~~~
+
+This plugin reads from the gateway's entity cache rather than implementing DataProvider
+or OperationProvider. It is a consumer of gateway data, not a provider of new data sources.
+This keeps it simple and avoids circular dependencies.
+
+PluginContext Read-Only Access
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The plugin only uses read-only ``PluginContext`` methods (``list_entities()``,
+``get_entity()``, ``get_entity_data()``). It never mutates gateway state.

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
@@ -15,8 +15,6 @@
   <depend>ros2_medkit_msgs</depend>
   <depend>ros2_medkit_gateway</depend>
   <depend>nlohmann-json-dev</depend>
-  <depend>libcpp-httplib-dev</depend>
-  <depend>libssl-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
# Pull Request

## Summary

Add per-entity provider routing for gateway plugins, enabling plugins to serve standard SOVD data, operation, and fault endpoints on entities they create via IntrospectionProvider.

**New provider interfaces:**
- `DataProvider` - per-entity data resources (list, read, write)
- `OperationProvider` - per-entity operations (list, execute)
- `FaultProvider` - per-entity faults/DTCs (list, get, clear, clear-all)

**Infrastructure:**
- PluginLoader discovers providers via dlsym (`get_data_provider`, `get_operation_provider`, `get_fault_provider`)
- PluginManager tracks entity ownership (entity_id -> plugin name) for handler delegation
- IntrospectionProvider now works in all discovery modes (not just hybrid)
- PluginLayer tags entities with `source = "plugin"`
- Data/operation/fault handlers delegate to plugin providers for owned entities
- Capability auto-deduction: entities automatically get data/operations/faults capabilities when providers are registered
- Entity ID validation in both hybrid (PluginLayer) and non-hybrid (gateway_node) injection paths

**Error handling:**
- All plugin provider calls wrapped in try/catch(std::exception) + catch(...)
- `send_plugin_error()` centralizes error sanitization (status clamped 400-599, message truncated 512 chars)
- Lock enforcement (validate_lock_access) applied before plugin delegation for all mutating operations
- Entity ownership refreshed on every discovery cycle (clear + re-register)

**Documentation:**
- DataProvider code example in plugin tutorial
- Entity ownership section in plugin tutorial
- Plugin entity delegation note in REST API docs
- Thread safety warning for provider implementations
- Design doc for sovd_service_interface plugin

---

## Issue

- closes #354

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- 16 new unit tests for entity ownership, provider routing, error propagation, status clamping, message truncation, vendor error wrapping, and operation list+filter contract
- Full gateway test suite: 2463 tests, 0 failures, 0 skipped

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed