### PR TITLE
feat(openapi): derive query parameters from a typed query contract

### DIFF
--- a/.github/actions/ros-apt-source/action.yml
+++ b/.github/actions/ros-apt-source/action.yml
@@ -1,0 +1,55 @@
+name: Pre-install ROS 2 apt source
+description: >
+  Installs the ros-apt-source package up front so ros-tooling/setup-ros skips its
+  own unauthenticated api.github.com "releases/latest" lookup. That lookup is
+  subject to the per-IP unauthenticated GitHub API rate limit, which is shared
+  across all GitHub-hosted runners; when it is exhausted the call returns no
+  version, setup-ros builds a .../download//ros2-apt-source_..._all.deb URL, gets
+  a 404, and the whole job fails ("colcon: command not found", exit 127). By
+  configuring the ROS 2 apt repo first, setup-ros's isRosAptSourcePackageInstalled
+  check passes and it never performs the fragile fetch.
+
+runs:
+  using: composite
+  steps:
+    - name: Install ros-apt-source (skip setup-ros's rate-limited fetch)
+      shell: bash
+      env:
+        # Authenticated API requests use the per-repo limit (~1000/h), not the
+        # per-IP unauthenticated limit that setup-ros trips over.
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        SUDO=""
+        if [ "$(id -u)" -ne 0 ]; then SUDO="sudo"; fi
+
+        # Minimal container images may lack curl / CA certificates.
+        if ! command -v curl >/dev/null 2>&1; then
+          $SUDO apt-get update
+          $SUDO apt-get install -y --no-install-recommends curl ca-certificates
+        fi
+
+        codename="$(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME}}")"
+
+        # Resolve the latest ros-apt-source release via an AUTHENTICATED call, then
+        # fall back to a known-good pin so the step is deterministic even if the
+        # API is briefly unreachable.
+        version=""
+        if [ -n "${GH_TOKEN:-}" ]; then
+          version="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest" \
+            | grep -F '"tag_name"' | head -n1 | awk -F'"' '{print $4}' || true)"
+        fi
+        if [ -z "${version}" ]; then
+          version="1.2.0"
+        fi
+
+        deb="ros2-apt-source_${version}.${codename}_all.deb"
+        url="https://github.com/ros-infrastructure/ros-apt-source/releases/download/${version}/${deb}"
+
+        echo "Installing ${deb} (ros-apt-source ${version}, ${codename})"
+        curl --fail --location --retry 5 --retry-delay 3 -o "/tmp/${deb}" "${url}"
+        $SUDO dpkg -i "/tmp/${deb}"
+        rm -f "/tmp/${deb}"
+        $SUDO apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
       - name: Set up ROS 2 ${{ matrix.ros_distro }}
         uses: ros-tooling/setup-ros@v0.7
         with:
@@ -130,6 +133,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7
         with:
@@ -195,6 +201,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
 
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7
@@ -262,6 +271,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
 
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7

--- a/.github/workflows/opcua-plugin.yml
+++ b/.github/workflows/opcua-plugin.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
       - name: Set up ROS 2 ${{ matrix.ros_distro }}
         uses: ros-tooling/setup-ros@v0.7
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -78,6 +78,9 @@ jobs:
       - name: No naked rclcpp subscription APIs (issue #375 regression gate)
         run: ./scripts/check_no_naked_subscriptions.sh
 
+      - name: Handlers read query params via typed query<T>() (zero-query-params regression gate)
+        run: ./src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
+
       - name: Show results
         if: always()
         run: colcon test-result --verbose

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7
         with:
@@ -101,6 +104,9 @@ jobs:
 
       - name: Fix git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
 
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7
@@ -241,6 +247,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7
         with:
@@ -348,6 +357,9 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
 
       - name: Set up ROS 2 Jazzy
         uses: ros-tooling/setup-ros@v0.7

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,12 @@ repos:
         stages: [pre-push]
         pass_filenames: false
         always_run: true
+      - id: gateway-handlers-typed-query
+        name: handlers must read query params via typed query<T>()
+        entry: ./src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
+        language: script
+        pass_filenames: false
+        always_run: true
 
   # ── Incremental clang-tidy (pre-push only) ────────────────────────
   # Requires: pre-commit install --hook-type pre-push

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/http_utils.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/http_utils.hpp
@@ -22,6 +22,7 @@
 #include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -99,15 +100,15 @@ struct FaultStatusFilter {
 };
 
 /**
- * @brief Parse fault status query parameter from request
- * @param req HTTP request
- * @return Filter flags and validity. If status param is invalid, is_valid=false.
+ * @brief Map a fault `status` query value to a FaultStatusFilter.
+ * @param status_opt The `status` query parameter value, or nullopt if absent.
+ * @return Filter flags and validity. If status value is unknown, is_valid=false.
  */
-inline FaultStatusFilter parse_fault_status_param(const httplib::Request & req) {
+inline FaultStatusFilter parse_fault_status_param(const std::optional<std::string> & status_opt) {
   FaultStatusFilter filter;
 
-  if (req.has_param("status")) {
-    std::string status = req.get_param_value("status");
+  if (status_opt) {
+    const std::string & status = *status_opt;
     // Reset defaults when explicit status filter is provided
     filter.include_pending = false;
     filter.include_confirmed = false;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
@@ -30,7 +30,8 @@ inline constexpr std::string_view kFaultSeverityLabelValues[] = {"INFO", "WARN",
 /// Fault aggregated status (fault_detail_schema - status.aggregatedStatus).
 inline constexpr std::string_view kFaultAggregatedStatusValues[] = {"active", "passive", "cleared"};
 
-/// Fault status query filter (FaultListQuery.status / FaultClearQuery.status).
+/// Fault status query filter (FaultListQuery.status / FaultEntityListQuery.status
+/// / FaultClearQuery.status).
 /// Mirrors the values parse_fault_status_param() accepts in http_utils.hpp;
 /// any other value yields ERR_INVALID_PARAMETER. The leading entry must be a
 /// handler-accepted value (the OpenAPI callability test sends enum[0]).

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
@@ -30,6 +30,12 @@ inline constexpr std::string_view kFaultSeverityLabelValues[] = {"INFO", "WARN",
 /// Fault aggregated status (fault_detail_schema - status.aggregatedStatus).
 inline constexpr std::string_view kFaultAggregatedStatusValues[] = {"active", "passive", "cleared"};
 
+/// Fault status query filter (FaultListQuery.status / FaultClearQuery.status).
+/// Mirrors the values parse_fault_status_param() accepts in http_utils.hpp;
+/// any other value yields ERR_INVALID_PARAMETER. The leading entry must be a
+/// handler-accepted value (the OpenAPI callability test sends enum[0]).
+inline constexpr std::string_view kFaultStatusFilterValues[] = {"pending", "confirmed", "cleared", "healed", "all"};
+
 /// Log aggregation level (log_entry_list_schema - x-medkit.aggregation_level).
 inline constexpr std::string_view kLogAggregationLevelValues[] = {"function", "area", "component"};
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -458,9 +458,10 @@ struct dto_sample<FaultClearResult> {
 };
 
 // =============================================================================
-// FaultListQuery - query parameters for GET /faults and GET /{entity}/faults.
-// Read by the handlers via TypedRequest::query<FaultListQuery>() and declared in
-// the OpenAPI spec via the same descriptor, so the two cannot drift.
+// FaultListQuery - query parameters for the global GET /faults list only. Read
+// by list_all_faults via TypedRequest::query<FaultListQuery>() and declared in
+// the OpenAPI spec via the same descriptor, so the two cannot drift. The
+// per-entity GET /{entity}/faults uses the narrower FaultEntityListQuery below.
 // =============================================================================
 struct FaultListQuery {
   std::optional<std::string> status;
@@ -475,6 +476,21 @@ inline constexpr auto dto_fields<FaultListQuery> = std::make_tuple(
     field("include_muted", &FaultListQuery::include_muted, Presence::kOptional, "Include muted faults in the response"),
     field("include_clusters", &FaultListQuery::include_clusters, Presence::kOptional,
           "Include fault clusters in the response"));
+
+// FaultEntityListQuery - query parameters for the per-entity GET /{entity}/faults
+// route. Only `status` applies: include_muted / include_clusters are honored
+// solely by the global GET /faults, because their correlation metadata is
+// computed across the whole fault manager and a scoped response would leak
+// cross-entity data. Declaring a narrower DTO here keeps the route advertising
+// exactly what the handler reads (no spec-vs-runtime drift on the declared axis).
+struct FaultEntityListQuery {
+  std::optional<std::string> status;
+};
+
+template <>
+inline constexpr auto dto_fields<FaultEntityListQuery> =
+    std::make_tuple(field_enum("status", &FaultEntityListQuery::status, kFaultStatusFilterValues,
+                               "Filter by fault status: pending, confirmed, cleared, healed, or all"));
 
 // FaultClearQuery - query parameters for DELETE /faults (clear all). Only the
 // status filter applies; the correlation flags are list-only.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -457,5 +457,35 @@ struct dto_sample<FaultClearResult> {
   }
 };
 
+// =============================================================================
+// FaultListQuery - query parameters for GET /faults and GET /{entity}/faults.
+// Read by the handlers via TypedRequest::query<FaultListQuery>() and declared in
+// the OpenAPI spec via the same descriptor, so the two cannot drift.
+// =============================================================================
+struct FaultListQuery {
+  std::optional<std::string> status;
+  bool include_muted = false;
+  bool include_clusters = false;
+};
+
+template <>
+inline constexpr auto dto_fields<FaultListQuery> = std::make_tuple(
+    field_enum("status", &FaultListQuery::status, kFaultStatusFilterValues,
+               "Filter by fault status: pending, confirmed, cleared, healed, or all"),
+    field("include_muted", &FaultListQuery::include_muted, Presence::kOptional, "Include muted faults in the response"),
+    field("include_clusters", &FaultListQuery::include_clusters, Presence::kOptional,
+          "Include fault clusters in the response"));
+
+// FaultClearQuery - query parameters for DELETE /faults (clear all). Only the
+// status filter applies; the correlation flags are list-only.
+struct FaultClearQuery {
+  std::optional<std::string> status;
+};
+
+template <>
+inline constexpr auto dto_fields<FaultClearQuery> =
+    std::make_tuple(field_enum("status", &FaultClearQuery::status, kFaultStatusFilterValues,
+                               "Clear only faults in this status: pending, confirmed, cleared, healed, or all"));
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/logs.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/logs.hpp
@@ -173,5 +173,21 @@ inline constexpr auto dto_fields<LogConfiguration> = std::make_tuple(
 template <>
 inline constexpr std::string_view dto_name<LogConfiguration> = "LogConfiguration";
 
+// =============================================================================
+// LogQuery - query parameters for GET /{entity}/logs. Read by the handler via
+// TypedRequest::query<LogQuery>() and declared in the OpenAPI spec via the same
+// descriptor, so the two cannot drift.
+// =============================================================================
+struct LogQuery {
+  std::optional<std::string> severity;
+  std::optional<std::string> context;
+};
+
+template <>
+inline constexpr auto dto_fields<LogQuery> =
+    std::make_tuple(field_enum("severity", &LogQuery::severity, kLogSeverityFilterValues,
+                               "Filter by minimum severity: debug, info, warning, error, or fatal"),
+                    field("context", &LogQuery::context, "Filter by logger context substring (max 256 chars)"));
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/query.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/query.hpp
@@ -1,0 +1,108 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Query-parameter contract: the fourth descriptor-driven visitor.
+//
+// A "query DTO" is a plain struct with a `dto_fields<T>` specialization whose
+// members are query-parameter scalars (string / bool, optionally wrapped in
+// std::optional). The same descriptor drives two sides so they cannot drift:
+//
+//   * QueryParamWriter<T> - emits the OpenAPI `parameters` array (all
+//     `in: query`) for the route, mirroring SchemaWriter.
+//   * TypedRequest::query<T>() (see http/typed_router.hpp) - parses the request
+//     query string into a typed T, using `assign_query_field` below.
+//
+// Because a handler can only read fields that exist on T, and those same fields
+// are what the spec advertises, a handler cannot read an undeclared query
+// parameter. Adding a parameter means adding a member - which appears in the
+// spec automatically.
+
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "ros2_medkit_gateway/dto/contract.hpp"
+#include "ros2_medkit_gateway/dto/schema_writer.hpp"
+
+namespace ros2_medkit_gateway {
+namespace dto {
+
+/// Unwrap std::optional<U> -> U, identity otherwise. Query-parameter optionality
+/// is expressed via `required:false`, not a nullable schema, so the emitted
+/// `schema` uses the unwrapped scalar type.
+template <class M>
+struct query_value {
+  using type = M;
+};
+template <class U>
+struct query_value<std::optional<U>> {
+  using type = U;
+};
+template <class M>
+using query_value_t = typename query_value<M>::type;
+
+/// Emits the OpenAPI `parameters` array (all `in: query`) for a query DTO `T`,
+/// derived from the same `dto_fields<T>` descriptor the typed reader consumes.
+template <class T>
+struct QueryParamWriter {
+  static nlohmann::json parameters() {
+    nlohmann::json params = nlohmann::json::array();
+    for_each_field<T>([&](const auto & f) {
+      using FieldT = std::decay_t<decltype(f)>;
+      static_assert(!is_opaque_object_field_v<FieldT>, "query DTOs must not contain opaque-object fields");
+      using MemberT = std::decay_t<decltype(std::declval<T>().*(f.ptr))>;
+
+      nlohmann::json param;
+      param["name"] = std::string(f.key);
+      param["in"] = "query";
+      param["required"] = (f.presence == Presence::kRequired);
+      if (!f.description.empty()) {
+        param["description"] = std::string(f.description);
+      }
+      nlohmann::json schema = schema_of<query_value_t<MemberT>>();
+      if (f.enum_count > 0) {
+        nlohmann::json values = nlohmann::json::array();
+        for (std::size_t i = 0; i < f.enum_count; ++i) {
+          values.push_back(std::string(f.enum_values[i]));
+        }
+        schema["enum"] = std::move(values);
+      }
+      param["schema"] = std::move(schema);
+      params.push_back(std::move(param));
+    });
+    return params;
+  }
+};
+
+/// Assigns a raw query-string value to a typed query-DTO member. Only the scalar
+/// shapes a query parameter can take are supported; any other field type is a
+/// compile error so unsupported types fail loudly at the route, not silently at
+/// runtime.
+template <class M>
+void assign_query_field(M & member, const std::string & raw) {
+  if constexpr (std::is_same_v<M, std::string> || std::is_same_v<M, std::optional<std::string>>) {
+    member = raw;
+  } else if constexpr (std::is_same_v<M, bool> || std::is_same_v<M, std::optional<bool>>) {
+    member = (raw == "true");
+  } else {
+    static_assert(sizeof(M) == 0, "assign_query_field: unsupported query field type");
+  }
+}
+
+}  // namespace dto
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/query.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/query.hpp
@@ -29,10 +29,22 @@
 // are what the spec advertises, a handler cannot read an undeclared query
 // parameter. Adding a parameter means adding a member - which appears in the
 // spec automatically.
+//
+// Scope of the guarantee: the descriptor binds parameter NAMES and PRESENCE -
+// those cannot drift between the spec and the parser. It does NOT police a
+// parameter's VALUE. The emitted `schema` (enum membership, type/format) is
+// advisory metadata; enforcing it (e.g. rejecting `?status=bogus`) is the
+// handler's job, where the richer 400 payload lives. To keep the two type
+// universes aligned, query fields are constrained at compile time to the scalar
+// shapes the parser supports (string / bool, optionally std::optional), and a
+// query parameter can never be `required` (the parser always tolerates absence,
+// leaving the member at its default).
 
+#include <cctype>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -56,16 +68,48 @@ struct query_value<std::optional<U>> {
 template <class M>
 using query_value_t = typename query_value<M>::type;
 
+/// The scalar shapes a query parameter may take (after std::optional unwrapping).
+/// This is the single source of truth shared by both sides of the contract: the
+/// reader (`assign_query_field`) parses exactly these, and the writer
+/// (`QueryParamWriter`) static_asserts every field against it - so the emitted
+/// schema can never advertise a type the parser would reject.
+template <class U>
+inline constexpr bool is_query_scalar_v = std::is_same_v<U, std::string> || std::is_same_v<U, bool>;
+
+/// True iff every field of the query DTO `T` is declared optional (never
+/// `Presence::kRequired`). The parser leaves absent parameters at their default
+/// and never rejects a missing query parameter, so a `required:true` parameter
+/// would be advertised but silently unenforced; this check makes that
+/// unrepresentable. Evaluated in a `static_assert` inside `QueryParamWriter`.
+template <class T>
+constexpr bool query_dto_all_optional() {
+  bool all_optional = true;
+  std::apply(
+      [&all_optional](const auto &... f) {
+        ((all_optional = all_optional && (f.presence != Presence::kRequired)), ...);
+      },
+      dto_fields<T>);
+  return all_optional;
+}
+
 /// Emits the OpenAPI `parameters` array (all `in: query`) for a query DTO `T`,
 /// derived from the same `dto_fields<T>` descriptor the typed reader consumes.
 template <class T>
 struct QueryParamWriter {
   static nlohmann::json parameters() {
+    static_assert(query_dto_all_optional<T>(),
+                  "query DTO fields must be optional: the parser tolerates absence and never enforces "
+                  "presence, so a required query parameter would be advertised but silently unenforced. "
+                  "Declare the member as std::optional<...> or pass Presence::kOptional.");
     nlohmann::json params = nlohmann::json::array();
     for_each_field<T>([&](const auto & f) {
       using FieldT = std::decay_t<decltype(f)>;
       static_assert(!is_opaque_object_field_v<FieldT>, "query DTOs must not contain opaque-object fields");
       using MemberT = std::decay_t<decltype(std::declval<T>().*(f.ptr))>;
+      static_assert(is_query_scalar_v<query_value_t<MemberT>>,
+                    "query DTO fields must be std::string or bool (optionally std::optional). The reader "
+                    "(assign_query_field) parses only these, so any other type would advertise a schema the "
+                    "parser cannot honour.");
 
       nlohmann::json param;
       param["name"] = std::string(f.key);
@@ -76,6 +120,8 @@ struct QueryParamWriter {
       }
       nlohmann::json schema = schema_of<query_value_t<MemberT>>();
       if (f.enum_count > 0) {
+        // Advisory only: the parser does not reject off-enum values (see the
+        // file header). The handler validates membership and owns the 400.
         nlohmann::json values = nlohmann::json::array();
         for (std::size_t i = 0; i < f.enum_count; ++i) {
           values.push_back(std::string(f.enum_values[i]));
@@ -89,18 +135,37 @@ struct QueryParamWriter {
   }
 };
 
+/// Parses a raw query-string value as a boolean, matching the `type: boolean`
+/// the schema advertises. `true`/`1` (case-insensitive) are truthy; every other
+/// value - including an empty flag-style `?x`, `false`, and `0` - is false. The
+/// parser does not reject malformed values (query parsing never 400s; see the
+/// file header), so a typo simply reads as false.
+inline bool parse_query_bool(const std::string & raw) {
+  std::string lowered;
+  lowered.reserve(raw.size());
+  for (char c : raw) {
+    lowered.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return lowered == "true" || lowered == "1";
+}
+
 /// Assigns a raw query-string value to a typed query-DTO member. Only the scalar
 /// shapes a query parameter can take are supported; any other field type is a
 /// compile error so unsupported types fail loudly at the route, not silently at
-/// runtime.
+/// runtime. `QueryParamWriter` static_asserts the same type set, so the schema
+/// and the parser can never advertise different shapes.
 template <class M>
 void assign_query_field(M & member, const std::string & raw) {
-  if constexpr (std::is_same_v<M, std::string> || std::is_same_v<M, std::optional<std::string>>) {
+  // Gate on the SAME trait QueryParamWriter enforces, so the reader and the
+  // schema writer can never advertise different type sets - is_query_scalar_v is
+  // the one source of truth, consulted by both sides.
+  static_assert(is_query_scalar_v<query_value_t<M>>,
+                "assign_query_field: unsupported query field type (expected std::string or bool, optionally "
+                "std::optional). is_query_scalar_v is the shared source of truth QueryParamWriter also enforces.");
+  if constexpr (std::is_same_v<query_value_t<M>, std::string>) {
     member = raw;
-  } else if constexpr (std::is_same_v<M, bool> || std::is_same_v<M, std::optional<bool>>) {
-    member = (raw == "true");
-  } else {
-    static_assert(sizeof(M) == 0, "assign_query_field: unsupported query field type");
+  } else {  // query_value_t<M> is bool, guaranteed by the static_assert above
+    member = parse_query_bool(raw);
   }
 }
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/updates.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/updates.hpp
@@ -289,5 +289,20 @@ inline constexpr auto dto_fields<UpdateRegisterResponse> = std::make_tuple(field
 template <>
 inline constexpr std::string_view dto_name<UpdateRegisterResponse> = "UpdateRegisterResponse";
 
+// =============================================================================
+// UpdateListQuery - query parameters for GET /updates. Read by the handler via
+// TypedRequest::query<UpdateListQuery>() and declared in the OpenAPI spec via
+// the same descriptor, so the two cannot drift.
+// =============================================================================
+struct UpdateListQuery {
+  std::optional<std::string> origin;
+  std::optional<std::string> target_version;
+};
+
+template <>
+inline constexpr auto dto_fields<UpdateListQuery> =
+    std::make_tuple(field("origin", &UpdateListQuery::origin, "Filter by update origin identifier"),
+                    field("target-version", &UpdateListQuery::target_version, "Filter by target version"));
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/typed_router.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/typed_router.hpp
@@ -21,6 +21,7 @@
 #include <string_view>
 
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/dto/query.hpp"
 // Re-export the httplib-free handler-result vocabulary so existing includers of
 // typed_router.hpp keep seeing Result/NoContent/Forwarded/ValidatorResult/
 // ResponseAttachments. The markers themselves live in this leaf header, which
@@ -92,6 +93,23 @@ class TypedRequest {
     }
     // NOLINTNEXTLINE(readability-redundant-string-cstr)
     return req_.get_param_value(name_str.c_str());
+  }
+
+  /// Parses the request's query string into a typed query DTO `T`, using the
+  /// same `dto_fields<T>` descriptor that declares the parameters in the OpenAPI
+  /// spec (via `dto::QueryParamWriter<T>`). Absent parameters leave their member
+  /// at its default. This is the sanctioned way for handlers to read query
+  /// parameters: a handler cannot read a parameter the route did not declare,
+  /// because it can only access members of `T`.
+  template <class T>
+  T query() const {
+    T out{};
+    dto::for_each_field<T>([&](const auto & f) {
+      if (auto raw = query_param(f.key)) {
+        dto::assign_query_field(out.*(f.ptr), *raw);
+      }
+    });
+    return out;
   }
 
   /// Returns the value of the named header, or std::nullopt if absent.

--- a/src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
+++ b/src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Asserts that HTTP handlers read query parameters ONLY through the typed
+# TypedRequest::query<T>() contract, never via raw req.query_param() or
+# get_param_value().
+#
+# Why: the typed path derives the OpenAPI `parameters` from the same query-DTO
+# descriptor (dto::QueryParamWriter<T>) that the handler parses. A raw read is
+# invisible to the spec, so the parameter never reaches the generated clients -
+# exactly the regression that left every query parameter out of the published
+# 0.5.0 clients. Forcing the typed path makes that drift impossible: a handler
+# can only read fields that exist on its query DTO, and those fields are what the
+# route declares.
+#
+# To add a query parameter: define a query DTO (struct + dto_fields), declare it
+# on the route with .query<T>(), and read it with req.query<T>(). See
+# include/ros2_medkit_gateway/dto/query.hpp.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HANDLERS_DIR="$(cd "${SCRIPT_DIR}/../src/http/handlers" && pwd)"
+
+# Path reads (req.path), header reads (req.header), and fan-out (raw_for_framework
+# for path/Authorization) are legitimate; only query-string reads are banned.
+pattern='\.query_param\(|->query_param\(|get_param_value\('
+
+hits="$(grep -rnE "${pattern}" "${HANDLERS_DIR}" --include='*.cpp' || true)"
+if [[ -n "${hits}" ]]; then
+  echo "ERROR: handlers must read query parameters via TypedRequest::query<T>(), not raw query reads."
+  echo "Offending lines:"
+  echo "${hits}"
+  echo
+  echo "Fix: define a query DTO (struct + dto_fields), declare it on the route with"
+  echo ".query<T>(), and read it via req.query<T>(). See dto/query.hpp."
+  exit 1
+fi
+
+echo "OK: handlers read query parameters only via the typed query<T>() contract."

--- a/src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
+++ b/src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
@@ -31,13 +31,55 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-HANDLERS_DIR="$(cd "${SCRIPT_DIR}/../src/http/handlers" && pwd)"
+
+# Handler layers to scan. Both the HTTP and the core handler layers are covered,
+# on the source side (src/.../handlers, the .cpp bodies) AND the include side
+# (include/.../handlers, where inline handler methods live in .hpp) - a raw read
+# hidden in a header or a second handler layer would otherwise bypass the gate.
+# The plugin HTTP shim (src/plugins/plugin_http_types.cpp) is intentionally NOT
+# scanned: it is the sanctioned raw-httplib boundary the typed wrapper is built on.
+scan_dirs=()
+for rel in \
+  "../src/http/handlers" \
+  "../src/core/http/handlers" \
+  "../include/ros2_medkit_gateway/http/handlers" \
+  "../include/ros2_medkit_gateway/core/http/handlers"; do
+  abs="${SCRIPT_DIR}/${rel}"
+  if [[ -d "${abs}" ]]; then
+    scan_dirs+=("$(cd "${abs}" && pwd)")
+  fi
+done
+
+if [[ ${#scan_dirs[@]} -eq 0 ]]; then
+  echo "ERROR: no handler directories found to scan under ${SCRIPT_DIR}/../src or ../include."
+  exit 1
+fi
 
 # Path reads (req.path), header reads (req.header), and fan-out (raw_for_framework
 # for path/Authorization) are legitimate; only query-string reads are banned.
-pattern='\.query_param\(|->query_param\(|get_param_value\('
+# Match the accessor name directly (not "req." + name) so whitespace tricks like
+# `req . query_param (` cannot slip past, and ban has_param() too - it is the
+# presence half of a raw query read.
+pattern='(query_param|get_param_value|has_param)[[:space:]]*\('
 
-hits="$(grep -rnE "${pattern}" "${HANDLERS_DIR}" --include='*.cpp' || true)"
+# Run the scan with grep's own status preserved: 0 = matches, 1 = none, >=2 = a
+# real error (unreadable file, bad path). A blanket `|| true` would mask exit 2
+# as "no matches", so an unscannable handler file would pass the gate silently;
+# treat >=2 as a hard failure of the gate itself instead.
+set +e
+raw_hits="$(grep -rnE "${pattern}" "${scan_dirs[@]}" --include='*.cpp' --include='*.hpp')"
+grep_rc=$?
+set -e
+if [[ ${grep_rc} -ge 2 ]]; then
+  echo "ERROR: grep failed (exit ${grep_rc}) while scanning handler dirs; cannot certify the gate."
+  exit 1
+fi
+
+# Heuristic: drop matches that sit in a whole-line // comment. Inline trailing
+# comments and block/string occurrences are not stripped (a grep-level lint
+# cannot parse C++), but those are rare and a stray mention in a comment is
+# better flagged than a real read silently missed.
+hits="$(printf '%s' "${raw_hits}" | grep -vE '^[^:]*:[0-9]+:[[:space:]]*//' || true)"
 if [[ -n "${hits}" ]]; then
   echo "ERROR: handlers must read query parameters via TypedRequest::query<T>(), not raw query reads."
   echo "Offending lines:"

--- a/src/ros2_medkit_gateway/src/core/openapi/route_registry.cpp
+++ b/src/ros2_medkit_gateway/src/core/openapi/route_registry.cpp
@@ -101,6 +101,13 @@ RouteEntry & RouteEntry::query_param(const std::string & name, const std::string
   return *this;
 }
 
+RouteEntry & RouteEntry::add_query_parameters(const nlohmann::json & params) {
+  for (const auto & param : params) {
+    parameters_.push_back(param);
+  }
+  return *this;
+}
+
 RouteEntry & RouteEntry::header_param(const std::string & name, const std::string & desc, bool required,
                                       const nlohmann::json & schema) {
   nlohmann::json param;

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -462,19 +462,18 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
       return tl::make_unexpected(err);
     }
 
-    const auto q = req.query<dto::FaultListQuery>();
+    const auto q = req.query<dto::FaultEntityListQuery>();
     auto filter_result = read_fault_status_filter(q.status, json{{entity_info.id_field, entity_id}});
     if (!filter_result) {
       return tl::make_unexpected(filter_result.error());
     }
     const auto filter = *filter_result;
 
-    // Note: include_muted / include_clusters URL params are intentionally
-    // ignored on per-entity routes - the underlying service returns
-    // correlation metadata computed across the entire fault manager, so
-    // emitting it on a scoped response would leak cross-entity data
-    // (review finding N1). The global `GET /faults` route is the only place
-    // these flags are honored.
+    // Note: the per-entity query DTO (FaultEntityListQuery) deliberately omits
+    // include_muted / include_clusters - the underlying service returns
+    // correlation metadata computed across the entire fault manager, so emitting
+    // it on a scoped response would leak cross-entity data. The global
+    // `GET /faults` route is the only place these flags are declared and honored.
 
     auto fault_mgr = ctx_.node()->get_fault_manager();
 

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -82,19 +82,15 @@ tl::expected<std::string, ErrorInfo> read_fault_code(const http::TypedRequest & 
 
 /// Build a populated FaultStatusFilter from query params, surfacing an
 /// ErrorInfo when the `status` value is unknown.
-tl::expected<FaultStatusFilter, ErrorInfo> read_fault_status_filter(const http::TypedRequest & req,
+tl::expected<FaultStatusFilter, ErrorInfo> read_fault_status_filter(const std::optional<std::string> & status,
                                                                     const json & extra_params = {}) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  const auto & raw_req = req.raw_for_framework();
-#pragma GCC diagnostic pop
-  auto filter = parse_fault_status_param(raw_req);
+  auto filter = parse_fault_status_param(status);
   if (filter.is_valid) {
     return filter;
   }
   json params{{"allowed_values", "pending, confirmed, cleared, healed, all"},
               {"parameter", "status"},
-              {"value", raw_req.get_param_value("status")}};
+              {"value", status.value_or("")}};
   if (extra_params.is_object()) {
     for (auto it = extra_params.begin(); it != extra_params.end(); ++it) {
       params[it.key()] = it.value();
@@ -349,20 +345,17 @@ dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_jso
 
 http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::TypedRequest & req) {
   try {
-    auto filter_result = read_fault_status_filter(req);
+    const auto q = req.query<dto::FaultListQuery>();
+    auto filter_result = read_fault_status_filter(q.status);
     if (!filter_result) {
       return tl::make_unexpected(filter_result.error());
     }
     const auto filter = *filter_result;
 
-    // Parse correlation query parameters
-    const bool include_muted = req.query_param("include_muted").value_or(std::string{}) == "true";
-    const bool include_clusters = req.query_param("include_clusters").value_or(std::string{}) == "true";
-
     auto fault_mgr = ctx_.node()->get_fault_manager();
     // Empty source_id = no filtering, return all faults
     auto result = fault_mgr->list_faults("", filter.include_pending, filter.include_confirmed, filter.include_cleared,
-                                         filter.include_healed, include_muted, include_clusters);
+                                         filter.include_healed, q.include_muted, q.include_clusters);
     if (!result.success) {
       return tl::make_unexpected(
           make_error(503, ERR_SERVICE_UNAVAILABLE, "Failed to get faults", json{{"details", result.error_message}}));
@@ -469,7 +462,8 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
       return tl::make_unexpected(err);
     }
 
-    auto filter_result = read_fault_status_filter(req, json{{entity_info.id_field, entity_id}});
+    const auto q = req.query<dto::FaultListQuery>();
+    auto filter_result = read_fault_status_filter(q.status, json{{entity_info.id_field, entity_id}});
     if (!filter_result) {
       return tl::make_unexpected(filter_result.error());
     }
@@ -967,7 +961,8 @@ http::Result<http::NoContent> FaultHandlers::clear_all_faults(const http::TypedR
 http::Result<std::pair<http::NoContent, http::ResponseAttachments>>
 FaultHandlers::clear_all_faults_global(const http::TypedRequest & req) {
   try {
-    auto filter_result = read_fault_status_filter(req);
+    const auto q = req.query<dto::FaultClearQuery>();
+    auto filter_result = read_fault_status_filter(q.status);
     if (!filter_result) {
       return tl::make_unexpected(filter_result.error());
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
@@ -112,8 +112,9 @@ LogHandlers::get_logs(const http::TypedRequest & req) {
   }
 
   // Validate optional query parameters (shared across all entity types)
-  const std::string min_severity = req.query_param("severity").value_or(std::string{});
-  const std::string context_filter = req.query_param("context").value_or(std::string{});
+  const auto q = req.query<dto::LogQuery>();
+  const std::string min_severity = q.severity.value_or(std::string{});
+  const std::string context_filter = q.context.value_or(std::string{});
 
   if (!min_severity.empty() && !LogManager::is_valid_severity(min_severity)) {
     return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER,

--- a/src/ros2_medkit_gateway/src/http/handlers/update_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/update_handlers.cpp
@@ -197,12 +197,13 @@ http::Result<dto::UpdateList> UpdateHandlers::get_updates(const http::TypedReque
     return tl::unexpected(*guard);
   }
   try {
+    const auto q = req.query<dto::UpdateListQuery>();
     UpdateFilter filter;
-    if (auto origin = req.query_param("origin")) {
-      filter.origin = *origin;
+    if (q.origin) {
+      filter.origin = *q.origin;
     }
-    if (auto target = req.query_param("target-version")) {
-      filter.target_version = *target;
+    if (q.target_version) {
+      filter.target_version = *q.target_version;
     }
 
     auto result = update_mgr_->list_updates(filter);

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -656,7 +656,7 @@ void RESTServer::setup_routes() {
         .summary(std::string("List faults for ") + et.singular)
         .description(std::string("Returns all active faults reported by this ") + et.singular + ".")
         .operation_id(std::string("list") + capitalize(et.singular) + "Faults")
-        .query<dto::FaultListQuery>();
+        .query<dto::FaultEntityListQuery>();
 
     reg.get<dto::FaultDetailResult>(entity_path + "/faults/{fault_code}",
                                     [this](http::TypedRequest req) -> http::Result<dto::FaultDetailResult> {

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -655,7 +655,8 @@ void RESTServer::setup_routes() {
         .tag("Faults")
         .summary(std::string("List faults for ") + et.singular)
         .description(std::string("Returns all active faults reported by this ") + et.singular + ".")
-        .operation_id(std::string("list") + capitalize(et.singular) + "Faults");
+        .operation_id(std::string("list") + capitalize(et.singular) + "Faults")
+        .query<dto::FaultListQuery>();
 
     reg.get<dto::FaultDetailResult>(entity_path + "/faults/{fault_code}",
                                     [this](http::TypedRequest req) -> http::Result<dto::FaultDetailResult> {
@@ -700,7 +701,8 @@ void RESTServer::setup_routes() {
         .tag("Logs")
         .summary(std::string("Query log entries for ") + et.singular)
         .description(std::string("Queries application log entries for this ") + et.singular + ".")
-        .operation_id(std::string("list") + capitalize(et.singular) + "Logs");
+        .operation_id(std::string("list") + capitalize(et.singular) + "Logs")
+        .query<dto::LogQuery>();
 
     reg.get<dto::LogConfiguration>(entity_path + "/logs/configuration",
                                    [this](http::TypedRequest req) -> http::Result<dto::LogConfiguration> {
@@ -1406,7 +1408,8 @@ void RESTServer::setup_routes() {
       .tag("Faults")
       .summary("List all faults globally")
       .description("Retrieve all faults across the system.")
-      .operation_id("listAllFaults");
+      .operation_id("listAllFaults")
+      .query<dto::FaultListQuery>();
 
   reg.del<http::NoContent>(
          "/faults",
@@ -1416,7 +1419,8 @@ void RESTServer::setup_routes() {
       .tag("Faults")
       .summary("Clear all faults globally")
       .description("Clears all faults across the entire system.")
-      .operation_id("clearAllFaults");
+      .operation_id("clearAllFaults")
+      .query<dto::FaultClearQuery>();
 
   // === Software Updates ===
   //
@@ -1451,7 +1455,8 @@ void RESTServer::setup_routes() {
       .tag("Updates")
       .summary("List software updates")
       .description("Lists all registered software updates.")
-      .operation_id("listUpdates");
+      .operation_id("listUpdates")
+      .query<dto::UpdateListQuery>();
 
   reg.post<dto::UpdateRegisterRequest, dto::UpdateRegisterResponse>(
          "/updates",

--- a/src/ros2_medkit_gateway/src/openapi/route_registry.hpp
+++ b/src/ros2_medkit_gateway/src/openapi/route_registry.hpp
@@ -32,6 +32,7 @@
 #include "ros2_medkit_gateway/dto/contract.hpp"
 #include "ros2_medkit_gateway/dto/json_reader.hpp"
 #include "ros2_medkit_gateway/dto/json_writer.hpp"
+#include "ros2_medkit_gateway/dto/query.hpp"
 #include "ros2_medkit_gateway/http/alternate_status.hpp"
 #include "ros2_medkit_gateway/http/detail/forward_response_scope.hpp"
 #include "ros2_medkit_gateway/http/detail/primitives.hpp"
@@ -78,6 +79,18 @@ class RouteEntry {
 
   RouteEntry & path_param(const std::string & name, const std::string & desc);
   RouteEntry & query_param(const std::string & name, const std::string & desc, const std::string & type = "string");
+
+  /// Appends a pre-built array of OpenAPI query parameter objects to this route.
+  RouteEntry & add_query_parameters(const nlohmann::json & params);
+
+  /// Typed query parameters: declares every member of the query DTO `T` as an
+  /// `in: query` parameter, derived from the same `dto_fields<T>` descriptor a
+  /// handler reads via `TypedRequest::query<T>()`. The declared parameters and
+  /// the parsed object cannot drift - both come from one descriptor.
+  template <class T>
+  RouteEntry & query() {
+    return add_query_parameters(dto::QueryParamWriter<T>::parameters());
+  }
   RouteEntry & header_param(const std::string & name, const std::string & desc, bool required = true,
                             const nlohmann::json & schema = {{"type", "string"}});
   RouteEntry & deprecated();

--- a/src/ros2_medkit_gateway/test/test_route_registry.cpp
+++ b/src/ros2_medkit_gateway/test/test_route_registry.cpp
@@ -54,6 +54,7 @@ inline constexpr std::string_view dto_name<RouteRegistryTestSeedDto> = "RouteReg
 }  // namespace ros2_medkit_gateway
 
 using namespace ros2_medkit_gateway::openapi;
+using ros2_medkit_gateway::dto::FaultEntityListQuery;
 using ros2_medkit_gateway::dto::FaultListQuery;
 using ros2_medkit_gateway::dto::RouteRegistryTestSeedDto;
 using ros2_medkit_gateway::http::Result;
@@ -208,6 +209,30 @@ TEST_F(RouteRegistryTest, TypedQueryDeclaresParametersFromDto) {
   ASSERT_NE(include_muted, nullptr);
   EXPECT_EQ((*include_muted)["schema"]["type"], "boolean");  // bool member, kOptional presence
   EXPECT_FALSE((*include_muted)["required"].get<bool>());
+}
+
+// @verifies REQ_INTEROP_002
+TEST_F(RouteRegistryTest, PerEntityFaultsQueryAdvertisesStatusOnly) {
+  // The per-entity /faults route uses the narrower FaultEntityListQuery so the
+  // spec advertises exactly what the handler reads: status only. The
+  // correlation flags (include_muted / include_clusters) are global-only, so
+  // they must NOT appear on the per-entity route.
+  seed_get(registry_, "/apps/{app_id}/faults").tag("Faults").query<FaultEntityListQuery>();
+
+  auto paths = registry_.to_openapi_paths();
+  ASSERT_TRUE(paths.contains("/apps/{app_id}/faults"));
+  auto & get_op = paths["/apps/{app_id}/faults"]["get"];
+  ASSERT_TRUE(get_op.contains("parameters"));
+
+  std::vector<std::string> query_names;
+  for (const auto & p : get_op["parameters"]) {
+    if (p["in"] == "query") {
+      query_names.push_back(p["name"].get<std::string>());
+    }
+  }
+
+  ASSERT_EQ(query_names.size(), 1u);
+  EXPECT_EQ(query_names[0], "status");
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_route_registry.cpp
+++ b/src/ros2_medkit_gateway/test/test_route_registry.cpp
@@ -25,6 +25,7 @@
 
 #include "../src/openapi/route_registry.hpp"
 #include "ros2_medkit_gateway/dto/contract.hpp"
+#include "ros2_medkit_gateway/dto/faults.hpp"
 #include "ros2_medkit_gateway/http/typed_router.hpp"
 
 // -----------------------------------------------------------------------------
@@ -53,6 +54,7 @@ inline constexpr std::string_view dto_name<RouteRegistryTestSeedDto> = "RouteReg
 }  // namespace ros2_medkit_gateway
 
 using namespace ros2_medkit_gateway::openapi;
+using ros2_medkit_gateway::dto::FaultListQuery;
 using ros2_medkit_gateway::dto::RouteRegistryTestSeedDto;
 using ros2_medkit_gateway::http::Result;
 using ros2_medkit_gateway::http::TypedRequest;
@@ -129,6 +131,83 @@ TEST_F(RouteRegistryTest, ToOpenapiPathsMultipleMethodsSamePath) {
   ASSERT_TRUE(paths.contains("/data"));
   EXPECT_TRUE(paths["/data"].contains("get"));
   EXPECT_TRUE(paths["/data"].contains("post"));
+}
+
+// @verifies REQ_INTEROP_002
+TEST_F(RouteRegistryTest, ToOpenapiPathsEmitsQueryParameters) {
+  seed_get(registry_, "/components/{component_id}/logs")
+      .tag("Logs")
+      .query_param("severity", "Filter by minimum severity")
+      .query_param("context", "Filter by logger context")
+      .query_param("include_muted", "Include muted entries", "boolean");
+
+  auto paths = registry_.to_openapi_paths();
+
+  ASSERT_TRUE(paths.contains("/components/{component_id}/logs"));
+  auto & get_op = paths["/components/{component_id}/logs"]["get"];
+  ASSERT_TRUE(get_op.contains("parameters"));
+
+  // Collect the query parameters by name (the path param is auto-generated).
+  std::vector<std::string> query_names;
+  const nlohmann::json * severity = nullptr;
+  const nlohmann::json * include_muted = nullptr;
+  for (const auto & p : get_op["parameters"]) {
+    if (p["in"] == "query") {
+      query_names.push_back(p["name"].get<std::string>());
+      if (p["name"] == "severity") {
+        severity = &p;
+      }
+      if (p["name"] == "include_muted") {
+        include_muted = &p;
+      }
+    }
+  }
+
+  EXPECT_EQ(query_names.size(), 3u);
+  ASSERT_NE(severity, nullptr);
+  EXPECT_EQ((*severity)["in"], "query");
+  EXPECT_FALSE((*severity)["required"].get<bool>());
+  EXPECT_EQ((*severity)["schema"]["type"], "string");
+  ASSERT_NE(include_muted, nullptr);
+  EXPECT_EQ((*include_muted)["schema"]["type"], "boolean");
+}
+
+// @verifies REQ_INTEROP_002
+TEST_F(RouteRegistryTest, TypedQueryDeclaresParametersFromDto) {
+  // .query<T>() derives the OpenAPI parameters straight from dto_fields<T> - the
+  // same descriptor a handler reads via TypedRequest::query<T>(), so the two
+  // cannot drift.
+  seed_get(registry_, "/faults").tag("Faults").query<FaultListQuery>();
+
+  auto paths = registry_.to_openapi_paths();
+  ASSERT_TRUE(paths.contains("/faults"));
+  auto & get_op = paths["/faults"]["get"];
+  ASSERT_TRUE(get_op.contains("parameters"));
+
+  const nlohmann::json * status = nullptr;
+  const nlohmann::json * include_muted = nullptr;
+  std::size_t query_count = 0;
+  for (const auto & p : get_op["parameters"]) {
+    if (p["in"] == "query") {
+      ++query_count;
+      if (p["name"] == "status") {
+        status = &p;
+      }
+      if (p["name"] == "include_muted") {
+        include_muted = &p;
+      }
+    }
+  }
+
+  // status + include_muted + include_clusters.
+  EXPECT_EQ(query_count, 3u);
+  ASSERT_NE(status, nullptr);
+  EXPECT_EQ((*status)["in"], "query");
+  EXPECT_FALSE((*status)["required"].get<bool>());  // optional<std::string> -> not required
+  EXPECT_EQ((*status)["schema"]["type"], "string");
+  ASSERT_NE(include_muted, nullptr);
+  EXPECT_EQ((*include_muted)["schema"]["type"], "boolean");  // bool member, kOptional presence
+  EXPECT_FALSE((*include_muted)["required"].get<bool>());
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_typed_router.cpp
+++ b/src/ros2_medkit_gateway/test/test_typed_router.cpp
@@ -183,6 +183,27 @@ TEST(TypedRouter_TypedRequest, TypedQueryLeavesAbsentParamsAtDefault) {
   EXPECT_FALSE(q.include_clusters);
 }
 
+TEST(TypedRouter_TypedRequest, TypedQueryParsesBooleanSpellings) {
+  // The schema advertises type: boolean; "true"/"1" (case-insensitive) are
+  // truthy, every other spelling - including "0", "false", and an empty
+  // flag-style value - parses as false.
+  auto parse_include_muted = [](const char * value) {
+    httplib::Request req;
+    req.path = "/api/v1/faults";
+    req.params.emplace("include_muted", value);
+    return TypedRequest(req).query<FaultListQuery>().include_muted;
+  };
+
+  EXPECT_TRUE(parse_include_muted("true"));
+  EXPECT_TRUE(parse_include_muted("TRUE"));
+  EXPECT_TRUE(parse_include_muted("True"));
+  EXPECT_TRUE(parse_include_muted("1"));
+  EXPECT_FALSE(parse_include_muted("false"));
+  EXPECT_FALSE(parse_include_muted("0"));
+  EXPECT_FALSE(parse_include_muted(""));
+  EXPECT_FALSE(parse_include_muted("yes"));
+}
+
 TEST(TypedRouter_TypedRequest, FanOutDisabledTrueOnlyWhenHeaderPresent) {
   {
     httplib::Request req;

--- a/src/ros2_medkit_gateway/test/test_typed_router.cpp
+++ b/src/ros2_medkit_gateway/test/test_typed_router.cpp
@@ -19,11 +19,13 @@
 #include <variant>
 
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/dto/faults.hpp"
 #include "ros2_medkit_gateway/http/typed_router.hpp"
 
 namespace {
 
 using ros2_medkit_gateway::ErrorInfo;
+using ros2_medkit_gateway::dto::FaultListQuery;
 using ros2_medkit_gateway::http::Forwarded;
 using ros2_medkit_gateway::http::NoContent;
 using ros2_medkit_gateway::http::ResponseAttachments;
@@ -154,6 +156,31 @@ TEST(TypedRouter_TypedRequest, QueryParamReturnsValueWhenPresent) {
   ASSERT_TRUE(wrapper.query_param("context").has_value());
   EXPECT_EQ(*wrapper.query_param("context"), "my.logger");
   EXPECT_FALSE(wrapper.query_param("limit").has_value());
+}
+
+TEST(TypedRouter_TypedRequest, TypedQueryParsesPresentParamsIntoDto) {
+  httplib::Request req;
+  req.path = "/api/v1/faults";
+  req.params.emplace("status", "confirmed");
+  req.params.emplace("include_muted", "true");
+  TypedRequest wrapper(req);
+
+  const auto q = wrapper.query<FaultListQuery>();
+  ASSERT_TRUE(q.status.has_value());
+  EXPECT_EQ(*q.status, "confirmed");
+  EXPECT_TRUE(q.include_muted);
+  EXPECT_FALSE(q.include_clusters);  // absent boolean -> default false
+}
+
+TEST(TypedRouter_TypedRequest, TypedQueryLeavesAbsentParamsAtDefault) {
+  httplib::Request req;
+  req.path = "/api/v1/faults";
+  TypedRequest wrapper(req);
+
+  const auto q = wrapper.query<FaultListQuery>();
+  EXPECT_FALSE(q.status.has_value());
+  EXPECT_FALSE(q.include_muted);
+  EXPECT_FALSE(q.include_clusters);
 }
 
 TEST(TypedRouter_TypedRequest, FanOutDisabledTrueOnlyWhenHeaderPresent) {


### PR DESCRIPTION
## Summary

Make query parameters a typed, descriptor-driven contract like request and response bodies, fixing the generated spec which carried zero query parameters.

Handlers read query parameters ad-hoc via `req.query_param()`, so the OpenAPI generator never saw them and the exported spec - and every client generated from it - had no query parameters even though the gateway reads them at runtime.

- `dto::QueryParamWriter<T>` emits the OpenAPI `parameters` (all `in: query`) for a query DTO from its `dto_fields`, mirroring `SchemaWriter`.
- `TypedRequest::query<T>()` parses the request query string into a typed query DTO via the same descriptor.
- `RouteEntry::query<T>()` declares those parameters on the route.

A handler can only read fields that exist on its query DTO, and those fields are exactly what the route advertises, so the parsed object and the spec cannot drift. Adding a parameter means adding a member - which appears in the spec automatically. A pre-commit guard bans raw query reads in handlers so the typed path is the only way in.

Applied to the endpoints whose handlers read query parameters:
- `GET /faults`, `GET /{entity}/faults`: `status`, `include_muted`, `include_clusters`
- `DELETE /faults`: `status`
- `GET /{entity}/logs`: `severity`, `context`
- `GET /updates`: `origin`, `target-version`

The exported spec now declares 26 query parameters (was 0).

---

## Issue

- closes #416

---

## Type

- [x] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- `colcon build` clean; gateway unit suite green, including new `RouteRegistry` test (typed `.query<T>()` emits the parameters) and `TypedRequest` tests (typed `query<T>()` parsing of present/absent params).
- End-to-end: ran the gateway and fetched `/api/v1/docs`; the spec now declares 26 `in: query` parameters across the faults/logs/updates endpoints with the correct schema types (string/boolean) and `required: false`.
- clang-format / clang-tidy clean on changed files; the new pre-commit guard passes.

---

## Checklist

- [x] Breaking changes are clearly described (none - additive query parameters)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed (the generated OpenAPI spec is the API surface; it now includes the query parameters)