### PR TITLE
fix(aggregation): read app-to-component binding from SOVD is-located-on

### DIFF
--- a/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
@@ -198,7 +198,11 @@ Component parse_component(const nlohmann::json & j) {
  * URI (ISO 17978-3, §7.6). Peers may emit it as either an absolute URL
  * (``http://host:port/api/v1/components/{id}``) or a path-only reference
  * (``/api/v1/components/{id}``). Extract the trailing segment after the
- * ``/components/`` marker.
+ * ``/components/`` marker and validate it with ``is_valid_entity_id`` so
+ * that a malformed or hostile peer URI cannot smuggle path traversal or
+ * percent-encoded junk into the aggregator's entity cache.
+ * Returns an empty string if the URI contains no marker or if the
+ * extracted segment fails validation.
  */
 std::string component_id_from_located_on(const std::string & uri) {
   static const std::string kMarker = "/components/";
@@ -211,7 +215,8 @@ std::string component_id_from_located_on(const std::string & uri) {
     return "";
   }
   auto id_end = uri.find_first_of("/?#", id_start);
-  return uri.substr(id_start, id_end - id_start);
+  auto candidate = uri.substr(id_start, id_end - id_start);
+  return is_valid_entity_id(candidate) ? candidate : std::string{};
 }
 
 /**
@@ -243,9 +248,13 @@ App parse_app(const nlohmann::json & j) {
     const auto & xm = j["x-medkit"];
     // Vendor fallback: gateway emits x-medkit.component_id (snake_case) via
     // XMedkit builder in discovery_handlers.cpp. Only used if the SOVD
-    // standard is-located-on field is absent.
+    // standard is-located-on field is absent. Validated for the same
+    // reasons as component_id_from_located_on - the value is peer-provided.
     if (app.component_id.empty()) {
-      app.component_id = xm.value("component_id", "");
+      auto candidate = xm.value("component_id", "");
+      if (is_valid_entity_id(candidate)) {
+        app.component_id = candidate;
+      }
     }
     app.source = xm.value("source", "");
     app.is_online = xm.value("is_online", false);

--- a/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
@@ -192,16 +192,61 @@ Component parse_component(const nlohmann::json & j) {
 }
 
 /**
- * @brief Parse an App from JSON
+ * @brief Extract the component ID from an ``is-located-on`` URI.
+ *
+ * SOVD exposes the app-to-component binding as a standard relationship
+ * URI (ISO 17978-3, §7.6). Peers may emit it as either an absolute URL
+ * (``http://host:port/api/v1/components/{id}``) or a path-only reference
+ * (``/api/v1/components/{id}``). Extract the trailing segment after the
+ * ``/components/`` marker.
+ */
+std::string component_id_from_located_on(const std::string & uri) {
+  static const std::string kMarker = "/components/";
+  auto pos = uri.rfind(kMarker);
+  if (pos == std::string::npos) {
+    return "";
+  }
+  auto id_start = pos + kMarker.size();
+  if (id_start >= uri.size()) {
+    return "";
+  }
+  auto id_end = uri.find_first_of("/?#", id_start);
+  return uri.substr(id_start, id_end - id_start);
+}
+
+/**
+ * @brief Parse an App from JSON.
+ *
+ * The app-to-component binding is recovered from SOVD's standard
+ * ``is-located-on`` relationship (body field or ``_links`` entry),
+ * which every SOVD-compliant peer emits. Vendor fallback:
+ * ``x-medkit.component_id`` (gateway's own extension).
  */
 App parse_app(const nlohmann::json & j) {
   App app;
   app.id = j.value("id", "");
   app.name = j.value("name", "");
   app.description = j.value("description", "");
+
+  // SOVD-standard: is-located-on relationship (ISO 17978-3, §7.6)
+  if (j.contains("is-located-on") && j["is-located-on"].is_string()) {
+    app.component_id = component_id_from_located_on(j["is-located-on"].get<std::string>());
+  }
+  if (app.component_id.empty() && j.contains("_links") && j["_links"].is_object()) {
+    const auto & links = j["_links"];
+    if (links.contains("is-located-on") && links["is-located-on"].is_string()) {
+      app.component_id = component_id_from_located_on(links["is-located-on"].get<std::string>());
+    }
+  }
+
   if (j.contains("x-medkit") && j["x-medkit"].is_object()) {
     const auto & xm = j["x-medkit"];
-    app.component_id = xm.value("component_id", "");
+    // Vendor fallback: gateway emits x-medkit.component_id (snake_case) via
+    // XMedkit builder in discovery_handlers.cpp. Only used if the SOVD
+    // standard is-located-on field is absent.
+    if (app.component_id.empty()) {
+      app.component_id = xm.value("component_id", "");
+    }
     app.source = xm.value("source", "");
     app.is_online = xm.value("is_online", false);
     if (app.description.empty()) {

--- a/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/peer_client.cpp
@@ -241,6 +241,12 @@ App parse_app(const nlohmann::json & j) {
     const auto & links = j["_links"];
     if (links.contains("is-located-on") && links["is-located-on"].is_string()) {
       app.component_id = component_id_from_located_on(links["is-located-on"].get<std::string>());
+    } else if (links.contains("is-located-on") && links["is-located-on"].is_object()) {
+      // HAL+JSON object form: {"href": "/api/v1/components/ecu-a"}
+      auto href = links["is-located-on"].value("href", "");
+      if (!href.empty()) {
+        app.component_id = component_id_from_located_on(href);
+      }
     }
   }
 

--- a/src/ros2_medkit_gateway/test/test_peer_client.cpp
+++ b/src/ros2_medkit_gateway/test/test_peer_client.cpp
@@ -352,14 +352,23 @@ TEST(PeerClientHappyPath, fetch_entities_parses_is_located_on_without_vendor_ext
   svr.Get(R"(/api/v1/components/ecu-a/subcomponents)", [](const httplib::Request &, httplib::Response & res) {
     res.set_content(R"({"items":[]})", "application/json");
   });
-  // Absolute URL form of is-located-on (SOVD allows both)
+  // Exercises multiple URI forms: absolute URL, path-only _links (string),
+  // HAL+JSON object-form _links, trailing slash, query string, and fragment.
   svr.Get("/api/v1/apps", [](const httplib::Request &, httplib::Response & res) {
     res.set_content(
         R"({"items":[
           {"id":"app-standard","name":"Standard App",
            "is-located-on":"http://peer.local:8080/api/v1/components/ecu-a"},
           {"id":"app-hateoas","name":"HATEOAS App",
-           "_links":{"is-located-on":"/api/v1/components/ecu-a"}}
+           "_links":{"is-located-on":"/api/v1/components/ecu-a"}},
+          {"id":"app-hal-object","name":"HAL Object App",
+           "_links":{"is-located-on":{"href":"/api/v1/components/ecu-a"}}},
+          {"id":"app-trailing-slash","name":"Trailing Slash",
+           "is-located-on":"/api/v1/components/ecu-a/"},
+          {"id":"app-query","name":"Query Param",
+           "is-located-on":"/api/v1/components/ecu-a?foo=bar"},
+          {"id":"app-fragment","name":"Fragment",
+           "is-located-on":"/api/v1/components/ecu-a#section"}
         ]})",
         "application/json");
   });
@@ -376,11 +385,19 @@ TEST(PeerClientHappyPath, fetch_entities_parses_is_located_on_without_vendor_ext
   auto result = client.fetch_entities();
 
   ASSERT_TRUE(result.has_value());
-  ASSERT_EQ(result->apps.size(), 2u);
+  ASSERT_EQ(result->apps.size(), 6u);
   EXPECT_EQ(result->apps[0].id, "app-standard");
   EXPECT_EQ(result->apps[0].component_id, "ecu-a");
   EXPECT_EQ(result->apps[1].id, "app-hateoas");
   EXPECT_EQ(result->apps[1].component_id, "ecu-a");
+  EXPECT_EQ(result->apps[2].id, "app-hal-object");
+  EXPECT_EQ(result->apps[2].component_id, "ecu-a");
+  EXPECT_EQ(result->apps[3].id, "app-trailing-slash");
+  EXPECT_EQ(result->apps[3].component_id, "ecu-a");
+  EXPECT_EQ(result->apps[4].id, "app-query");
+  EXPECT_EQ(result->apps[4].component_id, "ecu-a");
+  EXPECT_EQ(result->apps[5].id, "app-fragment");
+  EXPECT_EQ(result->apps[5].component_id, "ecu-a");
 
   svr.stop();
   t.join();
@@ -431,6 +448,54 @@ TEST(PeerClientHappyPath, fetch_entities_rejects_malicious_component_id_in_locat
     EXPECT_TRUE(app.component_id.empty())
         << "app " << app.id << " should have empty component_id, got '" << app.component_id << "'";
   }
+
+  svr.stop();
+  t.join();
+}
+
+// Vendor-only fallback: app has x-medkit.component_id but no is-located-on.
+// Covers the happy-path for peers using the gateway's own vendor extension
+// without the SOVD standard relationship field.
+// @verifies REQ_INTEROP_018
+TEST(PeerClientHappyPath, fetch_entities_parses_vendor_only_component_id_fallback) {
+  httplib::Server svr;
+
+  svr.Get("/api/v1/areas", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  svr.Get("/api/v1/components", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[{"id":"perception-ecu","name":"Perception ECU"}]})", "application/json");
+  });
+  svr.Get(R"(/api/v1/components/perception-ecu)", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"id":"perception-ecu","name":"Perception ECU"})", "application/json");
+  });
+  svr.Get(R"(/api/v1/components/perception-ecu/subcomponents)", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  svr.Get("/api/v1/apps", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(
+        R"({"items":[
+          {"id":"lidar-driver","name":"Lidar Driver",
+           "x-medkit":{"component_id":"perception-ecu","source":"manifest","is_online":true}}
+        ]})",
+        "application/json");
+  });
+  svr.Get("/api/v1/functions", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread t([&]() {
+    svr.listen_after_bind();
+  });
+
+  PeerClient client("http://127.0.0.1:" + std::to_string(port), "peer_vendor", 5000);
+  auto result = client.fetch_entities();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->apps.size(), 1u);
+  EXPECT_EQ(result->apps[0].id, "lidar-driver");
+  EXPECT_EQ(result->apps[0].component_id, "perception-ecu");
 
   svr.stop();
   t.join();

--- a/src/ros2_medkit_gateway/test/test_peer_client.cpp
+++ b/src/ros2_medkit_gateway/test/test_peer_client.cpp
@@ -386,6 +386,56 @@ TEST(PeerClientHappyPath, fetch_entities_parses_is_located_on_without_vendor_ext
   t.join();
 }
 
+// Malicious peer attempts to smuggle path traversal / percent-encoding /
+// oversize IDs through the app->component binding. Both the SOVD-standard
+// is-located-on parser and the x-medkit vendor fallback must reject these
+// candidates (leaving App::component_id empty) so they cannot propagate into
+// the aggregator's entity cache or response-side path construction.
+// @verifies REQ_INTEROP_018
+TEST(PeerClientHappyPath, fetch_entities_rejects_malicious_component_id_in_located_on) {
+  httplib::Server svr;
+
+  svr.Get("/api/v1/areas", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  svr.Get("/api/v1/components", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  svr.Get("/api/v1/apps", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(
+        R"({"items":[
+          {"id":"app-traversal","name":"A","is-located-on":"/api/v1/components/..%2Fetc%2Fpasswd"},
+          {"id":"app-percent","name":"A","is-located-on":"/api/v1/components/bad%20id"},
+          {"id":"app-vendor-slash","name":"A",
+           "x-medkit":{"component_id":"bad/id","source":"manifest"}},
+          {"id":"app-vendor-empty","name":"A",
+           "x-medkit":{"component_id":"","source":"manifest"}}
+        ]})",
+        "application/json");
+  });
+  svr.Get("/api/v1/functions", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread t([&]() {
+    svr.listen_after_bind();
+  });
+
+  PeerClient client("http://127.0.0.1:" + std::to_string(port), "peer_hostile", 5000);
+  auto result = client.fetch_entities();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->apps.size(), 4u);
+  for (const auto & app : result->apps) {
+    EXPECT_TRUE(app.component_id.empty())
+        << "app " << app.id << " should have empty component_id, got '" << app.component_id << "'";
+  }
+
+  svr.stop();
+  t.join();
+}
+
 // @verifies REQ_INTEROP_018
 TEST(PeerClientHappyPath, forward_request_proxies_response_with_auth) {
   httplib::Server svr;

--- a/src/ros2_medkit_gateway/test/test_peer_client.cpp
+++ b/src/ros2_medkit_gateway/test/test_peer_client.cpp
@@ -274,10 +274,14 @@ TEST(PeerClientHappyPath, fetch_entities_parses_relationship_fields) {
     res.set_content(R"({"items":[]})", "application/json");
   });
 
+  // Apps response matches what real SOVD peers emit: is-located-on is the
+  // standard app->component relationship (ISO 17978-3, §7.6), and the gateway
+  // also emits x-medkit.component_id (snake_case) as a vendor extension.
   svr.Get("/api/v1/apps", [](const httplib::Request &, httplib::Response & res) {
     res.set_content(
         R"({"items":[
           {"id":"lidar-driver","name":"Lidar Driver",
+           "is-located-on":"/api/v1/components/perception-ecu",
            "x-medkit":{"component_id":"perception-ecu","source":"manifest","is_online":true}}
         ]})",
         "application/json");
@@ -324,6 +328,59 @@ TEST(PeerClientHappyPath, fetch_entities_parses_relationship_fields) {
   ASSERT_EQ(result->functions[0].hosts.size(), 2u);
   EXPECT_EQ(result->functions[0].hosts[0], "lidar-driver");
   EXPECT_EQ(result->functions[0].hosts[1], "path-planner");
+
+  svr.stop();
+  t.join();
+}
+
+// App->component binding via SOVD-standard is-located-on relationship only
+// (no x-medkit vendor extension). Exercises the parse path used by peers
+// implementing the ISO 17978-3 standard from other vendors.
+// @verifies REQ_INTEROP_018
+TEST(PeerClientHappyPath, fetch_entities_parses_is_located_on_without_vendor_extension) {
+  httplib::Server svr;
+
+  svr.Get("/api/v1/areas", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  svr.Get("/api/v1/components", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[{"id":"ecu-a","name":"ECU A"}]})", "application/json");
+  });
+  svr.Get(R"(/api/v1/components/ecu-a)", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"id":"ecu-a","name":"ECU A"})", "application/json");
+  });
+  svr.Get(R"(/api/v1/components/ecu-a/subcomponents)", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+  // Absolute URL form of is-located-on (SOVD allows both)
+  svr.Get("/api/v1/apps", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(
+        R"({"items":[
+          {"id":"app-standard","name":"Standard App",
+           "is-located-on":"http://peer.local:8080/api/v1/components/ecu-a"},
+          {"id":"app-hateoas","name":"HATEOAS App",
+           "_links":{"is-located-on":"/api/v1/components/ecu-a"}}
+        ]})",
+        "application/json");
+  });
+  svr.Get("/api/v1/functions", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"items":[]})", "application/json");
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread t([&]() {
+    svr.listen_after_bind();
+  });
+
+  PeerClient client("http://127.0.0.1:" + std::to_string(port), "peer_sovd", 5000);
+  auto result = client.fetch_entities();
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->apps.size(), 2u);
+  EXPECT_EQ(result->apps[0].id, "app-standard");
+  EXPECT_EQ(result->apps[0].component_id, "ecu-a");
+  EXPECT_EQ(result->apps[1].id, "app-hateoas");
+  EXPECT_EQ(result->apps[1].component_id, "ecu-a");
 
   svr.stop();
   t.join();

--- a/src/ros2_medkit_integration_tests/demo_nodes/brake_actuator.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/brake_actuator.cpp
@@ -46,15 +46,19 @@ class BrakeActuator : public rclcpp::Node {
   }
 
   ~BrakeActuator() {
-    cmd_sub_.reset();
     timer_->cancel();
     std::lock_guard<std::mutex> lock(callback_mutex_);
+    cmd_sub_.reset();
     timer_.reset();
     pressure_pub_.reset();
   }
 
  private:
   void command_callback(const std_msgs::msg::Float32::SharedPtr msg) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    if (!pressure_pub_) {
+      return;
+    }
     target_pressure_ = msg->data;
 
     // Clamp to valid range (0-100 bar)

--- a/src/ros2_medkit_integration_tests/demo_nodes/light_controller.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/light_controller.cpp
@@ -46,15 +46,19 @@ class LightController : public rclcpp::Node {
   }
 
   ~LightController() {
-    cmd_sub_.reset();
     timer_->cancel();
     std::lock_guard<std::mutex> lock(callback_mutex_);
+    cmd_sub_.reset();
     timer_.reset();
     status_pub_.reset();
   }
 
  private:
   void command_callback(const std_msgs::msg::Bool::SharedPtr msg) {
+    std::lock_guard<std::mutex> lock(callback_mutex_);
+    if (!status_pub_) {
+      return;
+    }
     light_on_ = msg->data;
     RCLCPP_INFO(this->get_logger(), "Light command: %s", light_on_ ? "ON" : "OFF");
   }


### PR DESCRIPTION
## Summary

Aggregation dropped the app-to-component binding when fetching apps from peers because ``parse_app()`` read ``x-medkit.componentId`` (camelCase), while the gateway's own serializer emits ``x-medkit.component_id`` (snake_case) via the ``XMedkit`` builder in ``handle_list_apps`` / ``handle_get_app``. The key never matched and ``App::component_id`` stayed empty.

Rather than fixing the vendor key spelling, switch to SOVD's standard ``is-located-on`` relationship (ISO 17978-3, section 7.6). The gateway already emits this at the entity root and in ``_links.is-located-on``, and any SOVD-compliant peer will emit it too. ``x-medkit.component_id`` (snake_case) is kept as a fallback for backward compatibility.

``parse_app`` now:
1. Reads ``is-located-on`` (direct field) and extracts the trailing segment after ``/components/``. Handles both absolute URLs and path-only references.
2. Falls back to ``_links.is-located-on`` if the root field is absent.
3. Falls back to ``x-medkit.component_id`` (snake_case, matching the live ``XMedkit`` builder) only if the standard fields are absent.

---

## Issue

- closes #369

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- ``colcon test --packages-select ros2_medkit_gateway`` - 1995 tests, 0 failures
- ``ctest -R test_peer_client -V`` - 25/25 pass including the new case below
- New test ``PeerClientHappyPath.fetch_entities_parses_is_located_on_without_vendor_extension`` exercises the standard-only parse path (no ``x-medkit`` extension) with both the direct ``is-located-on`` field and the ``_links.is-located-on`` HATEOAS variant. It also covers the absolute-URL form of the URI.
- Updated ``PeerClientHappyPath.fetch_entities_parses_relationship_fields`` to mirror what real gateways emit (both the standard relationship and the vendor fallback, with correct snake_case spelling).

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed) - no breaking changes
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed - no API change, purely internal parser fix