### PR TITLE
Release v0.5.0: version bump and changelogs

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -33,7 +33,7 @@ All packages in the repository share the same version number.
 
 ### Version Stability [1.ii]
 
-The current version is **0.3.0**.
+The current version is **0.5.0**.
 The package follows semver; the pre-1.0 version reflects that the public API may still evolve
 based on early adopter feedback, not a lack of quality infrastructure.
 The 1.0.0 release is planned after the API has been validated through pilot deployments.
@@ -225,7 +225,7 @@ Security issues can be reported via GitHub Security Advisories on the
 
 | Requirement | Status | Notes |
 |---|---|---|
-| Version policy | Met | Semver, all packages at 0.3.0 |
+| Version policy | Met | Semver, all packages at 0.5.0 |
 | Stable version (>=1.0.0) | Caveat | Pre-1.0; API versioned, 1.0.0 planned post-pilot |
 | Change requests | Met | All changes via PR |
 | CI | Met | Build + test + coverage on every PR |
@@ -237,6 +237,6 @@ Security issues can be reported via GitHub Security Advisories on the
 | Platform support | Met | Ubuntu Noble / ROS 2 Jazzy + Ubuntu Jammy / ROS 2 Humble + Ubuntu Resolute / ROS 2 Lyrical |
 | Security policy | Met | REP-2006 compliant |
 
-**Caveat:** Version is 0.3.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
+**Caveat:** Version is 0.5.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
 and the package meets all other Level 3 requirements. The 1.0.0 release is planned after
 API validation through pilot deployments.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2,7 +2,7 @@
 # Used by Breathe extension to integrate with Sphinx
 
 PROJECT_NAME           = "ros2_medkit"
-PROJECT_NUMBER         = "0.1.0"
+PROJECT_NUMBER         = "0.5.0"
 PROJECT_BRIEF          = "SOVD Gateway for ROS 2"
 
 # Input settings

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -25,7 +25,7 @@ Server Capabilities
 
       {
         "name": "ROS 2 Medkit Gateway",
-        "version": "0.4.0",
+        "version": "0.5.0",
         "api_base": "/api/v1",
         "endpoints": [
           "GET /api/v1/health",
@@ -78,7 +78,7 @@ Server Capabilities
             "version": "1.0.0",
             "base_uri": "/api/v1",
             "vendor_info": {
-              "version": "0.4.0",
+              "version": "0.5.0",
               "name": "ros2_medkit"
             }
           }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,3 +33,5 @@ This page aggregates changelogs from all ros2_medkit packages.
 .. include:: ../src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
 
 .. include:: ../src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
+
+.. include:: ../src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ project = "ros2_medkit"
 project_copyright = f"{datetime.now().year}, selfpatch"
 author = "selfpatch Team"
 
-version = "0.4.0"
-release = "0.4.0"
+version = "0.5.0"
+release = "0.5.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ros2-medkit-docs"
-version = "0.4.0"
+version = "0.5.0"
 description = "Documentation for ROS 2 Medkit"
 authors = [{ name = "bburda", email = "bartoszburda93@gmail.com" }]
 requires-python = ">=3.12"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -30,7 +30,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 SRC_DIR="${REPO_ROOT}/src"
-VERSION_HPP="${SRC_DIR}/ros2_medkit_gateway/include/ros2_medkit_gateway/version.hpp"
+VERSION_HPP="${SRC_DIR}/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp"
 CONF_PY="${REPO_ROOT}/docs/conf.py"
 DOCS_PYPROJECT="${REPO_ROOT}/docs/pyproject.toml"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,7 @@ CONF_PY="${REPO_ROOT}/docs/conf.py"
 DOCS_PYPROJECT="${REPO_ROOT}/docs/pyproject.toml"
 DOXYFILE="${REPO_ROOT}/docs/Doxyfile"
 QUALITY_DECL="${REPO_ROOT}/QUALITY_DECLARATION.md"
+REST_RST="${REPO_ROOT}/docs/api/rest.rst"
 
 usage() {
     echo "Usage: $0 {bump <version>|verify [<version>]}"
@@ -124,6 +125,20 @@ cmd_bump() {
             -e "s|Version is [0-9]\+\.[0-9]\+\.[0-9]\+|Version is ${target_version}|" \
             "$QUALITY_DECL"
         echo "  QUALITY_DECLARATION.md: -> ${target_version}"
+    fi
+
+    # Update the gateway-version literals in docs/api/rest.rst example responses.
+    # Each is anchored on its adjacent "name" key so the SOVD API "version":
+    # "1.0.0" (which has neither anchor) is never rewritten:
+    #   - root "/" response:       "name": "ROS 2 Medkit Gateway" then "version"
+    #   - version-info vendor_info: "version" then "name": "ros2_medkit"
+    if [ -f "$REST_RST" ]; then
+        REST_TARGET="$target_version" perl -0pi -e '
+            my $v = $ENV{REST_TARGET};
+            s/("name": "ROS 2 Medkit Gateway",\s*\n\s*"version": ")\d+\.\d+\.\d+(")/$1$v$2/g;
+            s/("version": ")\d+\.\d+\.\d+(",\s*\n\s*"name": "ros2_medkit")/$1$v$2/g;
+        ' "$REST_RST"
+        echo "  docs/api/rest.rst example versions: -> ${target_version}"
     fi
 
     echo ""
@@ -222,8 +237,38 @@ cmd_verify() {
         versions_seen+=("$qd_version")
     fi
 
+    # Check docs/api/rest.rst example-response versions (gateway version only;
+    # the SOVD API "version": "1.0.0" is excluded via the same name anchors as
+    # the bump path, so it is neither rewritten nor verified here).
+    if [ -f "$REST_RST" ]; then
+        local rest_versions
+        rest_versions=$(perl -0ne '
+            while (/"name": "ROS 2 Medkit Gateway",\s*\n\s*"version": "(\d+\.\d+\.\d+)"/g) { print "$1\n" }
+            while (/"version": "(\d+\.\d+\.\d+)",\s*\n\s*"name": "ros2_medkit"/g) { print "$1\n" }
+        ' "$REST_RST")
+        [ -n "$rest_versions" ] || rest_versions="unknown"
+        while IFS= read -r rest_version; do
+            if [ -n "$expected_version" ] && [ "$rest_version" != "$expected_version" ]; then
+                echo "  MISMATCH: docs/api/rest.rst example version is ${rest_version}, expected ${expected_version}"
+                all_ok=false
+            else
+                echo "  OK: docs/api/rest.rst example version = ${rest_version}"
+            fi
+            versions_seen+=("$rest_version")
+        done <<< "$rest_versions"
+    fi
+
     # Check consistency if no expected version given
     if [ -z "$expected_version" ]; then
+        # An "unknown" means a version pattern failed to match in some file.
+        # Without this guard an all-"unknown" run collapses to one unique value
+        # and would false-pass the consistency check below.
+        if printf '%s\n' "${versions_seen[@]}" | grep -qx "unknown"; then
+            echo ""
+            echo "ERROR: could not parse a version from one or more files (got 'unknown')."
+            all_ok=false
+        fi
+
         local unique_versions
         unique_versions=$(printf '%s\n' "${versions_seen[@]}" | sort -u)
         local unique_count

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,6 +33,8 @@ SRC_DIR="${REPO_ROOT}/src"
 VERSION_HPP="${SRC_DIR}/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp"
 CONF_PY="${REPO_ROOT}/docs/conf.py"
 DOCS_PYPROJECT="${REPO_ROOT}/docs/pyproject.toml"
+DOXYFILE="${REPO_ROOT}/docs/Doxyfile"
+QUALITY_DECL="${REPO_ROOT}/QUALITY_DECLARATION.md"
 
 usage() {
     echo "Usage: $0 {bump <version>|verify [<version>]}"
@@ -107,6 +109,23 @@ cmd_bump() {
         echo "  docs/pyproject.toml: -> ${target_version}"
     fi
 
+    # Update docs/Doxyfile PROJECT_NUMBER
+    if [ -f "$DOXYFILE" ]; then
+        sed -i "s|\(PROJECT_NUMBER[[:space:]]*=[[:space:]]*\)\"[0-9]\+\.[0-9]\+\.[0-9]\+\"|\1\"${target_version}\"|" "$DOXYFILE"
+        echo "  docs/Doxyfile PROJECT_NUMBER: -> ${target_version}"
+    fi
+
+    # Update QUALITY_DECLARATION.md current-version references (leave the
+    # ">=1.0.0" stability-policy mentions untouched via anchored patterns)
+    if [ -f "$QUALITY_DECL" ]; then
+        sed -i \
+            -e "s|current version is \*\*[0-9]\+\.[0-9]\+\.[0-9]\+\*\*|current version is **${target_version}**|" \
+            -e "s|all packages at [0-9]\+\.[0-9]\+\.[0-9]\+|all packages at ${target_version}|" \
+            -e "s|Version is [0-9]\+\.[0-9]\+\.[0-9]\+|Version is ${target_version}|" \
+            "$QUALITY_DECL"
+        echo "  QUALITY_DECLARATION.md: -> ${target_version}"
+    fi
+
     echo ""
     echo "Bumped ${count} packages + version.hpp + docs to ${target_version}."
     echo ""
@@ -175,6 +194,32 @@ cmd_verify() {
             echo "  OK: docs/pyproject.toml = ${pyproject_version}"
         fi
         versions_seen+=("$pyproject_version")
+    fi
+
+    # Check docs/Doxyfile PROJECT_NUMBER
+    if [ -f "$DOXYFILE" ]; then
+        local doxy_version
+        doxy_version=$(grep -oP 'PROJECT_NUMBER\s*=\s*"\K[0-9]+\.[0-9]+\.[0-9]+' "$DOXYFILE" || echo "unknown")
+        if [ -n "$expected_version" ] && [ "$doxy_version" != "$expected_version" ]; then
+            echo "  MISMATCH: docs/Doxyfile PROJECT_NUMBER is ${doxy_version}, expected ${expected_version}"
+            all_ok=false
+        else
+            echo "  OK: docs/Doxyfile PROJECT_NUMBER = ${doxy_version}"
+        fi
+        versions_seen+=("$doxy_version")
+    fi
+
+    # Check QUALITY_DECLARATION.md current version
+    if [ -f "$QUALITY_DECL" ]; then
+        local qd_version
+        qd_version=$(grep -oP 'current version is \*\*\K[0-9]+\.[0-9]+\.[0-9]+' "$QUALITY_DECL" || echo "unknown")
+        if [ -n "$expected_version" ] && [ "$qd_version" != "$expected_version" ]; then
+            echo "  MISMATCH: QUALITY_DECLARATION.md current version is ${qd_version}, expected ${expected_version}"
+            all_ok=false
+        else
+            echo "  OK: QUALITY_DECLARATION.md current version = ${qd_version}"
+        fi
+        versions_seen+=("$qd_version")
     fi
 
     # Check consistency if no expected version given

--- a/src/ros2_medkit_cmake/CHANGELOG.rst
+++ b/src/ros2_medkit_cmake/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package ros2_medkit_cmake
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* ``ROS2MedkitWarnings.cmake`` module centralizes compiler warning flags across all packages, with selective ``-Werror`` (namespaced ``MEDKIT_ENABLE_WERROR``, defaults OFF) applied only to flags safe against external headers
+* ``ROS2MedkitSanitizers.cmake`` module adds ASan/UBSan and TSan support for sanitizer CI jobs
+* ``ROS2MedkitTestDomain.cmake`` centralizes ``ROS_DOMAIN_ID`` allocation for per-test DDS isolation
+* Vendored cpp-httplib 0.14.3 as a build-farm fallback (``VENDORED_DIR`` parameter), marked as a SYSTEM include to suppress third-party warnings
+* Contributors: @bburda, @mfaferek93
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - shared cmake modules extracted from gateway package (`#294 <https://github.com/selfpatch/ros2_medkit/pull/294>`_)

--- a/src/ros2_medkit_cmake/CHANGELOG.rst
+++ b/src/ros2_medkit_cmake/CHANGELOG.rst
@@ -2,12 +2,13 @@
 Changelog for package ros2_medkit_cmake
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * ``ROS2MedkitWarnings.cmake`` module centralizes compiler warning flags across all packages, with selective ``-Werror`` (namespaced ``MEDKIT_ENABLE_WERROR``, defaults OFF) applied only to flags safe against external headers
 * ``ROS2MedkitSanitizers.cmake`` module adds ASan/UBSan and TSan support for sanitizer CI jobs
 * ``ROS2MedkitTestDomain.cmake`` centralizes ``ROS_DOMAIN_ID`` allocation for per-test DDS isolation
 * Vendored cpp-httplib 0.14.3 as a build-farm fallback (``VENDORED_DIR`` parameter), marked as a SYSTEM include to suppress third-party warnings
+* ``medkit_find_cpp_httplib`` caps cpp-httplib at ``< 0.20`` across both the pkg-config and ``find_package(httplib)`` tiers, so distros shipping 0.20+ (Ubuntu 26.04 ships 0.26, which dropped the multipart ``Request::has_file`` API the gateway uses) fall through to the vendored 0.14.3 header instead of failing the build; ``ROS2MedkitCompat.cmake`` extended to cover ROS 2 Lyrical / Ubuntu 26.04 Resolute (rclcpp 32, ``yaml_cpp_vendor`` target export, ``ament_target_dependencies`` removal in ament_cmake 2.8.5+), which replaces Rolling in CI (`#405 <https://github.com/selfpatch/ros2_medkit/pull/405>`_)
 * Contributors: @bburda, @mfaferek93
 
 0.4.0 (2026-03-20)

--- a/src/ros2_medkit_cmake/package.xml
+++ b/src/ros2_medkit_cmake/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_cmake</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Shared CMake modules for ros2_medkit packages (multi-distro compat, ccache, linting)</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros2_medkit_diagnostic_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
+* Tests: use centralized ``ROS_DOMAIN_ID`` allocation for DDS isolation
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Build: use shared cmake modules from ``ros2_medkit_cmake`` package

--- a/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_diagnostic_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
 * Tests: use centralized ``ROS_DOMAIN_ID`` allocation for DDS isolation

--- a/src/ros2_medkit_diagnostic_bridge/package.xml
+++ b/src/ros2_medkit_diagnostic_bridge/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_diagnostic_bridge</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Bridge node converting ROS2 /diagnostics to FaultManager faults</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros2_medkit_beacon_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Updated include paths for the gateway core / ROS 2 ``PluginContext`` layer split and removal of backwards-compat shim headers
+* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - shared utilities for beacon discovery plugins

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_beacon_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Updated include paths for the gateway core / ROS 2 ``PluginContext`` layer split and removal of backwards-compat shim headers
 * Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_beacon_common</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Shared library for ros2_medkit beacon discovery plugins</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package ros2_medkit_linux_introspection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Migrated the introspection plugins to the ``get_routes()`` plugin API
+* Declared ``pkg-config`` as a ``buildtool_depend`` and fixed a route-separator bug
+* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - Linux process introspection plugins for ros2_medkit gateway

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_linux_introspection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Migrated the introspection plugins to the ``get_routes()`` plugin API
 * Declared ``pkg-config`` as a ``buildtool_depend`` and fixed a route-separator bug

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_linux_introspection</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Linux introspection plugins for ros2_medkit gateway - procfs, systemd, and container</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_param_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Migrated ``ParameterBeaconPlugin`` to the ``get_routes()`` plugin API
 * Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV; the graph poll now swallows ``rcl`` "context invalid" during shutdown

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package ros2_medkit_param_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Migrated ``ParameterBeaconPlugin`` to the ``get_routes()`` plugin API
+* Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV; the graph poll now swallows ``rcl`` "context invalid" during shutdown
+* Added post-shutdown guard unit tests
+* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - parameter-based beacon discovery plugin

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_param_beacon</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Parameter-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package ros2_medkit_topic_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Migrated ``TopicBeaconPlugin`` to the ``get_routes()`` plugin API
+* Added shutdown guards and ``noexcept`` destructors (with ``override``) that reset rclcpp resources before member destruction, preventing teardown SIGSEGV
+* Added post-shutdown guard unit tests
+* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - topic-based beacon discovery plugin

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_topic_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Migrated ``TopicBeaconPlugin`` to the ``get_routes()`` plugin API
 * Added shutdown guards and ``noexcept`` destructors (with ``override``) that reset rclcpp resources before member destruction, preventing teardown SIGSEGV

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_topic_beacon</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Topic-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_fault_manager/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_manager/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package ros2_medkit_fault_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* ``ClearFault`` honors the new ``skip_correlation_auto_clear`` request flag so per-entity fault clears can opt out of cascade-clearing correlated symptom fault codes (`#395 <https://github.com/selfpatch/ros2_medkit/issues/395>`_)
+* Three-layer protection against unbounded snapshot growth (bounded buffers plus pruning)
+* Concurrency and lifetime hardening: serialize concurrent subscription creation in ``SnapshotCapture``, join capture threads in the ``FaultManagerNode`` destructor, and defense-in-depth shutdown guards to prevent teardown crashes across distros
+* Aggregation security hardening and improved test coverage
+* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules and ``bugprone`` / ``special-member-functions`` clang-tidy checks
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Per-entity confirmation and healing thresholds via manifest configuration (`#269 <https://github.com/selfpatch/ros2_medkit/pull/269>`_)

--- a/src/ros2_medkit_fault_manager/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_manager/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_fault_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * ``ClearFault`` honors the new ``skip_correlation_auto_clear`` request flag so per-entity fault clears can opt out of cascade-clearing correlated symptom fault codes (`#395 <https://github.com/selfpatch/ros2_medkit/issues/395>`_)
 * Three-layer protection against unbounded snapshot growth (bounded buffers plus pruning)

--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_manager</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Central fault manager node for ros2_medkit fault management system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_fault_reporter/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_reporter/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_fault_reporter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * ``LocalFilter`` now debounces ``PASSED`` events with the same threshold / window filtering as ``FAILED``, preventing rapid CONFIRMED/CLEARED status cycling from triggering unbounded snapshot recapture (`#308 <https://github.com/selfpatch/ros2_medkit/issues/308>`_)
 * Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules

--- a/src/ros2_medkit_fault_reporter/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_reporter/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros2_medkit_fault_reporter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* ``LocalFilter`` now debounces ``PASSED`` events with the same threshold / window filtering as ``FAILED``, preventing rapid CONFIRMED/CLEARED status cycling from triggering unbounded snapshot recapture (`#308 <https://github.com/selfpatch/ros2_medkit/issues/308>`_)
+* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
+* Contributors: @bburda, @mfaferek93
+
 0.4.0 (2026-03-20)
 ------------------
 * Build: use shared cmake modules from ``ros2_medkit_cmake`` package

--- a/src/ros2_medkit_fault_reporter/package.xml
+++ b/src/ros2_medkit_fault_reporter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_reporter</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Client library for easy fault reporting with local filtering</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -51,9 +51,7 @@ Changelog for package ros2_medkit_gateway
   ``parameters`` / ``error`` (``GET .../scripts/{id}/executions/{eid}``) and
   the script ``parameters_schema`` field (``GET .../scripts/{id}``). Clients
   that tested ``field === null`` or relied on the key always being present must
-  treat an absent key the same as ``null``. The ``rtmaps_medkit`` variant is
-  explicitly NOT covered by this PR - its handlers continue to run on the
-  pre-typed HandlerContext surface and will be migrated separately
+  treat an absent key the same as ``null``
   (`#403 <https://github.com/selfpatch/ros2_medkit/issues/403>`_)
 * Synchronous operation-execution service-call failures
   (``POST /api/v1/{entity-path}/operations/{id}/executions`` when the underlying
@@ -102,6 +100,9 @@ Changelog for package ros2_medkit_gateway
 * All-or-nothing fragment semantics: a single malformed or forbidden fragment fails the entire load / reload and keeps the previously-loaded manifest active (`#376 <https://github.com/selfpatch/ros2_medkit/issues/376>`_)
 * ``ManifestParser::parse_fragment_file`` convenience entrypoint that injects a synthetic ``manifest_version`` header when the fragment omits one
 * See ``design/plugin_entity_notifications.rst`` for the lifecycle, merge-rule, and plugin-side write-contract walkthrough
+* New ``GET /api/v1/apps/{app_id}/belongs-to`` discovery endpoint returning the areas and components an app belongs to; the ``belongs-to`` URI is advertised on ``GET /apps/{app_id}`` (`#196 <https://github.com/selfpatch/ros2_medkit/issues/196>`_)
+* Pool-backed ``TopicDataProvider`` for live topic data: a shared subscription pool owned by a single-writer executor node, with LRU and idle eviction and publisher-QoS matching, replacing per-request subscriptions. Pool and executor health are surfaced as the ``x-medkit-subscription-executor`` vendor-extension stats on ``GET /api/v1/health``, read atomically so ``/health`` never blocks under load (`#384 <https://github.com/selfpatch/ros2_medkit/issues/384>`_)
+* ``GET /api/v1/updates/{id}/status`` exposes the update lifecycle ``phase`` under the response ``x-medkit`` object
 * Contributors: @bburda, @mfaferek93, @eclipse0922
 
 0.4.0 (2026-03-20)

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros2_medkit_gateway
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Unreleased
-----------
+0.5.0 (2026-06-01)
+------------------
 
 **Breaking Changes:**
 
@@ -102,6 +102,7 @@ Unreleased
 * All-or-nothing fragment semantics: a single malformed or forbidden fragment fails the entire load / reload and keeps the previously-loaded manifest active (`#376 <https://github.com/selfpatch/ros2_medkit/issues/376>`_)
 * ``ManifestParser::parse_fragment_file`` convenience entrypoint that injects a synthetic ``manifest_version`` header when the fragment omits one
 * See ``design/plugin_entity_notifications.rst`` for the lifecycle, merge-rule, and plugin-side write-contract walkthrough
+* Contributors: @bburda, @mfaferek93, @eclipse0922
 
 0.4.0 (2026-03-20)
 ------------------

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_gateway
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 
 **Breaking Changes:**
@@ -103,7 +103,9 @@ Changelog for package ros2_medkit_gateway
 * New ``GET /api/v1/apps/{app_id}/belongs-to`` discovery endpoint returning the areas and components an app belongs to; the ``belongs-to`` URI is advertised on ``GET /apps/{app_id}`` (`#196 <https://github.com/selfpatch/ros2_medkit/issues/196>`_)
 * Pool-backed ``TopicDataProvider`` for live topic data: a shared subscription pool owned by a single-writer executor node, with LRU and idle eviction and publisher-QoS matching, replacing per-request subscriptions. Pool and executor health are surfaced as the ``x-medkit-subscription-executor`` vendor-extension stats on ``GET /api/v1/health``, read atomically so ``/health`` never blocks under load (`#384 <https://github.com/selfpatch/ros2_medkit/issues/384>`_)
 * ``GET /api/v1/updates/{id}/status`` exposes the update lifecycle ``phase`` under the response ``x-medkit`` object
-* Contributors: @bburda, @mfaferek93, @eclipse0922
+* ``gateway.launch.py`` and ``gateway_https.launch.py`` accept a ``config_file`` launch argument pointing at an external parameter YAML. Parameters present in the file override the matching gateway defaults; parameters the file omits keep their launch defaults instead of being reset (`#408 <https://github.com/selfpatch/ros2_medkit/pull/408>`_)
+* Plugin-facing headers are httplib-free across the ``.so`` boundary: the handler-result vocabulary (``Result``, ``NoContent``, ``Forwarded``, ``ValidatorResult``, ``ResponseAttachments``) moved to a new leaf header ``http/handler_result.hpp`` so provider and DTO interfaces no longer transitively include ``<httplib.h>``. Out-of-tree plugins built against the installed gateway (build-farm / Docker topology, where the vendored httplib is not on the include path) compile again; no ABI, wire, or behaviour change. A pre-push gate and CI scan keep the plugin-facing headers httplib-free (`#411 <https://github.com/selfpatch/ros2_medkit/pull/411>`_)
+* Contributors: @bburda, @eclipse0922, @evTessellate, @mfaferek93
 
 0.4.0 (2026-03-20)
 ------------------

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp
@@ -21,7 +21,7 @@ namespace ros2_medkit_gateway {
 #ifdef GATEWAY_VERSION_STRING
 constexpr const char * kGatewayVersion = GATEWAY_VERSION_STRING;
 #else
-constexpr const char * kGatewayVersion = "0.4.0";
+constexpr const char * kGatewayVersion = "0.5.0";
 #endif
 
 /// SOVD specification version

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_gateway</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>HTTP gateway for ros2_medkit diagnostics system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_integration_tests/CHANGELOG.rst
+++ b/src/ros2_medkit_integration_tests/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog for package ros2_medkit_integration_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* New peer-aggregation suites: peer aggregation, cross-ECU fan-out across all resource types, daisy-chain hierarchical aggregation, leaf-collision aggregation, and cross-ECU log aggregation
+* New SOVD-aligned entity-model suites: runtime entity model, flat entity tree without areas, hybrid suppression, and per-entity fault scope isolation
+* New OpenAPI conformance suites: ``test_openapi_callability`` and ``test_openapi_response_drift`` validate the published spec against live responses
+* New graph-event discovery suite covering rclcpp graph-event driven discovery refresh
+* Coverage for the ``GET /apps/{id}/belongs-to`` discovery endpoint, nested ``x-medkit`` vendor payloads (`#385 <https://github.com/selfpatch/ros2_medkit/issues/385>`_), version-info aggregation, and pending-after-register update status (`#378 <https://github.com/selfpatch/ros2_medkit/issues/378>`_)
+* Tests: centralized ``ROS_DOMAIN_ID`` allocation and widened shutdown timeouts for sanitizer overhead
+* Contributors: @bburda, @eclipse0922
+
 0.4.0 (2026-03-20)
 ------------------
 * Integration tests for SOVD resource locking (acquire, release, extend, fault clear with locks, expiration, parent propagation)

--- a/src/ros2_medkit_integration_tests/CHANGELOG.rst
+++ b/src/ros2_medkit_integration_tests/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_integration_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * New peer-aggregation suites: peer aggregation, cross-ECU fan-out across all resource types, daisy-chain hierarchical aggregation, leaf-collision aggregation, and cross-ECU log aggregation
 * New SOVD-aligned entity-model suites: runtime entity model, flat entity tree without areas, hybrid suppression, and per-entity fault scope isolation

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_integration_tests</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Integration tests and demo nodes for ros2_medkit</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_msgs/CHANGELOG.rst
+++ b/src/ros2_medkit_msgs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros2_medkit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* New service definitions ``ListEntities.srv``, ``GetEntityData.srv``, ``GetCapabilities.srv`` and the ``EntityInfo.msg`` type for exposing the entity tree over ROS 2 services (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)
+* ``ClearFault.srv`` request gains a ``bool skip_correlation_auto_clear`` field so callers can opt out of cascade-clearing correlated symptom fault codes; out-of-tree callers must rebuild against the new message (`#395 <https://github.com/selfpatch/ros2_medkit/issues/395>`_)
+* Contributors: @bburda, @mfaferek93
+
 0.4.0 (2026-03-20)
 ------------------
 * ``MedkitDiscoveryHint`` message type for beacon discovery publishers

--- a/src/ros2_medkit_msgs/CHANGELOG.rst
+++ b/src/ros2_medkit_msgs/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * New service definitions ``ListEntities.srv``, ``GetEntityData.srv``, ``GetCapabilities.srv`` and the ``EntityInfo.msg`` type for exposing the entity tree over ROS 2 services (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)
 * ``ClearFault.srv`` request gains a ``bool skip_correlation_auto_clear`` field so callers can opt out of cascade-clearing correlated symptom fault codes; out-of-tree callers must rebuild against the new message (`#395 <https://github.com/selfpatch/ros2_medkit/issues/395>`_)

--- a/src/ros2_medkit_msgs/package.xml
+++ b/src/ros2_medkit_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_msgs</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>ROS 2 message and service definitions for ros2_medkit fault management</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_graph_provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Migrated ``GraphProviderPlugin`` to the ``get_routes()`` plugin API and fixed a route-separator bug
 * Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package ros2_medkit_graph_provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* Migrated ``GraphProviderPlugin`` to the ``get_routes()`` plugin API and fixed a route-separator bug
+* Added shutdown guards and ``noexcept`` destructors that reset rclcpp resources before member destruction, preventing teardown SIGSEGV
+* Added post-shutdown guard unit tests; dropped the cpp-httplib source install from the Dockerfile (now vendored via ``ros2_medkit_cmake``)
+* Build: adopt the centralized ``ROS2MedkitWarnings`` cmake module
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Initial release - extracted from ``ros2_medkit_gateway`` package

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_graph_provider</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Graph provider plugin for ros2_medkit gateway</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_opcua
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Native OPC-UA Part 9 ``AlarmConditionType`` event subscription. The plugin now subscribes to vendor-defined alarms (Siemens S7-1500 ``Program_Alarm`` / ProDiag, Beckhoff TF6100, CodeSys 3.5+, Rockwell via FactoryTalk Linx) and bridges each event into the SOVD fault lifecycle. Configured via a new top-level ``event_alarms:`` block in the node map YAML; mutually exclusive per entry with the existing threshold-based ``alarm`` form. (issue #386)
 * New SOVD operations on entities that host alarm sources: ``acknowledge_fault`` invokes the inherited ``Acknowledge`` method on the live ``ConditionId`` (i=9111, EventId tracked per Part 9 §5.7.3); ``confirm_fault`` invokes ``Confirm`` (i=9113). Both accept an optional ``comment`` rendered as ``LocalizedText`` on the server.

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ros2_medkit_opcua
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.5.0 (2026-06-01)
+------------------
 * Native OPC-UA Part 9 ``AlarmConditionType`` event subscription. The plugin now subscribes to vendor-defined alarms (Siemens S7-1500 ``Program_Alarm`` / ProDiag, Beckhoff TF6100, CodeSys 3.5+, Rockwell via FactoryTalk Linx) and bridges each event into the SOVD fault lifecycle. Configured via a new top-level ``event_alarms:`` block in the node map YAML; mutually exclusive per entry with the existing threshold-based ``alarm`` form. (issue #386)
 * New SOVD operations on entities that host alarm sources: ``acknowledge_fault`` invokes the inherited ``Acknowledge`` method on the live ``ConditionId`` (i=9111, EventId tracked per Part 9 §5.7.3); ``confirm_fault`` invokes ``Confirm`` (i=9113). Both accept an optional ``comment`` rendered as ``LocalizedText`` on the server.
 * ``OpcuaClient`` gains ``add_event_monitored_item`` / ``remove_event_monitored_item`` / ``call_method`` and a generation counter that filters callbacks fired from defunct subscriptions after a reconnect. Heap-owned ``EventCallbackContext`` resolves the open62541pp / raw-C lifetime hazard.
@@ -11,6 +11,7 @@ Forthcoming
 * ``ConditionRefresh`` (Server method i=3875) is invoked on subscribe and on every reconnect, with ``RefreshStartEvent`` / ``RefreshEndEvent`` bracketing tracked for diagnostics.
 * New ``test_alarm_server`` fixture (open62541-based, full namespace 0 + alarms enabled) emits AlarmConditionType events on stdin commands; integration test ``run_alarm_tests.sh`` runs in CI alongside the existing OpenPLC threshold suite. The fixture builds by default via the workspace ``colcon build`` (gated on ``MEDKIT_OPCUA_BUILD_ALARM_SERVER`` which defaults to ON; ``ExternalProject_Add`` rebuilds open62541 with ``UA_NAMESPACE_ZERO=FULL`` and alarms ON, with a serial sub-build to dodge the upstream ``-j`` race on ``namespace0_generated.c``).
 * New CTest wrapper ``test_alarm_server_smoke`` boots the fixture on an ephemeral port and runs the asyncua smoke test against it; skips with CTest exit 77 (treated as pass) when ``asyncua`` is not importable, so iterating on plugin code without the Python dependency does not fail the suite.
+* Contributors: @mfaferek93, @bburda
 
 0.4.0 (2026-04-11)
 ------------------

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_opcua</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>OPC-UA gateway plugin for ros2_medkit - bridges PLC systems into the SOVD entity tree</description>
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros2_medkit_sovd_service_interface
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.5.0 (2026-06-01)
+------------------
+* Initial release - gateway plugin that exposes the medkit entity tree and fault data over standard ROS 2 services, so other ROS 2 nodes can query entities and faults without going through the HTTP API (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)
+* Creates ROS 2 services under a configurable prefix (default ``/medkit``): ``list_entities``, ``list_entity_faults``, and ``get_capabilities``; a ``get_entity_data`` service is also registered but currently returns "not implemented" (use the HTTP REST API for topic data) pending (`#351 <https://github.com/selfpatch/ros2_medkit/issues/351>`_)
+* Runs as a gateway MODULE plugin with read-only ``PluginContext`` access to the entity cache and fault manager; implements no provider interfaces
+* Shutdown guards and ``noexcept`` destructors reset ROS resources before member destruction to prevent teardown crashes
+* Contributors: @bburda, @mfaferek93

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_sovd_service_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * Initial release - gateway plugin that exposes the medkit entity tree and fault data over standard ROS 2 services, so other ROS 2 nodes can query entities and faults without going through the HTTP API (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)
 * Creates ROS 2 services under a configurable prefix (default ``/medkit``): ``list_entities``, ``list_entity_faults``, and ``get_capabilities``; a ``get_entity_data`` service is also registered but currently returns "not implemented" (use the HTTP REST API for topic data) pending (`#351 <https://github.com/selfpatch/ros2_medkit/issues/351>`_)

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_sovd_service_interface</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>SOVD Service Interface plugin - exposes medkit entity tree and fault data via ROS 2 services</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_serialization/CHANGELOG.rst
+++ b/src/ros2_medkit_serialization/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package ros2_medkit_serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-0.5.0 (2026-06-01)
+0.5.0 (2026-06-08)
 ------------------
 * ``TypeIntrospection`` relocated into this package as part of the gateway core / ROS 2 layer split
 * Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules

--- a/src/ros2_medkit_serialization/CHANGELOG.rst
+++ b/src/ros2_medkit_serialization/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ros2_medkit_serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.5.0 (2026-06-01)
+------------------
+* ``TypeIntrospection`` relocated into this package as part of the gateway core / ROS 2 layer split
+* Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules
+* Contributors: @bburda
+
 0.4.0 (2026-03-20)
 ------------------
 * Enable ``POSITION_INDEPENDENT_CODE`` for MODULE target compatibility

--- a/src/ros2_medkit_serialization/package.xml
+++ b/src/ros2_medkit_serialization/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_serialization</name>
-  <version>0.4.0</version>
+  <version>0.5.0</version>
   <description>Runtime JSON to ROS 2 message serialization library</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Summary

Release preparation for **v0.5.0**:

- **Version bump** to `0.5.0` across all 15 packages, the `version.hpp` fallback constant, `docs/conf.py`, `docs/pyproject.toml`, and the version literals in the root / version-info API example responses (via `scripts/release.sh bump 0.5.0`).
- **Changelogs finalized**: the gateway `Unreleased` and OPC-UA `Forthcoming` sections are promoted to `0.5.0 (2026-06-01)`, `0.5.0` entries are added to the remaining packages, and an initial `CHANGELOG.rst` is added for the new `ros2_medkit_sovd_service_interface` package (wired into `docs/changelog.rst`).
- **Bug fix** in `scripts/release.sh`: it pointed at `include/ros2_medkit_gateway/version.hpp`, but the version constant lives at `.../core/version.hpp`, so `bump` silently skipped the `kGatewayVersion` fallback and `verify` never validated it. Path corrected; the fallback is now bumped and verified.

The 0.5.0 changelog calls out the breaking changes that already merged this cycle (typed router / `HandlerContext` API, typed provider ABI, fault-route scoping, plugin API v7 / `get_routes()`, entity-model shift to Functions, nested `x-medkit` payload fields).

---

## Issue

Part of #406

---

## Type

- [x] Bug fix (`release.sh` version.hpp path)
- [ ] New feature or tests
- [ ] Breaking change
- [x] Documentation only (changelogs + version)

---

## Testing

- `./scripts/release.sh verify 0.5.0` → all 15 packages + `version.hpp` + `docs/conf.py` + `docs/pyproject.toml` consistent at `0.5.0`.
- `colcon build --packages-up-to ros2_medkit_gateway` builds cleanly; `info.version` reported by `/api/v1/docs` is `0.5.0`.
- Sphinx docs build of the changelog page is clean (no changelog-related warnings; the only warnings are the pre-existing doxygen-XML/`requirements/verification` ones that need the doxygen + generation steps CI runs first).

---

## Checklist

- [x] Breaking changes are clearly described (announced in the gateway/per-package changelogs)
- [x] Tests were added or updated if needed (no code-logic change; version/changelog only)
- [x] Docs were updated if behavior or public API changed (changelogs + API example version literals)
