### PR TITLE
fix(aggregation): hierarchical/leaf Component routing with provenance and warnings

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -8,6 +8,7 @@ This section contains API documentation for ros2_medkit.
 
    rest
    locking
+   warning_codes
    messages
    cpp
 
@@ -21,6 +22,10 @@ REST API
 :doc:`locking`
    SOVD resource locking API - acquire, extend, release locks on components
    and apps with scoped access control and automatic expiry.
+
+:doc:`warning_codes`
+   Stable aggregation warning codes surfaced via the ``/health.warnings``
+   x-medkit extension, with remediation guidance.
 
 Message Definitions
 -------------------

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -89,8 +89,8 @@ Server Capabilities
    Health check endpoint. Returns HTTP 200 if gateway is operational.
 
    When aggregation is enabled (``capabilities.aggregation == true`` in
-   the root response), the body includes two additional x-medkit
-   extension fields:
+   the root response), the body includes additional x-medkit extension
+   fields:
 
    - ``peers`` - array of peer status objects (URL, name, reachability,
      last-seen timestamp) for every configured or discovered peer.
@@ -99,6 +99,22 @@ Server Capabilities
      there are no active anomalies). Each warning carries ``code``,
      ``message``, ``entity_ids``, and ``peer_names``. See
      :doc:`warning_codes` for the stable list of codes.
+   - ``warning_schema_version`` - integer contract version for the
+     ``warnings`` array. Clients key on this instead of string-matching
+     codes. See :doc:`warning_codes` ``Schema versioning``.
+
+   .. note::
+
+      Security: ``/health`` is currently reachable without
+      authentication by default (``auth.enabled`` defaults to
+      ``false``), and even with auth enabled the endpoint is readable
+      by the ``viewer``, ``operator``, and ``configurator`` roles. The
+      ``peers`` array enumerates every configured peer's name and URL,
+      which reveals deployment topology. This is by design for
+      operator observability in trusted LANs, but on shared-infra or
+      multi-tenant installs you should front the endpoint with an
+      authenticating reverse proxy or restrict the peer-name field to
+      admin-gated callers at the ingress.
 
    **Example Response (aggregation enabled, one leaf collision):**
 
@@ -115,6 +131,7 @@ Server Capabilities
           {"name": "peer_b", "url": "http://peer-b:8080", "healthy": true},
           {"name": "peer_c", "url": "http://peer-c:8080", "healthy": true}
         ],
+        "warning_schema_version": 1,
         "warnings": [
           {
             "code": "leaf_id_collision",

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -54,11 +54,16 @@ Server Capabilities
         }
       }
 
-   The ``capabilities.aggregation`` flag is ``true`` when the gateway has
-   one or more aggregation peers configured. Clients can feature-detect
-   aggregation-only response fields (``peers``, ``warnings`` on ``/health``
-   and ``x-medkit.contributors`` on entities) using this flag instead of
-   probing for field presence.
+   The ``capabilities.aggregation`` flag is ``true`` when the aggregation
+   subsystem is enabled on this gateway (i.e. ``aggregation.enabled=true``
+   in config, which wires up an ``AggregationManager``). It does NOT
+   require peers to be present - a gateway with aggregation enabled but
+   zero peers still reports ``true`` and still emits the
+   aggregation-only response fields (``peers``, which may be an empty
+   array, and ``warnings`` on ``/health``; ``x-medkit.contributors`` on
+   entities, which will contain only ``"local"`` until a peer
+   contributes). Clients can feature-detect those fields using this
+   flag instead of probing for field presence.
 
 ``GET /api/v1/version-info``
    Get gateway version and status information.

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -49,9 +49,16 @@ Server Capabilities
           "triggers": true,
           "updates": false,
           "authentication": false,
-          "tls": false
+          "tls": false,
+          "aggregation": false
         }
       }
+
+   The ``capabilities.aggregation`` flag is ``true`` when the gateway has
+   one or more aggregation peers configured. Clients can feature-detect
+   aggregation-only response fields (``peers``, ``warnings`` on ``/health``
+   and ``x-medkit.contributors`` on entities) using this flag instead of
+   probing for field presence.
 
 ``GET /api/v1/version-info``
    Get gateway version and status information.
@@ -75,6 +82,43 @@ Server Capabilities
 
 ``GET /api/v1/health``
    Health check endpoint. Returns HTTP 200 if gateway is operational.
+
+   When aggregation is enabled (``capabilities.aggregation == true`` in
+   the root response), the body includes two additional x-medkit
+   extension fields:
+
+   - ``peers`` - array of peer status objects (URL, name, reachability,
+     last-seen timestamp) for every configured or discovered peer.
+   - ``warnings`` - array of structured operator-actionable aggregation
+     warnings (always present when aggregation is active; empty when
+     there are no active anomalies). Each warning carries ``code``,
+     ``message``, ``entity_ids``, and ``peer_names``. See
+     :doc:`warning_codes` for the stable list of codes.
+
+   **Example Response (aggregation enabled, one leaf collision):**
+
+   .. code-block:: json
+
+      {
+        "status": "healthy",
+        "timestamp": 1776185189048036615,
+        "discovery": {
+          "mode": "hybrid",
+          "strategy": "hybrid_discovery"
+        },
+        "peers": [
+          {"name": "peer_b", "url": "http://peer-b:8080", "healthy": true},
+          {"name": "peer_c", "url": "http://peer-c:8080", "healthy": true}
+        ],
+        "warnings": [
+          {
+            "code": "leaf_id_collision",
+            "message": "Component 'ecu-x' is announced by multiple peers (peer_b, peer_c); routing falls back to last-writer-wins which is non-deterministic. Resolve by renaming the Component on one side or by modelling it as a hierarchical parent (declare a child Component with parentComponentId='ecu-x' on the owning peer).",
+            "entity_ids": ["ecu-x"],
+            "peer_names": ["peer_b", "peer_c"]
+          }
+        ]
+      }
 
 Discovery Endpoints
 -------------------

--- a/docs/api/warning_codes.rst
+++ b/docs/api/warning_codes.rst
@@ -1,0 +1,43 @@
+Warning Codes
+=============
+
+The ``/api/v1/health`` endpoint surfaces operator-actionable aggregation
+anomalies in the top-level ``warnings`` array (x-medkit extension).
+Each entry has the shape:
+
+.. code-block:: json
+
+   {
+     "code": "leaf_id_collision",
+     "message": "Component 'ecu-x' is announced by multiple peers (peer_b, peer_c); routing falls back to last-writer-wins which is non-deterministic. Resolve by renaming the Component on one side or by modelling it as a hierarchical parent (declare a child Component with parentComponentId='ecu-x' on the owning peer).",
+     "entity_ids": ["ecu-x"],
+     "peer_names": ["peer_b", "peer_c"]
+   }
+
+Codes are stable machine-readable identifiers: renaming a code is a
+breaking change for downstream consumers that key on the string.
+
+The canonical list of codes is maintained in
+``src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/warning_codes.hpp``;
+this page mirrors it for API consumers.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Code
+     - Meaning / Remediation
+   * - ``leaf_id_collision``
+     - More than one peer announces the same **leaf** (non-hierarchical)
+       Component ID during aggregation merge. Routing falls back to
+       last-writer-wins, so requests for the affected Component reach one
+       peer non-deterministically. Resolve by renaming the Component on one
+       side, or by modelling it as a hierarchical parent - declare a child
+       Component with ``parentComponentId`` pointing at the colliding ID on
+       the owning peer. The warning lists every claiming peer in
+       ``peer_names``.
+
+When aggregation is enabled (``GET /`` -> ``capabilities.aggregation``
+is ``true``), ``warnings`` is always an array on the ``/health`` response:
+empty when no anomalies are active, non-empty otherwise. When aggregation
+is disabled, the field is omitted entirely.

--- a/docs/api/warning_codes.rst
+++ b/docs/api/warning_codes.rst
@@ -41,3 +41,27 @@ When aggregation is enabled (``GET /`` -> ``capabilities.aggregation``
 is ``true``), ``warnings`` is always an array on the ``/health`` response:
 empty when no anomalies are active, non-empty otherwise. When aggregation
 is disabled, the field is omitted entirely.
+
+Schema versioning
+-----------------
+
+Alongside ``warnings`` the ``/health`` response exposes an integer
+``warning_schema_version`` (present whenever aggregation is enabled,
+regardless of whether any warnings are active). Typed clients key on this
+field to decide which codes they can feature-detect without reverting to
+string-matching every time a new anomaly class is added.
+
+The contract is:
+
+- Current version: ``1``.
+- Bumped by one whenever a code is added, removed, or the shape of a
+  warning object changes.
+- Within a given version, every code listed on this page is guaranteed to
+  appear verbatim; clients seeing an unknown code at a known version
+  should log-and-ignore rather than fail.
+- Across versions, clients are expected to treat unknown codes as
+  future-compatible: log-and-ignore, do not crash.
+
+Clients that need strong typing (MCP tools, Web UI badges, Foxglove
+panels) should branch on ``warning_schema_version`` before mapping codes
+onto internal enums.

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -193,6 +193,7 @@ add_library(gateway_lib STATIC
   # Aggregation module
   src/aggregation/peer_client.cpp
   src/aggregation/entity_merger.cpp
+  src/aggregation/classification.cpp
   src/aggregation/aggregation_manager.cpp
   src/aggregation/mdns_discovery.cpp
   src/aggregation/sse_stream_proxy.cpp

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -693,6 +693,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_aggregation_manager test/test_aggregation_manager.cpp)
   target_link_libraries(test_aggregation_manager gateway_lib)
 
+  # Aggregation classification tests (hierarchical vs leaf Component routing)
+  ament_add_gtest(test_aggregation_classification test/test_aggregation_classification.cpp)
+  target_link_libraries(test_aggregation_classification gateway_lib)
+
   # Stream proxy tests (SSE parsing, aggregation module)
   ament_add_gtest(test_stream_proxy test/test_stream_proxy.cpp)
   target_link_libraries(test_stream_proxy gateway_lib)
@@ -776,6 +780,7 @@ if(BUILD_TESTING)
       test_entity_merger
       test_fan_out_helpers
       test_aggregation_manager
+      test_aggregation_classification
       test_stream_proxy
       test_mdns_discovery
       test_network_utils

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -200,7 +200,7 @@ type-specific merge rules:
    elseif (Component) then
        if (Same ID exists locally?) then (yes)
            :Merge metadata (tags, description);
-           :Add routing entry\n(peer owns runtime state);
+           :Add provisional routing entry;
        else (no)
            :Add as new entity;
            :Add routing entry;
@@ -214,6 +214,39 @@ type-specific merge rules:
        :Add routing entry;
    endif
    :Tag with peer source metadata;
+   :Append "peer:<name>" to contributors;
+   stop
+
+   @enduml
+
+After every peer has been merged, ``AggregationManager`` runs a
+classification pass over the full Component set:
+
+.. plantuml::
+   :caption: Component Classification (post-merge)
+
+   @startuml component_classification
+
+   title Component Classification (post-merge)
+
+   start
+   :Collect all merged Components
+   and per-peer Component claims;
+   repeat
+     :Pick next Component;
+     if (Referenced as parent_component_id
+     by any other Component?) then (yes)
+       :Classify as hierarchical parent;
+       :Remove routing entry\n(serve locally like an Area);
+     else (no)
+       :Classify as leaf (ECU);
+       :Keep routing entry\n(forward to owning peer);
+       if (Claimed by >1 peer?) then (yes)
+         :Emit LeafCollisionWarning\n(last-writer-wins for routing);
+       endif
+     endif
+   repeat while (more Components?)
+   :Attach warnings to /health.warnings;
    stop
 
    @enduml
@@ -229,15 +262,35 @@ type-specific merge rules:
   If both gateways expose a ``navigation`` Function, the merged entity lists
   hosts from both gateways. Same ownership semantics as Areas.
 
-- **Components**: Merge by ID, combining tags and metadata. Components represent
-  physical hosts or ECUs defined in manifests - the same Component ID across
-  peers refers to the same physical entity, and the peer owns the authoritative
-  runtime state (data, logs, hosts, operations, faults). Both remote-only
-  Components and collision-merged Components therefore get a routing table
-  entry, so that every request for such a Component - including the detail
-  endpoint and all sub-resources - is forwarded to the peer. The primary's
-  role for merged Components is limited to aggregating their presence in
-  discovery listings; it never serves their runtime data locally.
+- **Components**: Merge by ID, combining tags and metadata. Components
+  represent either a single physical ECU *or* a hierarchical parent that
+  groups other Components across ECUs (``parent_component_id`` is used to
+  model the hierarchy). The ownership rule is applied symmetrically to how
+  Areas handle shared roots:
+
+  * **Leaf Component** - no other Component in the merged set references it
+    as ``parent_component_id``. Leaves are tied to exactly one ECU, so on
+    collision the peer owns the runtime state (data, logs, hosts,
+    operations, faults). Leaves get a routing table entry and every request
+    - detail endpoint and all sub-resources - is forwarded to the peer.
+  * **Hierarchical parent Component** - referenced as
+    ``parent_component_id`` by at least one other Component in the merged
+    set (local, remote, or transitively merged from any peer). The parent
+    itself has no runtime state; it only groups its children. The parent is
+    served locally with the merged view (tags/description/``contributors``
+    combined) exactly like an Area. No routing table entry is created for
+    a hierarchical parent, even when multiple peers announce it.
+
+  Classification happens after all peers have been merged
+  (``classify_component_routing`` in ``aggregation/classification.hpp``) so
+  that sub-components arriving from different peers still unlock parent
+  behaviour on the primary.
+
+  **Multi-peer leaf collisions** (two or more peers announce the same leaf
+  Component ID) are surfaced as structured ``/health.warnings`` entries and
+  RCLCPP_WARN log lines. Routing falls back to last-writer-wins;
+  rejection would not fix the deployment and would only take the gateway
+  offline.
 
 - **Apps**: Prefix on collision. If a remote App has the same ID as a local one,
   the remote entity's ID is prefixed with ``peername__`` (double underscore
@@ -246,9 +299,34 @@ type-specific merge rules:
 
 The ``EntityMerger::SEPARATOR`` constant (``__``) is used as the prefix
 separator for Apps. The routing table maps ``entity_id -> peer_name`` for
-entities whose runtime state lives on the peer: remote-only Areas/Functions,
-remote-only and collision-merged Components, and remote-only or prefixed
-Apps.
+entities whose runtime state lives on the peer: remote-only Areas and
+Functions, leaf Components (remote-only or collision-merged), and
+remote-only or prefixed Apps. Hierarchical parent Components are not in the
+routing table - they are served locally.
+
+Provenance (``x-medkit.contributors``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Every merged entity carries a ``contributors`` list in its ``x-medkit``
+block that names each source which contributed to the merged view. The
+list is populated during merge:
+
+- Each local entity is seeded with ``"local"`` before the peer merge loop
+  runs.
+- ``EntityMerger`` appends ``"peer:<name>"`` on collisions (Areas,
+  hierarchical parent Components, Functions) and on remote-only additions;
+  the append is deduplicated, so merging with the same peer twice does not
+  produce duplicate entries.
+- Apps that collide receive only ``"peer:<name>"`` because the
+  prefix strategy turns them into distinct entities.
+
+Clients (web UI, MCP, Foxglove, VDA 5050 agent) can use ``contributors``
+to distinguish a locally-owned entity from one that came in over
+aggregation, and to display which peers participated in a hierarchical
+parent's view. In daisy-chain topologies each hop surfaces only its
+direct upstream; an operator looking at the top-level aggregator sees
+``"peer:<direct_neighbour>"`` and must drill into the neighbour to see
+its own contributor list.
 
 Request Routing
 ---------------

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -190,9 +190,17 @@ type-specific merge rules:
 
    start
    :Receive remote entity from peer;
-   if (Entity type?) then (Area, Function, or Component)
+   if (Entity type?) then (Area or Function)
        if (Same ID exists locally?) then (yes)
            :Merge into existing entity\n(combine relations/tags);
+       else (no)
+           :Add as new entity;
+           :Add routing entry;
+       endif
+   elseif (Component) then
+       if (Same ID exists locally?) then (yes)
+           :Merge metadata (tags, description);
+           :Add routing entry\n(peer owns runtime state);
        else (no)
            :Add as new entity;
            :Add routing entry;
@@ -223,8 +231,13 @@ type-specific merge rules:
 
 - **Components**: Merge by ID, combining tags and metadata. Components represent
   physical hosts or ECUs defined in manifests - the same Component ID across
-  peers refers to the same physical entity. Remote-only Components get a routing
-  table entry.
+  peers refers to the same physical entity, and the peer owns the authoritative
+  runtime state (data, logs, hosts, operations, faults). Both remote-only
+  Components and collision-merged Components therefore get a routing table
+  entry, so that every request for such a Component - including the detail
+  endpoint and all sub-resources - is forwarded to the peer. The primary's
+  role for merged Components is limited to aggregating their presence in
+  discovery listings; it never serves their runtime data locally.
 
 - **Apps**: Prefix on collision. If a remote App has the same ID as a local one,
   the remote entity's ID is prefixed with ``peername__`` (double underscore
@@ -233,7 +246,9 @@ type-specific merge rules:
 
 The ``EntityMerger::SEPARATOR`` constant (``__``) is used as the prefix
 separator for Apps. The routing table maps ``entity_id -> peer_name`` for
-remote-only entities and prefixed Apps that need request forwarding.
+entities whose runtime state lives on the peer: remote-only Areas/Functions,
+remote-only and collision-merged Components, and remote-only or prefixed
+Apps.
 
 Request Routing
 ---------------

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -292,6 +292,36 @@ classification pass over the full Component set:
   rejection would not fix the deployment and would only take the gateway
   offline.
 
+  **Cross-snapshot instability under peer churn.** The "last writer" in
+  last-writer-wins is determined by the order of healthy peers in the
+  merge snapshot (``aggregation_manager.cpp`` iterates ``peers_`` and
+  filters via ``is_healthy()``). Two consequences operators should plan
+  around:
+
+  - If a colliding peer goes unhealthy between merges, it drops out of
+    the snapshot. The remaining peer becomes the new last-writer and
+    routing silently flips to it. The request itself cannot fail (the
+    dead peer cannot serve it), so this flip is required behaviour -
+    but the ``/health.warnings`` entry also disappears (only one
+    claimant is left), which hides the routing change from a snapshot
+    comparison. Alert on the transition from ``warnings`` non-empty to
+    empty, not just on the presence of warnings.
+  - Insertion order within ``peers_`` is stable across a merge but can
+    vary across gateway restarts, so two fresh primaries with the same
+    peer list may pick different last-writers. Sticky routing across
+    snapshots is intentionally not implemented - it would mask a
+    deployment anomaly rather than surface it. Resolve collisions at
+    the manifest level instead.
+
+  **Malformed parent_component_id.** ``classify_component_routing``
+  validates every ``parent_component_id`` edge before running
+  hierarchical-parent detection. Self-parent references, parent IDs not
+  present in the merged Component set, and cycles
+  (``A -> B -> ... -> A``) are dropped with a diagnostic on
+  ``malformed_parent_warnings`` (logged by the aggregation manager via
+  ``RCLCPP_WARN``). Affected Components fall back to leaf routing so a
+  misconfigured peer cannot mask itself behind a phantom parent.
+
 - **Apps**: Prefix on collision. If a remote App has the same ID as a local one,
   the remote entity's ID is prefixed with ``peername__`` (double underscore
   separator). Apps represent individual ROS 2 nodes with unique behavior - two

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -313,12 +313,18 @@ list is populated during merge:
 
 - Each local entity is seeded with ``"local"`` before the peer merge loop
   runs.
-- ``EntityMerger`` appends ``"peer:<name>"`` on collisions (Areas,
-  hierarchical parent Components, Functions) and on remote-only additions;
-  the append is deduplicated, so merging with the same peer twice does not
-  produce duplicate entries.
+- ``EntityMerger`` appends ``"peer:<name>"`` on every Area / Component /
+  Function collision and on every remote-only addition, without knowing
+  yet whether a Component will later be classified as a hierarchical
+  parent or a leaf. The classification pass runs afterwards and only
+  rewrites the routing table; ``contributors`` reflects the merge
+  inputs. Appends are deduplicated, so merging with the same peer twice
+  never produces duplicate entries.
 - Apps that collide receive only ``"peer:<name>"`` because the
   prefix strategy turns them into distinct entities.
+- Outputs are sorted with ``"local"`` first (when present) and
+  ``"peer:<name>"`` entries alphabetically, so clients and snapshot
+  tests can rely on a stable order regardless of peer merge order.
 
 Clients (web UI, MCP, Foxglove, VDA 5050 agent) can use ``contributors``
 to distinguish a locally-owned entity from one that came in over
@@ -449,6 +455,25 @@ fetching.
 When a peer recovers (health check succeeds again), it is automatically
 re-included.
 
+The aggregator also publishes its own ``/health`` response with two
+additional fields when aggregation is enabled (x-medkit extensions on our
+own endpoint, outside the SOVD core contract):
+
+- ``peers`` - array of peer status objects describing each configured or
+  discovered peer (URL, name, reachability, last-seen timestamp).
+- ``warnings`` - array of operator-actionable aggregation warnings. The
+  array is always present (possibly empty) when aggregation is active, so
+  clients do not have to differentiate "no warnings" from "aggregation
+  disabled" (use ``/.capabilities.aggregation`` in the root endpoint for
+  that).
+
+Warning objects carry ``code`` (stable machine-readable identifier,
+documented in ``warning_codes.hpp``), ``message`` (human-readable text
+including a remediation hint), ``entity_ids`` (SOVD IDs touched by the
+anomaly), and ``peer_names`` (peers involved). The only code emitted
+today is ``leaf_id_collision`` - see the classification section for the
+detection algorithm and the fall-back routing behaviour.
+
 Stream Proxy
 ~~~~~~~~~~~~
 
@@ -527,8 +552,17 @@ Key Classes
 ``EntityMerger``
     Stateless merge engine that combines local and remote entity sets using
     type-specific rules (merge by ID for Area/Function/Component, prefix on
-    collision for App). Produces a routing table mapping remote entity IDs to
-    peer names.
+    collision for App). Produces a provisional routing table mapping remote
+    entity IDs to peer names - the Component entries are later refined by
+    ``classify_component_routing``.
+
+``classify_component_routing`` (``aggregation/classification.hpp``)
+    Pure free function that takes the fully merged Component set plus the
+    per-peer ``PeerClaim`` list and returns a ``ClassifiedRouting`` with
+    hierarchical-parent Components removed from the routing table (served
+    locally with merged view) and leaves kept. Multi-peer leaf collisions
+    surface as ``LeafCollisionWarning`` entries consumed by
+    ``/health.warnings``.
 
 ``AggregationManager``
     Central coordinator that manages the set of ``PeerClient`` instances, runs

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "ros2_medkit_gateway/aggregation/classification.hpp"
 #include "ros2_medkit_gateway/aggregation/peer_client.hpp"
 
 namespace ros2_medkit_gateway {
@@ -86,6 +87,10 @@ class AggregationManager {
     std::vector<App> apps;
     std::vector<Function> functions;
     std::unordered_map<std::string, std::string> routing_table;
+    /// Multi-peer leaf-Component collisions detected during merge. Surfaced
+    /// to operators via /health.warnings; runtime falls back to last-writer
+    /// for routing.
+    std::vector<LeafCollisionWarning> leaf_warnings;
   };
 
   /**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
@@ -182,6 +182,21 @@ class AggregationManager {
   void update_routing_table(const std::unordered_map<std::string, std::string> & table);
 
   /**
+   * @brief Publish the latest leaf-collision warnings (replaces previous list).
+   *
+   * Warnings describe deployment-level anomalies where more than one peer
+   * announced the same leaf Component ID. Exposed on /health.warnings so
+   * operators can notice without tailing logs. Thread-safe.
+   */
+  void set_leaf_warnings(std::vector<LeafCollisionWarning> warnings);
+
+  /**
+   * @brief Snapshot the current leaf-collision warnings.
+   * @return Copy of the warning list (may be empty). Thread-safe.
+   */
+  std::vector<LeafCollisionWarning> get_leaf_warnings() const;
+
+  /**
    * @brief Look up which peer owns a given entity
    * @param entity_id Entity ID to look up
    * @return Peer name if entity is remote, std::nullopt if local or unknown
@@ -233,6 +248,7 @@ class AggregationManager {
   mutable std::shared_mutex mutex_;  // Declared before data it protects (destruction order)
   std::vector<std::shared_ptr<PeerClient>> peers_;
   std::unordered_map<std::string, std::string> routing_table_;
+  std::vector<LeafCollisionWarning> leaf_warnings_;
 
   /**
    * @brief Find a peer by name (caller must hold lock)

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/classification.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/classification.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "ros2_medkit_gateway/discovery/models/component.hpp"
+
+namespace ros2_medkit_gateway {
+
+/// Deployment-level anomaly: >1 peer announced the same leaf Component ID.
+/// Emitted as operator-visible warning (RCLCPP_WARN + optional /health field);
+/// runtime falls back to last-writer-wins for the routing table entry.
+struct LeafCollisionWarning {
+  std::string entity_id;
+  std::vector<std::string> peer_names;
+};
+
+/// Result of classifying a merged Component set into hierarchical parents
+/// (served locally) and leaves (routed to an owning peer).
+struct ClassifiedRouting {
+  std::unordered_map<std::string, std::string> routing_table;
+  std::vector<LeafCollisionWarning> leaf_warnings;
+};
+
+/// Per-peer set of Component IDs that peer contributed to the routing table.
+/// Used to detect multi-peer leaf collisions that would otherwise be hidden
+/// by the last-writer-wins merge of per-peer routing tables.
+struct PeerClaim {
+  std::string peer_name;
+  std::unordered_set<std::string> claimed_entity_ids;
+};
+
+/// Classify merged Components into hierarchical parents and leaves.
+///
+/// A Component is a hierarchical parent iff some other Component in the
+/// merged set references it via parent_component_id. Hierarchical parents
+/// are removed from the routing table (served locally from the merged
+/// cache, mirroring how Areas/Functions are handled). Leaves stay in the
+/// routing table and forward on request.
+///
+/// Multi-peer collisions on a leaf Component ID are reported as warnings;
+/// routing falls back to last-writer-wins (the last peer in @p peer_claims
+/// whose claim set contains the ID).
+ClassifiedRouting classify_component_routing(const std::vector<Component> & merged_components,
+                                             const std::vector<PeerClaim> & peer_claims);
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/classification.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/classification.hpp
@@ -33,9 +33,17 @@ struct LeafCollisionWarning {
 
 /// Result of classifying a merged Component set into hierarchical parents
 /// (served locally) and leaves (routed to an owning peer).
+///
+/// ``malformed_parent_warnings`` surfaces diagnostic strings for invalid
+/// ``parent_component_id`` references detected during classification
+/// (self-parent, non-existent parent, or a parent cycle). Such references are
+/// ignored for hierarchical-parent detection, so the affected Components fall
+/// back to leaf routing. Caller is expected to log each string so operators
+/// can fix the underlying manifest or peer configuration.
 struct ClassifiedRouting {
   std::unordered_map<std::string, std::string> routing_table;
   std::vector<LeafCollisionWarning> leaf_warnings;
+  std::vector<std::string> malformed_parent_warnings;
 };
 
 /// Per-peer set of Component IDs that peer contributed to the routing table.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/app.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/app.hpp
@@ -118,8 +118,9 @@ struct App {
   std::vector<ActionInfo> actions;
 
   // === Discovery metadata ===
-  std::string source = "manifest";  ///< "manifest" or "runtime"
-  std::string original_id;          ///< Pre-rename ID when collision-prefixed by aggregation
+  std::string source = "manifest";        ///< "manifest" or "runtime"
+  std::string original_id;                ///< Pre-rename ID when collision-prefixed by aggregation
+  std::vector<std::string> contributors;  ///< Aggregation provenance: "local" and/or "peer:<name>"
 
   // === Serialization methods ===
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "ros2_medkit_gateway/discovery/models/common.hpp"
+
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
@@ -29,15 +29,16 @@ using json = nlohmann::json;
  * They provide a hierarchical organization of components.
  */
 struct Area {
-  std::string id;                 ///< Unique identifier (e.g., "powertrain")
-  std::string name;               ///< Human-readable name (e.g., "Powertrain System")
-  std::string namespace_path;     ///< ROS 2 namespace path (e.g., "/powertrain")
-  std::string type = "Area";      ///< Entity type (always "Area")
-  std::string translation_id;     ///< Internationalization key
-  std::string description;        ///< Human-readable description
-  std::vector<std::string> tags;  ///< Tags for filtering
-  std::string parent_area_id;     ///< Parent area ID for sub-areas
-  std::string source;             ///< Origin of this area (e.g., "manifest", "heuristic")
+  std::string id;                         ///< Unique identifier (e.g., "powertrain")
+  std::string name;                       ///< Human-readable name (e.g., "Powertrain System")
+  std::string namespace_path;             ///< ROS 2 namespace path (e.g., "/powertrain")
+  std::string type = "Area";              ///< Entity type (always "Area")
+  std::string translation_id;             ///< Internationalization key
+  std::string description;                ///< Human-readable description
+  std::vector<std::string> tags;          ///< Tags for filtering
+  std::string parent_area_id;             ///< Parent area ID for sub-areas
+  std::string source;                     ///< Origin of this area (e.g., "manifest", "heuristic")
+  std::vector<std::string> contributors;  ///< Aggregation provenance: "local" and/or "peer:<name>"
 
   /**
    * @brief Convert to JSON representation
@@ -70,6 +71,9 @@ struct Area {
     }
     if (!source.empty()) {
       x_medkit["source"] = source;
+    }
+    if (!contributors.empty()) {
+      x_medkit["contributors"] = contributors;
     }
     j["x-medkit"] = x_medkit;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/area.hpp
@@ -73,7 +73,7 @@ struct Area {
       x_medkit["source"] = source;
     }
     if (!contributors.empty()) {
-      x_medkit["contributors"] = contributors;
+      x_medkit["contributors"] = sorted_contributors(contributors);
     }
     j["x-medkit"] = x_medkit;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/common.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/common.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
@@ -22,6 +23,23 @@
 namespace ros2_medkit_gateway {
 
 using json = nlohmann::json;
+
+/// Order aggregation `contributors` for stable presentation: "local" first
+/// (when present), then "peer:<name>" entries alphabetically. Used by every
+/// entity to_json() so list and detail responses agree on ordering regardless
+/// of how peers were merged internally.
+inline std::vector<std::string> sorted_contributors(const std::vector<std::string> & input) {
+  std::vector<std::string> out(input.begin(), input.end());
+  std::sort(out.begin(), out.end(), [](const std::string & a, const std::string & b) {
+    const bool a_local = (a == "local");
+    const bool b_local = (b == "local");
+    if (a_local != b_local) {
+      return a_local;
+    }
+    return a < b;
+  });
+  return out;
+}
 
 /**
  * @brief QoS profile information for a topic endpoint

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
@@ -88,7 +88,7 @@ struct Component {
       x_medkit["dependsOn"] = depends_on;
     }
     if (!contributors.empty()) {
-      x_medkit["contributors"] = contributors;
+      x_medkit["contributors"] = sorted_contributors(contributors);
     }
     x_medkit["topics"] = topics.to_json();
     if (host_metadata.has_value()) {

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/component.hpp
@@ -32,23 +32,24 @@ using json = nlohmann::json;
  * They expose operations (services/actions), data (topics), and configurations (parameters).
  */
 struct Component {
-  std::string id;                       ///< Unique identifier (node name)
-  std::string name;                     ///< Human-readable name
-  std::string namespace_path;           ///< ROS 2 namespace path
-  std::string fqn;                      ///< Fully qualified name (namespace + id)
-  std::string type = "Component";       ///< Entity type (always "Component")
-  std::string area;                     ///< Parent area ID
-  std::string source = "node";          ///< Discovery source: "node", "topic", or "manifest"
-  std::string translation_id;           ///< Internationalization key
-  std::string description;              ///< Human-readable description
-  std::string variant;                  ///< Hardware variant identifier
-  std::vector<std::string> tags;        ///< Tags for filtering
-  std::string parent_component_id;      ///< Parent component ID for sub-components
-  std::vector<std::string> depends_on;  ///< Component IDs this component depends on
-  std::vector<ServiceInfo> services;    ///< Services exposed by this component
-  std::vector<ActionInfo> actions;      ///< Actions exposed by this component
-  ComponentTopics topics;               ///< Topics this component publishes/subscribes
-  std::optional<json> host_metadata;    ///< Host system metadata (for runtime default component)
+  std::string id;                         ///< Unique identifier (node name)
+  std::string name;                       ///< Human-readable name
+  std::string namespace_path;             ///< ROS 2 namespace path
+  std::string fqn;                        ///< Fully qualified name (namespace + id)
+  std::string type = "Component";         ///< Entity type (always "Component")
+  std::string area;                       ///< Parent area ID
+  std::string source = "node";            ///< Discovery source: "node", "topic", or "manifest"
+  std::string translation_id;             ///< Internationalization key
+  std::string description;                ///< Human-readable description
+  std::string variant;                    ///< Hardware variant identifier
+  std::vector<std::string> tags;          ///< Tags for filtering
+  std::string parent_component_id;        ///< Parent component ID for sub-components
+  std::vector<std::string> depends_on;    ///< Component IDs this component depends on
+  std::vector<std::string> contributors;  ///< Aggregation provenance: "local" and/or "peer:<name>"
+  std::vector<ServiceInfo> services;      ///< Services exposed by this component
+  std::vector<ActionInfo> actions;        ///< Actions exposed by this component
+  ComponentTopics topics;                 ///< Topics this component publishes/subscribes
+  std::optional<json> host_metadata;      ///< Host system metadata (for runtime default component)
 
   /**
    * @brief Convert to JSON representation
@@ -85,6 +86,9 @@ struct Component {
     }
     if (!depends_on.empty()) {
       x_medkit["dependsOn"] = depends_on;
+    }
+    if (!contributors.empty()) {
+      x_medkit["contributors"] = contributors;
     }
     x_medkit["topics"] = topics.to_json();
     if (host_metadata.has_value()) {

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "ros2_medkit_gateway/discovery/models/common.hpp"
+
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/models/function.hpp
@@ -46,7 +46,8 @@ struct Function {
   std::vector<std::string> depends_on;  ///< depends-on relationship (Function IDs)
 
   // === Discovery metadata ===
-  std::string source = "manifest";  ///< Discovery source: manifest or runtime
+  std::string source = "manifest";        ///< Discovery source: manifest or runtime
+  std::vector<std::string> contributors;  ///< Aggregation provenance: "local" and/or "peer:<name>"
 
   // === Serialization methods ===
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/warning_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/warning_codes.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace ros2_medkit_gateway {
+
+/// Warning codes surfaced on /health.warnings.
+///
+/// These describe deployment anomalies the gateway chooses to flag without
+/// taking itself offline (contrast with error codes in error_codes.hpp which
+/// fail individual requests). Operators can key on these strings to drive
+/// dashboards, alerts, or automated remediation.
+///
+/// Keep this list in sync with docs/api/warning_codes.rst. All codes MUST be
+/// stable strings; rename = breaking change for downstream consumers.
+
+/// A leaf (non-hierarchical) Component ID was announced by more than one peer
+/// during aggregation merge. Routing falls back to last-writer-wins, so
+/// requests for the affected Component reach one peer non-deterministically.
+/// Resolve by renaming the Component on one side or by modelling it as a
+/// hierarchical parent (declare a child Component with
+/// ``parentComponentId`` pointing at the colliding ID on the owning peer).
+inline constexpr const char * WARN_LEAF_ID_COLLISION = "leaf_id_collision";
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/warning_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/warning_codes.hpp
@@ -34,4 +34,11 @@ namespace ros2_medkit_gateway {
 /// ``parentComponentId`` pointing at the colliding ID on the owning peer).
 inline constexpr const char * WARN_LEAF_ID_COLLISION = "leaf_id_collision";
 
+/// Schema version for the ``warnings`` array on ``GET /health``. Clients can
+/// key on this integer to detect supported warning codes without
+/// string-matching on individual codes. Increment whenever a code is added,
+/// removed, or the shape of an individual warning object changes. Keep in
+/// sync with docs/api/warning_codes.rst.
+inline constexpr int kWarningSchemaVersion = 1;
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/x_medkit.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/x_medkit.hpp
@@ -16,6 +16,7 @@
 
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
 namespace ros2_medkit_gateway {
 
@@ -170,6 +171,16 @@ class XMedkit {
   XMedkit & last_feedback(const nlohmann::json & feedback);
 
   // ==================== Generic methods ====================
+
+  /**
+   * @brief Append aggregation provenance ("local" and/or "peer:<name>").
+   *
+   * Emits ``contributors`` only when the vector is non-empty, so single-origin
+   * entities on non-aggregating gateways do not see the field.
+   *
+   * @param contributors Provenance list populated by the aggregation layer
+   */
+  XMedkit & contributors(const std::vector<std::string> & contributors);
 
   /**
    * @brief Add a custom field to the x-medkit object (top level).

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <future>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -397,6 +398,11 @@ AggregationManager::MergedPeerResult AggregationManager::fetch_and_merge_peer_en
     }));
   }
 
+  // Per-peer Component IDs each peer claimed, fed into classify_component_routing
+  // after the loop so that hierarchical-vs-leaf classification sees the full
+  // merged Component set (including subcomponents from other peers).
+  std::vector<PeerClaim> peer_component_claims;
+
   // Collect results and merge sequentially (merge order must be deterministic)
   for (auto & f : futures) {
     auto pfr = f.get();
@@ -406,6 +412,13 @@ AggregationManager::MergedPeerResult AggregationManager::fetch_and_merge_peer_en
       }
       continue;
     }
+
+    PeerClaim claim;
+    claim.peer_name = pfr.peer_name;
+    for (const auto & c : pfr.entities.components) {
+      claim.claimed_entity_ids.insert(c.id);
+    }
+    peer_component_claims.push_back(std::move(claim));
 
     EntityMerger merger(pfr.peer_name);
     merged.areas = merger.merge_areas(merged.areas, pfr.entities.areas);
@@ -449,6 +462,43 @@ AggregationManager::MergedPeerResult AggregationManager::fetch_and_merge_peer_en
           RCLCPP_WARN(*logger, "Entity ID collision: '%s' prefixed for peer '%s'", id.c_str(), name.c_str());
         }
       }
+    }
+  }
+
+  // Reclassify Component routing entries against the fully-merged Component
+  // set. Hierarchical parents (Components referenced as parent_component_id by
+  // another Component) are removed from the routing table so they are served
+  // locally with the merged view, mirroring Areas and Functions. Leaves keep
+  // routing to the owning peer. Multi-peer leaf collisions surface as warnings.
+  std::unordered_set<std::string> all_component_ids;
+  all_component_ids.reserve(merged.components.size());
+  for (const auto & c : merged.components) {
+    all_component_ids.insert(c.id);
+  }
+  for (auto it = merged.routing_table.begin(); it != merged.routing_table.end();) {
+    if (all_component_ids.count(it->first) > 0u) {
+      it = merged.routing_table.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  auto classified = classify_component_routing(merged.components, peer_component_claims);
+  for (auto & [id, name] : classified.routing_table) {
+    merged.routing_table[id] = std::move(name);
+  }
+  merged.leaf_warnings = std::move(classified.leaf_warnings);
+
+  for (const auto & w : merged.leaf_warnings) {
+    if (logger) {
+      std::string peers_str;
+      for (size_t i = 0; i < w.peer_names.size(); ++i) {
+        if (i > 0u) {
+          peers_str += ", ";
+        }
+        peers_str += w.peer_names[i];
+      }
+      RCLCPP_WARN(*logger, "Leaf Component '%s' announced by multiple peers: %s. Routing uses last-writer-wins.",
+                  w.entity_id.c_str(), peers_str.c_str());
     }
   }
 

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -347,6 +347,21 @@ AggregationManager::MergedPeerResult AggregationManager::fetch_and_merge_peer_en
   merged.apps = local_apps;
   merged.functions = local_functions;
 
+  // Seed aggregation provenance: every locally-sourced entity contributes
+  // "local" to its own contributors list. EntityMerger will append
+  // "peer:<name>" entries as peer contributions are folded in.
+  auto seed_local = [](auto & entities) {
+    for (auto & e : entities) {
+      if (e.contributors.empty()) {
+        e.contributors.emplace_back("local");
+      }
+    }
+  };
+  seed_local(merged.areas);
+  seed_local(merged.components);
+  seed_local(merged.apps);
+  seed_local(merged.functions);
+
   // Snapshot healthy peers under lock, release before network I/O.
   // shared_ptr copies keep PeerClients alive even if remove_discovered_peer()
   // erases them from peers_ concurrently.

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -503,8 +503,11 @@ AggregationManager::MergedPeerResult AggregationManager::fetch_and_merge_peer_en
   }
   merged.leaf_warnings = std::move(classified.leaf_warnings);
 
-  for (const auto & w : merged.leaf_warnings) {
-    if (logger) {
+  if (logger) {
+    for (const auto & msg : classified.malformed_parent_warnings) {
+      RCLCPP_WARN(*logger, "Aggregation: %s", msg.c_str());
+    }
+    for (const auto & w : merged.leaf_warnings) {
       std::string peers_str;
       for (size_t i = 0; i < w.peer_names.size(); ++i) {
         if (i > 0u) {

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -510,6 +510,16 @@ void AggregationManager::update_routing_table(const std::unordered_map<std::stri
   routing_table_ = table;
 }
 
+void AggregationManager::set_leaf_warnings(std::vector<LeafCollisionWarning> warnings) {
+  std::unique_lock<std::shared_mutex> lock(mutex_);
+  leaf_warnings_ = std::move(warnings);
+}
+
+std::vector<LeafCollisionWarning> AggregationManager::get_leaf_warnings() const {
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  return leaf_warnings_;
+}
+
 std::optional<std::string> AggregationManager::find_peer_for_entity(const std::string & entity_id) const {
   std::shared_lock<std::shared_mutex> lock(mutex_);
   auto it = routing_table_.find(entity_id);

--- a/src/ros2_medkit_gateway/src/aggregation/classification.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/classification.cpp
@@ -15,19 +15,113 @@
 #include "ros2_medkit_gateway/aggregation/classification.hpp"
 
 #include <algorithm>
+#include <functional>
 
 namespace ros2_medkit_gateway {
+
+namespace {
+
+/// Resolve valid parent edges from merged Components. Self-references,
+/// references to unknown IDs, and cycle participants are excluded and a
+/// warning string is emitted for each case. The returned map contains only
+/// edges safe to use for hierarchical-parent detection.
+std::unordered_map<std::string, std::string> resolve_valid_parents(const std::vector<Component> & merged_components,
+                                                                   std::vector<std::string> & warnings_out) {
+  std::unordered_set<std::string> known_ids;
+  known_ids.reserve(merged_components.size());
+  for (const auto & comp : merged_components) {
+    known_ids.insert(comp.id);
+  }
+
+  std::unordered_map<std::string, std::string> valid_parent;
+  for (const auto & comp : merged_components) {
+    const auto & p = comp.parent_component_id;
+    if (p.empty()) {
+      continue;
+    }
+    if (p == comp.id) {
+      warnings_out.push_back("Component '" + comp.id +
+                             "' declares itself as parent_component_id; ignoring to preserve leaf routing");
+      continue;
+    }
+    if (known_ids.count(p) == 0u) {
+      warnings_out.push_back("Component '" + comp.id + "' references non-existent parent_component_id '" + p +
+                             "'; ignoring (missing from merged entity set)");
+      continue;
+    }
+    valid_parent[comp.id] = p;
+  }
+
+  // Cycle detection via 3-color DFS on the parent chain. Any Component whose
+  // parent chain closes back on itself (A->B->A or longer) is removed from
+  // valid_parent so it stays a routed leaf. One warning per cycle, listing
+  // member IDs alphabetically for stable operator output.
+  enum Color { White, Gray, Black };
+  std::unordered_map<std::string, Color> color;
+  std::unordered_set<std::string> cycle_members;
+
+  std::function<void(const std::string &, std::vector<std::string> &)> visit = [&](const std::string & node,
+                                                                                   std::vector<std::string> & stack) {
+    color[node] = Gray;
+    stack.push_back(node);
+    auto edge = valid_parent.find(node);
+    if (edge != valid_parent.end()) {
+      const auto & next = edge->second;
+      auto c = color.find(next);
+      if (c != color.end() && c->second == Gray) {
+        auto cycle_start = std::find(stack.begin(), stack.end(), next);
+        for (auto it = cycle_start; it != stack.end(); ++it) {
+          cycle_members.insert(*it);
+        }
+      } else if (c == color.end()) {
+        visit(next, stack);
+      }
+    }
+    stack.pop_back();
+    color[node] = Black;
+  };
+
+  for (const auto & [id, _] : valid_parent) {
+    if (color.count(id) == 0u) {
+      std::vector<std::string> stack;
+      visit(id, stack);
+    }
+  }
+
+  if (!cycle_members.empty()) {
+    std::vector<std::string> sorted_members(cycle_members.begin(), cycle_members.end());
+    std::sort(sorted_members.begin(), sorted_members.end());
+    std::string joined;
+    for (size_t i = 0; i < sorted_members.size(); ++i) {
+      if (i > 0u) {
+        joined += ", ";
+      }
+      joined += sorted_members[i];
+    }
+    warnings_out.push_back("Parent cycle detected among Components [" + joined +
+                           "]; cycle members kept as routed leaves");
+    for (const auto & id : cycle_members) {
+      valid_parent.erase(id);
+    }
+  }
+
+  return valid_parent;
+}
+
+}  // namespace
 
 ClassifiedRouting classify_component_routing(const std::vector<Component> & merged_components,
                                              const std::vector<PeerClaim> & peer_claims) {
   ClassifiedRouting result;
 
-  // Identify hierarchical parents: any Component referenced as parent_component_id.
+  // Validate parent edges first. Self-references, unknown parents, and cycle
+  // members are dropped before hierarchical-parent detection so malformed
+  // manifests cannot silently mask leaves.
+  auto valid_parent = resolve_valid_parents(merged_components, result.malformed_parent_warnings);
+
   std::unordered_set<std::string> hierarchical_parents;
-  for (const auto & comp : merged_components) {
-    if (!comp.parent_component_id.empty()) {
-      hierarchical_parents.insert(comp.parent_component_id);
-    }
+  for (const auto & [_, p] : valid_parent) {
+    hierarchical_parents.insert(p);
   }
 
   // Rebuild routing table applying last-writer-wins, skipping hierarchical

--- a/src/ros2_medkit_gateway/src/aggregation/classification.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/classification.cpp
@@ -14,6 +14,8 @@
 
 #include "ros2_medkit_gateway/aggregation/classification.hpp"
 
+#include <algorithm>
+
 namespace ros2_medkit_gateway {
 
 ClassifiedRouting classify_component_routing(const std::vector<Component> & merged_components,
@@ -30,10 +32,15 @@ ClassifiedRouting classify_component_routing(const std::vector<Component> & merg
 
   // Rebuild routing table applying last-writer-wins, skipping hierarchical
   // parents. Track which peers claimed each ID so we can emit warnings on
-  // leaf IDs contested by more than one peer.
+  // leaf IDs contested by more than one peer. Iteration here is intentionally
+  // driven by the input vector order (peer_claims), but the per-peer set is
+  // unordered - sort each peer's IDs before consuming to keep downstream
+  // output deterministic across runs.
   std::unordered_map<std::string, std::vector<std::string>> claims_by_id;
   for (const auto & pc : peer_claims) {
-    for (const auto & id : pc.claimed_entity_ids) {
+    std::vector<std::string> sorted_ids(pc.claimed_entity_ids.begin(), pc.claimed_entity_ids.end());
+    std::sort(sorted_ids.begin(), sorted_ids.end());
+    for (const auto & id : sorted_ids) {
       claims_by_id[id].push_back(pc.peer_name);
       if (hierarchical_parents.count(id) == 0u) {
         result.routing_table[id] = pc.peer_name;
@@ -42,14 +49,23 @@ ClassifiedRouting classify_component_routing(const std::vector<Component> & merg
   }
 
   // Warnings: emit ONLY for leaves (never for hierarchical parents, whose
-  // multi-peer presence is expected by design).
+  // multi-peer presence is expected by design). Produce results in a stable
+  // order so operator logs and /health.warnings snapshot cleanly: collect
+  // colliding leaf IDs, sort them, sort each peer_names list alphabetically.
+  std::vector<std::string> colliding_leaf_ids;
+  colliding_leaf_ids.reserve(claims_by_id.size());
   for (const auto & [id, peers] : claims_by_id) {
     if (peers.size() >= 2u && hierarchical_parents.count(id) == 0u) {
-      LeafCollisionWarning w;
-      w.entity_id = id;
-      w.peer_names = peers;
-      result.leaf_warnings.push_back(std::move(w));
+      colliding_leaf_ids.push_back(id);
     }
+  }
+  std::sort(colliding_leaf_ids.begin(), colliding_leaf_ids.end());
+  for (const auto & id : colliding_leaf_ids) {
+    LeafCollisionWarning w;
+    w.entity_id = id;
+    w.peer_names = claims_by_id.at(id);
+    std::sort(w.peer_names.begin(), w.peer_names.end());
+    result.leaf_warnings.push_back(std::move(w));
   }
 
   return result;

--- a/src/ros2_medkit_gateway/src/aggregation/classification.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/classification.cpp
@@ -1,0 +1,58 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/aggregation/classification.hpp"
+
+namespace ros2_medkit_gateway {
+
+ClassifiedRouting classify_component_routing(const std::vector<Component> & merged_components,
+                                             const std::vector<PeerClaim> & peer_claims) {
+  ClassifiedRouting result;
+
+  // Identify hierarchical parents: any Component referenced as parent_component_id.
+  std::unordered_set<std::string> hierarchical_parents;
+  for (const auto & comp : merged_components) {
+    if (!comp.parent_component_id.empty()) {
+      hierarchical_parents.insert(comp.parent_component_id);
+    }
+  }
+
+  // Rebuild routing table applying last-writer-wins, skipping hierarchical
+  // parents. Track which peers claimed each ID so we can emit warnings on
+  // leaf IDs contested by more than one peer.
+  std::unordered_map<std::string, std::vector<std::string>> claims_by_id;
+  for (const auto & pc : peer_claims) {
+    for (const auto & id : pc.claimed_entity_ids) {
+      claims_by_id[id].push_back(pc.peer_name);
+      if (hierarchical_parents.count(id) == 0u) {
+        result.routing_table[id] = pc.peer_name;
+      }
+    }
+  }
+
+  // Warnings: emit ONLY for leaves (never for hierarchical parents, whose
+  // multi-peer presence is expected by design).
+  for (const auto & [id, peers] : claims_by_id) {
+    if (peers.size() >= 2u && hierarchical_parents.count(id) == 0u) {
+      LeafCollisionWarning w;
+      w.entity_id = id;
+      w.peer_names = peers;
+      result.leaf_warnings.push_back(std::move(w));
+    }
+  }
+
+  return result;
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
@@ -29,6 +29,17 @@ std::string EntityMerger::peer_source() const {
   return "peer:" + peer_name_;
 }
 
+namespace {
+void append_contributor_unique(std::vector<std::string> & contributors, const std::string & entry) {
+  for (const auto & existing : contributors) {
+    if (existing == entry) {
+      return;
+    }
+  }
+  contributors.push_back(entry);
+}
+}  // namespace
+
 const std::unordered_map<std::string, std::string> & EntityMerger::get_routing_table() const {
   return routing_table_;
 }
@@ -62,11 +73,14 @@ std::vector<Area> EntityMerger::merge_areas(const std::vector<Area> & local, con
         merged.description = remote_area.description;
       }
 
+      append_contributor_unique(merged.contributors, peer_source());
+
       // Merged areas do NOT go into routing table - they are combined local+remote
     } else {
       // No collision: add remote area with source tagged
       Area added = remote_area;
       added.source = peer_source();
+      append_contributor_unique(added.contributors, peer_source());
       result.push_back(added);
 
       // Remote-only areas get a routing entry
@@ -109,11 +123,14 @@ std::vector<Function> EntityMerger::merge_functions(const std::vector<Function> 
         }
       }
 
+      append_contributor_unique(merged.contributors, peer_source());
+
       // Merged functions do NOT go into routing table
     } else {
       // No collision: add remote function with source tagged
       Function added = remote_func;
       added.source = peer_source();
+      append_contributor_unique(added.contributors, peer_source());
       result.push_back(added);
 
       // Remote-only functions get a routing entry
@@ -160,10 +177,12 @@ std::vector<Component> EntityMerger::merge_components(const std::vector<Componen
       // faults). Route all requests for the merged Component to the peer;
       // the primary only aggregates its presence in discovery listings.
       routing_table_[merged.id] = peer_name_;
+      append_contributor_unique(merged.contributors, peer_source());
     } else {
       // No collision: add remote component with source tagged
       Component added = remote_comp;
       added.source = peer_source();
+      append_contributor_unique(added.contributors, peer_source());
       result.push_back(added);
 
       // Remote-only components get a routing entry
@@ -199,6 +218,7 @@ std::vector<App> EntityMerger::merge_apps(const std::vector<App> & local, const 
       added.name = peer_name_ + SEPARATOR + remote_app.name;
     }
 
+    append_contributor_unique(added.contributors, peer_source());
     routing_table_[added.id] = peer_name_;
     result.push_back(added);
   }

--- a/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
@@ -154,10 +154,11 @@ std::vector<Component> EntityMerger::merge_components(const std::vector<Componen
         merged.description = remote_comp.description;
       }
 
-      // Merged components get a routing entry so sub-resource requests
-      // (data, logs, hosts, operations) are forwarded to the peer that
-      // owns the component's runtime state. Without this, requests like
-      // GET /components/{id}/logs return empty on the primary.
+      // A Component ID refers to one physical ECU. When the same ID is
+      // present locally and remotely, the peer is the authoritative owner
+      // of the Component's runtime state (data, logs, hosts, operations,
+      // faults). Route all requests for the merged Component to the peer;
+      // the primary only aggregates its presence in discovery listings.
       routing_table_[merged.id] = peer_name_;
     } else {
       // No collision: add remote component with source tagged

--- a/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/entity_merger.cpp
@@ -154,7 +154,11 @@ std::vector<Component> EntityMerger::merge_components(const std::vector<Componen
         merged.description = remote_comp.description;
       }
 
-      // Merged components do NOT go into routing table - they are combined local+remote
+      // Merged components get a routing entry so sub-resource requests
+      // (data, logs, hosts, operations) are forwarded to the peer that
+      // owns the component's runtime state. Without this, requests like
+      // GET /components/{id}/logs return empty on the primary.
+      routing_table_[merged.id] = peer_name_;
     } else {
       // No collision: add remote component with source tagged
       Component added = remote_comp;

--- a/src/ros2_medkit_gateway/src/discovery/models/app.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/models/app.cpp
@@ -54,6 +54,9 @@ json App::to_json() const {
   if (!original_id.empty()) {
     x_medkit["original_id"] = original_id;
   }
+  if (!contributors.empty()) {
+    x_medkit["contributors"] = contributors;
+  }
   // Add topics if present
   if (!topics.publishes.empty() || !topics.subscribes.empty()) {
     x_medkit["topics"] = topics.to_json();

--- a/src/ros2_medkit_gateway/src/discovery/models/app.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/models/app.cpp
@@ -55,7 +55,7 @@ json App::to_json() const {
     x_medkit["original_id"] = original_id;
   }
   if (!contributors.empty()) {
-    x_medkit["contributors"] = contributors;
+    x_medkit["contributors"] = sorted_contributors(contributors);
   }
   // Add topics if present
   if (!topics.publishes.empty() || !topics.subscribes.empty()) {

--- a/src/ros2_medkit_gateway/src/discovery/models/function.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/models/function.cpp
@@ -42,7 +42,7 @@ json Function::to_json() const {
     x_medkit["dependsOn"] = depends_on;
   }
   if (!contributors.empty()) {
-    x_medkit["contributors"] = contributors;
+    x_medkit["contributors"] = sorted_contributors(contributors);
   }
   j["x-medkit"] = x_medkit;
 

--- a/src/ros2_medkit_gateway/src/discovery/models/function.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/models/function.cpp
@@ -41,6 +41,9 @@ json Function::to_json() const {
   if (!depends_on.empty()) {
     x_medkit["dependsOn"] = depends_on;
   }
+  if (!contributors.empty()) {
+    x_medkit["contributors"] = contributors;
+  }
   j["x-medkit"] = x_medkit;
 
   return j;

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1543,6 +1543,7 @@ void GatewayNode::refresh_cache() {
       functions = std::move(merged.functions);
       peer_routing_table = std::move(merged.routing_table);
       aggregation_mgr_->update_routing_table(peer_routing_table);
+      aggregation_mgr_->set_leaf_warnings(std::move(merged.leaf_warnings));
     }
 
     // Inject plugin entities (non-hybrid) and refresh entity ownership (all modes).

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -210,6 +210,7 @@ void DiscoveryHandlers::handle_get_area(const httplib::Request & req, httplib::R
     if (!area.parent_area_id.empty()) {
       ext.add("parent_area_id", area.parent_area_id);
     }
+    ext.contributors(area.contributors);
     response["x-medkit"] = ext.build();
 
     HandlerContext::send_json(res, response);
@@ -603,9 +604,7 @@ void DiscoveryHandlers::handle_get_component(const httplib::Request & req, httpl
     if (!comp.description.empty()) {
       ext.add("description", comp.description);
     }
-    if (!comp.contributors.empty()) {
-      ext.add("contributors", nlohmann::json(comp.contributors));
-    }
+    ext.contributors(comp.contributors);
 
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {
@@ -1014,6 +1013,7 @@ void DiscoveryHandlers::handle_get_app(const httplib::Request & req, httplib::Re
     if (!app.component_id.empty()) {
       ext.component_id(app.component_id);
     }
+    ext.contributors(app.contributors);
     response["x-medkit"] = ext.build();
 
     HandlerContext::send_json(res, response);
@@ -1306,6 +1306,7 @@ void DiscoveryHandlers::handle_get_function(const httplib::Request & req, httpli
     if (!func.description.empty()) {
       ext.add("description", func.description);
     }
+    ext.contributors(func.contributors);
     response["x-medkit"] = ext.build();
 
     HandlerContext::send_json(res, response);

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -603,6 +603,9 @@ void DiscoveryHandlers::handle_get_component(const httplib::Request & req, httpl
     if (!comp.description.empty()) {
       ext.add("description", comp.description);
     }
+    if (!comp.contributors.empty()) {
+      ext.add("contributors", nlohmann::json(comp.contributors));
+    }
 
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -14,7 +14,6 @@
 
 #include "ros2_medkit_gateway/http/handlers/health_handlers.hpp"
 
-#include <algorithm>
 #include <chrono>
 
 #include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
@@ -70,6 +69,13 @@ void HealthHandlers::handle_health(const httplib::Request & req, httplib::Respon
     // Add peer status when aggregation is active
     if (auto * agg = ctx_.aggregation_manager()) {
       response["peers"] = agg->get_peer_status();
+
+      // Contract version for the warnings array. Increment whenever a code
+      // is added or the shape of a warning object changes so typed clients
+      // (MCP, Web UI, Foxglove) can feature-detect instead of relying on
+      // capabilities.aggregation (a boolean, too coarse).
+      // Keep in sync with docs/api/warning_codes.rst "Schema versioning".
+      response["warning_schema_version"] = kWarningSchemaVersion;
 
       // Surface operator-actionable aggregation warnings (x-medkit extension).
       // Always an array when aggregation is active; empty means no active

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -69,6 +69,19 @@ void HealthHandlers::handle_health(const httplib::Request & req, httplib::Respon
     // Add peer status when aggregation is active
     if (auto * agg = ctx_.aggregation_manager()) {
       response["peers"] = agg->get_peer_status();
+
+      // Surface operator-actionable aggregation warnings (x-medkit extension).
+      // Empty array when there are no active warnings.
+      json warnings = json::array();
+      for (const auto & w : agg->get_leaf_warnings()) {
+        warnings.push_back({
+            {"code", "leaf_id_collision"},
+            {"message", "Component '" + w.entity_id + "' announced by multiple peers; routing uses last-writer-wins."},
+            {"entity_ids", json::array({w.entity_id})},
+            {"peer_names", w.peer_names},
+        });
+      }
+      response["warnings"] = std::move(warnings);
     }
 
     HandlerContext::send_json(res, response);

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -25,6 +25,7 @@
 #include "ros2_medkit_gateway/http/error_codes.hpp"
 #include "ros2_medkit_gateway/http/fan_out_helpers.hpp"
 #include "ros2_medkit_gateway/http/http_utils.hpp"
+#include "ros2_medkit_gateway/http/warning_codes.hpp"
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
 #include "ros2_medkit_gateway/version.hpp"
 
@@ -71,12 +72,26 @@ void HealthHandlers::handle_health(const httplib::Request & req, httplib::Respon
       response["peers"] = agg->get_peer_status();
 
       // Surface operator-actionable aggregation warnings (x-medkit extension).
-      // Empty array when there are no active warnings.
+      // Always an array when aggregation is active; empty means no active
+      // warnings. Clients can feature-detect via /.capabilities.aggregation
+      // in the root response.
       json warnings = json::array();
       for (const auto & w : agg->get_leaf_warnings()) {
+        std::string peers_list;
+        for (size_t i = 0; i < w.peer_names.size(); ++i) {
+          if (i > 0u) {
+            peers_list += ", ";
+          }
+          peers_list += w.peer_names[i];
+        }
+        std::string message = "Component '" + w.entity_id + "' is announced by multiple peers (" + peers_list +
+                              "); routing falls back to last-writer-wins which is non-deterministic. Resolve by "
+                              "renaming the Component on one side or by modelling it as a hierarchical parent "
+                              "(declare a child Component with parentComponentId='" +
+                              w.entity_id + "' on the owning peer).";
         warnings.push_back({
-            {"code", "leaf_id_collision"},
-            {"message", "Component '" + w.entity_id + "' announced by multiple peers; routing uses last-writer-wins."},
+            {"code", WARN_LEAF_ID_COLLISION},
+            {"message", std::move(message)},
             {"entity_ids", json::array({w.entity_id})},
             {"peer_names", w.peer_names},
         });
@@ -143,6 +158,7 @@ void HealthHandlers::handle_root(const httplib::Request & req, httplib::Response
         {"tls", tls_config.enabled},
         {"scripts", ctx_.node() && ctx_.node()->get_script_manager() != nullptr &&
                         ctx_.node()->get_script_manager()->has_backend()},
+        {"aggregation", ctx_.aggregation_manager() != nullptr},
         {"vendor_extensions",
          ctx_.node() && ctx_.node()->get_plugin_manager() && ctx_.node()->get_plugin_manager()->has_plugins()},
     };

--- a/src/ros2_medkit_gateway/src/http/x_medkit.cpp
+++ b/src/ros2_medkit_gateway/src/http/x_medkit.cpp
@@ -14,6 +14,9 @@
 
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
 
+#include <algorithm>
+#include <utility>
+
 namespace ros2_medkit_gateway {
 
 // ==================== ROS2 metadata ====================
@@ -101,6 +104,26 @@ XMedkit & XMedkit::goal_status(const std::string & status) {
 
 XMedkit & XMedkit::last_feedback(const nlohmann::json & feedback) {
   other_["last_feedback"] = feedback;
+  return *this;
+}
+
+XMedkit & XMedkit::contributors(const std::vector<std::string> & contributors) {
+  if (contributors.empty()) {
+    return *this;
+  }
+  // Stable presentation order: "local" first (when present), then "peer:<name>"
+  // entries alphabetically. Lets UI badges and snapshot tests rely on a
+  // consistent order regardless of how peers were merged internally.
+  std::vector<std::string> sorted(contributors.begin(), contributors.end());
+  std::sort(sorted.begin(), sorted.end(), [](const std::string & a, const std::string & b) {
+    const bool a_local = (a == "local");
+    const bool b_local = (b == "local");
+    if (a_local != b_local) {
+      return a_local;
+    }
+    return a < b;
+  });
+  other_["contributors"] = std::move(sorted);
   return *this;
 }
 

--- a/src/ros2_medkit_gateway/src/http/x_medkit.cpp
+++ b/src/ros2_medkit_gateway/src/http/x_medkit.cpp
@@ -14,8 +14,7 @@
 
 #include "ros2_medkit_gateway/http/x_medkit.hpp"
 
-#include <algorithm>
-#include <utility>
+#include "ros2_medkit_gateway/discovery/models/common.hpp"
 
 namespace ros2_medkit_gateway {
 
@@ -111,19 +110,11 @@ XMedkit & XMedkit::contributors(const std::vector<std::string> & contributors) {
   if (contributors.empty()) {
     return *this;
   }
-  // Stable presentation order: "local" first (when present), then "peer:<name>"
-  // entries alphabetically. Lets UI badges and snapshot tests rely on a
-  // consistent order regardless of how peers were merged internally.
-  std::vector<std::string> sorted(contributors.begin(), contributors.end());
-  std::sort(sorted.begin(), sorted.end(), [](const std::string & a, const std::string & b) {
-    const bool a_local = (a == "local");
-    const bool b_local = (b == "local");
-    if (a_local != b_local) {
-      return a_local;
-    }
-    return a < b;
-  });
-  other_["contributors"] = std::move(sorted);
+  // Delegate to sorted_contributors() in common.hpp so list responses (which
+  // serialise entities directly) and detail responses (which route through
+  // XMedkit) share a single ordering implementation. Two copies silently drift
+  // apart; one helper cannot.
+  other_["contributors"] = sorted_contributors(contributors);
   return *this;
 }
 

--- a/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
@@ -122,12 +122,30 @@ nlohmann::json SchemaBuilder::fault_list_schema() {
 }
 
 nlohmann::json SchemaBuilder::entity_detail_schema() {
+  // Aggregation provenance surfaced on every merged entity (x-medkit vendor
+  // extension). Present only when non-empty; ordering is stable ("local"
+  // first when present, then "peer:<name>" entries alphabetically) so that
+  // clients and snapshot tests can rely on it. See design/aggregation.rst.
+  nlohmann::json x_medkit_schema = {
+      {"type", "object"},
+      {"properties",
+       {{"contributors",
+         {{"type", "array"},
+          {"items", {{"type", "string"}}},
+          {"description",
+           "Aggregation provenance: 'local' and/or 'peer:<name>' entries naming the sources that "
+           "contributed to this merged entity. Sorted with 'local' first and 'peer:*' entries "
+           "alphabetically. Present only when aggregation is active and the entity has at least "
+           "one known source."}}}}},
+      {"additionalProperties", true}};
+
   return {{"type", "object"},
           {"properties",
            {{"id", {{"type", "string"}}},
             {"name", {{"type", "string"}}},
             {"type", {{"type", "string"}}},
-            {"uri", {{"type", "string"}}}}},
+            {"uri", {{"type", "string"}}},
+            {"x-medkit", x_medkit_schema}}},
           {"required", {"id", "name"}}};
 }
 

--- a/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
@@ -199,10 +199,44 @@ nlohmann::json SchemaBuilder::health_schema() {
                                        {"linking", linking_schema}}},
                                      {"description", "Discovery subsystem status"}};
 
-  return {{"type", "object"},
-          {"properties",
-           {{"status", {{"type", "string"}}}, {"timestamp", {{"type", "integer"}}}, {"discovery", discovery_schema}}},
-          {"required", {"status"}}};
+  nlohmann::json peer_status_schema = {{"type", "object"}, {"additionalProperties", true}};
+
+  nlohmann::json aggregation_warning_schema = {
+      {"type", "object"},
+      {"description",
+       "Operator-actionable aggregation warning. Codes are documented in "
+       "docs/api/warning_codes.rst and stable across releases."},
+      {"properties",
+       {{"code",
+         {{"type", "string"}, {"description", "Stable machine-readable identifier, e.g. 'leaf_id_collision'."}}},
+        {"message", {{"type", "string"}, {"description", "Human-readable description including remediation hints."}}},
+        {"entity_ids",
+         {{"type", "array"},
+          {"items", {{"type", "string"}}},
+          {"description", "SOVD entity IDs affected by the warning."}}},
+        {"peer_names",
+         {{"type", "array"},
+          {"items", {{"type", "string"}}},
+          {"description", "Aggregation peers involved in the anomaly."}}}}},
+      {"required", {"code", "message", "entity_ids", "peer_names"}}};
+
+  return {
+      {"type", "object"},
+      {"properties",
+       {{"status", {{"type", "string"}}},
+        {"timestamp", {{"type", "integer"}}},
+        {"discovery", discovery_schema},
+        {"peers",
+         {{"type", "array"},
+          {"items", peer_status_schema},
+          {"description", "Aggregation peer status (x-medkit extension; present only when aggregation is enabled)."}}},
+        {"warnings",
+         {{"type", "array"},
+          {"items", aggregation_warning_schema},
+          {"description",
+           "Operator-actionable aggregation warnings (x-medkit extension; always an array when "
+           "aggregation is enabled, empty when there are no active warnings)."}}}}},
+      {"required", {"status"}}};
 }
 
 nlohmann::json SchemaBuilder::version_info_schema() {

--- a/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
+++ b/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
@@ -200,3 +200,102 @@ TEST(AggregationClassification, leaf_collision_across_multiple_peers_emits_warni
   EXPECT_EQ(claimants.count("peer_c"), 1u);
   EXPECT_EQ(claimants.size(), 2u);
 }
+
+// @verifies REQ_INTEROP_003
+TEST(AggregationClassification, leaf_collision_routing_respects_input_order) {
+  // Flipped input: peer_b last -> routing must resolve to peer_b. Guards
+  // against regressions that sort peer_claims before classification and thus
+  // break the documented last-writer-wins contract.
+  std::vector<Component> merged = {
+      make_comp("ecu-shared"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_c", {"ecu-shared"}),
+      make_claim("peer_b", {"ecu-shared"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  ASSERT_EQ(result.routing_table.count("ecu-shared"), 1u);
+  EXPECT_EQ(result.routing_table.at("ecu-shared"), "peer_b");
+  ASSERT_EQ(result.leaf_warnings.size(), 1u);
+  EXPECT_EQ(result.leaf_warnings.front().entity_id, "ecu-shared");
+}
+
+// =============================================================================
+// Malformed parent_component_id: self, nonexistent, cycle
+// =============================================================================
+
+// @verifies REQ_INTEROP_003
+TEST(AggregationClassification, parent_references_nonexistent_component_falls_back_to_leaf) {
+  // Peer declares a Component whose parent_component_id points at an ID not
+  // present anywhere in the merged set. Prior behaviour silently excluded the
+  // ghost ID from routing while leaving the child as a routed leaf; that
+  // caused a dangling parent pointer in the serialised child response and no
+  // operator signal. The classifier now ignores the ghost edge and records a
+  // diagnostic so the misconfiguration surfaces via RCLCPP_WARN.
+  std::vector<Component> merged = {
+      make_comp("child", "ghost-parent"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"child"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  ASSERT_EQ(result.routing_table.count("child"), 1u);
+  EXPECT_EQ(result.routing_table.at("child"), "peer_b");
+  EXPECT_EQ(result.routing_table.count("ghost-parent"), 0u);
+  ASSERT_EQ(result.malformed_parent_warnings.size(), 1u);
+  EXPECT_NE(result.malformed_parent_warnings.front().find("ghost-parent"), std::string::npos);
+  EXPECT_NE(result.malformed_parent_warnings.front().find("non-existent"), std::string::npos);
+}
+
+// @verifies REQ_INTEROP_003
+TEST(AggregationClassification, self_parent_is_ignored_and_warned) {
+  // A Component declaring itself as parent would otherwise be excluded from
+  // the routing table AND never render children (it has none), effectively
+  // disappearing into the local merged cache. Treat it as a leaf and warn.
+  std::vector<Component> merged = {
+      make_comp("orphan", "orphan"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"orphan"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  ASSERT_EQ(result.routing_table.count("orphan"), 1u);
+  EXPECT_EQ(result.routing_table.at("orphan"), "peer_b");
+  ASSERT_EQ(result.malformed_parent_warnings.size(), 1u);
+  EXPECT_NE(result.malformed_parent_warnings.front().find("orphan"), std::string::npos);
+  EXPECT_NE(result.malformed_parent_warnings.front().find("itself"), std::string::npos);
+}
+
+// @verifies REQ_INTEROP_003
+TEST(AggregationClassification, two_way_parent_cycle_falls_back_to_leaves_with_warning) {
+  // A<->B cycle: prior behaviour marked both A and B as hierarchical parents
+  // of each other, excluded both from the routing table, then served empty
+  // local stubs instead of forwarding to the owning peer. The classifier now
+  // detects the cycle, drops both edges, and emits a single diagnostic
+  // listing the cycle members.
+  std::vector<Component> merged = {
+      make_comp("node-a", "node-b"),
+      make_comp("node-b", "node-a"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"node-a", "node-b"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  ASSERT_EQ(result.routing_table.count("node-a"), 1u);
+  EXPECT_EQ(result.routing_table.at("node-a"), "peer_b");
+  ASSERT_EQ(result.routing_table.count("node-b"), 1u);
+  EXPECT_EQ(result.routing_table.at("node-b"), "peer_b");
+  ASSERT_EQ(result.malformed_parent_warnings.size(), 1u);
+  const auto & w = result.malformed_parent_warnings.front();
+  EXPECT_NE(w.find("cycle"), std::string::npos);
+  EXPECT_NE(w.find("node-a"), std::string::npos);
+  EXPECT_NE(w.find("node-b"), std::string::npos);
+}

--- a/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
+++ b/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
@@ -20,8 +20,7 @@
 #include <vector>
 
 #include "ros2_medkit_gateway/aggregation/classification.hpp"
-#include "ros2_medkit_gateway/models/app.hpp"
-#include "ros2_medkit_gateway/models/component.hpp"
+#include "ros2_medkit_gateway/discovery/models/component.hpp"
 
 using namespace ros2_medkit_gateway;
 
@@ -118,10 +117,9 @@ TEST(AggregationClassification, hierarchical_parent_drops_routing_across_multipl
   // as parent; each peer brings its own ECU-leaf child. "robot" stays local,
   // each ECU-leaf routes to the peer that contributed it.
   std::vector<Component> merged = {
-      make_comp("robot"),
-      make_comp("perception-ecu", "robot"),  // local
-      make_comp("planning-ecu", "robot"),    // from peer_b
-      make_comp("actuation-ecu", "robot"),   // from peer_c
+      make_comp("robot"), make_comp("perception-ecu", "robot"),  // local
+      make_comp("planning-ecu", "robot"),                        // from peer_b
+      make_comp("actuation-ecu", "robot"),                       // from peer_c
   };
   std::vector<PeerClaim> claims = {
       make_claim("peer_b", {"robot", "planning-ecu"}),

--- a/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
+++ b/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
@@ -49,6 +49,7 @@ PeerClaim make_claim(const std::string & peer, std::initializer_list<std::string
 // Leaf ECU Component: collision routes to peer
 // =============================================================================
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, leaf_collision_keeps_routing_to_peer) {
   // Two peers each with an ECU-level leaf "ecu-x" that collides with primary's
   // local one. No Component references "ecu-x" as its parent -> leaf -> stays
@@ -71,6 +72,7 @@ TEST(AggregationClassification, leaf_collision_keeps_routing_to_peer) {
 // Hierarchical parent Component: collision stays local (merged view)
 // =============================================================================
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, hierarchical_parent_drops_routing_when_local_subcomponents_exist) {
   // Primary declares "robot" as parent of its local "perception-ecu".
   // Peer also declares "robot" (collision). Because "perception-ecu" in the
@@ -90,6 +92,7 @@ TEST(AggregationClassification, hierarchical_parent_drops_routing_when_local_sub
   EXPECT_TRUE(result.leaf_warnings.empty());
 }
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, hierarchical_parent_drops_routing_when_remote_subcomponents_exist) {
   // Primary has only "robot" (no local children). Peer brings both "robot"
   // (collision) and "planning-ecu" with parent_component_id=robot. After
@@ -112,6 +115,7 @@ TEST(AggregationClassification, hierarchical_parent_drops_routing_when_remote_su
   EXPECT_TRUE(result.leaf_warnings.empty());
 }
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, hierarchical_parent_drops_routing_across_multiple_peers) {
   // multi_ecu_aggregation demo case: primary + 2 peers all declare "robot"
   // as parent; each peer brings its own ECU-leaf child. "robot" stays local,
@@ -145,6 +149,7 @@ TEST(AggregationClassification, hierarchical_parent_drops_routing_across_multipl
 // Sub-components of hierarchical parent still route
 // =============================================================================
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, subcomponents_of_hierarchical_parent_still_route_to_peer) {
   // Confirms that removing routing for a hierarchical parent does NOT cascade
   // to its sub-components - those remain peer-owned leaves.
@@ -167,6 +172,7 @@ TEST(AggregationClassification, subcomponents_of_hierarchical_parent_still_route
 // Multi-peer leaf collision: warning + last-writer-wins
 // =============================================================================
 
+// @verifies REQ_INTEROP_003
 TEST(AggregationClassification, leaf_collision_across_multiple_peers_emits_warning) {
   // Two peers both claim the same leaf ECU "ecu-shared" (deployment anomaly -
   // two peers exposing the same physical ECU). Routing uses last-writer; a

--- a/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
+++ b/src/ros2_medkit_gateway/test/test_aggregation_classification.cpp
@@ -1,0 +1,198 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "ros2_medkit_gateway/aggregation/classification.hpp"
+#include "ros2_medkit_gateway/models/app.hpp"
+#include "ros2_medkit_gateway/models/component.hpp"
+
+using namespace ros2_medkit_gateway;
+
+namespace {
+
+Component make_comp(const std::string & id, const std::string & parent_id = "") {
+  Component c;
+  c.id = id;
+  c.name = id;
+  c.parent_component_id = parent_id;
+  return c;
+}
+
+PeerClaim make_claim(const std::string & peer, std::initializer_list<std::string> ids) {
+  PeerClaim pc;
+  pc.peer_name = peer;
+  for (const auto & id : ids) {
+    pc.claimed_entity_ids.insert(id);
+  }
+  return pc;
+}
+
+}  // namespace
+
+// =============================================================================
+// Leaf ECU Component: collision routes to peer
+// =============================================================================
+
+TEST(AggregationClassification, leaf_collision_keeps_routing_to_peer) {
+  // Two peers each with an ECU-level leaf "ecu-x" that collides with primary's
+  // local one. No Component references "ecu-x" as its parent -> leaf -> stays
+  // in routing table (peer authoritative for runtime state).
+  std::vector<Component> merged = {
+      make_comp("ecu-x"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"ecu-x"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  ASSERT_EQ(result.routing_table.count("ecu-x"), 1u);
+  EXPECT_EQ(result.routing_table.at("ecu-x"), "peer_b");
+  EXPECT_TRUE(result.leaf_warnings.empty());
+}
+
+// =============================================================================
+// Hierarchical parent Component: collision stays local (merged view)
+// =============================================================================
+
+TEST(AggregationClassification, hierarchical_parent_drops_routing_when_local_subcomponents_exist) {
+  // Primary declares "robot" as parent of its local "perception-ecu".
+  // Peer also declares "robot" (collision). Because "perception-ecu" in the
+  // merged set references "robot" as parent, "robot" is a hierarchical
+  // parent -> removed from routing table (served locally with merged view).
+  std::vector<Component> merged = {
+      make_comp("robot"),
+      make_comp("perception-ecu", "robot"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"robot"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  EXPECT_EQ(result.routing_table.count("robot"), 0u);
+  EXPECT_TRUE(result.leaf_warnings.empty());
+}
+
+TEST(AggregationClassification, hierarchical_parent_drops_routing_when_remote_subcomponents_exist) {
+  // Primary has only "robot" (no local children). Peer brings both "robot"
+  // (collision) and "planning-ecu" with parent_component_id=robot. After
+  // merge, "planning-ecu" in the set references "robot" -> still
+  // hierarchical parent -> no routing entry.
+  std::vector<Component> merged = {
+      make_comp("robot"),
+      make_comp("planning-ecu", "robot"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"robot", "planning-ecu"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  EXPECT_EQ(result.routing_table.count("robot"), 0u);
+  // The sub-component is peer-owned -> routes to peer_b.
+  ASSERT_EQ(result.routing_table.count("planning-ecu"), 1u);
+  EXPECT_EQ(result.routing_table.at("planning-ecu"), "peer_b");
+  EXPECT_TRUE(result.leaf_warnings.empty());
+}
+
+TEST(AggregationClassification, hierarchical_parent_drops_routing_across_multiple_peers) {
+  // multi_ecu_aggregation demo case: primary + 2 peers all declare "robot"
+  // as parent; each peer brings its own ECU-leaf child. "robot" stays local,
+  // each ECU-leaf routes to the peer that contributed it.
+  std::vector<Component> merged = {
+      make_comp("robot"),
+      make_comp("perception-ecu", "robot"),  // local
+      make_comp("planning-ecu", "robot"),    // from peer_b
+      make_comp("actuation-ecu", "robot"),   // from peer_c
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"robot", "planning-ecu"}),
+      make_claim("peer_c", {"robot", "actuation-ecu"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  // "robot" is a hierarchical parent - no routing entry even with 2 peers
+  // colliding on it.
+  EXPECT_EQ(result.routing_table.count("robot"), 0u);
+  // Each ECU-leaf routes to its owning peer.
+  ASSERT_EQ(result.routing_table.count("planning-ecu"), 1u);
+  EXPECT_EQ(result.routing_table.at("planning-ecu"), "peer_b");
+  ASSERT_EQ(result.routing_table.count("actuation-ecu"), 1u);
+  EXPECT_EQ(result.routing_table.at("actuation-ecu"), "peer_c");
+  // Multi-peer collision on "robot" is EXPECTED (hierarchical) and must NOT
+  // produce a warning.
+  EXPECT_TRUE(result.leaf_warnings.empty());
+}
+
+// =============================================================================
+// Sub-components of hierarchical parent still route
+// =============================================================================
+
+TEST(AggregationClassification, subcomponents_of_hierarchical_parent_still_route_to_peer) {
+  // Confirms that removing routing for a hierarchical parent does NOT cascade
+  // to its sub-components - those remain peer-owned leaves.
+  std::vector<Component> merged = {
+      make_comp("robot"),
+      make_comp("planning-ecu", "robot"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"robot", "planning-ecu"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  EXPECT_EQ(result.routing_table.count("robot"), 0u);
+  ASSERT_EQ(result.routing_table.count("planning-ecu"), 1u);
+  EXPECT_EQ(result.routing_table.at("planning-ecu"), "peer_b");
+}
+
+// =============================================================================
+// Multi-peer leaf collision: warning + last-writer-wins
+// =============================================================================
+
+TEST(AggregationClassification, leaf_collision_across_multiple_peers_emits_warning) {
+  // Two peers both claim the same leaf ECU "ecu-shared" (deployment anomaly -
+  // two peers exposing the same physical ECU). Routing uses last-writer; a
+  // structured warning lists all colliding peers.
+  std::vector<Component> merged = {
+      make_comp("ecu-shared"),
+  };
+  std::vector<PeerClaim> claims = {
+      make_claim("peer_b", {"ecu-shared"}),
+      make_claim("peer_c", {"ecu-shared"}),
+  };
+
+  auto result = classify_component_routing(merged, claims);
+
+  // Routing exists - last-writer-wins (peer_c processed last here).
+  ASSERT_EQ(result.routing_table.count("ecu-shared"), 1u);
+  EXPECT_EQ(result.routing_table.at("ecu-shared"), "peer_c");
+
+  // Warning enumerates every peer that claimed the leaf (order-agnostic).
+  ASSERT_EQ(result.leaf_warnings.size(), 1u);
+  const auto & w = result.leaf_warnings.front();
+  EXPECT_EQ(w.entity_id, "ecu-shared");
+  std::unordered_set<std::string> claimants(w.peer_names.begin(), w.peer_names.end());
+  EXPECT_EQ(claimants.count("peer_b"), 1u);
+  EXPECT_EQ(claimants.count("peer_c"), 1u);
+  EXPECT_EQ(claimants.size(), 2u);
+}

--- a/src/ros2_medkit_gateway/test/test_entity_merger.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_merger.cpp
@@ -340,17 +340,40 @@ TEST(EntityMerger, routing_table_uses_prefixed_id_on_app_collision) {
   EXPECT_EQ(table.count("shared_app"), 0u);
 }
 
-TEST(EntityMerger, merged_components_not_in_routing_table) {
+TEST(EntityMerger, merged_components_route_to_peer) {
   EntityMerger merger("peer_x");
 
-  // Same component ID -> merged, should NOT appear in routing table
+  // Same component ID across peers refers to the same physical ECU, but only
+  // the peer owns the runtime state (data, logs, hosts, operations). The
+  // collision-merged entity must route to the peer so sub-resource requests
+  // reach the owning gateway instead of returning empty locally.
   auto local_comps = std::vector<Component>{make_component("robot-alpha")};
   auto remote_comps = std::vector<Component>{make_component("robot-alpha")};
 
   merger.merge_components(local_comps, remote_comps);
 
   const auto & table = merger.get_routing_table();
-  EXPECT_EQ(table.count("robot-alpha"), 0u);
+  ASSERT_EQ(table.count("robot-alpha"), 1u);
+  EXPECT_EQ(table.at("robot-alpha"), "peer_x");
+}
+
+// @verifies REQ_INTEROP_003
+TEST(EntityMerger, merged_component_hybrid_synthetic_collision_routes_to_peer) {
+  // Scenario: primary in hybrid mode creates a synthetic component from its
+  // namespace (source "node"), and a peer announces a real component with the
+  // same ID. The peer is the authoritative owner of runtime state - all
+  // sub-resource requests (/logs, /hosts, /data, /operations) must forward
+  // to the peer instead of being handled locally.
+  EntityMerger merger("ecu_peer");
+
+  auto local_synthetic = make_component("engine_ctrl", "powertrain", "node");
+  auto remote_real = make_component("engine_ctrl", "powertrain", "manifest");
+
+  merger.merge_components({local_synthetic}, {remote_real});
+
+  const auto & table = merger.get_routing_table();
+  ASSERT_EQ(table.count("engine_ctrl"), 1u);
+  EXPECT_EQ(table.at("engine_ctrl"), "ecu_peer");
 }
 
 TEST(EntityMerger, remote_only_component_gets_routing_entry) {

--- a/src/ros2_medkit_gateway/test/test_entity_merger.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_merger.cpp
@@ -431,6 +431,77 @@ TEST(EntityMerger, remote_only_area_gets_routing_entry) {
 // Source tagging tests
 // =============================================================================
 
+// =============================================================================
+// Contributors provenance tests
+// =============================================================================
+
+TEST(EntityMerger, components_collision_appends_peer_contributor) {
+  EntityMerger merger("peer_b");
+
+  auto local_comp = make_component("robot-alpha");
+  local_comp.contributors = {"local"};
+  auto remote_comp = make_component("robot-alpha");
+
+  auto result = merger.merge_components({local_comp}, {remote_comp});
+
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_EQ(result[0].contributors.size(), 2u);
+  EXPECT_EQ(result[0].contributors[0], "local");
+  EXPECT_EQ(result[0].contributors[1], "peer:peer_b");
+}
+
+TEST(EntityMerger, components_remote_only_gets_peer_contributor_only) {
+  EntityMerger merger("peer_b");
+
+  auto remote_comp = make_component("ecu-c");
+
+  auto result = merger.merge_components({}, {remote_comp});
+
+  ASSERT_EQ(result.size(), 1u);
+  ASSERT_EQ(result[0].contributors.size(), 1u);
+  EXPECT_EQ(result[0].contributors[0], "peer:peer_b");
+}
+
+TEST(EntityMerger, apps_collision_prefixed_gets_peer_contributor_only) {
+  EntityMerger merger("peer_b");
+
+  auto local_app = make_app("camera");
+  local_app.contributors = {"local"};
+  auto remote_app = make_app("camera");
+
+  auto result = merger.merge_apps({local_app}, {remote_app});
+
+  ASSERT_EQ(result.size(), 2u);
+  // Local keeps "local"
+  ASSERT_EQ(result[0].contributors.size(), 1u);
+  EXPECT_EQ(result[0].contributors[0], "local");
+  // Prefixed remote gets only peer contributor
+  ASSERT_EQ(result[1].contributors.size(), 1u);
+  EXPECT_EQ(result[1].contributors[0], "peer:peer_b");
+}
+
+TEST(EntityMerger, contributors_no_duplicate_on_repeat_merge) {
+  // If the same peer is merged twice (defensive check), contributors must
+  // stay unique.
+  EntityMerger merger("peer_b");
+
+  auto local_area = make_area("root");
+  local_area.contributors = {"local"};
+  auto remote_area = make_area("root");
+
+  auto first = merger.merge_areas({local_area}, {remote_area});
+  auto second = merger.merge_areas(first, {remote_area});
+
+  ASSERT_EQ(second.size(), 1u);
+  ASSERT_EQ(second[0].contributors.size(), 2u);
+  EXPECT_EQ(second[0].contributors[0], "local");
+  EXPECT_EQ(second[0].contributors[1], "peer:peer_b");
+}
+
+// =============================================================================
+// Source tagging tests
+// =============================================================================
+
 TEST(EntityMerger, remote_source_tagged) {
   EntityMerger merger("robot_arm");
 

--- a/src/ros2_medkit_gateway/test/test_entity_merger.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_merger.cpp
@@ -435,6 +435,7 @@ TEST(EntityMerger, remote_only_area_gets_routing_entry) {
 // Contributors provenance tests
 // =============================================================================
 
+// @verifies REQ_INTEROP_003
 TEST(EntityMerger, components_collision_appends_peer_contributor) {
   EntityMerger merger("peer_b");
 
@@ -450,6 +451,7 @@ TEST(EntityMerger, components_collision_appends_peer_contributor) {
   EXPECT_EQ(result[0].contributors[1], "peer:peer_b");
 }
 
+// @verifies REQ_INTEROP_003
 TEST(EntityMerger, components_remote_only_gets_peer_contributor_only) {
   EntityMerger merger("peer_b");
 
@@ -462,6 +464,7 @@ TEST(EntityMerger, components_remote_only_gets_peer_contributor_only) {
   EXPECT_EQ(result[0].contributors[0], "peer:peer_b");
 }
 
+// @verifies REQ_INTEROP_003
 TEST(EntityMerger, apps_collision_prefixed_gets_peer_contributor_only) {
   EntityMerger merger("peer_b");
 
@@ -480,6 +483,7 @@ TEST(EntityMerger, apps_collision_prefixed_gets_peer_contributor_only) {
   EXPECT_EQ(result[1].contributors[0], "peer:peer_b");
 }
 
+// @verifies REQ_INTEROP_003
 TEST(EntityMerger, contributors_no_duplicate_on_repeat_merge) {
   // If the same peer is merged twice (defensive check), contributors must
   // stay unique.

--- a/src/ros2_medkit_gateway/test/test_x_medkit.cpp
+++ b/src/ros2_medkit_gateway/test/test_x_medkit.cpp
@@ -300,3 +300,42 @@ TEST_F(XMedkitTest, HandlesNestedJsonObjects) {
   auto result = ext.build();
   EXPECT_EQ(result["nested"]["level1"]["level2"]["level3"], "deep_value");
 }
+
+// ==================== contributors() ordering tests ====================
+
+// @verifies REQ_INTEROP_003
+TEST_F(XMedkitTest, ContributorsOmitsFieldWhenInputEmpty) {
+  XMedkit ext;
+  ext.contributors({});
+  EXPECT_TRUE(ext.empty());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(XMedkitTest, ContributorsPlacesLocalFirstThenPeersAlphabeticallyFromReverseInput) {
+  // Mirrors the user-visible path: detail handlers feed contributors into
+  // XMedkit which must normalise order regardless of how the aggregation
+  // layer appended peers. Reverse-order input guards against a regression
+  // that accidentally flipped the sort direction in sorted_contributors().
+  XMedkit ext;
+  ext.contributors({"peer:zulu", "peer:alpha", "local"});
+
+  auto result = ext.build();
+  ASSERT_TRUE(result.contains("contributors"));
+  ASSERT_TRUE(result["contributors"].is_array());
+  ASSERT_EQ(result["contributors"].size(), 3u);
+  EXPECT_EQ(result["contributors"][0], "local");
+  EXPECT_EQ(result["contributors"][1], "peer:alpha");
+  EXPECT_EQ(result["contributors"][2], "peer:zulu");
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(XMedkitTest, ContributorsWithoutLocalStaysAlphabetical) {
+  XMedkit ext;
+  ext.contributors({"peer:charlie", "peer:alpha", "peer:bravo"});
+
+  auto result = ext.build();
+  ASSERT_EQ(result["contributors"].size(), 3u);
+  EXPECT_EQ(result["contributors"][0], "peer:alpha");
+  EXPECT_EQ(result["contributors"][1], "peer:bravo");
+  EXPECT_EQ(result["contributors"][2], "peer:charlie");
+}

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -133,6 +133,16 @@ if(BUILD_TESTING)
   if(_MEDKIT_DOMAIN_COUNTER GREATER _MEDKIT_DOMAIN_END)
     message(FATAL_ERROR "Integration test domain range exhausted (${_MEDKIT_DOMAIN_START}-${_MEDKIT_DOMAIN_END})")
   endif()
+
+  # Serialise multi-gateway tests that share the secondary DDS domain pool
+  # (230-232, see ros2_medkit_test_utils.constants.get_test_domain_id). CTest
+  # will not run two tests holding this resource lock concurrently, so they
+  # cannot collide on those shared domains.
+  set_tests_properties(
+    test_peer_aggregation
+    test_daisy_chain_aggregation
+    PROPERTIES RESOURCE_LOCK medkit_secondary_dds_domains
+  )
 endif()
 
 ament_package()

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -143,6 +143,7 @@ if(BUILD_TESTING)
     test_peer_aggregation
     test_cross_ecu_fanout
     test_daisy_chain_aggregation
+    test_leaf_collision_aggregation
     PROPERTIES RESOURCE_LOCK medkit_secondary_dds_domains
   )
 endif()

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -137,9 +137,11 @@ if(BUILD_TESTING)
   # Serialise multi-gateway tests that share the secondary DDS domain pool
   # (230-232, see ros2_medkit_test_utils.constants.get_test_domain_id). CTest
   # will not run two tests holding this resource lock concurrently, so they
-  # cannot collide on those shared domains.
+  # cannot collide on those shared domains. Every integration test that
+  # calls get_test_domain_id(offset>0) must be listed here.
   set_tests_properties(
     test_peer_aggregation
+    test_cross_ecu_fanout
     test_daisy_chain_aggregation
     PROPERTIES RESOURCE_LOCK medkit_secondary_dds_domains
   )

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
@@ -39,17 +39,27 @@ def get_test_domain_id(offset=0):
     (stride of 1, range 140-229). For offset 0, returns the assigned
     domain ID directly.
 
-    For offset > 0 (multi-gateway tests needing a second DDS domain),
-    derives a unique secondary domain from the primary via modular
-    mapping into the 230-232 range (DDS max domain is 232). The offset
-    value itself is not used as a multiplier - any non-zero offset
-    selects the same derived secondary for a given primary. Each test's
-    unique primary ensures a deterministic secondary. With 3 buckets
-    and currently 2 multi-gateway tests, collisions are avoided.
+    For offset in 1..3 (multi-gateway tests needing extra DDS domains),
+    returns one of the three secondary domains 230, 231, 232 so each
+    offset produces a distinct domain. These three secondaries sit
+    outside the per-package allocation in
+    ``ROS2MedkitTestDomain.cmake`` and are shared across every
+    multi-gateway integration test; CTest serialises those tests via a
+    ``RESOURCE_LOCK`` (see ``CMakeLists.txt``) so two of them never
+    hold the same secondary domain simultaneously.
+
+    DDS max domain ID is 232 (UDP port formula: 7400 + 250 * domain_id).
+    Offsets above 3 would exceed that ceiling and are rejected up front.
     """
     if offset == 0:
         return DEFAULT_DOMAIN_ID
-    return 230 + ((DEFAULT_DOMAIN_ID - 140) % 3)
+    if not 1 <= offset <= 3:
+        raise ValueError(
+            f'secondary DDS domain offset {offset} out of range 1..3 '
+            '(only domains 230-232 are available; DDS max is 232). '
+            'Add a new offset only after extending the allocation scheme.'
+        )
+    return 229 + offset
 
 
 # Gateway startup

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -279,6 +279,9 @@ class TestDaisyChainAggregation(unittest.TestCase):
         self.assertIn('peers', body)
         self.assertIn('warnings', body)
         self.assertEqual(body['warnings'], [])
+        # Schema version must be present whenever aggregation is active so
+        # typed clients can feature-detect codes without string-matching.
+        self.assertEqual(body.get('warning_schema_version'), 1)
 
     # --- Root capability flag --------------------------------------------
 

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -301,15 +301,22 @@ class TestDaisyChainAggregation(unittest.TestCase):
     # --- Contributors on non-Component entity types ----------------------
 
     def test_leaf_component_detail_contributors_single_peer(self):
-        # A leaf ECU that came entirely from peer_b must have contributors
-        # ["peer:peer_b"]. This used to pass silently even if the field
-        # was dropped (because the test looked at a forwarded response from
-        # peer_b which emits the field itself). We only assert the shape
-        # here - forwarding origin is covered by the 1-hop test above.
+        """@verifies REQ_INTEROP_003.
+
+        GET /components/ecu-b through the primary is transparently forwarded
+        to peer_b (1-hop). The response body is peer_b's own serialised view
+        of ecu-b, where peer_b is the local gateway, so contributors starts
+        with "local" under the stable "local first, then peer:* sorted"
+        ordering. The assertion therefore validates that peer_b's
+        x-medkit.contributors is present and proxied intact - a regression
+        dropping the field on Area/App/Function detail handlers would flip
+        this test. That the request is forwarded (not served with a merged
+        primary view) is verified separately by
+        test_primary_forwards_ecu_b_detail_one_hop.
+        """
         r = requests.get(f'{PRIMARY_URL}/components/ecu-b', timeout=5)
         self.assertEqual(r.status_code, 200)
         contributors = r.json().get('x-medkit', {}).get('contributors', [])
-        # Stable ordering: "local" first when present, then peer:* sorted.
         self.assertEqual(contributors[:1], ['local'])
 
     def test_app_detail_contributors_present(self):

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Daisy-chain aggregation: primary -> peer_B -> peer_C.
+
+Validates the extended aggregation model end-to-end:
+
+- Hierarchical parent Component (``robot-x``) is served locally by every
+  gateway in the chain; it is NEVER forwarded because the routing table
+  excludes hierarchical parents.
+- Leaf ECU Components (``ecu-a``, ``ecu-b``, ``ecu-c``) route to their
+  owning peer. ``ecu-c`` requires a 2-hop forward from the primary, via
+  ``peer_B``, to reach ``peer_C``.
+- ``x-medkit.contributors`` on the primary's ``robot-x`` lists "local"
+  plus "peer:peer_b"; each hop surfaces only its direct upstream.
+- ``/health.warnings`` is an empty array when there are no deployment
+  anomalies.
+
+DDS isolation uses three distinct domain IDs so that the gateways cannot
+discover each other's nodes via ROS 2 graph introspection - the only
+channel is HTTP aggregation.
+"""
+
+import os
+import tempfile
+import textwrap
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    GATEWAY_STARTUP_INTERVAL,
+    GATEWAY_STARTUP_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+)
+
+# Port layout: primary at base+0, peer_B at base+1, peer_C at base+2.
+PRIMARY_PORT = get_test_port(0)
+PEER_B_PORT = get_test_port(1)
+PEER_C_PORT = get_test_port(2)
+PRIMARY_URL = f'http://localhost:{PRIMARY_PORT}{API_BASE_PATH}'
+PEER_B_URL = f'http://localhost:{PEER_B_PORT}{API_BASE_PATH}'
+PEER_C_URL = f'http://localhost:{PEER_C_PORT}{API_BASE_PATH}'
+
+# Secondary DDS domains: avoid collision with test_peer_aggregation (offset=1
+# -> domain 230). Daisy chain uses offsets 2 and 3 -> domains 231 and 232.
+PRIMARY_DOMAIN = get_test_domain_id(0)
+PEER_B_DOMAIN = get_test_domain_id(2)
+PEER_C_DOMAIN = get_test_domain_id(3)
+
+
+def _manifest(name, ecu_id):
+    """Return a minimal manifest for a daisy-chain gateway.
+
+    Every manifest shares ``robot-x`` as the hierarchical parent and
+    declares a single leaf ECU sub-component with one stub App. The
+    App's ros_binding does not need a running node because the tests
+    only exercise discovery endpoints and request forwarding - not
+    live runtime sampling.
+    """
+    return textwrap.dedent(f'''
+        manifest_version: "1.0"
+        metadata:
+          name: {name}
+          description: Daisy-chain test
+          version: "0.1.0"
+        config:
+          unmanifested_nodes: ignore
+          inherit_runtime_resources: false
+        components:
+          - id: robot-x
+            name: Robot X
+            type: mobile-robot
+            description: Shared hierarchical parent across all ECUs
+          - id: {ecu_id}
+            name: {ecu_id}
+            type: compute-unit
+            parent_component_id: robot-x
+        apps:
+          - id: {ecu_id}-app
+            name: {ecu_id}-app
+            category: infrastructure
+            is_located_on: {ecu_id}
+            ros_binding:
+              node_name: {ecu_id}_app
+              namespace: /{ecu_id}
+    ''').strip()
+
+
+def _write_manifest(name, ecu_id):
+    fd, path = tempfile.mkstemp(prefix=f'medkit_daisy_{name}_', suffix='.yaml')
+    os.write(fd, _manifest(name, ecu_id).encode('utf-8'))
+    os.close(fd)
+    return path
+
+
+PRIMARY_MANIFEST = _write_manifest('primary', 'ecu-a')
+PEER_B_MANIFEST = _write_manifest('peer_b', 'ecu-b')
+PEER_C_MANIFEST = _write_manifest('peer_c', 'ecu-c')
+
+
+def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
+    params = {
+        'refresh_interval_ms': 1000,
+        'server.port': port,
+        'discovery.mode': 'manifest_only',
+        'discovery.manifest_path': manifest_path,
+        'discovery.manifest_strict_validation': False,
+    }
+    if aggregation_peers:
+        urls = [url for url, _ in aggregation_peers]
+        names = [nm for _, nm in aggregation_peers]
+        params.update({
+            'aggregation.enabled': True,
+            'aggregation.timeout_ms': 5000,
+            'aggregation.announce': False,
+            'aggregation.discover': False,
+            'aggregation.peer_urls': urls,
+            'aggregation.peer_names': names,
+        })
+    return launch_ros.actions.Node(
+        package='ros2_medkit_gateway',
+        executable='gateway_node',
+        name=name,
+        output='screen',
+        parameters=[params],
+        additional_env={'ROS_DOMAIN_ID': str(domain)},
+    )
+
+
+def generate_test_description():
+    primary = _gateway(
+        PRIMARY_PORT, 'daisy_primary', PRIMARY_MANIFEST, PRIMARY_DOMAIN,
+        aggregation_peers=[(f'http://localhost:{PEER_B_PORT}', 'peer_b')],
+    )
+    peer_b = _gateway(
+        PEER_B_PORT, 'daisy_peer_b', PEER_B_MANIFEST, PEER_B_DOMAIN,
+        aggregation_peers=[(f'http://localhost:{PEER_C_PORT}', 'peer_c')],
+    )
+    peer_c = _gateway(
+        PEER_C_PORT, 'daisy_peer_c', PEER_C_MANIFEST, PEER_C_DOMAIN,
+    )
+
+    ld = LaunchDescription([
+        SetEnvironmentVariable('ROS_DOMAIN_ID', str(PRIMARY_DOMAIN)),
+        primary,
+        peer_b,
+        peer_c,
+        launch_testing.actions.ReadyToTest(),
+    ])
+    return ld, {
+        'primary': primary,
+        'peer_b': peer_b,
+        'peer_c': peer_c,
+    }
+
+
+class TestDaisyChainAggregation(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        for label, url in (('primary', PRIMARY_URL),
+                           ('peer_b', PEER_B_URL),
+                           ('peer_c', PEER_C_URL)):
+            cls._wait_for_health(url, label)
+        # Primary must see ecu-b (1 hop) AND ecu-c (2 hops) via aggregation.
+        # Sub-components (with parent_component_id) appear under the parent's
+        # /subcomponents endpoint, not the top-level /components list.
+        cls._wait_for_subcomponents(
+            PRIMARY_URL, 'robot-x', {'ecu-a', 'ecu-b', 'ecu-c'}, 'primary',
+        )
+
+    @classmethod
+    def _wait_for_health(cls, base_url, label):
+        deadline = time.monotonic() + GATEWAY_STARTUP_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                if requests.get(f'{base_url}/health', timeout=2).ok:
+                    return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(GATEWAY_STARTUP_INTERVAL)
+        raise AssertionError(f'{label} not healthy after {GATEWAY_STARTUP_TIMEOUT}s')
+
+    @classmethod
+    def _wait_for_subcomponents(cls, base_url, parent_id, required_ids, label):
+        deadline = time.monotonic() + DISCOVERY_TIMEOUT
+        last_ids = set()
+        while time.monotonic() < deadline:
+            try:
+                r = requests.get(
+                    f'{base_url}/components/{parent_id}/subcomponents',
+                    timeout=5,
+                )
+                if r.ok:
+                    last_ids = {c.get('id', '') for c in r.json().get('items', [])}
+                    if required_ids.issubset(last_ids):
+                        return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(1.0)
+        raise AssertionError(
+            f'{label}: subcomponents of {parent_id} expected {required_ids}, '
+            f'last seen {last_ids}',
+        )
+
+    # --- Discovery across the chain --------------------------------------
+
+    def test_primary_sees_all_ecus_as_subcomponents_of_robot_x(self):
+        r = requests.get(f'{PRIMARY_URL}/components/robot-x/subcomponents', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        sub_ids = {item['id'] for item in r.json().get('items', [])}
+        self.assertEqual(sub_ids, {'ecu-a', 'ecu-b', 'ecu-c'})
+
+    # --- Hierarchical parent served locally ------------------------------
+
+    def test_primary_serves_robot_x_detail_locally_with_contributors(self):
+        r = requests.get(f'{PRIMARY_URL}/components/robot-x', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body['id'], 'robot-x')
+        contributors = body.get('x-medkit', {}).get('contributors', [])
+        # Primary contributed locally; peer_b contributed via aggregation.
+        # peer_c's contribution is hidden behind peer_b (daisy chain policy).
+        self.assertIn('local', contributors)
+        self.assertIn('peer:peer_b', contributors)
+
+    # --- 1-hop and 2-hop leaf forwarding ---------------------------------
+
+    def test_primary_forwards_ecu_b_detail_one_hop(self):
+        r = requests.get(f'{PRIMARY_URL}/components/ecu-b', timeout=5)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json().get('id'), 'ecu-b')
+
+    def test_primary_forwards_ecu_c_detail_two_hops(self):
+        # ecu-c lives on peer_c; primary reaches it via peer_b -> peer_c.
+        r = requests.get(f'{PRIMARY_URL}/components/ecu-c', timeout=10)
+        self.assertEqual(r.status_code, 200, r.text)
+        self.assertEqual(r.json().get('id'), 'ecu-c')
+
+    # --- /health ---------------------------------------------------------
+
+    def test_primary_health_reports_peer_and_empty_warnings(self):
+        r = requests.get(f'{PRIMARY_URL}/health', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn('peers', body)
+        self.assertIn('warnings', body)
+        self.assertEqual(body['warnings'], [])
+
+
+@launch_testing.post_shutdown_test()
+class TestDaisyShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -119,6 +119,7 @@ def _write_manifest(name, ecu_id):
 PRIMARY_MANIFEST = _write_manifest('primary', 'ecu-a')
 PEER_B_MANIFEST = _write_manifest('peer_b', 'ecu-b')
 PEER_C_MANIFEST = _write_manifest('peer_c', 'ecu-c')
+MANIFEST_FILES = [PRIMARY_MANIFEST, PEER_B_MANIFEST, PEER_C_MANIFEST]
 
 
 def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
@@ -181,6 +182,11 @@ class TestDaisyChainAggregation(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        # Ensure the tmp manifest files written at import time do not leak
+        # past the test process, even if setUpClass fails later.
+        for path in MANIFEST_FILES:
+            cls.addClassCleanup(lambda p=path: os.path.exists(p) and os.unlink(p))
+
         for label, url in (('primary', PRIMARY_URL),
                            ('peer_b', PEER_B_URL),
                            ('peer_c', PEER_C_URL)):
@@ -229,6 +235,7 @@ class TestDaisyChainAggregation(unittest.TestCase):
     # --- Discovery across the chain --------------------------------------
 
     def test_primary_sees_all_ecus_as_subcomponents_of_robot_x(self):
+        """@verifies REQ_INTEROP_003."""
         r = requests.get(f'{PRIMARY_URL}/components/robot-x/subcomponents', timeout=5)
         self.assertEqual(r.status_code, 200)
         sub_ids = {item['id'] for item in r.json().get('items', [])}
@@ -237,6 +244,7 @@ class TestDaisyChainAggregation(unittest.TestCase):
     # --- Hierarchical parent served locally ------------------------------
 
     def test_primary_serves_robot_x_detail_locally_with_contributors(self):
+        """@verifies REQ_INTEROP_003."""
         r = requests.get(f'{PRIMARY_URL}/components/robot-x', timeout=5)
         self.assertEqual(r.status_code, 200)
         body = r.json()
@@ -250,11 +258,13 @@ class TestDaisyChainAggregation(unittest.TestCase):
     # --- 1-hop and 2-hop leaf forwarding ---------------------------------
 
     def test_primary_forwards_ecu_b_detail_one_hop(self):
+        """@verifies REQ_INTEROP_003."""
         r = requests.get(f'{PRIMARY_URL}/components/ecu-b', timeout=5)
         self.assertEqual(r.status_code, 200, r.text)
         self.assertEqual(r.json().get('id'), 'ecu-b')
 
     def test_primary_forwards_ecu_c_detail_two_hops(self):
+        """@verifies REQ_INTEROP_003 (2-hop forward through daisy chain)."""
         # ecu-c lives on peer_c; primary reaches it via peer_b -> peer_c.
         r = requests.get(f'{PRIMARY_URL}/components/ecu-c', timeout=10)
         self.assertEqual(r.status_code, 200, r.text)
@@ -269,6 +279,46 @@ class TestDaisyChainAggregation(unittest.TestCase):
         self.assertIn('peers', body)
         self.assertIn('warnings', body)
         self.assertEqual(body['warnings'], [])
+
+    # --- Root capability flag --------------------------------------------
+
+    def test_root_capabilities_flag_aggregation_enabled(self):
+        # Clients should be able to feature-detect that /health.warnings
+        # and x-medkit.contributors may be present via the root capabilities
+        # object.
+        r = requests.get(f'{PRIMARY_URL}/', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        caps = r.json().get('capabilities', {})
+        self.assertIs(caps.get('aggregation'), True)
+
+    def test_peer_c_root_capabilities_reports_aggregation_disabled(self):
+        # peer_c has no aggregation configured; capability must reflect that.
+        r = requests.get(f'{PEER_C_URL}/', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        caps = r.json().get('capabilities', {})
+        self.assertIs(caps.get('aggregation'), False)
+
+    # --- Contributors on non-Component entity types ----------------------
+
+    def test_leaf_component_detail_contributors_single_peer(self):
+        # A leaf ECU that came entirely from peer_b must have contributors
+        # ["peer:peer_b"]. This used to pass silently even if the field
+        # was dropped (because the test looked at a forwarded response from
+        # peer_b which emits the field itself). We only assert the shape
+        # here - forwarding origin is covered by the 1-hop test above.
+        r = requests.get(f'{PRIMARY_URL}/components/ecu-b', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        contributors = r.json().get('x-medkit', {}).get('contributors', [])
+        # Stable ordering: "local" first when present, then peer:* sorted.
+        self.assertEqual(contributors[:1], ['local'])
+
+    def test_app_detail_contributors_present(self):
+        # Apps flow through x-medkit.contributors the same way Components do
+        # after the detail-handler fix. ecu-a-app is the primary's local App.
+        r = requests.get(f'{PRIMARY_URL}/apps/ecu-a-app', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        contributors = r.json().get('x-medkit', {}).get('contributors', [])
+        self.assertIn('local', contributors)
 
 
 @launch_testing.post_shutdown_test()

--- a/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Leaf-Component-ID collision across peers: primary + peer_b + peer_c.
+
+Covers the "deployment anomaly" branch that the daisy-chain test deliberately
+avoids: two peers simultaneously announcing the same leaf Component ID. On
+the wire this surfaces as:
+
+- ``/health.warnings`` contains a ``leaf_id_collision`` entry listing both
+  peers under ``peer_names``.
+- ``GET /components/ecu-shared`` from the primary resolves to one of the
+  peers (last-writer-wins) and returns 200 - never a local stub.
+- The resolving peer's ``x-medkit.contributors`` reflects THAT peer only,
+  not both.
+
+Three gateways, three distinct DDS domains, aggregation is the only channel
+between them. Serialised against ``test_daisy_chain_aggregation`` and
+``test_peer_aggregation`` via ``RESOURCE_LOCK medkit_secondary_dds_domains``
+in CMakeLists.txt.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+import launch_ros.actions
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    GATEWAY_STARTUP_INTERVAL,
+    GATEWAY_STARTUP_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+)
+
+PRIMARY_PORT = get_test_port(0)
+PEER_B_PORT = get_test_port(1)
+PEER_C_PORT = get_test_port(2)
+PRIMARY_URL = f'http://localhost:{PRIMARY_PORT}{API_BASE_PATH}'
+PEER_B_URL = f'http://localhost:{PEER_B_PORT}{API_BASE_PATH}'
+PEER_C_URL = f'http://localhost:{PEER_C_PORT}{API_BASE_PATH}'
+
+PRIMARY_DOMAIN = get_test_domain_id(0)
+PEER_B_DOMAIN = get_test_domain_id(1)
+PEER_C_DOMAIN = get_test_domain_id(2)
+
+SHARED_LEAF_ID = 'ecu-shared'
+
+
+def _manifest(name, include_shared_leaf):
+    """Render a manifest for one leaf-collision gateway.
+
+    Peer manifests both declare ``ecu-shared`` as a top-level leaf
+    Component so the primary's aggregation merge sees the collision.
+    The primary manifest does not declare it - it is peer-owned only.
+    """
+    lines = [
+        'manifest_version: "1.0"',
+        'metadata:',
+        f'  name: {name}',
+        '  description: Leaf-collision test',
+        '  version: "0.1.0"',
+        'config:',
+        '  unmanifested_nodes: ignore',
+        '  inherit_runtime_resources: false',
+        'components:',
+        f'  - id: {name}-local',
+        f'    name: {name}-local',
+        '    type: compute-unit',
+    ]
+    if include_shared_leaf:
+        lines += [
+            f'  - id: {SHARED_LEAF_ID}',
+            '    name: Shared ECU',
+            '    type: compute-unit',
+        ]
+    lines.append('apps: []')
+    return '\n'.join(lines) + '\n'
+
+
+def _write_manifest(name, include_shared_leaf):
+    fd, path = tempfile.mkstemp(prefix=f'medkit_leafcoll_{name}_', suffix='.yaml')
+    os.write(fd, _manifest(name, include_shared_leaf).encode('utf-8'))
+    os.close(fd)
+    return path
+
+
+PRIMARY_MANIFEST = _write_manifest('primary', include_shared_leaf=False)
+PEER_B_MANIFEST = _write_manifest('peer_b', include_shared_leaf=True)
+PEER_C_MANIFEST = _write_manifest('peer_c', include_shared_leaf=True)
+MANIFEST_FILES = [PRIMARY_MANIFEST, PEER_B_MANIFEST, PEER_C_MANIFEST]
+
+
+def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
+    params = {
+        'refresh_interval_ms': 1000,
+        'server.port': port,
+        'discovery.mode': 'manifest_only',
+        'discovery.manifest_path': manifest_path,
+        'discovery.manifest_strict_validation': False,
+    }
+    if aggregation_peers:
+        urls = [url for url, _ in aggregation_peers]
+        names = [nm for _, nm in aggregation_peers]
+        params.update({
+            'aggregation.enabled': True,
+            'aggregation.timeout_ms': 5000,
+            'aggregation.announce': False,
+            'aggregation.discover': False,
+            'aggregation.peer_urls': urls,
+            'aggregation.peer_names': names,
+        })
+    return launch_ros.actions.Node(
+        package='ros2_medkit_gateway',
+        executable='gateway_node',
+        name=name,
+        output='screen',
+        parameters=[params],
+        additional_env={'ROS_DOMAIN_ID': str(domain)},
+    )
+
+
+def generate_test_description():
+    # Primary aggregates peer_b AND peer_c directly (fan-out, not daisy).
+    primary = _gateway(
+        PRIMARY_PORT, 'leafcoll_primary', PRIMARY_MANIFEST, PRIMARY_DOMAIN,
+        aggregation_peers=[
+            (f'http://localhost:{PEER_B_PORT}', 'peer_b'),
+            (f'http://localhost:{PEER_C_PORT}', 'peer_c'),
+        ],
+    )
+    peer_b = _gateway(PEER_B_PORT, 'leafcoll_peer_b', PEER_B_MANIFEST, PEER_B_DOMAIN)
+    peer_c = _gateway(PEER_C_PORT, 'leafcoll_peer_c', PEER_C_MANIFEST, PEER_C_DOMAIN)
+
+    ld = LaunchDescription([
+        SetEnvironmentVariable('ROS_DOMAIN_ID', str(PRIMARY_DOMAIN)),
+        primary,
+        peer_b,
+        peer_c,
+        launch_testing.actions.ReadyToTest(),
+    ])
+    return ld, {
+        'primary': primary,
+        'peer_b': peer_b,
+        'peer_c': peer_c,
+    }
+
+
+class TestLeafCollisionAggregation(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        for path in MANIFEST_FILES:
+            cls.addClassCleanup(lambda p=path: os.path.exists(p) and os.unlink(p))
+
+        for label, url in (('primary', PRIMARY_URL),
+                           ('peer_b', PEER_B_URL),
+                           ('peer_c', PEER_C_URL)):
+            cls._wait_for_health(url, label)
+        # Wait until the merge has folded both peers in AND detected the
+        # collision. Both conditions must hold before any test method runs,
+        # otherwise the tests race the aggregation refresh cycle.
+        cls._wait_for_collision_warning(PRIMARY_URL, SHARED_LEAF_ID)
+
+    @classmethod
+    def _wait_for_health(cls, base_url, label):
+        deadline = time.monotonic() + GATEWAY_STARTUP_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                if requests.get(f'{base_url}/health', timeout=2).ok:
+                    return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(GATEWAY_STARTUP_INTERVAL)
+        raise AssertionError(f'{label} not healthy after {GATEWAY_STARTUP_TIMEOUT}s')
+
+    @classmethod
+    def _wait_for_collision_warning(cls, base_url, entity_id):
+        deadline = time.monotonic() + DISCOVERY_TIMEOUT
+        last_warnings = None
+        while time.monotonic() < deadline:
+            try:
+                r = requests.get(f'{base_url}/health', timeout=5)
+                if r.ok:
+                    warnings = r.json().get('warnings', [])
+                    last_warnings = warnings
+                    if any(w.get('code') == 'leaf_id_collision'
+                           and entity_id in w.get('entity_ids', [])
+                           for w in warnings):
+                        return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(1.0)
+        raise AssertionError(
+            f'collision warning for {entity_id} not surfaced within '
+            f'{DISCOVERY_TIMEOUT}s (last warnings: {last_warnings})',
+        )
+
+    def test_health_surfaces_leaf_collision_with_both_peers(self):
+        """@verifies REQ_INTEROP_003."""
+        r = requests.get(f'{PRIMARY_URL}/health', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn('warning_schema_version', body)
+        self.assertEqual(body['warning_schema_version'], 1)
+        collisions = [
+            w for w in body.get('warnings', [])
+            if w.get('code') == 'leaf_id_collision'
+            and SHARED_LEAF_ID in w.get('entity_ids', [])
+        ]
+        self.assertEqual(
+            len(collisions), 1,
+            f'expected exactly one leaf_id_collision for {SHARED_LEAF_ID}, got: {body}',
+        )
+        self.assertEqual(set(collisions[0]['peer_names']), {'peer_b', 'peer_c'})
+
+    def test_shared_leaf_resolves_to_exactly_one_peer(self):
+        """@verifies REQ_INTEROP_003."""
+        # Last-writer-wins: the primary must still forward to SOME peer and
+        # return 200, never 404. The primary has no local ``ecu-shared`` so
+        # a 404 would prove the routing table missed the collision case;
+        # any 2xx proves a peer served the request.
+        r = requests.get(f'{PRIMARY_URL}/components/{SHARED_LEAF_ID}', timeout=5)
+        self.assertEqual(r.status_code, 200, r.text)
+        body = r.json()
+        self.assertEqual(body.get('id'), SHARED_LEAF_ID)
+        # peer_b and peer_c do not run aggregation themselves, so their
+        # local responses do not emit x-medkit.contributors. That absence
+        # is the signal: the request reached a peer directly (rather than
+        # being synthesised by the primary's merge), otherwise contributors
+        # would be populated. A non-empty contributors list here would
+        # indicate the primary fabricated a merged view for a leaf ID,
+        # which is precisely what the routing table must prevent.
+        contributors = body.get('x-medkit', {}).get('contributors', [])
+        self.assertEqual(
+            contributors, [],
+            f'routed leaf response must not carry merged contributors, got: {contributors}',
+        )
+
+    def test_root_capabilities_flag_aggregation_enabled(self):
+        r = requests.get(f'{PRIMARY_URL}/', timeout=5)
+        self.assertEqual(r.status_code, 200)
+        caps = r.json().get('capabilities', {})
+        self.assertIs(caps.get('aggregation'), True)
+
+
+@launch_testing.post_shutdown_test()
+class TestLeafCollisionShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/src/sovd_service_interface.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/src/sovd_service_interface.hpp
@@ -34,8 +34,8 @@ namespace ros2_medkit_gateway {
 ///
 /// Exposes medkit entity tree, fault data, and capabilities via ROS 2
 /// services. Designed for consumption by VDA 5050 agent, BT.CPP,
-/// PlotJuggler, RTMaps, and any other ROS 2 node that needs SOVD data
-/// without going through HTTP.
+/// PlotJuggler, and any other ROS 2 node that needs SOVD data without
+/// going through HTTP.
 class SovdServiceInterface : public GatewayPlugin {
  public:
   std::string name() const override;


### PR DESCRIPTION
## Summary

Make the aggregation layer treat Components with the same symmetry as Areas, so collision-merged peer Components work correctly for every deployment shape the project supports (single peer, multi-peer, hierarchical parent, daisy chain).

- ``EntityMerger::merge_components`` now records a provisional routing entry on collision. Every Component ID refers to at most one ECU when it is a leaf, and the peer owns the runtime state.
- A new pure ``classify_component_routing`` free function (``aggregation/classification.hpp``) runs after all peers have been merged. A Component is classified as a **hierarchical parent** if any other Component in the merged set references it via ``parent_component_id``; those are removed from the routing table and served locally from the merged cache. Leaves stay routed to the owning peer.
- Multi-peer leaf collisions are reported as structured ``LeafCollisionWarning`` objects. ``AggregationManager`` surfaces them on ``MergedPeerResult.leaf_warnings``, writes an RCLCPP_WARN line listing every claimant, and exposes the list via a new ``/health.warnings`` array. Routing falls back to last-writer-wins because rejection does not fix a deployment anomaly.
- Every merged entity (Area, Component, App, Function) now carries an optional ``x-medkit.contributors`` list populated during merge (``local`` seeded before the peer loop, ``peer:<name>`` appended by ``EntityMerger`` with de-duplication). Clients can distinguish local-only, peer-only, and merged views without relying on the single-valued ``source`` field. In daisy-chain topologies each hop surfaces only its direct upstream by design.
- Pre-existing doc comment referencing a third-party commercial product was stripped from ``sovd_service_interface.hpp``.
- Aggregation design doc now documents the symmetric classification, the multi-peer warning behaviour, and the ``contributors`` provenance, with an updated PlantUML merge diagram plus a new post-merge classification diagram.

### SOVD API impact

- **No changes** to SOVD-defined request paths, response schemas, or error codes.
- Additive x-medkit extensions only: new optional ``x-medkit.contributors`` field on entity responses and a new optional ``warnings`` array on ``/health``. Both are emitted only when non-empty / when aggregation is active, so existing clients ignoring unknown fields are unaffected.

---

## Issue

- closes #373

---

## Type

- [x] Bug fix
- [x] New feature or tests (classification seam, /health.warnings, contributors, daisy-chain integration test)
- [ ] Breaking change
- [x] Documentation only (design doc updates)

---

## Testing

All local runs green:

- ``./scripts/test.sh unit --packages-select ros2_medkit_gateway`` - 1976 tests, 0 failures. Includes:
  - 6 new ``AggregationClassification`` tests covering leaf vs hierarchical, single/multi-peer, subcomponents, and warning emission.
  - 4 new ``EntityMerger`` contributor tests (local/peer append, dedup, app-prefix-only-peer).
  - Updated ``merged_components_route_to_peer`` plus the synthetic-collision test from the previous iteration.
- ``./scripts/test.sh test_peer_aggregation --packages-select ros2_medkit_integration_tests`` - prior integration coverage still green, 82 tests.
- ``./scripts/test.sh test_daisy_chain_aggregation --packages-select ros2_medkit_integration_tests`` - new integration test with 3 gateways in isolated DDS domains (primary -> peer_B -> peer_C). Verifies hierarchical parent served locally, 1-hop and 2-hop leaf forwarding, contributors, and empty /health.warnings.
- ``./scripts/test.sh lint --packages-select ros2_medkit_gateway`` - clean.
- Sphinx docs build with no new warnings.

---

## Checklist

- [x] Breaking changes are clearly described (there are none; only additive x-medkit extensions)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed