### PR TITLE
Fixed an error where the service request to get all faults with include_muted=false also returned the muted faults.

### DIFF
--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -476,9 +476,10 @@ void FaultManagerNode::handle_list_faults(
     response->muted_count = correlation_engine_->get_muted_count();
     response->cluster_count = correlation_engine_->get_cluster_count();
 
+    auto muted_faults = correlation_engine_->get_muted_faults();
+
     // Include muted faults details if requested
     if (request->include_muted) {
-      auto muted_faults = correlation_engine_->get_muted_faults();
       response->muted_faults.reserve(muted_faults.size());
       for (const auto & muted : muted_faults) {
         ros2_medkit_msgs::msg::MutedFaultInfo info;
@@ -488,6 +489,20 @@ void FaultManagerNode::handle_list_faults(
         info.delay_ms = muted.delay_ms;
         response->muted_faults.push_back(info);
       }
+    } else {
+      // Build a set of muted codes for O(1) lookup.
+      std::unordered_set<std::string> muted_codes;
+      for (const auto & muted : muted_faults) {
+        muted_codes.insert(muted.fault_code);
+      }
+
+      // Remove all faults whose code is muted, in one pass.
+      auto & faults = response->faults;
+      faults.erase(std::remove_if(faults.begin(), faults.end(),
+                                  [&muted_codes](const ros2_medkit_msgs::msg::Fault & fault) {
+                                    return muted_codes.count(fault.fault_code) > 0;
+                                  }),
+                   faults.end());
     }
 
     // Include cluster details if requested


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary
The gateway returns a list of muted faults even when the service request ask to exclude them. It caused the web UI and Foxglove to display muted faults even if muting correlation rules where defined.

---

## Issue

Link the related issue (required):

- closes #413 

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

How was this tested / how should reviewers verify it?
As described in the #413 issue, I created a small setup with a `MAIN_FAULT` and a `CASCADED_FAULT` where the former should mute the later based on a hierarchical correlation_rule. The same setup was used to resolve the problem. I used the Foxglove plugin to validate that with the changes the `CASCADED_FAULT` didn't appear in the UI. Also `curl "http://localhost:8080/api/v1/faults?include_muted=false"` now excludes the muted faults while `curl "http://localhost:8080/api/v1/faults?include_muted=true" keeps it.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
