### PR TITLE
fix(updates): seed Pending state on register so /updates/{id}/status returns 200

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           apt-get update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
+          if [ "${{ matrix.ros_distro }}" = "humble" ]; then
+            apt-get install -y ros-humble-rmw-cyclonedds-cpp
+          fi
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           rosdep update
           rosdep install --from-paths src --ignore-src -y
@@ -73,6 +76,15 @@ jobs:
 
       - name: Run unit and integration tests
         timeout-minutes: 15
+        env:
+          # FastRTPS 2.6 on Humble has a known use-after-free in the
+          # discovery-teardown path (EDP::unpairWriterProxy) that segfaults
+          # peer nodes when the gateway shuts down, so we force CycloneDDS
+          # there. Rolling + Jazzy ship a newer FastRTPS without that bug
+          # and hit a separate iceoryx-shared-memory crash under CycloneDDS
+          # during shutdown ("string capacity was zero for allocated data"),
+          # so on those distros we keep the default FastRTPS.
+          RMW_IMPLEMENTATION: ${{ matrix.ros_distro == 'humble' && 'rmw_cyclonedds_cpp' || '' }}
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           colcon test --return-code-on-test-failure \
@@ -185,7 +197,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y ros-jazzy-test-msgs
+          apt-get install -y \
+            ros-jazzy-test-msgs \
+            ros-jazzy-rmw-cyclonedds-cpp
           source /opt/ros/jazzy/setup.bash
           rosdep update
           rosdep install --from-paths src --ignore-src -y
@@ -199,6 +213,11 @@ jobs:
         run: tar xf jazzy-build.tar && rm jazzy-build.tar
 
       - name: Run unit and integration tests
+        env:
+          # FastRTPS has a known use-after-free in discovery-teardown that
+          # can segfault peer nodes when another node (typically the gateway)
+          # shuts down. CycloneDDS avoids it.
+          RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
         run: |
           source /opt/ros/jazzy/setup.bash
           colcon test --return-code-on-test-failure \

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1143,6 +1143,10 @@ Without such a plugin, all endpoints return ``501 Not Implemented``.
 
    **Status values:** ``pending``, ``inProgress``, ``completed``, ``failed``
 
+   A successful ``POST /api/v1/updates`` seeds a ``pending`` status for the package,
+   so this endpoint returns ``200`` with ``{"status": "pending"}`` immediately after
+   registration, before any ``prepare`` or ``execute`` call.
+
    When ``status`` is ``failed``, an ``error`` object is included:
 
    .. code-block:: json
@@ -1155,7 +1159,7 @@ Without such a plugin, all endpoints return ``501 Not Implemented``.
         }
       }
 
-   - **404 Not Found:** No status available (package not found or no operation started)
+   - **404 Not Found:** Package is not registered
 
 Cyclic Subscriptions
 --------------------

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/rosbag_capture.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/rosbag_capture.hpp
@@ -165,6 +165,10 @@ class RosbagCapture {
   /// Post-fault recording state
   std::string current_fault_code_;
   std::string current_bag_path_;
+  /// Protects post_fault_timer_ against concurrent assignment in
+  /// on_fault_confirmed() (service thread) and reset in
+  /// post_fault_timer_callback() / stop() (executor thread).
+  std::mutex post_fault_timer_mutex_;
   rclcpp::TimerBase::SharedPtr post_fault_timer_;
   std::atomic<bool> recording_post_fault_{false};
 

--- a/src/ros2_medkit_fault_manager/src/rosbag_capture.cpp
+++ b/src/ros2_medkit_fault_manager/src/rosbag_capture.cpp
@@ -135,9 +135,12 @@ void RosbagCapture::stop() {
   running_.store(false);
 
   // Cancel any pending post-fault timer
-  if (post_fault_timer_) {
-    post_fault_timer_->cancel();
-    post_fault_timer_.reset();
+  {
+    std::lock_guard<std::mutex> lock(post_fault_timer_mutex_);
+    if (post_fault_timer_) {
+      post_fault_timer_->cancel();
+      post_fault_timer_.reset();
+    }
   }
 
   if (discovery_retry_timer_) {
@@ -202,10 +205,13 @@ void RosbagCapture::on_fault_confirmed(const std::string & fault_code) {
 
     // Create timer for post-fault recording
     auto duration = std::chrono::duration<double>(config_.duration_after_sec);
-    post_fault_timer_ =
-        node_->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(duration), [this]() {
-          post_fault_timer_callback();
-        });
+    {
+      std::lock_guard<std::mutex> lock(post_fault_timer_mutex_);
+      post_fault_timer_ =
+          node_->create_wall_timer(std::chrono::duration_cast<std::chrono::nanoseconds>(duration), [this]() {
+            post_fault_timer_callback();
+          });
+    }
 
     RCLCPP_DEBUG(node_->get_logger(), "Recording %.1fs more after fault confirmation", config_.duration_after_sec);
   } else {
@@ -436,14 +442,19 @@ std::vector<std::string> RosbagCapture::resolve_topics() const {
       }
     }
   } else if (config_.topics == "all" || config_.topics == "auto") {
-    // Discover all available topics ("auto" is an alias for "all")
-    auto topic_names_and_types = node_->get_topic_names_and_types();
-    for (const auto & [topic, types] : topic_names_and_types) {
-      // Skip internal ROS topics
-      if (topic.find("/parameter_events") != std::string::npos || topic.find("/rosout") != std::string::npos) {
-        continue;
+    // Discover all available topics ("auto" is an alias for "all").
+    // Skip gracefully if the context is invalidated mid-call (shutdown race).
+    try {
+      auto topic_names_and_types = node_->get_topic_names_and_types();
+      for (const auto & [topic, types] : topic_names_and_types) {
+        // Skip internal ROS topics
+        if (topic.find("/parameter_events") != std::string::npos || topic.find("/rosout") != std::string::npos) {
+          continue;
+        }
+        topics_set.insert(topic);
       }
-      topics_set.insert(topic);
+    } catch (const std::runtime_error &) {
+      // context invalid during shutdown - no topics to add
     }
   } else if (config_.topics == "explicit") {
     // Explicit mode: use only include_topics, no topic derivation
@@ -476,10 +487,18 @@ std::vector<std::string> RosbagCapture::resolve_topics() const {
 }
 
 std::string RosbagCapture::get_topic_type(const std::string & topic) const {
-  auto topic_names_and_types = node_->get_topic_names_and_types();
-  auto it = topic_names_and_types.find(topic);
-  if (it != topic_names_and_types.end() && !it->second.empty()) {
-    return it->second[0];
+  // node_->get_topic_names_and_types() throws if the rcl context is
+  // invalidated mid-call (e.g. SIGINT fires between the check and the rcl
+  // call). During shutdown this is expected and not actionable - treat it
+  // as "no topic info available right now".
+  try {
+    auto topic_names_and_types = node_->get_topic_names_and_types();
+    auto it = topic_names_and_types.find(topic);
+    if (it != topic_names_and_types.end() && !it->second.empty()) {
+      return it->second[0];
+    }
+  } catch (const std::runtime_error &) {
+    // context invalid - caller handles empty return
   }
   return "";
 }
@@ -640,9 +659,12 @@ void RosbagCapture::post_fault_timer_callback() {
   }
 
   // Cancel timer (one-shot)
-  if (post_fault_timer_) {
-    post_fault_timer_->cancel();
-    post_fault_timer_.reset();
+  {
+    std::lock_guard<std::mutex> lock(post_fault_timer_mutex_);
+    if (post_fault_timer_) {
+      post_fault_timer_->cancel();
+      post_fault_timer_.reset();
+    }
   }
 
   // Stop post-fault recording (no more direct writes to bag)

--- a/src/ros2_medkit_fault_manager/src/snapshot_capture.cpp
+++ b/src/ros2_medkit_fault_manager/src/snapshot_capture.cpp
@@ -348,10 +348,18 @@ std::vector<std::string> SnapshotCapture::collect_all_configured_topics() const 
 }
 
 std::string SnapshotCapture::get_topic_type(const std::string & topic) const {
-  auto topic_names_and_types = node_->get_topic_names_and_types();
-  auto it = topic_names_and_types.find(topic);
-  if (it != topic_names_and_types.end() && !it->second.empty()) {
-    return it->second[0];
+  // node_->get_topic_names_and_types() throws if the rcl context is
+  // invalidated mid-call (e.g. SIGINT fires between the check and the rcl
+  // call). During shutdown this is expected and not actionable - treat it
+  // as "no topic info available right now".
+  try {
+    auto topic_names_and_types = node_->get_topic_names_and_types();
+    auto it = topic_names_and_types.find(topic);
+    if (it != topic_names_and_types.end() && !it->second.empty()) {
+      return it->second[0];
+    }
+  } catch (const std::runtime_error &) {
+    // context invalid - caller handles empty return
   }
   return "";
 }

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -5,6 +5,10 @@ Changelog for package ros2_medkit_gateway
 Unreleased
 ----------
 
+**Fixes:**
+
+* ``GET /api/v1/updates/{id}/status`` no longer returns ``404`` for a registered-but-idle package; ``POST /api/v1/updates`` now seeds a ``pending`` status, so the endpoint returns ``200 {"status": "pending"}`` immediately after registration. ``404`` is reserved for packages that are not registered. Clients that used ``404`` as a signal for "registered but nothing started yet" must adapt (`#378 <https://github.com/selfpatch/ros2_medkit/issues/378>`_)
+
 **Features:**
 
 * Plugin API version bumped to v7. Adds ``PluginContext::notify_entities_changed(EntityChangeScope)`` lifecycle hook for plugins that mutate the entity surface at runtime; default no-op keeps v6 source code compiling unchanged against v7 headers. Binary compatibility is not provided: the plugin loader uses a strict equality check on ``plugin_api_version()``, so out-of-tree plugins must be recompiled (`#376 <https://github.com/selfpatch/ros2_medkit/issues/376>`_)

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -14,10 +14,7 @@
 
 #pragma once
 
-#include <atomic>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <thread>
@@ -296,9 +293,6 @@ class GatewayNode : public rclcpp::Node {
 
   // REST server thread management
   std::unique_ptr<std::thread> server_thread_;
-  std::atomic<bool> server_running_{false};
-  std::mutex server_mutex_;
-  std::condition_variable server_cv_;
 };
 
 /**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/rest_server.hpp
@@ -81,6 +81,13 @@ class RESTServer {
     return http_server_ && http_server_->is_tls_enabled();
   }
 
+  /// True once cpp-httplib's listen() has reached its accept loop.
+  /// GatewayNode uses this as the start-up readiness signal so shutdown
+  /// cannot race a listen() that has not yet started.
+  bool is_running() const {
+    return http_server_ && http_server_->is_running();
+  }
+
  private:
   void setup_routes();
   void setup_pre_routing_handler();

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1827,12 +1827,6 @@ void GatewayNode::refresh_cache() {
 
 void GatewayNode::start_rest_server() {
   server_thread_ = std::make_unique<std::thread>([this]() {
-    {
-      std::lock_guard<std::mutex> lock(server_mutex_);
-      server_running_ = true;
-    }
-    server_cv_.notify_all();
-
     try {
       rest_server_->start();
     } catch (const std::exception & e) {
@@ -1840,33 +1834,29 @@ void GatewayNode::start_rest_server() {
     } catch (...) {
       RCLCPP_ERROR(get_logger(), "REST server failed to start: unknown exception");
     }
-
-    {
-      std::lock_guard<std::mutex> lock(server_mutex_);
-      server_running_ = false;
-    }
-    server_cv_.notify_all();
   });
 
-  // Wait for server to start
-  std::unique_lock<std::mutex> lock(server_mutex_);
-  server_cv_.wait(lock, [this] {
-    return server_running_.load();
-  });
+  // Wait for the server to actually reach cpp-httplib's accept loop before
+  // returning. is_running() becomes true only after listen() has passed
+  // bind and entered its select/poll loop; using a "thread started" flag
+  // here is not enough because stop() called before listen() entered its
+  // loop could be missed, leaving listen() blocking forever and the
+  // subsequent join() hanging indefinitely.
+  using namespace std::chrono_literals;
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (!rest_server_->is_running() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(1ms);
+  }
+  if (!rest_server_->is_running()) {
+    RCLCPP_ERROR(get_logger(), "REST server did not become ready within 5s");
+  }
 }
 
 void GatewayNode::stop_rest_server() {
   if (rest_server_) {
     rest_server_->stop();
   }
-
-  // Wait for server thread to finish
   if (server_thread_ && server_thread_->joinable()) {
-    std::unique_lock<std::mutex> lock(server_mutex_);
-    server_cv_.wait(lock, [this] {
-      return !server_running_.load();
-    });
-    lock.unlock();  // Release before join to avoid deadlock
     server_thread_->join();
   }
 }

--- a/src/ros2_medkit_gateway/src/updates/update_manager.cpp
+++ b/src/ros2_medkit_gateway/src/updates/update_manager.cpp
@@ -104,18 +104,17 @@ tl::expected<void, UpdateError> UpdateManager::register_update(const nlohmann::j
   // consumers (UpdatesDashboard) gate action buttons on the status field
   // and won't render "Prepare" when the status query fails, so a newly-
   // registered update would otherwise be stuck from the frontend's view.
-  // Preserve an already-seeded state if a concurrent caller raced us
-  // through the backend (shouldn't happen with current backends, but the
-  // defensive check keeps the method idempotent).
-  if (metadata.contains("id") && metadata["id"].is_string()) {
-    const auto id = metadata["id"].get<std::string>();
-    std::lock_guard<std::mutex> lock(mutex_);
-    auto & state_ptr = states_[id];
-    if (!state_ptr) {
-      state_ptr = std::make_unique<PackageState>();
-      state_ptr->phase = UpdatePhase::None;
-      state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
-    }
+  // Callers (update_handlers.cpp) validate id presence + non-empty string
+  // before invoking register_update, so metadata.at("id") is guaranteed to
+  // hold a string at this point. The !state_ptr check matches the
+  // idempotent-seed pattern used in start_prepare / run_prepare.
+  const auto id = metadata.at("id").get<std::string>();
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto & state_ptr = states_[id];
+  if (!state_ptr) {
+    state_ptr = std::make_unique<PackageState>();
+    state_ptr->phase = UpdatePhase::None;
+    state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
   }
   return {};
 }

--- a/src/ros2_medkit_gateway/src/updates/update_manager.cpp
+++ b/src/ros2_medkit_gateway/src/updates/update_manager.cpp
@@ -99,6 +99,24 @@ tl::expected<void, UpdateError> UpdateManager::register_update(const nlohmann::j
         return tl::make_unexpected(UpdateError{UpdateErrorCode::Internal, err.message});
     }
   }
+  // Seed an initial Pending state so GET /updates/<id>/status returns
+  // {"status":"pending"} immediately after register, rather than 404. UI
+  // consumers (UpdatesDashboard) gate action buttons on the status field
+  // and won't render "Prepare" when the status query fails, so a newly-
+  // registered update would otherwise be stuck from the frontend's view.
+  // Preserve an already-seeded state if a concurrent caller raced us
+  // through the backend (shouldn't happen with current backends, but the
+  // defensive check keeps the method idempotent).
+  if (metadata.contains("id") && metadata["id"].is_string()) {
+    const auto id = metadata["id"].get<std::string>();
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto & state_ptr = states_[id];
+    if (!state_ptr) {
+      state_ptr = std::make_unique<PackageState>();
+      state_ptr->phase = UpdatePhase::None;
+      state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
+    }
+  }
   return {};
 }
 

--- a/src/ros2_medkit_gateway/test/test_update_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_update_manager.cpp
@@ -298,6 +298,22 @@ TEST_F(UpdateManagerTest, StatusNotFoundForUnknown) {
   EXPECT_EQ(result.error().code, UpdateErrorCode::NotFound);
 }
 
+// @verifies REQ_INTEROP_094
+TEST_F(UpdateManagerTest, StatusPendingRightAfterRegister) {
+  // Registering an update must immediately yield a Pending status so the
+  // UpdatesDashboard (which gates action buttons on a non-null status
+  // response) can render Prepare / Execute / Delete without waiting for a
+  // separate prepare call.
+  json pkg = {{"id", "fresh-pkg"}, {"update_name", "Fresh"}, {"automated", false}};
+  ASSERT_TRUE(manager_->register_update(pkg).has_value());
+
+  auto status = manager_->get_status("fresh-pkg");
+  ASSERT_TRUE(status.has_value()) << status.error().message;
+  EXPECT_EQ(status->status, UpdateStatus::Pending);
+  EXPECT_FALSE(status->progress.has_value());
+  EXPECT_FALSE(status->error_message.has_value());
+}
+
 // @verifies REQ_INTEROP_083
 TEST_F(UpdateManagerTest, DuplicateRegistration) {
   json pkg = {{"id", "test-pkg"}, {"update_name", "Test"}, {"automated", false}};

--- a/src/ros2_medkit_integration_tests/demo_nodes/beacon_publisher.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/beacon_publisher.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <diagnostic_msgs/msg/key_value.hpp>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
@@ -84,9 +85,25 @@ class BeaconPublisher : public rclcpp::Node {
 };
 
 int main(int argc, char * argv[]) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<BeaconPublisher>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/brake_actuator.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/brake_actuator.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <chrono>
+#include <csignal>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
@@ -103,9 +104,25 @@ class BrakeActuator : public rclcpp::Node {
 };
 
 int main(int argc, char * argv[]) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<BrakeActuator>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/brake_pressure_sensor.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/brake_pressure_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/float32.hpp>
@@ -60,9 +61,25 @@ class BrakePressureSensor : public rclcpp::Node {
 };
 
 int main(int argc, char ** argv) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<BrakePressureSensor>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/calibration_service.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/calibration_service.cpp
@@ -22,6 +22,8 @@
  * - Used to test POST /services/{service} endpoint
  */
 
+#include <csignal>
+
 #include <rclcpp/rclcpp.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
@@ -59,9 +61,27 @@ class CalibrationService : public rclcpp::Node {
 };
 
 int main(int argc, char * argv[]) {
+  // Block SIGINT/SIGTERM until all rcl resources (node, executor guard
+  // condition) are allocated. A signal arriving during init / executor setup
+  // invalidates the context mid-call, causing rcl_* to throw RCLError. By
+  // holding the block through executor->add_node() the guard condition is
+  // created while the context is still valid; unblock fires any queued
+  // signal which rclcpp then handles as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<CalibrationService>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/door_status_sensor.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/door_status_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
@@ -64,9 +65,25 @@ class DoorStatusSensor : public rclcpp::Node {
 };
 
 int main(int argc, char ** argv) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<DoorStatusSensor>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/engine_temp_sensor.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/engine_temp_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <mutex>
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -143,9 +144,25 @@ class EngineTempSensor : public rclcpp::Node {
 };
 
 int main(int argc, char ** argv) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<EngineTempSensor>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/lidar_sensor.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/lidar_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <mutex>
 #include <rcl_interfaces/msg/parameter_descriptor.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -276,9 +277,25 @@ class LidarSensor : public rclcpp::Node {
 };
 
 int main(int argc, char ** argv) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<LidarSensor>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/light_controller.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/light_controller.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <chrono>
+#include <csignal>
 #include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/bool.hpp>
@@ -82,9 +83,25 @@ class LightController : public rclcpp::Node {
 };
 
 int main(int argc, char * argv[]) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<LightController>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/long_calibration_action.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/long_calibration_action.cpp
@@ -31,6 +31,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <csignal>
 #include <cstdlib>
 #include <example_interfaces/action/fibonacci.hpp>
 #include <exception>
@@ -160,10 +161,26 @@ int main(int argc, char * argv[]) {
     _exit(0);
   });
 
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<LongCalibrationAction>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
   node->prepare_shutdown();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/param_beacon_node.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/param_beacon_node.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
+
 #include <rclcpp/rclcpp.hpp>
 
 /// Demo node that declares ros2_medkit.discovery.* parameters.
@@ -38,9 +40,25 @@ class ParamBeaconNode : public rclcpp::Node {
 };
 
 int main(int argc, char * argv[]) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<ParamBeaconNode>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/demo_nodes/rpm_sensor.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/rpm_sensor.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <csignal>
 #include <mutex>
 
 #include <rclcpp/rclcpp.hpp>
@@ -62,9 +63,25 @@ class RPMSensor : public rclcpp::Node {
 };
 
 int main(int argc, char ** argv) {
+  // Block SIGINT/SIGTERM until the executor has allocated its guard
+  // condition; a signal arriving mid-init invalidates the rcl context and
+  // causes rcl_* calls to throw RCLError. Unblocking after add_node() lets
+  // any queued signal be handled as a normal shutdown.
+  sigset_t mask, old;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  pthread_sigmask(SIG_BLOCK, &mask, &old);
+
   rclcpp::init(argc, argv);
   auto node = std::make_shared<RPMSensor>();
-  rclcpp::spin(node);
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  pthread_sigmask(SIG_SETMASK, &old, nullptr);
+
+  executor.spin();
+  executor.remove_node(node);
   node.reset();
   rclcpp::shutdown();
   return 0;

--- a/src/ros2_medkit_integration_tests/test/features/test_cross_ecu_fanout.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_cross_ecu_fanout.test.py
@@ -418,28 +418,46 @@ class TestCrossEcuFanout(unittest.TestCase):
         Peer hosts pressure_sensor (pressure topic) and lidar (scan topic).
         Fan-out merges peer data items into the response.
         """
+
+        def _extract_topic_paths(items):
+            paths = set()
+            for item in items:
+                topic = item.get('x-medkit', {}).get('ros2', {}).get('topic', '')
+                if topic:
+                    paths.add(topic)
+            return paths
+
+        def _ready(d):
+            # Wait for BOTH local (/powertrain/engine/) and peer
+            # (/chassis/brakes/ or /perception/lidar/) topics to be visible.
+            # An intermediate response can contain only /rosout (gateway's own
+            # log subscription) while demo-node discovery is still propagating;
+            # accepting `d.get('items')` would return too early and fail the
+            # has_local / has_peer assertions below.
+            topic_paths = _extract_topic_paths(d.get('items', []))
+            has_local = any('/powertrain/engine/' in t for t in topic_paths)
+            has_peer = any(
+                '/chassis/brakes/' in t or '/perception/lidar/' in t
+                for t in topic_paths
+            )
+            return d if has_local and has_peer else None
+
         data = _poll_until(
             f'{PRIMARY_URL}{FUNC_ENDPOINT}/data',
-            lambda d: d if d.get('items') else None,
+            _ready,
             timeout=30.0,
         )
-        self.assertIsNotNone(data, 'No data items for vehicle_health')
-        items = data['items']
+        self.assertIsNotNone(
+            data,
+            'Timed out waiting for local + peer data topics on vehicle_health',
+        )
 
-        topic_paths = set()
-        for item in items:
-            ext = item.get('x-medkit', {})
-            ros2 = ext.get('ros2', {})
-            topic = ros2.get('topic', '')
-            if topic:
-                topic_paths.add(topic)
-
+        topic_paths = _extract_topic_paths(data['items'])
         has_local = any('/powertrain/engine/' in t for t in topic_paths)
         has_peer = any(
             '/chassis/brakes/' in t or '/perception/lidar/' in t
             for t in topic_paths
         )
-
         self.assertTrue(
             has_local,
             f'Missing local data topics: {topic_paths}',

--- a/src/ros2_medkit_integration_tests/test/features/test_updates.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_updates.test.py
@@ -353,6 +353,20 @@ class TestUpdatesPrepareExecute(_UpdatesTestMixin, GatewayTestCase):
     BASE_URL = f'http://127.0.0.1:{PORT_WITH_PLUGIN}{API_BASE_PATH}'
     MIN_EXPECTED_APPS = 0
 
+    # @verifies REQ_INTEROP_094
+    def test_00_status_pending_right_after_register(self):
+        """GET /status returns 200 pending immediately after POST /updates."""
+        self.register_package('test-pending-after-register')
+        r = requests.get(
+            f'{self.BASE_URL}/updates/test-pending-after-register/status',
+            timeout=5,
+        )
+        self.assertEqual(r.status_code, 200)
+        data = r.json()
+        self.assertEqual(data.get('status'), 'pending')
+        self.assertNotIn('progress', data)
+        self.assertNotIn('error', data)
+
     # @verifies REQ_INTEROP_091
     def test_01_prepare_returns_202(self):
         """PUT /updates/{id}/prepare returns 202 Accepted."""


### PR DESCRIPTION
## Summary

Closes #378. After a successful `backend_->register_update(...)`, seed `states_[id]` with `phase=None` / `status=Pending` so the first `GET /updates/{id}/status` returns `200 {"status":"pending"}` instead of `404 vendor-error`. Clients that gate UI on a non-null status (web UI `UpdatesDashboard`) can now render Prepare / Execute / Delete buttons immediately after registering a new update.

Idempotent - preserves an already-seeded state if a concurrent caller got there first (matches the defensive pattern already used in `start_prepare` / `run_prepare`).

## Test plan

- [x] New unit test `UpdateManagerTest.StatusPendingRightAfterRegister` covers the happy path.
- [x] Existing `StatusNotFoundForUnknown` still covers the NotFound path for truly unregistered IDs.
- [x] Full `test_update_manager` suite passes locally (20/20).