### PR TITLE
ci(coverage): bump codecov-action v5 -> v7 for Keybase GPG key migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info


### PR DESCRIPTION
## Summary

The `coverage` job has failed on every push to `main` since June 7 at the **Upload coverage to Codecov** step:

```
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
==> Verifying GPG signature integrity
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
```

Codecov migrated the Keybase account that hosts the uploader's GPG public key. `codecov/codecov-action@v5` fetches that key from the pre-migration path, receives non-OpenPGP data, so the key import yields 0 keys and the subsequent signature check of the downloaded CLI fails. Because the step runs with `fail_ci_if_error: true`, the whole coverage job goes red. All tests pass and the HTML coverage artifact uploads fine - only the third-party uploader's GPG self-verification breaks.

Upstream released `codecov-action@v7.0.0` specifically to fix the migrated key path (see codecov/codecov-action#1956, #1955). This bumps `@v5` -> `@v7`. GPG verification and `fail_ci_if_error: true` stay enabled - no validation is skipped.

## Issue

N/A - one-line CI hotfix for an upstream tooling breakage.

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

## Testing

The Codecov step is gated to `push` on `main`, so PR CI does not exercise it; it runs on the first push to `main` after merge. Change is config-only (action major-version bump); the rest of CI validates the workflow parses and runs.

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed