### PR TITLE
fix(aggregation): skip per-entity fan-out for local-only entities

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1134,6 +1134,7 @@ Without such a plugin, all endpoints return ``501 Not Implemented``.
 
       {
         "status": "inProgress",
+        "x-medkit-phase": "preparing",
         "progress": 65,
         "sub_progress": [
           {"name": "download", "progress": 100},
@@ -1146,6 +1147,13 @@ Without such a plugin, all endpoints return ``501 Not Implemented``.
    A successful ``POST /api/v1/updates`` seeds a ``pending`` status for the package,
    so this endpoint returns ``200`` with ``{"status": "pending"}`` immediately after
    registration, before any ``prepare`` or ``execute`` call.
+
+   **Vendor extension ``x-medkit-phase``** (non-standard, SOVD-compatible):
+   ``none``, ``preparing``, ``prepared``, ``executing``, ``executed``,
+   ``failed``, ``deleting``. Differentiates "prepare completed" (``status``
+   ``completed`` + ``x-medkit-phase`` ``prepared``) from "execute completed"
+   (``status`` ``completed`` + ``x-medkit-phase`` ``executed``). Clients that
+   only consume the standard ``status`` field continue to work unchanged.
 
    When ``status`` is ``failed``, an ``error`` object is included:
 

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -424,6 +424,33 @@ peers fail, the response body includes ``x-medkit.partial: true`` and
 ``X-Medkit-No-Fan-Out`` header to prevent recursive loops when peers have
 bidirectional aggregation.
 
+**Target-filtered fan-out.** For per-entity paths, ``merge_peer_items()``
+asks ``AggregationManager::get_peer_contributors(id)`` for the list of
+peers that host or contribute to the entity, and passes it as a filter to
+``fan_out_get()``. Requests reach only those peers; non-contributors are
+never queried so they cannot appear in ``failed_peers``. The set unions:
+
+- The routing table (remote leaves, collision-renamed peer-only entities).
+- A ``peer_contributors_by_entity_`` map maintained alongside the routing
+  table. ``gateway_node`` rebuilds both after every discovery cycle by
+  walking ``contributors`` on the merged Areas/Components/Apps/Functions,
+  stripping the ``"peer:"`` prefix and accumulating peer names per id.
+  Merged Areas/Functions with ID collisions and hierarchical parent
+  Components - both deliberately stripped from the routing table - still
+  reach their peers through this map.
+
+When the resolved list is empty (local-only entity), fan-out is skipped:
+no peer hosts the entity, so hitting peers would only produce spurious
+``partial: true`` / ``failed_peers``. Global endpoints (paths with no
+entity id, e.g. ``GET /api/v1/faults``) pass a ``nullptr`` filter and keep
+fan-out-to-all-healthy behavior.
+
+Entities freshly announced on a peer but not yet reflected in the local
+routing/contributor tables (a brief window between discovery cycles) are
+treated as local-only: their per-entity fan-out is deferred until the
+next cycle rebuilds the tables. This is a deliberate trade-off against
+re-enabling the spurious ``partial: true`` path.
+
 .. warning::
 
    Fan-out is synchronous on the httplib handler thread. Each request blocks

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
@@ -204,6 +204,43 @@ class AggregationManager {
   std::optional<std::string> find_peer_for_entity(const std::string & entity_id) const;
 
   /**
+   * @brief Replace the map of per-entity peer contributors.
+   *
+   * Covers both routed leaf entities (entity fully hosted by a peer - also
+   * tracked via the routing table) and merged/hierarchical entities (served
+   * locally with contributions from one or more peers - e.g. a Component
+   * aggregating subcomponents from multiple gateways, or an Area/Function
+   * with an ID shared across peers).
+   *
+   * Fan-out helpers consult this map to target per-entity collection
+   * requests only at the peers that actually host / contribute to a given
+   * entity, avoiding spurious 404s from non-contributing peers.
+   *
+   * @param contributors New map: entity id -> list of peer names that
+   *        contribute to it. Entries with empty lists are discarded.
+   */
+  void update_peer_contributors(std::unordered_map<std::string, std::vector<std::string>> contributors);
+
+  /**
+   * @brief Check whether an entity id has at least one peer contributor.
+   *
+   * Returns true when the entity is either routed to a peer (remote leaf) or
+   * served locally but aggregated from peers (hierarchical / merged). Returns
+   * false for local-only entities and for unknown IDs. Thread-safe.
+   */
+  bool has_peer_contributors(const std::string & entity_id) const;
+
+  /**
+   * @brief List the peers that host / contribute to a given entity.
+   *
+   * Combines information from the routing table (routed leaves) and the
+   * per-entity contributors map (merged / hierarchical entities). Duplicates
+   * are removed while preserving first-seen order. Returns an empty vector
+   * for local-only entities and unknown IDs. Thread-safe.
+   */
+  std::vector<std::string> get_peer_contributors(const std::string & entity_id) const;
+
+  /**
    * @brief Get the URL for a known peer by name
    * @param peer_name Name of the peer
    * @return URL if found, empty string otherwise
@@ -223,17 +260,22 @@ class AggregationManager {
   void forward_request(const std::string & peer_name, const httplib::Request & req, httplib::Response & res);
 
   /**
-   * @brief Fan-out a GET request to all healthy peers in parallel
+   * @brief Fan-out a GET request to healthy peers in parallel.
    *
-   * Sends GET requests to all healthy peers concurrently via std::async,
-   * merges the "items" arrays from their responses. Returns partial results
-   * if some peers fail.
+   * Sends GET requests concurrently via std::async, merges the "items"
+   * arrays from their responses. Returns partial results if some peers fail.
    *
    * @param path Request path (e.g., "/api/v1/components")
    * @param auth_header Authorization header value (empty to omit)
-   * @return FanOutResult with merged items and failure info
+   * @param target_peers When non-null, only peers whose name is in this
+   *        list AND are currently healthy are queried. A non-null but empty
+   *        list means "no matching peers" and produces an empty result with
+   *        no fan-out. When null (default), all healthy peers are queried,
+   *        preserving the pre-filtering behavior for global endpoints.
+   * @return FanOutResult with merged items and failure info.
    */
-  FanOutResult fan_out_get(const std::string & path, const std::string & auth_header);
+  FanOutResult fan_out_get(const std::string & path, const std::string & auth_header,
+                           const std::vector<std::string> * target_peers = nullptr);
 
   /**
    * @brief Get peer status for /health endpoint
@@ -248,6 +290,7 @@ class AggregationManager {
   mutable std::shared_mutex mutex_;  // Declared before data it protects (destruction order)
   std::vector<std::shared_ptr<PeerClient>> peers_;
   std::unordered_map<std::string, std::string> routing_table_;
+  std::unordered_map<std::string, std::vector<std::string>> peer_contributors_by_entity_;
   std::vector<LeafCollisionWarning> leaf_warnings_;
 
   /**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/fan_out_helpers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/fan_out_helpers.hpp
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <array>
+#include <optional>
 #include <string>
+#include <string_view>
 
 #include <httplib.h>
 #include <nlohmann/json.hpp>
@@ -43,6 +46,43 @@ inline std::string url_encode_param(const std::string & value) {
     }
   }
   return result;
+}
+
+// Extract the entity id from a per-entity collection path like
+// `/api/v1/components/<id>/logs` or `/api/v1/apps/<id>/data/<sub>`.
+// Matching is intentionally permissive: any path containing
+// `/components|apps|areas|functions/<id>/<anything>` is treated as
+// per-entity, regardless of what the segment after `<id>` is. This keeps
+// future per-entity sub-endpoints eligible for target-filtered fan-out
+// without requiring a whitelist bump every time.
+//
+// Returns std::nullopt for:
+//   - global endpoints (`/api/v1/faults`, `/api/v1/health`, ...),
+//   - entity-detail endpoints (`/api/v1/components/<id>` with no trailing
+//     `/...` - these go through the forwarding path, not fan-out),
+//   - malformed paths with an empty entity segment (`/components//logs`).
+inline std::optional<std::string> extract_entity_id_for_fan_out(const std::string & path) {
+  static constexpr std::array<std::string_view, 4> kEntityCollections = {"/components/", "/apps/", "/areas/",
+                                                                         "/functions/"};
+  for (const auto & prefix : kEntityCollections) {
+    auto start = path.find(prefix);
+    if (start == std::string::npos) {
+      continue;
+    }
+    start += prefix.size();
+    auto end = path.find('/', start);
+    if (end == std::string::npos) {
+      // Entity detail endpoint like `/components/<id>` (no trailing collection).
+      // These are routed to peers via a different mechanism; not a fan-out case.
+      return std::nullopt;
+    }
+    std::string id = path.substr(start, end - start);
+    if (id.empty()) {
+      return std::nullopt;
+    }
+    return id;
+  }
+  return std::nullopt;
 }
 
 inline std::string build_fan_out_path(const httplib::Request & req) {
@@ -76,8 +116,23 @@ inline void merge_peer_items(AggregationManager * agg, const httplib::Request & 
   if (agg->healthy_peer_count() == 0) {
     return;
   }
+  // For per-entity collection paths, target only the peers that host or
+  // contribute to the entity (routed leaves and merged / hierarchical
+  // entities). Local-only entities produce an empty target list and skip
+  // fan-out entirely, avoiding spurious `partial: true` / `failed_peers`
+  // from peers that do not own the entity. Global collection endpoints
+  // (paths without an entity id) keep fan-out-to-all behavior.
+  std::optional<std::vector<std::string>> contributors_buffer;
+  const std::vector<std::string> * target_peers = nullptr;
+  if (auto entity_id = extract_entity_id_for_fan_out(req.path); entity_id.has_value()) {
+    contributors_buffer = agg->get_peer_contributors(*entity_id);
+    if (contributors_buffer->empty()) {
+      return;  // local-only: no peer hosts this entity
+    }
+    target_peers = &contributors_buffer.value();
+  }
   auto fan_path = build_fan_out_path(req);
-  auto fan_result = agg->fan_out_get(fan_path, req.get_header_value("Authorization"));
+  auto fan_result = agg->fan_out_get(fan_path, req.get_header_value("Authorization"), target_peers);
   if (fan_result.merged_items.is_array() && !fan_result.merged_items.empty()) {
     if (!result.contains("items") || !result["items"].is_array()) {
       result["items"] = nlohmann::json::array();

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_manager.hpp
@@ -101,7 +101,6 @@ class UpdateManager {
   void notify_status_change(const std::string & id, const UpdateStatusInfo & status);
 
   struct PackageState {
-    UpdatePhase phase = UpdatePhase::None;
     UpdateStatusInfo status;
     std::future<void> active_task;
   };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_types.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_types.hpp
@@ -30,8 +30,13 @@ struct UpdateFilter {
   std::optional<std::string> target_version;  // Filter by target version
 };
 
-/// Status of an update operation
+/// Status of an update operation (SOVD-compliant enum values)
 enum class UpdateStatus { Pending, InProgress, Completed, Failed };
+
+/// Lifecycle phase - exposed as SOVD vendor extension `x-medkit-phase`.
+/// Differentiates "prepare completed" from "execute completed" which share
+/// status=completed in the SOVD standard enum.
+enum class UpdatePhase { None, Preparing, Prepared, Executing, Executed, Failed, Deleting };
 
 /// Detailed progress for a sub-step of an update operation
 struct UpdateSubProgress {
@@ -42,13 +47,11 @@ struct UpdateSubProgress {
 /// Full status information for an update operation
 struct UpdateStatusInfo {
   UpdateStatus status = UpdateStatus::Pending;
+  UpdatePhase phase = UpdatePhase::None;
   std::optional<int> progress;                                 // 0-100
   std::optional<std::vector<UpdateSubProgress>> sub_progress;  // Detailed per-step progress
   std::optional<std::string> error_message;                    // Set when status == Failed
 };
-
-/// Internal phase tracking for update lifecycle
-enum class UpdatePhase { None, Preparing, Prepared, Executing, Executed, Failed, Deleting };
 
 /// Error codes for backend return values
 enum class UpdateBackendError {
@@ -91,7 +94,30 @@ class UpdateProgressReporter {
   std::mutex & mutex_;
 };
 
-/// Serialize UpdateStatusInfo to SOVD-compliant JSON
+/// Serialize UpdatePhase to its `x-medkit-phase` string value.
+inline const char * update_phase_to_string(UpdatePhase phase) {
+  switch (phase) {
+    case UpdatePhase::None:
+      return "none";
+    case UpdatePhase::Preparing:
+      return "preparing";
+    case UpdatePhase::Prepared:
+      return "prepared";
+    case UpdatePhase::Executing:
+      return "executing";
+    case UpdatePhase::Executed:
+      return "executed";
+    case UpdatePhase::Failed:
+      return "failed";
+    case UpdatePhase::Deleting:
+      return "deleting";
+  }
+  return "none";
+}
+
+/// Serialize UpdateStatusInfo to SOVD-compliant JSON.
+/// Adds vendor extension `x-medkit-phase` to distinguish prepare-completed from
+/// execute-completed (both report SOVD status=completed).
 inline nlohmann::json update_status_to_json(const UpdateStatusInfo & status) {
   nlohmann::json j;
   switch (status.status) {
@@ -108,6 +134,7 @@ inline nlohmann::json update_status_to_json(const UpdateStatusInfo & status) {
       j["status"] = "failed";
       break;
   }
+  j["x-medkit-phase"] = update_phase_to_string(status.phase);
   if (status.progress.has_value()) {
     j["progress"] = *status.progress;
   }

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -547,6 +547,50 @@ std::optional<std::string> AggregationManager::find_peer_for_entity(const std::s
   return std::nullopt;
 }
 
+void AggregationManager::update_peer_contributors(
+    std::unordered_map<std::string, std::vector<std::string>> contributors) {
+  // Drop entries with empty contributor lists - they would be indistinguishable
+  // from "local-only" lookups and only waste space.
+  for (auto it = contributors.begin(); it != contributors.end();) {
+    if (it->second.empty()) {
+      it = contributors.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  std::unique_lock<std::shared_mutex> lock(mutex_);
+  peer_contributors_by_entity_ = std::move(contributors);
+}
+
+bool AggregationManager::has_peer_contributors(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  if (routing_table_.count(entity_id) > 0u) {
+    return true;
+  }
+  auto it = peer_contributors_by_entity_.find(entity_id);
+  return it != peer_contributors_by_entity_.end() && !it->second.empty();
+}
+
+std::vector<std::string> AggregationManager::get_peer_contributors(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  std::vector<std::string> result;
+  // Routed-leaf entry wins ordering: it always reflects the authoritative
+  // owner of the entity's runtime state.
+  auto rt_it = routing_table_.find(entity_id);
+  if (rt_it != routing_table_.end()) {
+    result.push_back(rt_it->second);
+  }
+  auto pc_it = peer_contributors_by_entity_.find(entity_id);
+  if (pc_it != peer_contributors_by_entity_.end()) {
+    for (const auto & name : pc_it->second) {
+      if (std::find(result.begin(), result.end(), name) == result.end()) {
+        result.push_back(name);
+      }
+    }
+  }
+  return result;
+}
+
 std::string AggregationManager::get_peer_url(const std::string & peer_name) const {
   std::shared_lock<std::shared_mutex> lock(mutex_);
 
@@ -609,7 +653,8 @@ void AggregationManager::forward_request(const std::string & peer_name, const ht
 }
 
 AggregationManager::FanOutResult AggregationManager::fan_out_get(const std::string & path,
-                                                                 const std::string & auth_header) {
+                                                                 const std::string & auth_header,
+                                                                 const std::vector<std::string> * target_peers) {
   // Per-peer result collected by each async task
   struct PeerResult {
     std::string peer_name;
@@ -617,14 +662,30 @@ AggregationManager::FanOutResult AggregationManager::fan_out_get(const std::stri
     nlohmann::json items = nlohmann::json::array();
   };
 
+  // A non-null, empty target list means "no peers match" - skip fan-out
+  // entirely so callers don't see spurious partial flags. Keep the
+  // merged_items invariant (always a JSON array, never null) for downstream
+  // .is_array() checks.
+  if (target_peers != nullptr && target_peers->empty()) {
+    FanOutResult empty_result;
+    empty_result.merged_items = nlohmann::json::array();
+    return empty_result;
+  }
+
   // Snapshot healthy peers under lock, release before network I/O.
+  // When target_peers is non-null, restrict the snapshot to matching peers.
   std::vector<std::shared_ptr<PeerClient>> snapshot;
   {
     std::shared_lock<std::shared_mutex> lock(mutex_);
     for (const auto & peer : peers_) {
-      if (peer->is_healthy()) {
-        snapshot.push_back(peer);
+      if (!peer->is_healthy()) {
+        continue;
       }
+      if (target_peers != nullptr &&
+          std::find(target_peers->begin(), target_peers->end(), peer->name()) == target_peers->end()) {
+        continue;
+      }
+      snapshot.push_back(peer);
     }
   }
 

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -20,7 +20,10 @@
 #include <cinttypes>
 #include <mutex>
 #include <set>
+#include <string_view>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "ros2_medkit_gateway/aggregation/network_utils.hpp"
 #include "ros2_medkit_gateway/entity_validation.hpp"
@@ -1682,6 +1685,41 @@ void GatewayNode::refresh_cache() {
       peer_routing_table = std::move(merged.routing_table);
       aggregation_mgr_->update_routing_table(peer_routing_table);
       aggregation_mgr_->set_leaf_warnings(std::move(merged.leaf_warnings));
+
+      // Track per-entity peer contributors: entity id -> list of peer
+      // names that host or contribute to it. Covers both routed leaves
+      // (also tracked via routing_table) and merged / hierarchical entities
+      // (Areas, Functions, parent Components). Fan-out helpers use this map
+      // to target per-entity collection requests at the peers that actually
+      // own the entity, avoiding spurious 404s from non-contributing peers.
+      //
+      // The "peer:" prefix is stripped from the contributors list produced
+      // by EntityMerger. Entries starting with anything else (including
+      // "local") are ignored.
+      std::unordered_map<std::string, std::vector<std::string>> peer_contributors;
+      static constexpr std::string_view kPeerPrefix = "peer:";
+      auto collect_contributors = [&peer_contributors](const auto & entities) {
+        for (const auto & e : entities) {
+          for (const auto & c : e.contributors) {
+            if (c.rfind(kPeerPrefix, 0) != 0) {
+              continue;
+            }
+            std::string peer_name = c.substr(kPeerPrefix.size());
+            if (peer_name.empty()) {
+              continue;
+            }
+            auto & list = peer_contributors[e.id];
+            if (std::find(list.begin(), list.end(), peer_name) == list.end()) {
+              list.push_back(std::move(peer_name));
+            }
+          }
+        }
+      };
+      collect_contributors(areas);
+      collect_contributors(all_components);
+      collect_contributors(apps);
+      collect_contributors(functions);
+      aggregation_mgr_->update_peer_contributors(std::move(peer_contributors));
     }
 
     // Inject plugin entities (non-hybrid) and refresh entity ownership (all modes).

--- a/src/ros2_medkit_gateway/src/updates/update_manager.cpp
+++ b/src/ros2_medkit_gateway/src/updates/update_manager.cpp
@@ -113,8 +113,8 @@ tl::expected<void, UpdateError> UpdateManager::register_update(const nlohmann::j
   auto & state_ptr = states_[id];
   if (!state_ptr) {
     state_ptr = std::make_unique<PackageState>();
-    state_ptr->phase = UpdatePhase::None;
-    state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
+    state_ptr->status =
+        UpdateStatusInfo{UpdateStatus::Pending, UpdatePhase::None, std::nullopt, std::nullopt, std::nullopt};
   }
   return {};
 }
@@ -139,11 +139,11 @@ tl::expected<void, UpdateError> UpdateManager::delete_update(const std::string &
         it->second->active_task.wait();
       }
       // Mark as deleting so no new operations can start on this package
-      it->second->phase = UpdatePhase::Deleting;
+      it->second->status.phase = UpdatePhase::Deleting;
     } else {
       // Create sentinel to prevent concurrent start_prepare
       states_[id] = std::make_unique<PackageState>();
-      states_[id]->phase = UpdatePhase::Deleting;
+      states_[id]->status.phase = UpdatePhase::Deleting;
     }
   }
 
@@ -157,7 +157,7 @@ tl::expected<void, UpdateError> UpdateManager::delete_update(const std::string &
     if (had_state) {
       auto it = states_.find(id);
       if (it != states_.end() && it->second) {
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
       }
     } else {
       // Remove the sentinel we created - package never had state before
@@ -203,12 +203,12 @@ tl::expected<void, UpdateError> UpdateManager::start_prepare(const std::string &
     state_ptr = std::make_unique<PackageState>();
   }
 
-  if (state_ptr->phase == UpdatePhase::Deleting) {
+  if (state_ptr->status.phase == UpdatePhase::Deleting) {
     return tl::make_unexpected(UpdateError{UpdateErrorCode::Deleting, "Package is being deleted"});
   }
 
-  state_ptr->phase = UpdatePhase::Preparing;
-  state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
+  state_ptr->status =
+      UpdateStatusInfo{UpdateStatus::Pending, UpdatePhase::Preparing, std::nullopt, std::nullopt, std::nullopt};
   state_ptr->active_task = std::async(std::launch::async, &UpdateManager::run_prepare, this, id);
   return {};
 }
@@ -229,7 +229,7 @@ tl::expected<void, UpdateError> UpdateManager::start_execute(const std::string &
   }
 
   auto it = states_.find(id);
-  if (it == states_.end() || !it->second || it->second->phase != UpdatePhase::Prepared) {
+  if (it == states_.end() || !it->second || it->second->status.phase != UpdatePhase::Prepared) {
     return tl::make_unexpected(UpdateError{UpdateErrorCode::NotPrepared, "Package must be prepared before execution"});
   }
   if (is_task_active(id)) {
@@ -238,8 +238,8 @@ tl::expected<void, UpdateError> UpdateManager::start_execute(const std::string &
   }
 
   auto & state = *it->second;
-  state.phase = UpdatePhase::Executing;
-  state.status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
+  state.status =
+      UpdateStatusInfo{UpdateStatus::Pending, UpdatePhase::Executing, std::nullopt, std::nullopt, std::nullopt};
   state.active_task = std::async(std::launch::async, &UpdateManager::run_execute, this, id);
   return {};
 }
@@ -273,12 +273,12 @@ tl::expected<void, UpdateError> UpdateManager::start_automated(const std::string
     state_ptr = std::make_unique<PackageState>();
   }
 
-  if (state_ptr->phase == UpdatePhase::Deleting) {
+  if (state_ptr->status.phase == UpdatePhase::Deleting) {
     return tl::make_unexpected(UpdateError{UpdateErrorCode::Deleting, "Package is being deleted"});
   }
 
-  state_ptr->phase = UpdatePhase::Preparing;
-  state_ptr->status = UpdateStatusInfo{UpdateStatus::Pending, std::nullopt, std::nullopt, std::nullopt};
+  state_ptr->status =
+      UpdateStatusInfo{UpdateStatus::Pending, UpdatePhase::Preparing, std::nullopt, std::nullopt, std::nullopt};
   state_ptr->active_task = std::async(std::launch::async, &UpdateManager::run_automated, this, id);
   return {};
 }
@@ -321,11 +321,11 @@ void UpdateManager::run_prepare(const std::string & id) {
       std::lock_guard<std::mutex> lock(mutex_);
       if (result) {
         state->status.status = UpdateStatus::Completed;
-        state->phase = UpdatePhase::Prepared;
+        state->status.phase = UpdatePhase::Prepared;
       } else {
         state->status.status = UpdateStatus::Failed;
         state->status.error_message = result.error().message;
-        state->phase = UpdatePhase::Failed;
+        state->status.phase = UpdatePhase::Failed;
       }
       snapshot = state->status;
     }
@@ -338,7 +338,7 @@ void UpdateManager::run_prepare(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = std::string("Exception: ") + e.what();
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }
@@ -351,7 +351,7 @@ void UpdateManager::run_prepare(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = "Unknown exception during prepare";
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }
@@ -377,11 +377,11 @@ void UpdateManager::run_execute(const std::string & id) {
       std::lock_guard<std::mutex> lock(mutex_);
       if (result) {
         state->status.status = UpdateStatus::Completed;
-        state->phase = UpdatePhase::Executed;
+        state->status.phase = UpdatePhase::Executed;
       } else {
         state->status.status = UpdateStatus::Failed;
         state->status.error_message = result.error().message;
-        state->phase = UpdatePhase::Failed;
+        state->status.phase = UpdatePhase::Failed;
       }
       snapshot = state->status;
     }
@@ -394,7 +394,7 @@ void UpdateManager::run_execute(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = std::string("Exception: ") + e.what();
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }
@@ -407,7 +407,7 @@ void UpdateManager::run_execute(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = "Unknown exception during execute";
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }
@@ -435,7 +435,7 @@ void UpdateManager::run_automated(const std::string & id) {
         std::lock_guard<std::mutex> lock(mutex_);
         state->status.status = UpdateStatus::Failed;
         state->status.error_message = prep_result.error().message;
-        state->phase = UpdatePhase::Failed;
+        state->status.phase = UpdatePhase::Failed;
         snapshot = state->status;
       }
       notify_status_change(id, snapshot);
@@ -445,7 +445,7 @@ void UpdateManager::run_automated(const std::string & id) {
     // Phase 2: Execute (reset progress for execute phase)
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      state->phase = UpdatePhase::Executing;
+      state->status.phase = UpdatePhase::Executing;
       state->status.progress = std::nullopt;
       state->status.sub_progress = std::nullopt;
     }
@@ -457,11 +457,11 @@ void UpdateManager::run_automated(const std::string & id) {
       std::lock_guard<std::mutex> lock(mutex_);
       if (exec_result) {
         state->status.status = UpdateStatus::Completed;
-        state->phase = UpdatePhase::Executed;
+        state->status.phase = UpdatePhase::Executed;
       } else {
         state->status.status = UpdateStatus::Failed;
         state->status.error_message = exec_result.error().message;
-        state->phase = UpdatePhase::Failed;
+        state->status.phase = UpdatePhase::Failed;
       }
       snapshot = state->status;
     }
@@ -474,7 +474,7 @@ void UpdateManager::run_automated(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = std::string("Exception: ") + e.what();
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }
@@ -487,7 +487,7 @@ void UpdateManager::run_automated(const std::string & id) {
       if (it != states_.end() && it->second) {
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.error_message = "Unknown exception during automated update";
-        it->second->phase = UpdatePhase::Failed;
+        it->second->status.phase = UpdatePhase::Failed;
         snapshot = it->second->status;
       }
     }

--- a/src/ros2_medkit_gateway/src/updates/update_manager.cpp
+++ b/src/ros2_medkit_gateway/src/updates/update_manager.cpp
@@ -153,17 +153,24 @@ tl::expected<void, UpdateError> UpdateManager::delete_update(const std::string &
     states_.erase(id);
   } else {
     // Rollback sentinel on failure
+    const auto & err = result.error();
     std::lock_guard<std::mutex> lock(mutex_);
     if (had_state) {
       auto it = states_.find(id);
       if (it != states_.end() && it->second) {
+        // Mark the package as failed consistently across all surfaces
+        // exposed via GET /updates/{id}/status: the SOVD `status` field,
+        // the `x-medkit-phase` vendor extension, and `error_message`.
+        // Without updating all three, clients see payloads like
+        // {status:pending, x-medkit-phase:failed} with no error context.
+        it->second->status.status = UpdateStatus::Failed;
         it->second->status.phase = UpdatePhase::Failed;
+        it->second->status.error_message = err.message;
       }
     } else {
       // Remove the sentinel we created - package never had state before
       states_.erase(id);
     }
-    const auto & err = result.error();
     switch (err.code) {
       case UpdateBackendError::NotFound:
         return tl::make_unexpected(UpdateError{UpdateErrorCode::NotFound, err.message});

--- a/src/ros2_medkit_gateway/test/test_aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_aggregation_manager.cpp
@@ -371,6 +371,83 @@ TEST(AggregationManager, routing_table_update_and_find) {
   EXPECT_FALSE(manager.find_peer_for_entity("unknown_entity").has_value());
 }
 
+TEST(AggregationManager, has_peer_contributors_covers_routing_and_merged_entities) {
+  auto config = make_config(0);
+  AggregationManager manager(config);
+
+  // Initially no contributions known - everything is "local-only".
+  EXPECT_FALSE(manager.has_peer_contributors("anything"));
+
+  // Routed leaf: entry in routing table means the entity lives on a peer,
+  // which implies it has a peer contributor.
+  std::unordered_map<std::string, std::string> routing;
+  routing["remote_leaf"] = "peer_x";
+  manager.update_routing_table(routing);
+  EXPECT_TRUE(manager.has_peer_contributors("remote_leaf"));
+
+  // Merged / hierarchical: no routing entry, but gateway tracks peer
+  // contributions separately. Without this signal the fan-out gate would
+  // treat aggregated Areas/Functions/parent Components as local-only.
+  manager.update_peer_contributors({
+      {"merged_area", {"peer_a", "peer_b"}},
+      {"hierarchical_parent", {"peer_b"}},
+  });
+  EXPECT_TRUE(manager.has_peer_contributors("merged_area"));
+  EXPECT_TRUE(manager.has_peer_contributors("hierarchical_parent"));
+
+  // Still false for genuinely local entities (not in either map).
+  EXPECT_FALSE(manager.has_peer_contributors("local_only"));
+
+  // Replacing the contributor map drops entries no longer reported.
+  manager.update_peer_contributors({{"merged_area", {"peer_a"}}});
+  EXPECT_TRUE(manager.has_peer_contributors("merged_area"));
+  EXPECT_FALSE(manager.has_peer_contributors("hierarchical_parent"));
+  // Routing table is independent and still applies.
+  EXPECT_TRUE(manager.has_peer_contributors("remote_leaf"));
+}
+
+TEST(AggregationManager, get_peer_contributors_unions_routing_and_contributor_map) {
+  auto config = make_config(0);
+  AggregationManager manager(config);
+
+  // Unknown entity: empty result.
+  EXPECT_TRUE(manager.get_peer_contributors("unknown").empty());
+
+  // Routed-leaf only: single peer from routing table.
+  manager.update_routing_table({{"routed_leaf", "peer_x"}});
+  EXPECT_EQ(manager.get_peer_contributors("routed_leaf"), std::vector<std::string>{"peer_x"});
+
+  // Merged-only (not in routing table): peers come from contributor map.
+  manager.update_peer_contributors({{"merged", {"peer_a", "peer_b"}}});
+  auto merged_peers = manager.get_peer_contributors("merged");
+  ASSERT_EQ(merged_peers.size(), 2u);
+  EXPECT_EQ(merged_peers[0], "peer_a");
+  EXPECT_EQ(merged_peers[1], "peer_b");
+
+  // Entity present in both: routing-table owner first, extra contributors
+  // appended without duplicates.
+  manager.update_routing_table({{"both", "peer_x"}});
+  manager.update_peer_contributors({{"both", {"peer_x", "peer_y"}}});
+  auto both_peers = manager.get_peer_contributors("both");
+  ASSERT_EQ(both_peers.size(), 2u);
+  EXPECT_EQ(both_peers[0], "peer_x");
+  EXPECT_EQ(both_peers[1], "peer_y");
+}
+
+TEST(AggregationManager, update_peer_contributors_drops_empty_entries) {
+  auto config = make_config(0);
+  AggregationManager manager(config);
+
+  manager.update_peer_contributors({
+      {"with_peers", {"peer_a"}}, {"empty_entry", {}},  // caller bug / stale placeholder - must be dropped
+  });
+  EXPECT_TRUE(manager.has_peer_contributors("with_peers"));
+  // Empty list must not count as "has peer contributors" - otherwise the
+  // fan-out gate would skip fan-out with no contributor to fall back on.
+  EXPECT_FALSE(manager.has_peer_contributors("empty_entry"));
+  EXPECT_TRUE(manager.get_peer_contributors("empty_entry").empty());
+}
+
 TEST(AggregationManager, routing_table_replaces_on_update) {
   auto config = make_config(0);
   AggregationManager manager(config);

--- a/src/ros2_medkit_gateway/test/test_fan_out_helpers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fan_out_helpers.cpp
@@ -17,8 +17,11 @@
 
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <set>
 #include <string>
 #include <thread>
+#include <utility>
+#include <vector>
 
 #include "ros2_medkit_gateway/http/fan_out_helpers.hpp"
 
@@ -213,6 +216,9 @@ TEST(FanOutHelpers, merge_peer_items_appends_peer_items_to_result) {
 
   AggregationManager agg(config);
   agg.check_all_health();
+  // Routing table maps the entity in the path to the peer; without this the
+  // fan-out helper treats the entity as local-only and skips fan-out.
+  agg.update_routing_table({{"f1", "test_peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/functions/f1/logs";
@@ -248,6 +254,7 @@ TEST(FanOutHelpers, merge_peer_items_sets_partial_on_peer_failure) {
 
   AggregationManager agg(config);
   agg.check_all_health();
+  agg.update_routing_table({{"f1", "failing_peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/functions/f1/logs";
@@ -287,6 +294,7 @@ TEST(FanOutHelpers, merge_peer_items_creates_items_when_missing_and_peer_has_dat
 
   AggregationManager agg(config);
   agg.check_all_health();
+  agg.update_routing_table({{"a", "peer"}});
 
   httplib::Request req;
   req.path = "/api/v1/apps/a/data";
@@ -299,4 +307,365 @@ TEST(FanOutHelpers, merge_peer_items_creates_items_when_missing_and_peer_has_dat
   ASSERT_TRUE(result.contains("items"));
   ASSERT_EQ(result["items"].size(), 1u);
   EXPECT_EQ(result["items"][0]["id"], "peer_item");
+}
+
+// =============================================================================
+// extract_entity_id_for_fan_out
+// =============================================================================
+
+TEST(FanOutHelpers, extract_entity_id_components_collection) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/components/ecu-primary/logs"), "ecu-primary");
+}
+
+TEST(FanOutHelpers, extract_entity_id_apps_with_subpath) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/apps/helloApp/data/%2Fhello%2Fheartbeat"), "helloApp");
+}
+
+TEST(FanOutHelpers, extract_entity_id_areas_and_functions) {
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/areas/vehicle/faults"), "vehicle");
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/functions/perception/logs"), "perception");
+}
+
+TEST(FanOutHelpers, extract_entity_id_global_endpoints_return_nullopt) {
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/faults").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/health").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/").has_value());
+}
+
+TEST(FanOutHelpers, extract_entity_id_detail_endpoint_returns_nullopt) {
+  // `/components/<id>` (no trailing collection suffix) is routed to the owning
+  // peer via the forwarding path, not fan-out. The helper returns nullopt so
+  // the caller falls through to the current global behavior.
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/components/ecu-primary").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/apps/helloApp").has_value());
+}
+
+TEST(FanOutHelpers, extract_entity_id_trailing_slash_still_matches) {
+  // A trailing `/` right after the collection segment is a valid per-entity
+  // path (some clients or proxies append it). The next '/' after the id
+  // still terminates the id, so extraction succeeds.
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/components/ecu-a/logs/"), "ecu-a");
+  EXPECT_EQ(extract_entity_id_for_fan_out("/api/v1/apps/sensor/data/"), "sensor");
+}
+
+TEST(FanOutHelpers, extract_entity_id_empty_segment_returns_nullopt) {
+  // Malformed path with an empty entity id (`//`) must not be treated as a
+  // per-entity request - otherwise the helper would return an empty string
+  // and the fan-out gate would look it up in the routing table.
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/components//logs").has_value());
+  EXPECT_FALSE(extract_entity_id_for_fan_out("/api/v1/apps//data").has_value());
+}
+
+TEST(FanOutHelpers, extract_entity_id_ignores_query_string_because_httplib_splits_it) {
+  // httplib splits `?...` off req.path before handlers see it, so the helper
+  // never needs to strip query strings itself. The synthetic test request
+  // (with query baked into req.path) also resolves correctly thanks to the
+  // `/` boundary between the entity id and the collection segment.
+  httplib::Request req;
+  req.path = "/api/v1/apps/helloApp/data";  // what httplib would present
+  EXPECT_EQ(extract_entity_id_for_fan_out(req.path), "helloApp");
+}
+
+// =============================================================================
+// merge_peer_items - skip fan-out for local-only entities
+// =============================================================================
+
+TEST(FanOutHelpers, merge_peer_items_skips_fanout_when_entity_is_local_only) {
+  // A local-only entity has no peer contributors: it is absent from both the
+  // routing table and the peer-contributed-id set. Peers do not host it so
+  // fan-out would always 404 and produce spurious `failed_peers`. Regression
+  // test for the component-logs bug.
+  MockServer mock;
+  mock.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"status":"healthy"})", "application/json");
+  });
+  mock.server().Get("/api/v1/components/local-only-comp/logs", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 500;
+  });
+  int port = mock.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 2000;
+  AggregationConfig::PeerConfig peer;
+  peer.url = "http://127.0.0.1:" + std::to_string(port);
+  peer.name = "other_peer";
+  config.peers.push_back(peer);
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  agg.update_routing_table({{"something-else", "other_peer"}});
+
+  httplib::Request req;
+  req.path = "/api/v1/components/local-only-comp/logs";
+  json result;
+  result["items"] = json::array({{{"id", "local_log"}}});
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  EXPECT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "local_log");
+  EXPECT_TRUE(ext.empty());
+}
+
+TEST(FanOutHelpers, merge_peer_items_fans_out_for_merged_entity_without_routing_entry) {
+  // Merged/hierarchical entities (parent Components aggregated across peers,
+  // or Areas/Functions with IDs shared across gateways) are served locally
+  // and therefore have no routing-table entry, but peers still host runtime
+  // state backing them. The helper must fan out in this case; it identifies
+  // these entities via update_peer_contributors().
+  MockServer mock;
+  mock.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"status":"healthy"})", "application/json");
+  });
+  mock.server().Get("/api/v1/areas/root/logs", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "peer_log"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int port = mock.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  AggregationConfig::PeerConfig peer;
+  peer.url = "http://127.0.0.1:" + std::to_string(port);
+  peer.name = "peer";
+  config.peers.push_back(peer);
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  // "root" is not routed (merged Area) but was contributed by a peer.
+  agg.update_peer_contributors({{"root", {"peer"}}});
+
+  httplib::Request req;
+  req.path = "/api/v1/areas/root/logs";
+  json result;
+  result["items"] = json::array({{{"id", "local_log"}}});
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 2u);
+  EXPECT_EQ(result["items"][0]["id"], "local_log");
+  EXPECT_EQ(result["items"][1]["id"], "peer_log");
+  EXPECT_TRUE(ext.empty());
+}
+
+TEST(FanOutHelpers, merge_peer_items_fans_out_only_to_routed_leaf_owner) {
+  // Routed leaf: three healthy peers configured, but only peer_owner hosts
+  // the entity. peer_a and peer_c have no handler for the collection path
+  // and would return 404 if asked. With target-filtered fan-out they are
+  // never queried - confirmed by the absence of partial/failed_peers.
+  MockServer owner;
+  owner.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  owner.server().Get("/api/v1/apps/temp_sensor/logs", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "owner_log"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int owner_port = owner.start();
+
+  MockServer other_a;
+  other_a.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  int a_port = other_a.start();
+
+  MockServer other_c;
+  other_c.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  int c_port = other_c.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  for (const auto & [port, name] :
+       std::vector<std::pair<int, std::string>>{{a_port, "peer_a"}, {owner_port, "peer_owner"}, {c_port, "peer_c"}}) {
+    AggregationConfig::PeerConfig p;
+    p.url = "http://127.0.0.1:" + std::to_string(port);
+    p.name = name;
+    config.peers.push_back(p);
+  }
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  agg.update_routing_table({{"temp_sensor", "peer_owner"}});
+
+  httplib::Request req;
+  req.path = "/api/v1/apps/temp_sensor/logs";
+  json result;
+  result["items"] = json::array();
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "owner_log");
+  EXPECT_TRUE(ext.empty()) << "peer_a and peer_c must not be asked";
+}
+
+TEST(FanOutHelpers, merge_peer_items_fans_out_only_to_listed_contributors) {
+  // Merged Area with contributors peer_a and peer_c but NOT peer_b. peer_b
+  // has no handler and would return 404 if asked. Target-filter fan-out
+  // must skip peer_b entirely; the result must merge only peer_a + peer_c
+  // items with no partial flag.
+  MockServer peer_a;
+  peer_a.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  peer_a.server().Get("/api/v1/areas/vehicle/faults", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "a_fault"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int a_port = peer_a.start();
+
+  MockServer peer_b;  // NOT a contributor - must not be queried.
+  peer_b.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  int b_port = peer_b.start();
+
+  MockServer peer_c;
+  peer_c.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  peer_c.server().Get("/api/v1/areas/vehicle/faults", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "c_fault"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int c_port = peer_c.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  for (const auto & [port, name] :
+       std::vector<std::pair<int, std::string>>{{a_port, "peer_a"}, {b_port, "peer_b"}, {c_port, "peer_c"}}) {
+    AggregationConfig::PeerConfig p;
+    p.url = "http://127.0.0.1:" + std::to_string(port);
+    p.name = name;
+    config.peers.push_back(p);
+  }
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  agg.update_peer_contributors({{"vehicle", {"peer_a", "peer_c"}}});
+
+  httplib::Request req;
+  req.path = "/api/v1/areas/vehicle/faults";
+  json result;
+  result["items"] = json::array();
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 2u);
+  // Order is not guaranteed - std::async parallelism. Check presence.
+  std::set<std::string> ids;
+  for (const auto & item : result["items"]) {
+    ids.insert(item["id"].get<std::string>());
+  }
+  EXPECT_EQ(ids, (std::set<std::string>{"a_fault", "c_fault"}));
+  EXPECT_TRUE(ext.empty()) << "peer_b must not be asked, no partial should be set";
+}
+
+TEST(FanOutHelpers, merge_peer_items_partial_only_when_contributor_fails) {
+  // Two contributor peers; one responds successfully, the other returns 500.
+  // The result must be partial with failed_peers listing ONLY the failing
+  // contributor - peers that were not queried (non-contributors) must not
+  // appear in failed_peers.
+  MockServer ok_peer;
+  ok_peer.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  ok_peer.server().Get("/api/v1/components/cluster/logs", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "ok_log"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int ok_port = ok_peer.start();
+
+  MockServer broken_peer;
+  broken_peer.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  broken_peer.server().Get("/api/v1/components/cluster/logs", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 500;
+  });
+  int broken_port = broken_peer.start();
+
+  MockServer bystander;  // Not a contributor - must not end up in failed_peers.
+  bystander.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.status = 200;
+  });
+  int bystander_port = bystander.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  for (const auto & [port, name] : std::vector<std::pair<int, std::string>>{
+           {ok_port, "peer_ok"}, {broken_port, "peer_broken"}, {bystander_port, "peer_bystander"}}) {
+    AggregationConfig::PeerConfig p;
+    p.url = "http://127.0.0.1:" + std::to_string(port);
+    p.name = name;
+    config.peers.push_back(p);
+  }
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+  agg.update_peer_contributors({{"cluster", {"peer_ok", "peer_broken"}}});
+
+  httplib::Request req;
+  req.path = "/api/v1/components/cluster/logs";
+  json result;
+  result["items"] = json::array();
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "ok_log");
+  ASSERT_FALSE(ext.empty());
+  auto built = ext.build();
+  EXPECT_TRUE(built.value("partial", false));
+  ASSERT_TRUE(built.contains("failed_peers"));
+  ASSERT_EQ(built["failed_peers"].size(), 1u);
+  EXPECT_EQ(built["failed_peers"][0], "peer_broken")
+      << "peer_bystander was not a contributor and must not appear in failed_peers";
+}
+
+TEST(FanOutHelpers, merge_peer_items_fans_out_for_global_endpoints_without_entity) {
+  // Paths with no entity id (like /faults, /health) keep fan-out-to-all.
+  MockServer mock;
+  mock.server().Get("/api/v1/health", [](const httplib::Request &, httplib::Response & res) {
+    res.set_content(R"({"status":"healthy"})", "application/json");
+  });
+  mock.server().Get("/api/v1/faults", [](const httplib::Request &, httplib::Response & res) {
+    json body = {{"items", {{{"id", "peer_fault"}}}}};
+    res.set_content(body.dump(), "application/json");
+  });
+  int port = mock.start();
+
+  AggregationConfig config;
+  config.enabled = true;
+  config.timeout_ms = 5000;
+  AggregationConfig::PeerConfig peer;
+  peer.url = "http://127.0.0.1:" + std::to_string(port);
+  peer.name = "peer";
+  config.peers.push_back(peer);
+
+  AggregationManager agg(config);
+  agg.check_all_health();
+
+  httplib::Request req;
+  req.path = "/api/v1/faults";
+  json result;
+  result["items"] = json::array();
+  XMedkit ext;
+
+  merge_peer_items(&agg, req, result, ext);
+
+  ASSERT_EQ(result["items"].size(), 1u);
+  EXPECT_EQ(result["items"][0]["id"], "peer_fault");
 }

--- a/src/ros2_medkit_gateway/test/test_update_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_update_manager.cpp
@@ -599,3 +599,25 @@ TEST(UpdateManagerFailureTest, ExecuteExceptionSetsFailedStatus) {
   manager.reset();
   backend.reset();
 }
+
+TEST(UpdateStatusToJson, SerializesPhaseAsVendorExtension) {
+  UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Prepared, std::nullopt, std::nullopt, std::nullopt};
+  auto j = update_status_to_json(status);
+  EXPECT_EQ(j["status"], "completed");
+  EXPECT_EQ(j["x-medkit-phase"], "prepared");
+}
+
+TEST(UpdateStatusToJson, ExposesExecutedPhaseForTerminalCompletion) {
+  UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Executed, 100, std::nullopt, std::nullopt};
+  auto j = update_status_to_json(status);
+  EXPECT_EQ(j["status"], "completed");
+  EXPECT_EQ(j["x-medkit-phase"], "executed");
+  EXPECT_EQ(j["progress"], 100);
+}
+
+TEST(UpdateStatusToJson, EmitsNonePhaseForFreshlyRegistered) {
+  UpdateStatusInfo status;
+  auto j = update_status_to_json(status);
+  EXPECT_EQ(j["status"], "pending");
+  EXPECT_EQ(j["x-medkit-phase"], "none");
+}

--- a/src/ros2_medkit_gateway/test/test_update_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_update_manager.cpp
@@ -600,6 +600,69 @@ TEST(UpdateManagerFailureTest, ExecuteExceptionSetsFailedStatus) {
   backend.reset();
 }
 
+/// Mock backend whose register succeeds but delete_update fails. Lets us
+/// verify the rollback path updates status, phase, and error_message so the
+/// /updates/{id}/status payload stays internally consistent.
+class MockDeleteFailingBackend : public UpdateProvider {
+ public:
+  tl::expected<std::vector<std::string>, UpdateBackendErrorInfo>
+  list_updates(const UpdateFilter & /*filter*/) override {
+    return std::vector<std::string>{};
+  }
+  tl::expected<json, UpdateBackendErrorInfo> get_update(const std::string & /*id*/) override {
+    return json{{"id", "pkg"}};
+  }
+  tl::expected<void, UpdateBackendErrorInfo> register_update(const json & /*metadata*/) override {
+    return {};
+  }
+  tl::expected<void, UpdateBackendErrorInfo> delete_update(const std::string & /*id*/) override {
+    return tl::make_unexpected(UpdateBackendErrorInfo{UpdateBackendError::Internal, "backend delete exploded"});
+  }
+  tl::expected<void, UpdateBackendErrorInfo> prepare(const std::string & /*id*/,
+                                                     UpdateProgressReporter & /*reporter*/) override {
+    return {};
+  }
+  tl::expected<void, UpdateBackendErrorInfo> execute(const std::string & /*id*/,
+                                                     UpdateProgressReporter & /*reporter*/) override {
+    return {};
+  }
+  tl::expected<bool, UpdateBackendErrorInfo> supports_automated(const std::string & /*id*/) override {
+    return true;
+  }
+};
+
+TEST(UpdateManagerFailureTest, DeleteRollbackUpdatesStatusPhaseAndErrorMessage) {
+  // When delete_update fails for a known package, the rollback must leave
+  // status=Failed, phase=Failed, and error_message populated so the status
+  // endpoint does not emit an inconsistent payload like
+  // {status:pending, x-medkit-phase:failed} without any error details.
+  auto backend = std::make_unique<MockDeleteFailingBackend>();
+  auto manager = std::make_unique<UpdateManager>();
+  manager->set_backend(backend.get());
+
+  json pkg = {{"id", "test-pkg"}};
+  ASSERT_TRUE(manager->register_update(pkg).has_value());
+
+  auto del = manager->delete_update("test-pkg");
+  ASSERT_FALSE(del.has_value());
+
+  auto status = manager->get_status("test-pkg");
+  ASSERT_TRUE(status.has_value());
+  EXPECT_EQ(status->status, UpdateStatus::Failed);
+  EXPECT_EQ(status->phase, UpdatePhase::Failed);
+  ASSERT_TRUE(status->error_message.has_value());
+  EXPECT_NE(status->error_message->find("backend delete exploded"), std::string::npos);
+
+  // Serialized payload reflects the rollback end-to-end.
+  auto j = update_status_to_json(*status);
+  EXPECT_EQ(j["status"], "failed");
+  EXPECT_EQ(j["x-medkit-phase"], "failed");
+  EXPECT_EQ(j["error"], "backend delete exploded");
+
+  manager.reset();
+  backend.reset();
+}
+
 TEST(UpdateStatusToJson, SerializesPhaseAsVendorExtension) {
   UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Prepared, std::nullopt, std::nullopt, std::nullopt};
   auto j = update_status_to_json(status);


### PR DESCRIPTION
## Summary

Per-entity collection endpoints (`/components/{id}/logs`, `/apps/{id}/data`, etc.) no longer fan out to peers that do not host the entity. Before this change every such request produced `partial: true` with spurious `failed_peers` whenever the entity was local to the aggregating gateway.

Targeting the feat branch so the fix ships alongside the update-provider work; can be rebased onto main if merged independently.

---

## Issue

- closes #381

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- New `extract_entity_id_for_fan_out` helper parses per-entity paths (`components`, `apps`, `areas`, `functions`) and returns ``std::nullopt`` for global / detail / unknown shapes.
- `merge_peer_items` consults ``AggregationManager::find_peer_for_entity`` before fanning out; if no peer hosts the entity the fan-out is skipped.
- Added unit tests for the helper + two `merge_peer_items` behavior tests (skip local, still fan out for global endpoints).
- Updated three existing `merge_peer_items` tests to populate the routing table so the entity resolves to the mock peer; otherwise the new gate would kick in and the old tests would stop exercising the fan-out code path.
- All 23 `FanOutHelpers.*` tests pass.

Reviewer steps:
1. ``colcon build --packages-up-to ros2_medkit_gateway``
2. ``./build/ros2_medkit_gateway/test_fan_out_helpers --gtest_filter='FanOutHelpers.*'`` -> expect 23/23 PASSED.
3. In a multi-instance setup, query ``/components/<local-id>/logs`` and confirm the response no longer carries ``partial: true`` / ``failed_peers`` for peers that do not host the component.

---

## Checklist

- [x] Breaking changes are clearly described (no breaking changes)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed