### PR TITLE
fix(aggregation): skip per-entity fan-out for local-only entities

### DIFF
--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/fan_out_helpers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/fan_out_helpers.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <array>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -43,6 +46,35 @@ inline std::string url_encode_param(const std::string & value) {
     }
   }
   return result;
+}
+
+// Extract the entity id from a per-entity collection path like
+// `/api/v1/components/<id>/logs` or `/api/v1/apps/<id>/data/<sub>`.
+// Returns the bare id when the path matches a known per-entity collection,
+// otherwise returns std::nullopt (global endpoints like `/faults`, `/health`,
+// or unknown shapes that should not short-circuit fan-out).
+inline std::optional<std::string> extract_entity_id_for_fan_out(const std::string & path) {
+  static constexpr std::array<std::string_view, 4> kEntityCollections = {"/components/", "/apps/", "/areas/",
+                                                                         "/functions/"};
+  for (const auto & prefix : kEntityCollections) {
+    auto start = path.find(prefix);
+    if (start == std::string::npos) {
+      continue;
+    }
+    start += prefix.size();
+    auto end = path.find('/', start);
+    if (end == std::string::npos) {
+      // Entity detail endpoint like `/components/<id>` (no trailing collection).
+      // These are routed to peers via a different mechanism; not a fan-out case.
+      return std::nullopt;
+    }
+    std::string id = path.substr(start, end - start);
+    if (id.empty()) {
+      return std::nullopt;
+    }
+    return id;
+  }
+  return std::nullopt;
 }
 
 inline std::string build_fan_out_path(const httplib::Request & req) {
@@ -74,6 +106,14 @@ inline void merge_peer_items(AggregationManager * agg, const httplib::Request & 
   // per-entity collection endpoints, concurrent requests during a peer outage
   // could exhaust httplib's thread pool if we don't bail out early here.
   if (agg->healthy_peer_count() == 0) {
+    return;
+  }
+  // For per-entity collection paths, skip fan-out when the entity is local-only
+  // (no peer hosts it). Otherwise every peer returns 404 and the response is
+  // falsely flagged as `partial` with spurious `failed_peers`. Global endpoints
+  // with no entity id in the path keep fan-out-to-all behavior.
+  if (auto entity_id = extract_entity_id_for_fan_out(req.path);
+      entity_id.has_value() && !agg->find_peer_for_entity(*entity_id).has_value()) {
     return;
   }
   auto fan_path = build_fan_out_path(req);

--- a/src/ros2_medkit_gateway/test/test_fan_out_helpers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fan_out_helpers.cpp
@@ -213,6 +213,9 @@ TEST(FanOutHelpers, merge_peer_items_appends_peer_items_to_result) {
 
   AggregationManager agg(config);
   agg.check_all_health();
+  // Routing table maps the entity in the path to the peer; without this the
+  // fan-out helper treats the entity as local-only and skips fan-out.
+  agg.update_routing_table({{"f1", "test_peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/functions/f1/logs";
@@ -248,6 +251,7 @@ TEST(FanOutHelpers, merge_peer_items_sets_partial_on_peer_failure) {
 
   AggregationManager agg(config);
   agg.check_all_health();
+  agg.update_routing_table({{"f1", "failing_peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/functions/f1/logs";
@@ -287,6 +291,7 @@ TEST(FanOutHelpers, merge_peer_items_creates_items_when_missing_and_peer_has_dat
 
   AggregationManager agg(config);
   agg.check_all_health();
+  agg.update_routing_table({{"a", "peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/apps/a/data";
@@ -299,4 +304,119 @@ TEST(FanOutHelpers, merge_peer_items_creates_items_when_missing_and_peer_has_dat
   ASSERT_TRUE(result.contains("items"));
   ASSERT_EQ(result["items"].size(), 1u);
   EXPECT_EQ(result["items"][0]["id"], "peer_item");
+}
+
+// =============================================================================
+// extract_entity_id_for_fan_out
+// =============================================================================
+
+TEST(FanOutHelpers, extract_entity_id_components_collection) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/components/ecu-primary/logs"), "ecu-primary");
+}
+
+TEST(FanOutHelpers, extract_entity_id_apps_with_subpath) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/apps/helloApp/data/%2Fhello%2Fheartbeat"), "helloApp");
+}
+
+TEST(FanOutHelpers, extract_entity_id_areas_and_functions) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/areas/vehicle/faults"), "vehicle");
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/functions/perception/logs"), "perception");
+}
+
+TEST(FanOutHelpers, extract_entity_id_global_endpoints_return_nullopt) {
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/faults").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/health").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/").has_value());
+}
+
+TEST(FanOutHelpers, extract_entity_id_detail_endpoint_returns_nullopt) {
+  // `/components/<id>` (no trailing collection suffix) is routed to the owning
+  // peer via the forwarding path, not fan-out. The helper returns nullopt so
+  // the caller falls through to the current global behavior.
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/components/ecu-primary").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/apps/helloApp").has_value());
+}
+
+// =============================================================================
+// merge_peer_items - skip fan-out for local-only entities
+// =============================================================================
+
+TEST(FanOutHelpers, merge_peer_items_skips_fanout_when_entity_is_local_only) {
+  // A local entity is one not present in the AggregationManager's routing
+  // table. Peers do not host it so fan-out would always 404 and produce
+  // spurious `failed_peers`. Regression test for issue #381.
+  MockServer mock;
+  mock.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"status":"healthy"})", "application/json");
+  });
+  // If the helper wrongly fans out anyway, the mock has no handler for /logs
+  // and the peer would be marked failed. This handler would never be hit
+  // when the fix is active:
+  mock.server().Get("/api/v1/components/local-only-comp/logs",
+                    [](const httplib::Request &, httplib::Response & res) { res.status = 500; });
+  int port = mock.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 2000;
+  AggregationConfig::PeerConfig peer;
+  peer.url = "http://127.0.0.1:" + std::to_string(port);
+  peer.name = "other_peer";
+  config.peers.push_back(peer);
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  // Routing table contains only entities hosted by other_peer. local-only-comp
+  // is not in the table, so find_peer_for_entity returns nullopt.
+  agg.update_routing_table({{"something-else", "other_peer"}});
+
+  httplib::Request req;
+  req.path = "/api/v1/components/local-only-comp/logs";
+  json result;
+  result["items"] = json::array({{{"id", "local_log"}}});
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  // Local items preserved, no fan-out attempted, no partial marker.
+  EXPECT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "local_log");
+  EXPECT_TRUE(ext.empty());
+}
+
+TEST(FanOutHelpers, merge_peer_items_fans_out_for_global_endpoints_without_entity) {
+  // Paths with no entity id (like /faults, /health) keep fan-out-to-all.
+  MockServer mock;
+  mock.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"status":"healthy"})", "application/json");
+  });
+  mock.server().Get("/api/v1/faults", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "peer_fault"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int port = mock.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  AggregationConfig::PeerConfig peer;
+  peer.url = "http://127.0.0.1:" + std::to_string(port);
+  peer.name = "peer";
+  config.peers.push_back(peer);
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  // Empty routing table - still fans out because global endpoints have no
+  // entity id to gate on.
+
+  httplib::Request req;
+  req.path = "/api/v1/faults";
+  json result;
+  result["items"] = json::array();
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "peer_fault");
 }


### PR DESCRIPTION
## Summary

Per-entity collection endpoints (`/components/{id}/logs`, `/apps/{id}/data`, etc.) no longer fan out to peers that do not host the entity. Before this change every such request produced `partial: true` with spurious `failed_peers` whenever the entity was local to the aggregating gateway.

---

## Issue

- closes #381

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- Added unit tests for the new `extract_entity_id_for_fan_out` helper (collection shapes, global endpoints, entity-detail endpoints).
- Added two `merge_peer_items` behavior tests:
  - Skips fan-out when the entity id is absent from the routing table (regression test for #381).
  - Still fans out for global endpoints with no entity id in the path (e.g. `/faults`).
- Updated three existing `merge_peer_items` tests to populate the routing table so the entity path resolves to the mock peer; without that, the new gate would kick in and the tests would stop exercising the fan-out code path.
- All 23 `FanOutHelpers.*` tests pass.

Reviewer steps:
1. ``colcon build --packages-up-to ros2_medkit_gateway``
2. ``./build/ros2_medkit_gateway/test_fan_out_helpers --gtest_filter='FanOutHelpers.*'`` -> expect 23/23 PASSED.
3. In a multi-instance setup, query ``/components/<local-id>/logs`` and confirm the response no longer carries ``partial: true`` / ``failed_peers`` for peers that do not host the component.

---

## Checklist

- [x] Breaking changes are clearly described (no breaking changes)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed