### PR TITLE
Nest x-medkit vendor fields on SOVD endpoint payloads

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -217,7 +217,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-    timeout-minutes: 45
+    # Cold-cache ASan builds are ~33 min; with the 12-min test budget this
+    # left ~0 headroom and was already cancelling at thermal_protection on
+    # PR branches that miss the ccache restore key. 60 min covers a full
+    # cold-cache cycle so the cache always gets saved on the post step.
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1154,25 +1154,27 @@ Without such a plugin, all endpoints return ``501 Not Implemented``.
 
       {
         "status": "inProgress",
-        "x-medkit-phase": "preparing",
         "progress": 65,
         "sub_progress": [
           {"name": "download", "progress": 100},
           {"name": "verify", "progress": 30}
-        ]
+        ],
+        "x-medkit": {
+          "phase": "preparing"
+        }
       }
 
    **Status values:** ``pending``, ``inProgress``, ``completed``, ``failed``
 
    A successful ``POST /api/v1/updates`` seeds a ``pending`` status for the package,
-   so this endpoint returns ``200`` with ``{"status": "pending"}`` immediately after
-   registration, before any ``prepare`` or ``execute`` call.
+   so this endpoint returns ``200`` with ``{"status": "pending", "x-medkit": {"phase": "none"}}``
+   immediately after registration, before any ``prepare`` or ``execute`` call.
 
-   **Vendor extension ``x-medkit-phase``** (non-standard, SOVD-compatible):
+   **Vendor extension ``x-medkit.phase``** (non-standard, SOVD-compatible):
    ``none``, ``preparing``, ``prepared``, ``executing``, ``executed``,
    ``failed``, ``deleting``. Differentiates "prepare completed" (``status``
-   ``completed`` + ``x-medkit-phase`` ``prepared``) from "execute completed"
-   (``status`` ``completed`` + ``x-medkit-phase`` ``executed``). Clients that
+   ``completed`` + ``x-medkit.phase`` ``prepared``) from "execute completed"
+   (``status`` ``completed`` + ``x-medkit.phase`` ``executed``). Clients that
    only consume the standard ``status`` field continue to work unchanged.
 
    When ``status`` is ``failed``, an ``error`` object is included:

--- a/src/ros2_medkit_fault_manager/src/snapshot_capture.cpp
+++ b/src/ros2_medkit_fault_manager/src/snapshot_capture.cpp
@@ -40,6 +40,18 @@ struct LockedSubscriptionGuard {
   rclcpp::GenericSubscription::SharedPtr subscription;
   rclcpp::CallbackGroup::SharedPtr callback_group;
 
+  // Explicit constructor instead of relying on aggregate initialization:
+  // C++20 [dcl.init.aggr] disqualifies a class as an aggregate if it has
+  // any user-declared constructors, including ``= delete`` ones (the rule
+  // tightened from "user-provided" in C++17 to "user-declared" in C++20).
+  // Rolling's gcc 14 / libstdc++ enforces the C++20 wording even when
+  // CMAKE_CXX_STANDARD is 17, so brace-init ``LockedSubscriptionGuard{
+  // &mtx, sub, cg}`` would fail to find a matching constructor on rolling.
+  // An explicit constructor sidesteps the aggregate-init rules entirely.
+  LockedSubscriptionGuard(std::mutex * m, rclcpp::GenericSubscription::SharedPtr s, rclcpp::CallbackGroup::SharedPtr cg)
+    : mtx(m), subscription(std::move(s)), callback_group(std::move(cg)) {
+  }
+
   ~LockedSubscriptionGuard() {
     if (!subscription && !callback_group) {
       return;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp
@@ -189,12 +189,19 @@ class Ros2SubscriptionExecutor final {
    * disappearing, types changing). Use to invalidate per-topic caches or evict stale
    * pool entries.
    *
-   * @warning A registered callback must NOT call remove_graph_change() on its own
-   *          token from inside the callback - graph_mtx_ is non-recursive and the
-   *          synchronous in-flight drain in remove_graph_change() would wait
-   *          indefinitely on the very call holding the slot's in_flight counter.
-   *          Drop the token through a separate task posted to the worker if
-   *          dynamic deregistration is needed.
+   * @warning DO NOT call remove_graph_change() on this token from inside the
+   *          callback body. The deadlock is concrete: remove_graph_change()
+   *          acquires graph_mtx_ and waits for graph_in_flight_[token] to
+   *          drain to zero, but the wrapper that decrements is the very call
+   *          frame that ran your callback. The worker thread is now blocked
+   *          on cv.wait, the decrement never runs, the wait never returns.
+   *          Symptom in production: hung worker thread, /health stops
+   *          updating, no log line. There is no runtime detection (would
+   *          need thread_local TLS, banned in code linked into the gateway
+   *          plugin MODULE; see CLAUDE.md). Workaround for dynamic
+   *          deregistration: have the callback hand the token to a
+   *          non-worker thread via a queue/promise, and call
+   *          remove_graph_change() from there.
    *
    * @return Opaque token in range [0, kMaxGraphListeners). `kMaxGraphListeners` if
    *         all slots are taken.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp
@@ -190,16 +190,29 @@ class Ros2SubscriptionExecutor final {
    * pool entries.
    *
    * @warning A registered callback must NOT call remove_graph_change() on its own
-   *          token from inside the callback - graph_mtx_ is non-recursive and a
-   *          self-removal attempt deadlocks. Drop the token through a separate task
-   *          posted to the worker if dynamic deregistration is needed.
+   *          token from inside the callback - graph_mtx_ is non-recursive and the
+   *          synchronous in-flight drain in remove_graph_change() would wait
+   *          indefinitely on the very call holding the slot's in_flight counter.
+   *          Drop the token through a separate task posted to the worker if
+   *          dynamic deregistration is needed.
    *
    * @return Opaque token in range [0, kMaxGraphListeners). `kMaxGraphListeners` if
    *         all slots are taken.
    */
   [[nodiscard]] std::size_t on_graph_change(GraphCallback cb);
 
-  /// Remove a previously-registered graph callback. Idempotent. See warning on on_graph_change.
+  /**
+   * @brief Remove a previously-registered graph callback. Idempotent.
+   *
+   * Synchronously drains in-flight execution: returns only after any worker
+   * thread that already entered this slot's callback has exited it. After
+   * remove_graph_change() returns, the caller can safely tear down state that
+   * the callback's captured `this` pointer references; the executor guarantees
+   * no further dispatch and no in-flight call.
+   *
+   * See warning on on_graph_change(): self-removal from inside the callback
+   * deadlocks.
+   */
   void remove_graph_change(std::size_t token);
 
   /// True after shutdown has started. Monotonic. Use to skip re-posting work on teardown.
@@ -269,10 +282,19 @@ class Ros2SubscriptionExecutor final {
   std::atomic<std::size_t> watchdog_trips_{0};
   std::atomic<std::size_t> graph_events_received_{0};
 
-  // Graph callbacks (pre-allocated, Tier 1)
+  // Graph callbacks (pre-allocated, Tier 1).
+  // graph_in_flight_[i] tracks how many worker invocations of slot i's
+  // callback are currently mid-execution. fire_graph_callbacks() increments
+  // it when snapshotting under graph_mtx_, the snapshot wrapper decrements
+  // it after the callback returns and notifies graph_in_flight_cv_. This
+  // lets remove_graph_change() block until in-flight execution drains, so a
+  // consumer's destructor can safely tear down state that the callback's
+  // captured `this` references.
   mutable std::mutex graph_mtx_;
   std::array<GraphCallback, kMaxGraphListeners> graph_callbacks_{};
   std::array<bool, kMaxGraphListeners> graph_slot_used_{};
+  std::array<int, kMaxGraphListeners> graph_in_flight_{};
+  std::condition_variable graph_in_flight_cv_;
 
   // Public rclcpp graph API - stable across Humble / Jazzy / Rolling
   rclcpp::Event::SharedPtr graph_event_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_types.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/updates/update_types.hpp
@@ -33,7 +33,7 @@ struct UpdateFilter {
 /// Status of an update operation (SOVD-compliant enum values)
 enum class UpdateStatus { Pending, InProgress, Completed, Failed };
 
-/// Lifecycle phase - exposed as SOVD vendor extension `x-medkit-phase`.
+/// Lifecycle phase - exposed as SOVD vendor extension `x-medkit.phase`.
 /// Differentiates "prepare completed" from "execute completed" which share
 /// status=completed in the SOVD standard enum.
 enum class UpdatePhase { None, Preparing, Prepared, Executing, Executed, Failed, Deleting };
@@ -94,7 +94,7 @@ class UpdateProgressReporter {
   std::mutex & mutex_;
 };
 
-/// Serialize UpdatePhase to its `x-medkit-phase` string value.
+/// Serialize UpdatePhase to its `x-medkit.phase` string value.
 inline const char * update_phase_to_string(UpdatePhase phase) {
   switch (phase) {
     case UpdatePhase::None:
@@ -116,7 +116,7 @@ inline const char * update_phase_to_string(UpdatePhase phase) {
 }
 
 /// Serialize UpdateStatusInfo to SOVD-compliant JSON.
-/// Adds vendor extension `x-medkit-phase` to distinguish prepare-completed from
+/// Adds vendor extension `x-medkit.phase` to distinguish prepare-completed from
 /// execute-completed (both report SOVD status=completed).
 inline nlohmann::json update_status_to_json(const UpdateStatusInfo & status) {
   nlohmann::json j;
@@ -134,7 +134,7 @@ inline nlohmann::json update_status_to_json(const UpdateStatusInfo & status) {
       j["status"] = "failed";
       break;
   }
-  j["x-medkit-phase"] = update_phase_to_string(status.phase);
+  j["x-medkit"] = {{"phase", update_phase_to_string(status.phase)}};
   if (status.progress.has_value()) {
     j["progress"] = *status.progress;
   }

--- a/src/ros2_medkit_gateway/src/http/handlers/config_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/config_handlers.cpp
@@ -311,15 +311,14 @@ void ConfigHandlers::handle_list_configurations(const httplib::Request & req, ht
 
             // Add source info for aggregated configurations
             if (agg_configs.is_aggregated) {
-              config_meta["x-medkit-source"] = node_info.app_id;
+              config_meta["x-medkit"] = {{"source", node_info.app_id}};
             }
 
             items.push_back(config_meta);
 
             // Also track full parameter info
             json param_with_source = param;
-            param_with_source["x-medkit-source"] = node_info.app_id;
-            param_with_source["x-medkit-node"] = node_info.node_fqn;
+            param_with_source["x-medkit"] = {{"source", node_info.app_id}, {"node", node_info.node_fqn}};
             all_parameters.push_back(param_with_source);
           }
         }

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -1127,8 +1127,8 @@ void RESTServer::setup_routes() {
               })
           .tag("Discovery")
           .summary("Get app host component")
-          .description("Returns the component hosting this app.")
-          .response(200, "Host component", SB::ref("EntityDetail"))
+          .description("Returns the component hosting this app as a single-element collection.")
+          .response(200, "Host component(s)", SB::ref("EntityList"))
           .operation_id("getAppHost");
 
       reg.get(entity_path + "/depends-on",

--- a/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
@@ -160,12 +160,20 @@ nlohmann::json SchemaBuilder::items_wrapper(const nlohmann::json & item_schema) 
 }
 
 nlohmann::json SchemaBuilder::configuration_metadata_schema() {
-  return {{"type", "object"},
+  return {
+      {"type", "object"},
+      {"properties",
+       {{"id", {{"type", "string"}, {"description", "Configuration parameter ID"}}},
+        {"name", {{"type", "string"}, {"description", "Parameter name"}}},
+        {"type", {{"type", "string"}, {"description", "Parameter type (e.g. 'parameter')"}}},
+        {"x-medkit",
+         {{"type", "object"},
+          {"description", "Vendor extensions (medkit)"},
           {"properties",
-           {{"id", {{"type", "string"}, {"description", "Configuration parameter ID"}}},
-            {"name", {{"type", "string"}, {"description", "Parameter name"}}},
-            {"type", {{"type", "string"}, {"description", "Parameter type (e.g. 'parameter')"}}}}},
-          {"required", {"id", "name", "type"}}};
+           {{"source",
+             {{"type", "string"},
+              {"description", "App ID that owns this parameter (only present in aggregated configurations)"}}}}}}}}},
+      {"required", {"id", "name", "type"}}};
 }
 
 nlohmann::json SchemaBuilder::configuration_read_value_schema() {
@@ -538,13 +546,24 @@ nlohmann::json SchemaBuilder::update_status_schema() {
       {"properties", {{"name", {{"type", "string"}}}, {"progress", {{"type", "number"}}}}},
       {"required", {"name", "progress"}}};
 
+  nlohmann::json x_medkit_schema = {
+      {"type", "object"},
+      {"description", "Vendor extensions (medkit)"},
+      {"properties",
+       {{"phase",
+         {{"type", "string"},
+          {"enum", {"none", "preparing", "prepared", "executing", "executed", "failed", "deleting"}},
+          {"description", "Internal lifecycle phase, distinguishes prepare-completed from execute-completed"}}}}},
+      {"required", {"phase"}}};
+
   return {{"type", "object"},
           {"properties",
            {{"status", {{"type", "string"}, {"enum", {"pending", "inProgress", "completed", "failed"}}}},
             {"progress", {{"type", "number"}}},
             {"sub_progress", {{"type", "array"}, {"items", sub_progress_schema}}},
-            {"error", {{"type", "string"}}}}},
-          {"required", {"status"}}};
+            {"error", {{"type", "string"}}},
+            {"x-medkit", x_medkit_schema}}},
+          {"required", {"status", "x-medkit"}}};
 }
 
 nlohmann::json SchemaBuilder::log_configuration_schema() {

--- a/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
@@ -172,7 +172,10 @@ nlohmann::json SchemaBuilder::configuration_metadata_schema() {
           {"properties",
            {{"source",
              {{"type", "string"},
-              {"description", "App ID that owns this parameter (only present in aggregated configurations)"}}}}}}}}},
+              {"description", "App ID that owns this parameter (only present in aggregated configurations)"}}},
+            {"node",
+             {{"type", "string"},
+              {"description", "Node FQN providing this parameter (only present in aggregated configurations)"}}}}}}}}},
       {"required", {"id", "name", "type"}}};
 }
 
@@ -556,11 +559,14 @@ nlohmann::json SchemaBuilder::update_status_schema() {
           {"description", "Internal lifecycle phase, distinguishes prepare-completed from execute-completed"}}}}},
       {"required", {"phase"}}};
 
-  // x-medkit is optional in the schema (matches the convention used by
-  // fault_detail_schema and entity_detail_schema): SOVD does not require
-  // vendor extensions, so a SOVD-compliant client must be able to ignore
-  // it. The gateway always emits it; the explicit handler guard in
-  // test_openapi_response_drift covers regression risk.
+  // x-medkit is optional in the SOVD payload (clients may ignore vendor
+  // extensions; matches the convention in fault_detail_schema and
+  // entity_detail_schema). When the gateway DOES emit the x-medkit object,
+  // however, ``phase`` is mandatory inside it - that scope is enforced by
+  // the inner ``required: {phase}`` above, NOT by listing x-medkit in the
+  // parent's required list. The drift test in test_openapi_response_drift
+  // covers regression on the emit side. If x-medkit is ever dropped from
+  // the parent properties, the inner required must be revisited too.
   return {{"type", "object"},
           {"properties",
            {{"status", {{"type", "string"}, {"enum", {"pending", "inProgress", "completed", "failed"}}}},

--- a/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/schema_builder.cpp
@@ -556,6 +556,11 @@ nlohmann::json SchemaBuilder::update_status_schema() {
           {"description", "Internal lifecycle phase, distinguishes prepare-completed from execute-completed"}}}}},
       {"required", {"phase"}}};
 
+  // x-medkit is optional in the schema (matches the convention used by
+  // fault_detail_schema and entity_detail_schema): SOVD does not require
+  // vendor extensions, so a SOVD-compliant client must be able to ignore
+  // it. The gateway always emits it; the explicit handler guard in
+  // test_openapi_response_drift covers regression risk.
   return {{"type", "object"},
           {"properties",
            {{"status", {{"type", "string"}, {"enum", {"pending", "inProgress", "completed", "failed"}}}},
@@ -563,7 +568,7 @@ nlohmann::json SchemaBuilder::update_status_schema() {
             {"sub_progress", {{"type", "array"}, {"items", sub_progress_schema}}},
             {"error", {{"type", "string"}}},
             {"x-medkit", x_medkit_schema}}},
-          {"required", {"status", "x-medkit"}}};
+          {"required", {"status"}}};
 }
 
 nlohmann::json SchemaBuilder::log_configuration_schema() {

--- a/src/ros2_medkit_gateway/src/ros2_common/ros2_subscription_executor.cpp
+++ b/src/ros2_medkit_gateway/src/ros2_common/ros2_subscription_executor.cpp
@@ -135,9 +135,17 @@ void Ros2SubscriptionExecutor::remove_graph_change(std::size_t token) {
   if (token >= kMaxGraphListeners) {
     return;
   }
-  std::lock_guard<std::mutex> lk(graph_mtx_);
+  std::unique_lock<std::mutex> lk(graph_mtx_);
   graph_slot_used_[token] = false;
   graph_callbacks_[token] = nullptr;
+  // Wait for any worker-thread invocation that already snapshotted this
+  // slot to finish executing the callback. Without this drain, a wrapper
+  // task posted by fire_graph_callbacks() could call cb() against a
+  // captured `this` after the consumer's destructor has freed members,
+  // producing the heap-use-after-free in the snapshotted callback body.
+  graph_in_flight_cv_.wait(lk, [this, token] {
+    return graph_in_flight_[token] == 0;
+  });
 }
 
 Ros2SubscriptionExecutor::Stats Ros2SubscriptionExecutor::stats() const {
@@ -309,30 +317,64 @@ void Ros2SubscriptionExecutor::fire_graph_callbacks() {
   // sweep, which can take 15 minutes by default. All-or-nothing delivery
   // means a single dropped post at most loses one whole graph event, which
   // graph_poll_tick() will refire on the next change.
-  std::vector<GraphCallback> snapshot;
+  //
+  // Each entry pairs the callback with its slot token: when the wrapper
+  // finishes invoking the callback, it decrements graph_in_flight_[token]
+  // so remove_graph_change() can synchronously wait for in-flight execution
+  // to drain.
+  struct PendingCb {
+    std::size_t token;
+    GraphCallback cb;
+  };
+  std::vector<PendingCb> snapshot;
   snapshot.reserve(kMaxGraphListeners);
   {
     std::lock_guard<std::mutex> lk(graph_mtx_);
     for (std::size_t i = 0; i < kMaxGraphListeners; ++i) {
       if (graph_slot_used_[i] && graph_callbacks_[i]) {
-        snapshot.push_back(graph_callbacks_[i]);
+        snapshot.push_back({i, graph_callbacks_[i]});
+        ++graph_in_flight_[i];
       }
     }
   }
   if (snapshot.empty()) {
     return;
   }
-  (void)post([cbs = std::move(snapshot)] {
-    for (const auto & cb : cbs) {
+  // Capture tokens before moving the snapshot into the wrapper so we can
+  // roll back graph_in_flight_ if post() rejects the wrapper (queue full
+  // or shutting down).
+  std::vector<std::size_t> reserved_tokens;
+  reserved_tokens.reserve(snapshot.size());
+  for (const auto & p : snapshot) {
+    reserved_tokens.push_back(p.token);
+  }
+  const bool posted = post([this, cbs = std::move(snapshot)] {
+    for (const auto & p : cbs) {
       try {
-        cb();
+        p.cb();
       } catch (const std::exception & ex) {
         RCLCPP_ERROR(rclcpp::get_logger("ros2_subscription_executor"), "Graph callback threw exception: %s", ex.what());
       } catch (...) {
         RCLCPP_ERROR(rclcpp::get_logger("ros2_subscription_executor"), "Graph callback threw unknown exception");
       }
+      {
+        std::lock_guard<std::mutex> lk(graph_mtx_);
+        --graph_in_flight_[p.token];
+      }
+      graph_in_flight_cv_.notify_all();
     }
   });
+  if (!posted) {
+    // Queue full or shutting down: the wrapper will not run, so we must
+    // decrement the counters we incremented to keep remove_graph_change()
+    // from waiting forever. snapshot is in moved-from state here; use
+    // reserved_tokens captured above the post() call.
+    std::lock_guard<std::mutex> lk(graph_mtx_);
+    for (auto t : reserved_tokens) {
+      --graph_in_flight_[t];
+    }
+    graph_in_flight_cv_.notify_all();
+  }
 }
 
 }  // namespace ros2_medkit_gateway::ros2_common

--- a/src/ros2_medkit_gateway/src/updates/update_manager.cpp
+++ b/src/ros2_medkit_gateway/src/updates/update_manager.cpp
@@ -160,9 +160,9 @@ tl::expected<void, UpdateError> UpdateManager::delete_update(const std::string &
       if (it != states_.end() && it->second) {
         // Mark the package as failed consistently across all surfaces
         // exposed via GET /updates/{id}/status: the SOVD `status` field,
-        // the `x-medkit-phase` vendor extension, and `error_message`.
+        // the `x-medkit.phase` vendor extension, and `error_message`.
         // Without updating all three, clients see payloads like
-        // {status:pending, x-medkit-phase:failed} with no error context.
+        // {status:pending, "x-medkit":{phase:failed}} with no error context.
         it->second->status.status = UpdateStatus::Failed;
         it->second->status.phase = UpdatePhase::Failed;
         it->second->status.error_message = err.message;

--- a/src/ros2_medkit_gateway/test/test_ros2_subscription_executor.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_subscription_executor.cpp
@@ -16,8 +16,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <future>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -233,6 +235,65 @@ TEST_F(Ros2SubscriptionExecutorTest, RemoveGraphChangeStopsFiring) {
   executor_->remove_node(other_node);
 
   EXPECT_EQ(fired.load(), 0);
+}
+
+TEST_F(Ros2SubscriptionExecutorTest, RemoveGraphChangeWaitsForInFlightCallback) {
+  // Regression: snapshotted graph callbacks running on the worker thread
+  // could touch members of a freed consumer (heap-use-after-free seen by
+  // ASan in DataAccessManagerWithPublisherTest). remove_graph_change()
+  // now drains in-flight execution synchronously so the consumer's
+  // destructor can safely tear down state captured by the lambda.
+  std::mutex m;
+  std::condition_variable in_cb;
+  std::condition_variable cb_release;
+  std::atomic<bool> entered{false};
+  std::atomic<bool> exited{false};
+  bool release = false;
+
+  auto token = sub_exec_->on_graph_change([&] {
+    entered.store(true);
+    in_cb.notify_all();
+    std::unique_lock<std::mutex> lk(m);
+    cb_release.wait(lk, [&] {
+      return release;
+    });
+    exited.store(true);
+  });
+  ASSERT_LT(token, 16u);
+
+  auto other_node = std::make_shared<rclcpp::Node>("other_node_for_in_flight");
+  auto pub = other_node->create_publisher<std_msgs::msg::String>("/in_flight_topic", 10);
+  executor_->add_node(other_node);
+
+  {
+    std::unique_lock<std::mutex> lk(m);
+    in_cb.wait_for(lk, 3s, [&] {
+      return entered.load();
+    });
+  }
+  ASSERT_TRUE(entered.load()) << "Callback never started; cannot exercise drain";
+  EXPECT_FALSE(exited.load());
+
+  std::atomic<bool> remove_returned{false};
+  std::thread remover([&] {
+    sub_exec_->remove_graph_change(token);
+    remove_returned.store(true);
+  });
+
+  std::this_thread::sleep_for(150ms);
+  EXPECT_FALSE(remove_returned.load()) << "remove_graph_change did not wait for in-flight callback";
+
+  {
+    std::lock_guard<std::mutex> lk(m);
+    release = true;
+  }
+  cb_release.notify_all();
+
+  remover.join();
+  EXPECT_TRUE(exited.load());
+  EXPECT_TRUE(remove_returned.load());
+
+  executor_->remove_node(other_node);
 }
 
 TEST_F(Ros2SubscriptionExecutorTest, WatchdogDetectsStuckTask) {

--- a/src/ros2_medkit_gateway/test/test_schema_builder.cpp
+++ b/src/ros2_medkit_gateway/test/test_schema_builder.cpp
@@ -175,6 +175,28 @@ TEST(SchemaBuilderStaticTest, ConfigurationMetaDataSchema) {
 }
 
 // @verifies REQ_INTEROP_002
+TEST(SchemaBuilderStaticTest, ConfigurationMetaDataXMedkitDeclaresAllEmittedFields) {
+  // Regression: the x-medkit object emitted by config_handlers.cpp on every
+  // per-parameter entry contains both `source` (app_id) and `node` (FQN).
+  // The schema must declare both, otherwise generated typed clients drop
+  // or fail-type the undeclared field - exactly the drift this PR fixes
+  // for x-medkit.phase. additionalProperties is intentionally left open
+  // (other endpoints use the same convention), so the drift integration
+  // test cannot detect missing properties here; this static check does.
+  auto schema = SchemaBuilder::configuration_metadata_schema();
+  ASSERT_TRUE(schema.contains("properties"));
+  ASSERT_TRUE(schema.at("properties").contains("x-medkit"));
+  const auto & x_medkit = schema.at("properties").at("x-medkit");
+  EXPECT_EQ(x_medkit.at("type"), "object");
+  ASSERT_TRUE(x_medkit.contains("properties"));
+  const auto & x_props = x_medkit.at("properties");
+  ASSERT_TRUE(x_props.contains("source"));
+  EXPECT_EQ(x_props.at("source").at("type"), "string");
+  ASSERT_TRUE(x_props.contains("node"));
+  EXPECT_EQ(x_props.at("node").at("type"), "string");
+}
+
+// @verifies REQ_INTEROP_002
 TEST(SchemaBuilderStaticTest, ConfigurationReadValueSchema) {
   auto schema = SchemaBuilder::configuration_read_value_schema();
   EXPECT_EQ(schema["type"], "object");

--- a/src/ros2_medkit_gateway/test/test_update_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_update_manager.cpp
@@ -653,11 +653,14 @@ TEST(UpdateManagerFailureTest, DeleteRollbackUpdatesStatusPhaseAndErrorMessage) 
   ASSERT_TRUE(status->error_message.has_value());
   EXPECT_NE(status->error_message->find("backend delete exploded"), std::string::npos);
 
-  // Serialized payload reflects the rollback end-to-end.
+  // Serialized payload reflects the rollback end-to-end. Use at() so a
+  // missing x-medkit/phase fails the test deterministically instead of being
+  // inserted as null by operator[].
   auto j = update_status_to_json(*status);
-  EXPECT_EQ(j["status"], "failed");
-  EXPECT_EQ(j["x-medkit"]["phase"], "failed");
-  EXPECT_EQ(j["error"], "backend delete exploded");
+  EXPECT_EQ(j.at("status"), "failed");
+  ASSERT_TRUE(j.contains("x-medkit"));
+  EXPECT_EQ(j.at("x-medkit").at("phase"), "failed");
+  EXPECT_EQ(j.at("error"), "backend delete exploded");
 
   manager.reset();
   backend.reset();
@@ -666,21 +669,24 @@ TEST(UpdateManagerFailureTest, DeleteRollbackUpdatesStatusPhaseAndErrorMessage) 
 TEST(UpdateStatusToJson, SerializesPhaseAsVendorExtension) {
   UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Prepared, std::nullopt, std::nullopt, std::nullopt};
   auto j = update_status_to_json(status);
-  EXPECT_EQ(j["status"], "completed");
-  EXPECT_EQ(j["x-medkit"]["phase"], "prepared");
+  EXPECT_EQ(j.at("status"), "completed");
+  ASSERT_TRUE(j.contains("x-medkit"));
+  EXPECT_EQ(j.at("x-medkit").at("phase"), "prepared");
 }
 
 TEST(UpdateStatusToJson, ExposesExecutedPhaseForTerminalCompletion) {
   UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Executed, 100, std::nullopt, std::nullopt};
   auto j = update_status_to_json(status);
-  EXPECT_EQ(j["status"], "completed");
-  EXPECT_EQ(j["x-medkit"]["phase"], "executed");
-  EXPECT_EQ(j["progress"], 100);
+  EXPECT_EQ(j.at("status"), "completed");
+  ASSERT_TRUE(j.contains("x-medkit"));
+  EXPECT_EQ(j.at("x-medkit").at("phase"), "executed");
+  EXPECT_EQ(j.at("progress"), 100);
 }
 
 TEST(UpdateStatusToJson, EmitsNonePhaseForFreshlyRegistered) {
   UpdateStatusInfo status;
   auto j = update_status_to_json(status);
-  EXPECT_EQ(j["status"], "pending");
-  EXPECT_EQ(j["x-medkit"]["phase"], "none");
+  EXPECT_EQ(j.at("status"), "pending");
+  ASSERT_TRUE(j.contains("x-medkit"));
+  EXPECT_EQ(j.at("x-medkit").at("phase"), "none");
 }

--- a/src/ros2_medkit_gateway/test/test_update_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_update_manager.cpp
@@ -635,7 +635,7 @@ TEST(UpdateManagerFailureTest, DeleteRollbackUpdatesStatusPhaseAndErrorMessage) 
   // When delete_update fails for a known package, the rollback must leave
   // status=Failed, phase=Failed, and error_message populated so the status
   // endpoint does not emit an inconsistent payload like
-  // {status:pending, x-medkit-phase:failed} without any error details.
+  // {status:pending, "x-medkit":{phase:failed}} without any error details.
   auto backend = std::make_unique<MockDeleteFailingBackend>();
   auto manager = std::make_unique<UpdateManager>();
   manager->set_backend(backend.get());
@@ -656,7 +656,7 @@ TEST(UpdateManagerFailureTest, DeleteRollbackUpdatesStatusPhaseAndErrorMessage) 
   // Serialized payload reflects the rollback end-to-end.
   auto j = update_status_to_json(*status);
   EXPECT_EQ(j["status"], "failed");
-  EXPECT_EQ(j["x-medkit-phase"], "failed");
+  EXPECT_EQ(j["x-medkit"]["phase"], "failed");
   EXPECT_EQ(j["error"], "backend delete exploded");
 
   manager.reset();
@@ -667,14 +667,14 @@ TEST(UpdateStatusToJson, SerializesPhaseAsVendorExtension) {
   UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Prepared, std::nullopt, std::nullopt, std::nullopt};
   auto j = update_status_to_json(status);
   EXPECT_EQ(j["status"], "completed");
-  EXPECT_EQ(j["x-medkit-phase"], "prepared");
+  EXPECT_EQ(j["x-medkit"]["phase"], "prepared");
 }
 
 TEST(UpdateStatusToJson, ExposesExecutedPhaseForTerminalCompletion) {
   UpdateStatusInfo status{UpdateStatus::Completed, UpdatePhase::Executed, 100, std::nullopt, std::nullopt};
   auto j = update_status_to_json(status);
   EXPECT_EQ(j["status"], "completed");
-  EXPECT_EQ(j["x-medkit-phase"], "executed");
+  EXPECT_EQ(j["x-medkit"]["phase"], "executed");
   EXPECT_EQ(j["progress"], 100);
 }
 
@@ -682,5 +682,5 @@ TEST(UpdateStatusToJson, EmitsNonePhaseForFreshlyRegistered) {
   UpdateStatusInfo status;
   auto j = update_status_to_json(status);
   EXPECT_EQ(j["status"], "pending");
-  EXPECT_EQ(j["x-medkit-phase"], "none");
+  EXPECT_EQ(j["x-medkit"]["phase"], "none");
 }

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -29,6 +29,7 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>ament_index_python</test_depend>
   <test_depend>python3-requests</test_depend>
+  <test_depend>python3-jsonschema</test_depend>
   <test_depend>ros2_medkit_gateway</test_depend>
   <test_depend>ros2_medkit_fault_manager</test_depend>
   <test_depend>ros2_medkit_linux_introspection</test_depend>

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -303,6 +303,53 @@ class TestOpenApiResponseDrift(GatewayTestCase):
         self.assertIn('x-medkit', body)
         self.assertIn('phase', body['x-medkit'])
 
+    def test_configurations_payload_uses_nested_x_medkit(self):
+        """Specific guard for issue #385: configurations vendor fields nested.
+
+        Items at the top level (only in aggregated mode) and parameters
+        inside ``x-medkit.parameters[]`` (always emitted) must carry vendor
+        source attribution under a nested ``x-medkit`` object, never as flat
+        ``x-medkit-source`` / ``x-medkit-node`` keys. The drift test cannot
+        catch reintroduction of the legacy flat keys because
+        ``ConfigurationMetaData`` does not set ``additionalProperties: false``.
+
+        ``temp_sensor`` declares four ROS 2 parameters in the test fixture,
+        which exercises the per-parameter emit path that #385 migrated.
+
+        @verifies REQ_INTEROP_002
+        """
+        resp = requests.get(
+            f'{self.BASE_URL}/apps/temp_sensor/configurations', timeout=10
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+
+        items = body.get('items', [])
+        self.assertGreater(
+            len(items), 0,
+            'Fixture broken: temp_sensor should declare ROS 2 parameters'
+        )
+        for item in items:
+            self.assertNotIn(
+                'x-medkit-source', item, f'Legacy flat key on item: {item}'
+            )
+            self.assertNotIn(
+                'x-medkit-node', item, f'Legacy flat key on item: {item}'
+            )
+
+        parameters = body.get('x-medkit', {}).get('parameters', [])
+        self.assertGreater(len(parameters), 0)
+        for param in parameters:
+            self.assertNotIn(
+                'x-medkit-source', param, f'Legacy flat key on parameter: {param}'
+            )
+            self.assertNotIn(
+                'x-medkit-node', param, f'Legacy flat key on parameter: {param}'
+            )
+            self.assertIn('x-medkit', param)
+            self.assertEqual(param['x-medkit'].get('source'), 'temp_sensor')
+            self.assertIn('node', param['x-medkit'])
+
 
 @launch_testing.post_shutdown_test()
 class TestExitCodes(unittest.TestCase):

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -275,5 +275,9 @@ class TestOpenApiResponseDrift(GatewayTestCase):
 class TestExitCodes(unittest.TestCase):
 
     def test_exit_codes(self, proc_info):
-        for proc in proc_info:
-            self.assertIn(proc_info[proc].returncode, ALLOWED_EXIT_CODES)
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with code {info.returncode}',
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -137,27 +137,60 @@ def _is_sse_endpoint(operation):
     return 'SSE' in summary or 'stream' in summary.lower()
 
 
+class _MissingEntityType(Exception):
+    """Raised when a path needs an entity type that was not discovered.
+
+    Substituting a placeholder (e.g. ``'test_entity'``) would yield a path
+    the gateway returns 404 for; the drift loop skips non-200 responses,
+    so the endpoint would silently exit unvalidated. Callers must catch
+    this and explicitly account for the skipped path.
+    """
+
+
 def _substitute_path_params(path, entity_map, resource_id='test_id'):
     def replacer(match):
         param = match.group(1)
         if param in _ENTITY_PARAM_MAP:
-            return entity_map.get(_ENTITY_PARAM_MAP[param], 'test_entity')
+            etype = _ENTITY_PARAM_MAP[param]
+            if etype not in entity_map:
+                raise _MissingEntityType(
+                    f'Path param {{{param}}} requires entity type '
+                    f'{etype!r} but none was discovered'
+                )
+            return entity_map[etype]
         return resource_id
 
     return re.sub(r'\{([^}]+)\}', replacer, path)
 
 
 class TestOpenApiResponseDrift(GatewayTestCase):
-    """Catches handler-vs-spec drift on GET response bodies."""
+    """Catches handler-vs-spec drift on GET response bodies.
+
+    Scope: GET endpoints declared at runtime under /docs only. POST/PUT/
+    DELETE request bodies and non-200 response shapes are out of scope;
+    extending coverage to all verbs is tracked under issue #338.
+    """
 
     MIN_EXPECTED_APPS = 2
     REQUIRED_APPS = {'temp_sensor', 'calibration'}
+    # Conservative lower bound on the number of paths a fully registered
+    # gateway exposes (currently ~50 with the test fixture). _fetch_spec
+    # polls until at least this many paths are present so a slow plugin
+    # registration cannot let the test read back a partial spec and
+    # silently skip the endpoints registered after the snapshot.
+    MIN_EXPECTED_PATHS = 30
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
-        # Discover real entity IDs to use in path substitution.
+        # Discover real entity IDs to use in path substitution. Each
+        # entity type may legitimately be empty in some fixture
+        # configurations (e.g. runtime_only mode without manifest-declared
+        # areas). Endpoints needing a type that was not discovered are
+        # skipped explicitly in the validation loop and reported in test
+        # output - no longer silently substituted with a placeholder that
+        # produces 404s the loop drops.
         cls._entity_map = {}
         for etype in ('areas', 'components', 'apps', 'functions'):
             resp = requests.get(f'{cls.BASE_URL}/{etype}', timeout=5)
@@ -198,7 +231,10 @@ class TestOpenApiResponseDrift(GatewayTestCase):
 
     def _fetch_spec(self):
         return self.poll_endpoint_until(
-            '/docs', lambda d: d if d.get('paths') else None
+            '/docs',
+            lambda d: d if (
+                d.get('paths') and len(d['paths']) >= self.MIN_EXPECTED_PATHS
+            ) else None,
         )
 
     def _validate_response(self, schema, body, schemas):
@@ -217,18 +253,27 @@ class TestOpenApiResponseDrift(GatewayTestCase):
         return 'test_id'
 
     def test_get_responses_match_declared_schema(self):
-        """Every 200 response must validate against its declared schema.
+        """GET 200 responses must validate against the declared schema.
 
         Iterates GET endpoints from /docs, fetches each, and validates
         bodies against the response schema declared for status 200. Schema
         drift (handler emits a field schema does not declare as required,
         or vice versa) raises an error.
 
+        Coverage limited to GET verbs; POST/PUT/DELETE request bodies and
+        non-200 response shapes are out of scope (tracked under issue
+        #338). Endpoints whose path placeholders need an entity type that
+        was not discovered (e.g. /functions/{function_id}/... when no
+        functions exist) are skipped explicitly with an entry in
+        ``skipped_for_missing_entity`` rather than substituted with a
+        bogus value that would silently 404 unvalidated.
+
         @verifies REQ_INTEROP_002
         """
         spec = self._fetch_spec()
         schemas = spec.get('components', {}).get('schemas', {})
         violations = []
+        skipped_for_missing_entity = []
         validated = 0
 
         for path, path_item in spec.get('paths', {}).items():
@@ -247,9 +292,13 @@ class TestOpenApiResponseDrift(GatewayTestCase):
             if not schema:
                 continue
 
-            uri = _substitute_path_params(
-                path, self._entity_map, self._resource_for_path(path)
-            )
+            try:
+                uri = _substitute_path_params(
+                    path, self._entity_map, self._resource_for_path(path)
+                )
+            except _MissingEntityType as exc:
+                skipped_for_missing_entity.append(f'{path}: {exc}')
+                continue
             resp = requests.get(f'{self.BASE_URL}{uri}', timeout=10)
 
             # Non-200 responses fall outside this drift check (handler may
@@ -278,6 +327,19 @@ class TestOpenApiResponseDrift(GatewayTestCase):
         self.assertGreater(
             validated, 0, 'No endpoints validated - test fixture broken?'
         )
+        # Surface paths skipped due to missing optional entity types
+        # (e.g. /functions/{function_id}/... when no functions were
+        # declared). The previous fallback substituted 'test_entity',
+        # which produced 404s the validation loop silently dropped -
+        # hiding entire entity types from the test. Print is captured
+        # in test output so the gap is visible without failing CI when
+        # the fixture legitimately omits an optional type.
+        if skipped_for_missing_entity:
+            print(
+                f'[drift] {len(skipped_for_missing_entity)} endpoint(s) '
+                f'unvalidated (missing optional entity type):\n'
+                + '\n'.join(f'  - {s}' for s in skipped_for_missing_entity)
+            )
         self.assertFalse(
             violations,
             f'{len(violations)} drift violation(s); validated {validated}:\n'
@@ -349,6 +411,37 @@ class TestOpenApiResponseDrift(GatewayTestCase):
             self.assertIn('x-medkit', param)
             self.assertEqual(param['x-medkit'].get('source'), 'temp_sensor')
             self.assertIn('node', param['x-medkit'])
+
+    def test_substitute_path_params_uses_discovered_entity_id(self):
+        """Helper resolves placeholders against the entity_map."""
+        uri = _substitute_path_params(
+            '/areas/{area_id}/components',
+            {'areas': 'my_area', 'components': 'my_comp'},
+            resource_id='resX',
+        )
+        self.assertEqual(uri, '/areas/my_area/components')
+
+    def test_substitute_path_params_resource_id_substituted(self):
+        """Non-entity placeholders use the resource_id argument."""
+        uri = _substitute_path_params(
+            '/updates/{id}/status', {}, resource_id='pkg-7'
+        )
+        self.assertEqual(uri, '/updates/pkg-7/status')
+
+    def test_substitute_path_params_raises_on_missing_entity_type(self):
+        """Missing entity type must raise rather than substitute a fake.
+
+        The previous fallback substituted 'test_entity' for unknown
+        types, producing 404s the validation loop silently dropped.
+        Now the helper forces callers to handle the missing type
+        explicitly (skip + report).
+        """
+        with self.assertRaises(_MissingEntityType):
+            _substitute_path_params('/functions/{function_id}/data', {})
+        with self.assertRaises(_MissingEntityType):
+            _substitute_path_params(
+                '/areas/{area_id}/components', {'components': 'c1'}
+            )
 
 
 @launch_testing.post_shutdown_test()

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""OpenAPI response-schema drift test.
+
+For every GET endpoint declared in the runtime OpenAPI spec served at
+GET /docs, this test fetches a real response from the live gateway and
+validates it against the response schema declared in the same spec for the
+returned status code. A mismatch means handler output and declared schema
+have drifted apart - either the handler emits a field the schema does not
+declare (the failure mode that caused issue #385's `x-medkit-phase` to
+silently slip past every typed client), or the schema declares a required
+field the handler does not emit.
+
+The test is intentionally narrow: only response *bodies* are validated,
+only against the 200 schema, and only on endpoints that return JSON. It
+does not check error envelope shapes, status code coverage, or request
+schemas - those are covered by other tests.
+
+The full structural contract (compile-time link from emitter to schema)
+will be solved by issue #338. This test is the runtime stop-gap until
+that lands - if it fails, fix the schema or the handler; do not silence
+the test.
+"""
+
+import os
+import re
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+from jsonschema.validators import Draft202012Validator
+import launch_testing
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+
+def _test_update_backend_path():
+    pkg_prefix = get_package_prefix('ros2_medkit_gateway')
+    return os.path.join(
+        pkg_prefix, 'lib', 'ros2_medkit_gateway', 'libtest_update_backend.so'
+    )
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor', 'calibration'],
+        gateway_params={
+            'updates.enabled': True,
+            'plugins': ['test_update_backend'],
+            'plugins.test_update_backend.path': _test_update_backend_path(),
+        },
+        fault_manager=True,
+    )
+
+
+# Path placeholders -> entity collection used for substitution.
+_ENTITY_PARAM_MAP = {
+    'area_id': 'areas',
+    'component_id': 'components',
+    'app_id': 'apps',
+    'function_id': 'functions',
+}
+
+
+def _inline_refs(schema, schemas, seen=None):
+    """Recursively inline $refs into a schema so jsonschema can validate it.
+
+    The runtime spec uses $refs that point at #/components/schemas/, but
+    Draft202012Validator constructed without a registry will not follow them.
+    Recursive types are guarded via ``seen`` to break cycles.
+    """
+    if seen is None:
+        seen = set()
+    if isinstance(schema, dict):
+        if '$ref' in schema:
+            ref = schema['$ref']
+            if ref in seen:
+                return {}
+            if ref.startswith('#/components/schemas/'):
+                name = ref.rsplit('/', 1)[-1]
+                target = schemas.get(name)
+                if target is None:
+                    return {}
+                return _inline_refs(target, schemas, seen | {ref})
+        return {k: _inline_refs(v, schemas, seen) for k, v in schema.items()}
+    if isinstance(schema, list):
+        return [_inline_refs(item, schemas, seen) for item in schema]
+    return schema
+
+
+def _is_sse_endpoint(operation):
+    """Detect SSE streaming endpoints that would hang on a plain GET."""
+    summary = (operation.get('summary') or '') + (operation.get('description') or '')
+    return 'SSE' in summary or 'stream' in summary.lower()
+
+
+def _substitute_path_params(path, entity_map, resource_id='test_id'):
+    def replacer(match):
+        param = match.group(1)
+        if param in _ENTITY_PARAM_MAP:
+            return entity_map.get(_ENTITY_PARAM_MAP[param], 'test_entity')
+        return resource_id
+
+    return re.sub(r'\{([^}]+)\}', replacer, path)
+
+
+class TestOpenApiResponseDrift(GatewayTestCase):
+    """Catches handler-vs-spec drift on GET response bodies."""
+
+    MIN_EXPECTED_APPS = 1
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Discover real entity IDs to use in path substitution.
+        cls._entity_map = {}
+        for etype in ('areas', 'components', 'apps', 'functions'):
+            resp = requests.get(f'{cls.BASE_URL}/{etype}', timeout=5)
+            resp.raise_for_status()
+            items = resp.json().get('items', [])
+            if items:
+                cls._entity_map[etype] = items[0].get('id')
+
+        # Register and prepare a test update package so /updates/{id}/status
+        # returns an interesting payload (status + x-medkit.phase).
+        cls._update_pkg_id = 'drift-test-pkg'
+        # Best-effort cleanup of any leftover from a previous interrupted run.
+        requests.delete(
+            f'{cls.BASE_URL}/updates/{cls._update_pkg_id}', timeout=5
+        )
+        post = requests.post(
+            f'{cls.BASE_URL}/updates',
+            json={
+                'id': cls._update_pkg_id,
+                'update_name': 'Drift test package',
+                'automated': False,
+                'origins': ['proximity'],
+            },
+            timeout=5,
+        )
+        post.raise_for_status()
+        prepare = requests.put(
+            f'{cls.BASE_URL}/updates/{cls._update_pkg_id}/prepare', timeout=5
+        )
+        prepare.raise_for_status()
+
+    @classmethod
+    def tearDownClass(cls):
+        requests.delete(
+            f'{cls.BASE_URL}/updates/{cls._update_pkg_id}', timeout=5
+        )
+        super().tearDownClass()
+
+    def _fetch_spec(self):
+        return self.poll_endpoint_until(
+            '/docs', lambda d: d if d.get('paths') else None
+        )
+
+    def _validate_response(self, schema, body, schemas):
+        """Validate body against schema with $refs inlined."""
+        inlined = _inline_refs(schema, schemas)
+        validator = Draft202012Validator(inlined)
+        return sorted(validator.iter_errors(body), key=lambda e: e.path)
+
+    def _resource_for_path(self, path):
+        """Pick a resource_id that makes a given path return 200 when possible.
+
+        Used for paths like /updates/{id}/status where 'test_id' would 404.
+        """
+        if path.startswith('/updates/{'):
+            return self._update_pkg_id
+        return 'test_id'
+
+    def test_get_responses_match_declared_schema(self):
+        """Every 200 response must validate against its declared schema.
+
+        Iterates GET endpoints from /docs, fetches each, and validates
+        bodies against the response schema declared for status 200. Schema
+        drift (handler emits a field schema does not declare as required,
+        or vice versa) raises an error.
+
+        @verifies REQ_INTEROP_002
+        """
+        spec = self._fetch_spec()
+        schemas = spec.get('components', {}).get('schemas', {})
+        violations = []
+        validated = 0
+
+        for path, path_item in spec.get('paths', {}).items():
+            operation = path_item.get('get')
+            if not operation or _is_sse_endpoint(operation):
+                continue
+
+            response_def = operation.get('responses', {}).get('200')
+            if not response_def:
+                continue
+            schema = (
+                response_def.get('content', {})
+                .get('application/json', {})
+                .get('schema')
+            )
+            if not schema:
+                continue
+
+            uri = _substitute_path_params(
+                path, self._entity_map, self._resource_for_path(path)
+            )
+            resp = requests.get(f'{self.BASE_URL}{uri}', timeout=10)
+
+            # Non-200 responses fall outside this drift check (handler may
+            # legitimately return 404/501 for the chosen path params); the
+            # callability test covers status code shape separately.
+            if resp.status_code != 200:
+                continue
+            if 'application/json' not in resp.headers.get('content-type', ''):
+                continue
+
+            body = resp.json()
+            errors = self._validate_response(schema, body, schemas)
+            if errors:
+                detail = '; '.join(
+                    f'{".".join(str(p) for p in e.absolute_path) or "<root>"}: {e.message}'
+                    for e in errors[:5]
+                )
+                violations.append(f'GET {uri}: schema drift: {detail}')
+            else:
+                validated += 1
+
+        self.assertGreater(
+            validated, 0, 'No endpoints validated - test fixture broken?'
+        )
+        self.assertFalse(
+            violations,
+            f'{len(violations)} drift violation(s); validated {validated}:\n'
+            + '\n'.join(violations),
+        )
+
+    def test_update_status_payload_uses_nested_x_medkit(self):
+        """Specific guard for issue #385: /updates/{id}/status payload.
+
+        The handler must emit ``x-medkit: {phase: ...}`` (nested object), not
+        the legacy flat ``x-medkit-phase`` key. The drift test above already
+        catches this via the schema declared in update_status_schema(); this
+        explicit assertion makes the regression intent obvious.
+
+        @verifies REQ_INTEROP_002
+        """
+        resp = requests.get(
+            f'{self.BASE_URL}/updates/{self._update_pkg_id}/status', timeout=5
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertNotIn('x-medkit-phase', body, 'Legacy flat key still emitted')
+        self.assertIn('x-medkit', body)
+        self.assertIn('phase', body['x-medkit'])
+
+
+@launch_testing.post_shutdown_test()
+class TestExitCodes(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        for proc in proc_info:
+            self.assertIn(proc_info[proc].returncode, ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -40,9 +40,17 @@ import re
 import unittest
 
 from ament_index_python.packages import get_package_prefix
-from jsonschema.validators import Draft202012Validator
 import launch_testing
 import requests
+
+# Humble (Ubuntu 22.04) ships python3-jsonschema 3.2 which only has draft-7;
+# Jazzy/Rolling (Ubuntu 24.04) ship 4.10+ with Draft202012. Prefer the newest
+# draft for OpenAPI 3.1 alignment, fall back to Draft7 on Humble. The properties
+# we validate (required, type, properties) behave identically across drafts.
+try:
+    from jsonschema.validators import Draft202012Validator as _Validator
+except ImportError:
+    from jsonschema.validators import Draft7Validator as _Validator
 
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
@@ -175,7 +183,7 @@ class TestOpenApiResponseDrift(GatewayTestCase):
     def _validate_response(self, schema, body, schemas):
         """Validate body against schema with $refs inlined."""
         inlined = _inline_refs(schema, schemas)
-        validator = Draft202012Validator(inlined)
+        validator = _Validator(inlined)
         return sorted(validator.iter_errors(body), key=lambda e: e.path)
 
     def _resource_for_path(self, path):

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -17,22 +17,30 @@
 
 For every GET endpoint declared in the runtime OpenAPI spec served at
 GET /docs, this test fetches a real response from the live gateway and
-validates it against the response schema declared in the same spec for the
-returned status code. A mismatch means handler output and declared schema
-have drifted apart - either the handler emits a field the schema does not
-declare (the failure mode that caused issue #385's `x-medkit-phase` to
-silently slip past every typed client), or the schema declares a required
-field the handler does not emit.
+validates it against the response schema declared in the same spec for
+status 200. The validator runs jsonschema in its default mode, so what
+this catches is the *subset* of drift that breaks the schema's positive
+constraints:
 
-The test is intentionally narrow: only response *bodies* are validated,
-only against the 200 schema, and only on endpoints that return JSON. It
-does not check error envelope shapes, status code coverage, or request
-schemas - those are covered by other tests.
+- ``required`` fields the handler does not emit
+- type mismatches (string vs number, etc.)
+- ``enum`` values the handler emits but the schema does not list
+- malformed nested objects against declared sub-schemas
 
-The full structural contract (compile-time link from emitter to schema)
-will be solved by issue #338. This test is the runtime stop-gap until
-that lands - if it fails, fix the schema or the handler; do not silence
-the test.
+What this does **not** catch (because most schemas in
+``schema_builder.cpp`` do not set ``additionalProperties: false``):
+
+- handler emits an extra top-level field the schema never declares
+  (this was exactly the failure mode that allowed flat
+  ``x-medkit-phase`` to slip through before issue #385 was filed)
+
+A closed-object check would surface dozens of pre-existing schema gaps
+that are out of scope for #385; the structural fix (compile-time link
+from each emitter to its schema) lives under issue #338. Until then,
+the explicit ``test_update_status_payload_uses_nested_x_medkit`` guards
+the specific regression #385 closes.
+
+If this test fails, fix the schema or the handler; do not silence it.
 """
 
 import os
@@ -85,12 +93,21 @@ _ENTITY_PARAM_MAP = {
 }
 
 
+class _RefResolutionError(Exception):
+    """Raised when a $ref in the spec cannot be resolved or forms a cycle.
+
+    Returning an empty schema on these conditions would let jsonschema
+    validate any payload, masking the drift the test is meant to detect.
+    """
+
+
 def _inline_refs(schema, schemas, seen=None):
     """Recursively inline $refs into a schema so jsonschema can validate it.
 
     The runtime spec uses $refs that point at #/components/schemas/, but
-    Draft202012Validator constructed without a registry will not follow them.
-    Recursive types are guarded via ``seen`` to break cycles.
+    Draft202012Validator constructed without a registry will not follow
+    them. Cycles and unresolved refs raise ``_RefResolutionError`` rather
+    than silently degrading the validator to "anything goes".
     """
     if seen is None:
         seen = set()
@@ -98,13 +115,16 @@ def _inline_refs(schema, schemas, seen=None):
         if '$ref' in schema:
             ref = schema['$ref']
             if ref in seen:
-                return {}
-            if ref.startswith('#/components/schemas/'):
-                name = ref.rsplit('/', 1)[-1]
-                target = schemas.get(name)
-                if target is None:
-                    return {}
-                return _inline_refs(target, schemas, seen | {ref})
+                raise _RefResolutionError(
+                    f'Cycle in $ref chain: {" -> ".join(sorted(seen))} -> {ref}'
+                )
+            if not ref.startswith('#/components/schemas/'):
+                raise _RefResolutionError(f'Unsupported $ref form: {ref}')
+            name = ref.rsplit('/', 1)[-1]
+            target = schemas.get(name)
+            if target is None:
+                raise _RefResolutionError(f'Unknown $ref target: {ref}')
+            return _inline_refs(target, schemas, seen | {ref})
         return {k: _inline_refs(v, schemas, seen) for k, v in schema.items()}
     if isinstance(schema, list):
         return [_inline_refs(item, schemas, seen) for item in schema]
@@ -130,7 +150,8 @@ def _substitute_path_params(path, entity_map, resource_id='test_id'):
 class TestOpenApiResponseDrift(GatewayTestCase):
     """Catches handler-vs-spec drift on GET response bodies."""
 
-    MIN_EXPECTED_APPS = 1
+    MIN_EXPECTED_APPS = 2
+    REQUIRED_APPS = {'temp_sensor', 'calibration'}
 
     @classmethod
     def setUpClass(cls):
@@ -240,7 +261,11 @@ class TestOpenApiResponseDrift(GatewayTestCase):
                 continue
 
             body = resp.json()
-            errors = self._validate_response(schema, body, schemas)
+            try:
+                errors = self._validate_response(schema, body, schemas)
+            except _RefResolutionError as exc:
+                violations.append(f'GET {uri}: spec error: {exc}')
+                continue
             if errors:
                 detail = '; '.join(
                     f'{".".join(str(p) for p in e.absolute_path) or "<root>"}: {e.message}'


### PR DESCRIPTION
## Summary

Migrates the two remaining SOVD-standard endpoint payloads that emit flat
`x-medkit-*` top-level vendor keys to the nested `x-medkit: {...}`
convention that every other endpoint already follows.

- `GET /updates/{id}/status` -> `x-medkit.phase` (was flat `x-medkit-phase`)
- `GET /apps|components/{id}/configurations` -> nested `x-medkit.source`
  on items, `x-medkit.{source,node}` on per-parameter entries (was flat
  `x-medkit-source` / `x-medkit-node`)

The OpenAPI schemas for `UpdateStatus` and `ConfigurationMetaData` now
declare the nested object so generated clients pick up accurate typing.

Adds `test_openapi_response_drift` - a runtime drift validator that
walks every GET endpoint declared in `GET /docs`, fetches a real
response, and validates it against the declared response schema. The
original `x-medkit-phase` divergence slipped past every typed client
because the schema never declared the field; this test catches that
class of regression. The compile-time `emitter -> schema` contract is
deferred to #338.

---

## Issue

- closes #385

---

## Type

- [x] Bug fix
- [x] New feature or tests
- [x] Breaking change
- [ ] Documentation only

Breaking on the wire format of two endpoints. Cross-repo grep showed
zero current consumers reading the legacy flat keys (web UI, MCP,
foxglove, demos, generated clients, commercial). 

---

## Testing

- `colcon build --packages-up-to ros2_medkit_gateway ros2_medkit_integration_tests` (Jazzy, Release)
- `colcon test --packages-select ros2_medkit_gateway --ctest-args -L linter` -> green
- `ctest -R test_update_manager` -> 24/24 passing (UpdateStatusToJson + UpdateManagerFailureTest assertions updated)
- Smoke: `GET /api/v1/docs` returns `UpdateStatus.properties.x-medkit` schema with `phase` enum
- Drift integration test (`test_openapi_response_drift`) runs in CI - requires `python3-jsonschema` (added to `ros2_medkit_integration_tests/package.xml`)

---

## Checklist

- [x] Breaking changes are clearly described
- [x] Tests were added or updated if needed
- [x] Docs were updated (`docs/api/rest.rst` example payload + vendor extension prose)