### PR TITLE
Add a config_file argument to the gateway launchfile to allow using an external config file.

### DIFF
--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -1271,6 +1271,22 @@ cors:
 
 > ⚠️ **Security Note:** Using `["*"]` as `allowed_origins` is not recommended for production. When `allow_credentials` is `true`, wildcard origins will cause the application to fail to start with an exception.
 
+**Use config from another package (`gateway.launch.py`):**
+
+```bash
+ros2 launch ros2_medkit_gateway gateway.launch.py \
+  config_file:=<your_package>/config/gateway_params.yaml
+```
+
+> **Parameter priority:** launch args > `config_file` > packaged defaults. `config_file` overrides only the keys it defines; `server_host`, `server_port`, and `refresh_interval_ms` are launch-arg only and always take precedence.
+
+| Launch Argument       | Default                               | Description                                                                                          |
+| --------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `config_file`         | packaged `config/gateway_params.yaml` | Path to a YAML parameter file applied on top of the packaged defaults.                               |
+| `server_host`         | `127.0.0.1`                           | Host to bind the REST server (`127.0.0.1` or `0.0.0.0`). Launch-arg only.                           |
+| `server_port`         | `8080`                                | Port for the REST API. Launch-arg only.                                                              |
+| `refresh_interval_ms` | `30000`                               | Safety-backstop refresh interval in ms (graph events drive the primary refresh). Launch-arg only.    |
+
 ### Authentication Configuration Examples
 
 **Enable authentication with write-only protection (recommended for development):**
@@ -1402,13 +1418,23 @@ ros2 launch ros2_medkit_gateway gateway_https.launch.py cert_dir:=/home/user/cer
 ros2 launch ros2_medkit_gateway gateway_https.launch.py min_tls_version:=1.3
 ```
 
-| Launch Argument       | Default                    | Description                                      |
-| --------------------- | -------------------------- | ------------------------------------------------ |
-| `cert_dir`            | `/tmp/ros2_medkit_certs`   | Directory for auto-generated certificates        |
-| `server_host`         | `127.0.0.1`                | Host to bind HTTPS server                        |
-| `server_port`         | `8443`                     | Port for HTTPS API                               |
-| `min_tls_version`     | `1.2`                      | Minimum TLS version (`1.2` or `1.3`)             |
-| `refresh_interval_ms` | `30000`                    | Safety-backstop refresh interval (graph events drive primary refresh) |
+**Use config from another package (`gateway_https.launch.py`):**
+
+```bash
+ros2 launch ros2_medkit_gateway gateway_https.launch.py \
+  config_file:=<your_package>/config/gateway_params.yaml
+```
+
+> **Parameter priority:** launch args > `config_file` > packaged defaults. `config_file` overrides only the keys it defines; `cert_dir`, `server_host`, `server_port`, `min_tls_version`, and `refresh_interval_ms` are launch-arg only and always take precedence.
+
+| Launch Argument       | Default                               | Description                                                                              |
+| --------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `config_file`         | packaged `config/gateway_params.yaml` | Path to a YAML parameter file applied on top of the packaged defaults.                   |
+| `cert_dir`            | `/tmp/ros2_medkit_certs`              | Directory for auto-generated certificates. Launch-arg only.                              |
+| `server_host`         | `127.0.0.1`                           | Host to bind HTTPS server. Launch-arg only.                                              |
+| `server_port`         | `8443`                                | Port for HTTPS API. Launch-arg only.                                                     |
+| `min_tls_version`     | `1.2`                                 | Minimum TLS version (`1.2` or `1.3`). Launch-arg only.                                  |
+| `refresh_interval_ms` | `30000`                               | Safety-backstop refresh interval (graph events drive primary refresh). Launch-arg only.  |
 
 **Usage with curl (self-signed certs):**
 ```bash

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -43,6 +43,10 @@ def generate_launch_description():
               f'{graph_provider_path} - plugin will not load')
         graph_provider_path = ''
 
+    declare_overide_config_arg = DeclareLaunchArgument(
+        'config_file', default_value=default_config,
+        description='Path to YAML config file for gateway parameters')
+
     declare_host_arg = DeclareLaunchArgument(
         'server_host', default_value='127.0.0.1',
         description='Host to bind REST server (127.0.0.1 or 0.0.0.0)')
@@ -74,10 +78,11 @@ def generate_launch_description():
         executable='gateway_node',
         name='ros2_medkit_gateway',
         output='screen',
-        parameters=[default_config, param_overrides],
+        parameters=[LaunchConfiguration('config_file'), param_overrides],
         arguments=['--ros-args', '--log-level', 'info'])
 
     return LaunchDescription([
+        declare_overide_config_arg,
         declare_host_arg,
         declare_port_arg,
         declare_refresh_arg,

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -45,7 +45,8 @@ def generate_launch_description():
 
     declare_override_config_arg = DeclareLaunchArgument(
         'config_file', default_value=default_config,
-        description='Path to YAML config file for gateway parameters')
+        description='Path to YAML config file to override gateway parameters. Default config '
+                    'is the ros2_medkit_gateway/config/gateway_params.yaml.')
 
     declare_host_arg = DeclareLaunchArgument(
         'server_host', default_value='127.0.0.1',
@@ -78,7 +79,7 @@ def generate_launch_description():
         executable='gateway_node',
         name='ros2_medkit_gateway',
         output='screen',
-        parameters=[LaunchConfiguration('config_file'), param_overrides],
+        parameters=[default_config, LaunchConfiguration('config_file'), param_overrides],
         arguments=['--ros-args', '--log-level', 'info'])
 
     return LaunchDescription([

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -43,7 +43,7 @@ def generate_launch_description():
               f'{graph_provider_path} - plugin will not load')
         graph_provider_path = ''
 
-    declare_overide_config_arg = DeclareLaunchArgument(
+    declare_override_config_arg = DeclareLaunchArgument(
         'config_file', default_value=default_config,
         description='Path to YAML config file for gateway parameters')
 
@@ -82,7 +82,7 @@ def generate_launch_description():
         arguments=['--ros-args', '--log-level', 'info'])
 
     return LaunchDescription([
-        declare_overide_config_arg,
+        declare_override_config_arg,
         declare_host_arg,
         declare_port_arg,
         declare_refresh_arg,

--- a/src/ros2_medkit_gateway/launch/gateway_https.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway_https.launch.py
@@ -142,6 +142,7 @@ def launch_setup(context):
     server_port = LaunchConfiguration('server_port').perform(context)
     refresh_interval = LaunchConfiguration('refresh_interval_ms').perform(context)
     min_tls_version = LaunchConfiguration('min_tls_version').perform(context)
+    override_config = LaunchConfiguration('config_file').perform(context)
 
     # Use temp directory if not specified
     if not cert_dir:
@@ -181,7 +182,7 @@ def launch_setup(context):
             name='ros2_medkit_gateway',
             output='screen',
             parameters=[
-                default_config,
+                default_config, override_config,
                 {
                     'server.host': server_host,
                     'server.port': int(server_port),
@@ -235,6 +236,14 @@ def generate_launch_description():
             'min_tls_version',
             default_value='1.2',
             description='Minimum TLS version (1.2 or 1.3)'
+        ),
+
+        DeclareLaunchArgument(
+            'config_file', default_value=os.path.join(
+                get_package_share_directory('ros2_medkit_gateway'),
+                'config', 'gateway_params.yaml'),
+            description='Path to YAML config file to override gateway parameters. Default config '
+                        'is the ros2_medkit_gateway/config/gateway_params.yaml.'
         ),
 
         # Use OpaqueFunction to generate certs and set up node


### PR DESCRIPTION
…

# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Added an optional config_file argument to the ros2_mekdit_gateway to be able to set the gateway parameters from outside the ros2_mekdit_gateway. This feature is proposed for large projects where the gateway config lives in another bringup package and needs to be feed to the gateway. 

---

## Issue

Link the related issue (required):
No issues, its new feature.

---

## Type

- [ ] Bug fix
- [X ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?:

I launched the gateway with and without the new config_file orverride:
```
launch:
  - include:
      file: $(find-pkg-share ros2_medkit_gateway)/launch/gateway.launch.py
```
and 
```
launch:
  - include:
      file: $(find-pkg-share ros2_medkit_gateway)/launch/gateway.launch.py
      arg:
        - name: config_file
          value: "$(find-pkg-share bringup_package)/config/medkit_config/gateway_params.yaml"    
```
In my `gateway_params.yaml` from my `bringup_package`, I enable the CORS parameters. So when I launched the gateway without the config file, the `rosout` log showed that CORS was disabled, and when I launched with the config_file, the log said CORS was enabled.


Also, I did all the test in https://github.com/selfpatch/ros2_medkit/blob/main/CONTRIBUTING.md with success.

Since no code had to be build, there wasn't that much build test to do.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
