### PR TITLE
feat(log_bridge): add /rosout to faults bridge

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -14,6 +14,8 @@ INPUT                  = ../src/ros2_medkit_gateway/include \
                          ../src/ros2_medkit_fault_reporter/src \
                          ../src/ros2_medkit_diagnostic_bridge/include \
                          ../src/ros2_medkit_diagnostic_bridge/src \
+                         ../src/ros2_medkit_log_bridge/include \
+                         ../src/ros2_medkit_log_bridge/src \
                          ../src/ros2_medkit_serialization/include \
                          ../src/ros2_medkit_serialization/src \
                          ../src/ros2_medkit_msgs

--- a/docs/api/cpp.rst
+++ b/docs/api/cpp.rst
@@ -83,6 +83,14 @@ Bridge node that converts ROS 2 /diagnostics messages to FaultManager faults.
 .. doxygenclass:: ros2_medkit_diagnostic_bridge::DiagnosticBridgeNode
    :members:
 
+ros2_medkit_log_bridge
+----------------------
+
+Bridge node that promotes ROS 2 /rosout log entries to FaultManager faults.
+
+.. doxygenclass:: ros2_medkit_log_bridge::LogBridgeNode
+   :members:
+
 ros2_medkit_serialization
 -------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ This page aggregates changelogs from all ros2_medkit packages.
 
 .. include:: ../src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
 
+.. include:: ../src/ros2_medkit_log_bridge/CHANGELOG.rst
+
 .. include:: ../src/ros2_medkit_serialization/CHANGELOG.rst
 
 .. include:: ../src/ros2_medkit_msgs/CHANGELOG.rst

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -59,6 +59,9 @@ ros2_medkit consists of several ROS 2 packages:
 **ros2_medkit_diagnostic_bridge**
    Bridge node that converts standard ROS 2 ``/diagnostics`` messages to fault manager faults.
 
+**ros2_medkit_log_bridge**
+   Bridge node that promotes ROS 2 ``/rosout`` log entries to fault manager faults.
+
 **ros2_medkit_msgs**
    Message and service definitions for fault management.
 

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -27,7 +27,9 @@
 #   ros2_medkit_topic_beacon:       110 - 119 (10 slots)
 #   ros2_medkit_graph_provider:     120 - 129 (10 slots)
 #   ros2_medkit_linux_introspection: 130 - 139 (10 slots)
-#   ros2_medkit_integration_tests:  140 - 219 (80 slots)
+#   ros2_medkit_integration_tests:  140 - 209 (70 slots)
+#   ros2_medkit_log_bridge:         210 - 214 (5 slots, carved from integration_tests)
+#   ros2_medkit_action_status_bridge: 215 - 219 (5 slots, carved from integration_tests)
 #   ros2_medkit_opcua:              220 - 229 (10 slots, carved from integration_tests)
 #   multi-domain tests (secondary): 230 - 232 (3 slots, reserved for peer_aggregation etc.)
 #

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -110,7 +110,7 @@ if(BUILD_TESTING)
   set(_INTEG_PORT 9100)
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 140 END 229)
+  medkit_init_test_domains(START 140 END 209)
 
   # Feature tests (atomic, independent, 120s timeout)
   file(GLOB FEATURE_TESTS test/features/*.test.py)

--- a/src/ros2_medkit_log_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_log_bridge/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros2_medkit_log_bridge
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release: promote ``/rosout`` log entries (WARN/ERROR/FATAL) to
+  FaultManager faults, attributed to the originating node via a per-source
+  FaultReporter, with auto-generated stable fault codes.

--- a/src/ros2_medkit_log_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_log_bridge/CMakeLists.txt
@@ -1,0 +1,114 @@
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.8)
+project(ros2_medkit_log_bridge)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(ros2_medkit_cmake REQUIRED)
+include(ROS2MedkitCcache)
+include(ROS2MedkitSanitizers)
+include(ROS2MedkitLinting)
+include(ROS2MedkitWarnings)
+
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+if(ENABLE_COVERAGE)
+  message(STATUS "Code coverage enabled")
+  add_compile_options(--coverage -O0 -g)
+  add_link_options(--coverage)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+include(ROS2MedkitCompat)
+
+find_package(rclcpp REQUIRED)
+find_package(rcl_interfaces REQUIRED)
+find_package(ros2_medkit_msgs REQUIRED)
+find_package(ros2_medkit_fault_reporter REQUIRED)
+
+# Library target (for testing)
+add_library(log_bridge_lib SHARED
+  src/log_bridge_node.cpp
+)
+
+target_include_directories(log_bridge_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+medkit_target_dependencies(log_bridge_lib
+  rclcpp
+  rcl_interfaces
+  ros2_medkit_msgs
+  ros2_medkit_fault_reporter
+)
+
+# Executable
+add_executable(log_bridge_node src/main.cpp)
+target_link_libraries(log_bridge_node log_bridge_lib)
+medkit_target_dependencies(log_bridge_node rclcpp)
+
+install(TARGETS log_bridge_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(TARGETS log_bridge_lib
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+install(DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp rcl_interfaces ros2_medkit_msgs ros2_medkit_fault_reporter)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  set(ament_cmake_clang_format_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify ament_cmake_cpplint ament_cmake_clang_tidy)
+  ament_lint_auto_find_test_dependencies()
+
+  ros2_medkit_clang_tidy()
+
+  include(ROS2MedkitTestDomain)
+  medkit_init_test_domains(START 90 END 99)
+
+  ament_add_gtest(test_log_bridge test/test_log_bridge.cpp)
+  target_link_libraries(test_log_bridge log_bridge_lib)
+  medkit_target_dependencies(test_log_bridge rclcpp rcl_interfaces ros2_medkit_msgs)
+  medkit_set_test_domain(test_log_bridge)
+
+  if(ENABLE_COVERAGE)
+    target_compile_options(test_log_bridge PRIVATE --coverage -O0 -g)
+    target_link_options(test_log_bridge PRIVATE --coverage)
+  endif()
+
+  ros2_medkit_relax_vendor_warnings()
+endif()
+
+ament_package()

--- a/src/ros2_medkit_log_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_log_bridge/CMakeLists.txt
@@ -88,6 +88,7 @@ ament_export_dependencies(rclcpp rcl_interfaces ros2_medkit_msgs ros2_medkit_fau
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
 
   set(ament_cmake_clang_format_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify ament_cmake_cpplint ament_cmake_clang_tidy)
@@ -96,7 +97,7 @@ if(BUILD_TESTING)
   ros2_medkit_clang_tidy()
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 90 END 99)
+  medkit_init_test_domains(START 210 END 214)
 
   ament_add_gtest(test_log_bridge test/test_log_bridge.cpp)
   target_link_libraries(test_log_bridge log_bridge_lib)
@@ -107,6 +108,16 @@ if(BUILD_TESTING)
     target_compile_options(test_log_bridge PRIVATE --coverage -O0 -g)
     target_link_options(test_log_bridge PRIVATE --coverage)
   endif()
+
+  # Integration test (launch_testing): fault_manager + bridge + synthetic /rosout
+  install(DIRECTORY test
+    DESTINATION share/${PROJECT_NAME}
+  )
+  add_launch_test(
+    test/test_integration.test.py
+    TARGET test_integration
+    TIMEOUT 90
+  )
 
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_log_bridge/README.md
+++ b/src/ros2_medkit_log_bridge/README.md
@@ -1,0 +1,65 @@
+# ros2_medkit_log_bridge
+
+Drop-in bridge that promotes ROS 2 `/rosout` log entries to structured medkit
+faults, attributing each fault to the node that logged it. No changes to the
+user's nodes are required.
+
+It is a compatibility adapter, the same category as
+`ros2_medkit_diagnostic_bridge`. Native `ros2_medkit_fault_reporter`
+instrumentation stays the canonical path for code you control; this bridge is
+the fallback for nodes that only log.
+
+## What it does
+
+Subscribes to `/rosout` (`rcl_interfaces/msg/Log`) and forwards entries at or
+above a severity floor to the FaultManager:
+
+| Log level | medkit severity |
+|-----------|-----------------|
+| DEBUG (10) / INFO (20) | dropped |
+| WARN (30) | `SEVERITY_WARN` |
+| ERROR (40) | `SEVERITY_ERROR` |
+| FATAL (50) | `SEVERITY_CRITICAL` |
+
+- `source_id` of each fault is the originating node (the `Log.name` field), via
+  a per-node `FaultReporter`, so faults attribute correctly and each node gets
+  its own local debounce.
+- `fault_code` is auto-generated as `<PREFIX>_<NODE>_<HASH>`, where the hash is
+  taken over a normalized message template (numbers / hex / paths stripped) so
+  the same logical message maps to the same code across occurrences.
+
+## WARN as PREFAILED
+
+The bridge forwards WARN immediately. Whether a WARN shows as `PREFAILED`
+(suspected, kept out of the confirmed-fault list) or `CONFIRMED` is decided by
+the FaultManager's `confirmation_threshold`, not the bridge. For the
+visible-but-quiet behaviour, launch the FaultManager with
+`confirmation_threshold:=-2` or lower (or an entity threshold for `LOG_*`
+codes). With the shipped default (`-1`), every WARN confirms on first
+occurrence.
+
+## Hard limitations (by construction)
+
+- Only sees logs that reach `/rosout` via rclcpp from a still-alive node.
+  Console-only loggers (e.g. some Micro XRCE-DDS / non-rclcpp loggers) are
+  invisible.
+- A node that crashes hard may not flush its final log to `/rosout`, so the
+  terminating ERROR can be missed. Process-death detection belongs to a
+  separate liveliness bridge, not here.
+
+## Run it
+
+```bash
+# next to an existing stack + the medkit gateway/fault_manager
+ros2 launch ros2_medkit_log_bridge log_bridge.launch.py
+```
+
+## Configuration (`config/log_bridge.yaml`)
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `rosout_topic` | `/rosout` | log topic to subscribe |
+| `severity_floor` | `30` (WARN) | minimum level promoted; raise to `40` on chatty / constrained targets |
+| `code_prefix` | `LOG` | prefix for generated fault codes |
+| `exclude_nodes` | `[]` | node-name substrings to skip |
+| `include_only_nodes` | `[]` | if set, only promote these nodes |

--- a/src/ros2_medkit_log_bridge/README.md
+++ b/src/ros2_medkit_log_bridge/README.md
@@ -21,22 +21,51 @@ above a severity floor to the FaultManager:
 | ERROR (40) | `SEVERITY_ERROR` |
 | FATAL (50) | `SEVERITY_CRITICAL` |
 
-- `source_id` of each fault is the originating node (the `Log.name` field), via
-  a per-node `FaultReporter`, so faults attribute correctly and each node gets
-  its own local debounce.
-- `fault_code` is auto-generated as `<PREFIX>_<NODE>_<HASH>`, where the hash is
-  taken over a normalized message template (numbers / hex / paths stripped) so
-  the same logical message maps to the same code across occurrences.
+- `source_id` of each fault is the originating node's fully-qualified name. It
+  is derived from `Log.name` by taking the first dotted segment (a `Log.name`
+  may carry a sub-logger suffix, e.g. `controller_manager.resource_manager`, and
+  node names cannot contain `.`) and prefixing `/`, giving e.g.
+  `/controller_manager`. The gateway discovers entities by node FQN, so this is
+  the form that lets a fault (and its snapshots / rosbag) associate with the
+  entity in the SOVD tree. Each node gets its own per-node `FaultReporter` and
+  therefore its own client-side debounce.
+- `fault_code` is auto-generated as `<PREFIX>_<NODE>_<HASH>`. `<HASH>` is a fixed
+  FNV-1a 32-bit digest (8 lowercase hex) of a normalized message template
+  (numbers / hex / paths stripped, isolated single-letter tokens dropped) so the
+  same logical message maps to the same code across occurrences. `<NODE>` is the
+  upper-snake of `source_id`. The 8-hex hash is never truncated; if the 64-char
+  cap is hit the node part is trimmed instead.
 
-## WARN as PREFAILED
+> Namespaced-node limitation: `Log.name` encodes a node's namespace with the same
+> `.` separator as a sub-logger suffix, so the two are indistinguishable from the
+> string alone. `source_id` takes the first dotted segment, which is right for a
+> non-namespaced node with a sub-logger but collapses a namespaced node
+> (`robot1.planner_server` -> `/robot1`) to its namespace, so same-named nodes in
+> different namespaces share one code. Multi-robot fleets typically isolate robots
+> by `ROS_DOMAIN_ID` (one gateway per robot, federated by peer aggregation), which
+> sidesteps this.
 
-The bridge forwards WARN immediately. Whether a WARN shows as `PREFAILED`
-(suspected, kept out of the confirmed-fault list) or `CONFIRMED` is decided by
-the FaultManager's `confirmation_threshold`, not the bridge. For the
-visible-but-quiet behaviour, launch the FaultManager with
-`confirmation_threshold:=-2` or lower (or an entity threshold for `LOG_*`
-codes). With the shipped default (`-1`), every WARN confirms on first
-occurrence.
+## Forwarding, the LocalFilter, and confirmation
+
+Two independent debounces sit between a log line and a confirmed fault:
+
+1. Per-node `FaultReporter` `LocalFilter` (client-side). WARN is held until
+   `default_threshold` (3) occurrences within `default_window_sec` (10s).
+   ERROR/FATAL have severity `>= bypass_severity` (2) and bypass the filter,
+   forwarding immediately.
+2. Bridge `report_cooldown_sec` cooldown, applied only to `ERROR`/`FATAL` (the
+   levels that bypass the LocalFilter). It forwards the first occurrence of a
+   `(fault_code, severity)` immediately and suppresses that same pair for
+   `report_cooldown_sec` (default 5s, `0.0` disables), bounding a flood. `WARN`
+   is never cooled here (that would starve its LocalFilter threshold counting),
+   and keying on severity means a `WARN` never suppresses a same-message `ERROR`
+   escalation.
+
+Whether a forwarded fault then shows as `PREFAILED` (suspected) or `CONFIRMED`
+is a separate, gateway-side decision driven by the FaultManager's
+`confirmation_threshold` - not by this bridge and not by the client-side
+LocalFilter. For visible-but-quiet WARNs, launch the FaultManager with a low
+`confirmation_threshold` (or an entity threshold for `LOG_*` codes).
 
 ## Hard limitations (by construction)
 
@@ -59,7 +88,14 @@ ros2 launch ros2_medkit_log_bridge log_bridge.launch.py
 | Param | Default | Meaning |
 |-------|---------|---------|
 | `rosout_topic` | `/rosout` | log topic to subscribe |
-| `severity_floor` | `30` (WARN) | minimum level promoted; raise to `40` on chatty / constrained targets |
-| `code_prefix` | `LOG` | prefix for generated fault codes |
-| `exclude_nodes` | `[]` | node-name substrings to skip |
-| `include_only_nodes` | `[]` | if set, only promote these nodes |
+| `severity_floor` | `30` (WARN) | minimum level promoted; raise to `40` on chatty / constrained targets. Clamped to `[0, 50]` at load (a value out of range is corrected with a warning) |
+| `code_prefix` | `LOG` | prefix for generated fault codes; normalized to `[A-Z0-9_]` at load |
+| `exclude_nodes` | `[]` | node-FQN substrings to skip |
+| `include_only_nodes` | `[]` | if set, only promote nodes whose FQN matches |
+| `max_tracked_nodes` | `512` | cap on per-node reporters; least-recently-used nodes evicted past this |
+| `report_cooldown_sec` | `5.0` | per-fault_code forward debounce; `0.0` disables |
+
+`exclude_nodes` / `include_only_nodes` match as **unanchored substrings**
+against the node FQN: `planner` matches `/planner_server` and
+`/robot1/planner_server`. Use a longer, more specific substring (e.g.
+`/planner_server`) to avoid accidental matches.

--- a/src/ros2_medkit_log_bridge/config/log_bridge.yaml
+++ b/src/ros2_medkit_log_bridge/config/log_bridge.yaml
@@ -1,0 +1,14 @@
+log_bridge:
+  ros__parameters:
+    # Topic carrying aggregated node logs.
+    rosout_topic: "/rosout"
+    # Minimum rcl_interfaces/msg/Log level promoted to a fault.
+    # 10=DEBUG 20=INFO 30=WARN 40=ERROR 50=FATAL. Default WARN.
+    # Raise to 40 (ERROR) on chatty / resource-constrained targets.
+    severity_floor: 30
+    # Prefix for auto-generated fault codes (<PREFIX>_<NODE>_<HASH>).
+    code_prefix: "LOG"
+    # Originating-node name substrings to skip (e.g. noisy debug nodes).
+    exclude_nodes: []
+    # If non-empty, ONLY promote logs from nodes matching these substrings.
+    include_only_nodes: []

--- a/src/ros2_medkit_log_bridge/config/log_bridge.yaml
+++ b/src/ros2_medkit_log_bridge/config/log_bridge.yaml
@@ -8,7 +8,14 @@ log_bridge:
     severity_floor: 30
     # Prefix for auto-generated fault codes (<PREFIX>_<NODE>_<HASH>).
     code_prefix: "LOG"
-    # Originating-node name substrings to skip (e.g. noisy debug nodes).
+    # Originating-node FQN substrings to skip (e.g. noisy debug nodes).
     exclude_nodes: []
     # If non-empty, ONLY promote logs from nodes matching these substrings.
     include_only_nodes: []
+    # Cap on per-node FaultReporters; least-recently-used nodes are evicted
+    # past this to bound memory under transient-node churn.
+    max_tracked_nodes: 512
+    # Per-fault_code forward debounce (seconds). First occurrence of a code is
+    # forwarded immediately; the same code within the window is suppressed.
+    # 0.0 disables. Tames ERROR/FATAL floods, which bypass the per-node filter.
+    report_cooldown_sec: 5.0

--- a/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
+++ b/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
@@ -1,0 +1,98 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/log.hpp"
+#include "ros2_medkit_fault_reporter/fault_reporter.hpp"
+
+namespace ros2_medkit_log_bridge {
+
+/// Bridge node that promotes ROS 2 /rosout log entries to FaultManager faults.
+///
+/// Subscribes to /rosout (rcl_interfaces/msg/Log) and forwards entries at or
+/// above a configurable severity floor to the FaultManager, attributing each
+/// fault to the originating node (the Log.name field) via a per-source
+/// FaultReporter. Drop-in compat adapter, same category as
+/// ros2_medkit_diagnostic_bridge: native FaultReporter instrumentation stays
+/// the canonical path; this bridge is the fallback for nodes that only log.
+/// Level mapping and the WARN-as-PREFAILED caveat are documented in README.md.
+///
+/// Hard limitation by construction: only sees rclcpp logs that reach /rosout
+/// from a still-alive node. Console-only loggers and crash-before-flush are out
+/// of reach.
+class LogBridgeNode : public rclcpp::Node {
+ public:
+  explicit LogBridgeNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  /// Map an rcl_interfaces/msg/Log level to a Fault severity.
+  /// Returns false when the level is below the floor / not promotable.
+  static bool map_level_to_severity(uint8_t log_level, uint8_t severity_floor, uint8_t * severity_out);
+
+  /// Auto-generate a stable fault code from the originating node name and the
+  /// log message. Numbers/hex/paths in the message are normalized away so the
+  /// same logical message maps to the same code across occurrences.
+  /// Format: <PREFIX>_<NODE>_<HASH>, clamped to medkit's [A-Z0-9_] / 64-char rule.
+  std::string generate_fault_code(const std::string & node_name, const std::string & message) const;
+
+  /// Normalize a log message into a stable template (lowercased, digit/hex/path
+  /// runs stripped, whitespace collapsed). Exposed for unit testing.
+  static std::string normalize_message(const std::string & message);
+
+  /// Whether a given originating node should be promoted, honouring the
+  /// include/exclude lists. Exposed for unit testing.
+  bool node_is_eligible(const std::string & node_name) const;
+
+  /// Map an rcl_interfaces/msg/Log.name (a logger name, e.g. "bt_navigator" or
+  /// "controller_manager.resource_manager") to the originating node's
+  /// fully-qualified name ("/bt_navigator", "/controller_manager"). The gateway
+  /// discovers runtime entities by node FQN, so the fault's source_id must use
+  /// the same form for faults (and their snapshots / rosbag) to associate with
+  /// the entity in the SOVD tree. Exposed for unit testing.
+  static std::string node_source_id(const std::string & log_name);
+
+ private:
+  void log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg);
+
+  /// Fetch (or lazily create) the per-source FaultReporter for an originating
+  /// node, so the fault's source_id is the node that logged, not the bridge.
+  ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & node_name);
+
+  void load_parameters();
+
+  static std::string to_upper_snake(const std::string & in, size_t max_len);
+
+  rclcpp::Subscription<rcl_interfaces::msg::Log>::SharedPtr log_sub_;
+
+  // One FaultReporter per originating node (correct source_id + own LocalFilter).
+  std::map<std::string, std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter>> reporters_;
+  std::mutex reporters_mutex_;
+
+  // Configuration
+  std::string rosout_topic_;
+  uint8_t severity_floor_;
+  std::string code_prefix_;
+  std::vector<std::string> exclude_nodes_;
+  std::vector<std::string> include_only_nodes_;
+  std::string own_node_name_;
+};
+
+}  // namespace ros2_medkit_log_bridge

--- a/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
+++ b/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <map>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
@@ -30,11 +31,11 @@ namespace ros2_medkit_log_bridge {
 ///
 /// Subscribes to /rosout (rcl_interfaces/msg/Log) and forwards entries at or
 /// above a configurable severity floor to the FaultManager, attributing each
-/// fault to the originating node (the Log.name field) via a per-source
+/// fault to the originating node's fully-qualified name via a per-source
 /// FaultReporter. Drop-in compat adapter, same category as
 /// ros2_medkit_diagnostic_bridge: native FaultReporter instrumentation stays
 /// the canonical path; this bridge is the fallback for nodes that only log.
-/// Level mapping and the WARN-as-PREFAILED caveat are documented in README.md.
+/// Level mapping and the WARN/LocalFilter caveat are documented in README.md.
 ///
 /// Hard limitation by construction: only sees rclcpp logs that reach /rosout
 /// from a still-alive node. Console-only loggers and crash-before-flush are out
@@ -47,19 +48,20 @@ class LogBridgeNode : public rclcpp::Node {
   /// Returns false when the level is below the floor / not promotable.
   static bool map_level_to_severity(uint8_t log_level, uint8_t severity_floor, uint8_t * severity_out);
 
-  /// Auto-generate a stable fault code from the originating node name and the
+  /// Auto-generate a stable fault code from the originating node's FQN and the
   /// log message. Numbers/hex/paths in the message are normalized away so the
   /// same logical message maps to the same code across occurrences.
   /// Format: <PREFIX>_<NODE>_<HASH>, clamped to medkit's [A-Z0-9_] / 64-char rule.
-  std::string generate_fault_code(const std::string & node_name, const std::string & message) const;
+  std::string generate_fault_code(const std::string & source_id, const std::string & message) const;
 
   /// Normalize a log message into a stable template (lowercased, digit/hex/path
-  /// runs stripped, whitespace collapsed). Exposed for unit testing.
+  /// runs stripped, whitespace collapsed, isolated single-letter tokens dropped).
+  /// Exposed for unit testing.
   static std::string normalize_message(const std::string & message);
 
   /// Whether a given originating node should be promoted, honouring the
   /// include/exclude lists. Exposed for unit testing.
-  bool node_is_eligible(const std::string & node_name) const;
+  bool node_is_eligible(const std::string & source_id) const;
 
   /// Map an rcl_interfaces/msg/Log.name (a logger name, e.g. "bt_navigator" or
   /// "controller_manager.resource_manager") to the originating node's
@@ -69,12 +71,26 @@ class LogBridgeNode : public rclcpp::Node {
   /// the entity in the SOVD tree. Exposed for unit testing.
   static std::string node_source_id(const std::string & log_name);
 
- private:
-  void log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg);
+  /// FNV-1a 32-bit hash, fixed spec, emitted as 8 lowercase hex chars. Exposed
+  /// for unit testing so a known input asserts a known constant.
+  static std::string fnv1a_hex(const std::string & in);
+
+  /// Whether a (fault_code, severity) may be forwarded now under the cooldown
+  /// (first occurrence passes; same code+severity within report_cooldown_sec is
+  /// suppressed; 0.0 disables). Keyed by severity so a WARN never suppresses a
+  /// same-message ERROR escalation. Exposed for unit testing.
+  bool cooldown_allows(const std::string & fault_code, uint8_t severity, rclcpp::Time now);
 
   /// Fetch (or lazily create) the per-source FaultReporter for an originating
   /// node, so the fault's source_id is the node that logged, not the bridge.
-  ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & node_name);
+  /// Bounded by max_tracked_nodes_ with LRU eviction. Exposed for unit testing.
+  ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & source_id);
+
+  /// Number of currently tracked per-node reporters. Exposed for unit testing.
+  size_t tracked_reporter_count();
+
+ private:
+  void log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg);
 
   void load_parameters();
 
@@ -82,9 +98,19 @@ class LogBridgeNode : public rclcpp::Node {
 
   rclcpp::Subscription<rcl_interfaces::msg::Log>::SharedPtr log_sub_;
 
-  // One FaultReporter per originating node (correct source_id + own LocalFilter).
-  std::map<std::string, std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter>> reporters_;
+  // One FaultReporter per originating node (correct source_id + own LocalFilter),
+  // LRU-ordered: front() is the least-recently-used entry.
+  struct ReporterEntry {
+    std::string source_id;
+    std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter> reporter;
+  };
+  std::list<ReporterEntry> reporters_lru_;
+  std::unordered_map<std::string, std::list<ReporterEntry>::iterator> reporters_;
   std::mutex reporters_mutex_;
+
+  // Per-fault_code forward cooldown: last time a code was forwarded.
+  std::unordered_map<std::string, rclcpp::Time> last_forward_;
+  std::mutex cooldown_mutex_;
 
   // Configuration
   std::string rosout_topic_;
@@ -92,6 +118,8 @@ class LogBridgeNode : public rclcpp::Node {
   std::string code_prefix_;
   std::vector<std::string> exclude_nodes_;
   std::vector<std::string> include_only_nodes_;
+  int max_tracked_nodes_;
+  double report_cooldown_sec_;
   std::string own_node_name_;
 };
 

--- a/src/ros2_medkit_log_bridge/launch/log_bridge.launch.py
+++ b/src/ros2_medkit_log_bridge/launch/log_bridge.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    config_file = os.path.join(
+        get_package_share_directory('ros2_medkit_log_bridge'),
+        'config',
+        'log_bridge.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='ros2_medkit_log_bridge',
+            executable='log_bridge_node',
+            name='log_bridge',
+            output='screen',
+            parameters=[config_file],
+        ),
+    ])

--- a/src/ros2_medkit_log_bridge/package.xml
+++ b/src/ros2_medkit_log_bridge/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_medkit_log_bridge</name>
+  <version>0.5.0</version>
+  <description>Bridge node promoting ROS2 /rosout log entries to FaultManager faults</description>
+
+  <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ros2_medkit_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rcl_interfaces</depend>
+  <depend>ros2_medkit_msgs</depend>
+  <depend>ros2_medkit_fault_reporter</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_clang_tidy</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>ros2_medkit_fault_manager</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_log_bridge/log_bridge_node.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <functional>
+
+#include "ros2_medkit_msgs/msg/fault.hpp"
+
+namespace ros2_medkit_log_bridge {
+
+namespace {
+
+// rcl_interfaces/msg/Log severity levels.
+constexpr uint8_t kLevelDebug = 10;
+constexpr uint8_t kLevelInfo = 20;
+constexpr uint8_t kLevelWarn = 30;
+constexpr uint8_t kLevelError = 40;
+constexpr uint8_t kLevelFatal = 50;
+
+bool contains_substr(const std::vector<std::string> & list, const std::string & value) {
+  for (const auto & item : list) {
+    if (!item.empty() && value.find(item) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+LogBridgeNode::LogBridgeNode(const rclcpp::NodeOptions & options) : Node("log_bridge", options) {
+  load_parameters();
+  own_node_name_ = get_fully_qualified_name();
+
+  // /rosout is published reliable+volatile; keep a deep queue so log bursts at
+  // fault time are not dropped before the bridge processes them.
+  log_sub_ = create_subscription<rcl_interfaces::msg::Log>(
+      rosout_topic_, rclcpp::QoS(rclcpp::KeepLast(1000)),
+      [this](const rcl_interfaces::msg::Log::ConstSharedPtr & msg) { log_callback(msg); });
+
+  RCLCPP_INFO(get_logger(), "LogBridge started (topic=%s, severity_floor=%u, prefix=%s)", rosout_topic_.c_str(),
+              static_cast<unsigned>(severity_floor_), code_prefix_.c_str());
+}
+
+void LogBridgeNode::load_parameters() {
+  rosout_topic_ = declare_parameter<std::string>("rosout_topic", "/rosout");
+  // Default floor is WARN: WARN lands as PREFAILED (with a low FaultManager
+  // confirmation_threshold), ERROR/FATAL confirm. Raise to 40 (ERROR) on
+  // chatty / constrained targets to cut volume.
+  severity_floor_ = static_cast<uint8_t>(declare_parameter<int>("severity_floor", kLevelWarn));
+  code_prefix_ = declare_parameter<std::string>("code_prefix", "LOG");
+  exclude_nodes_ = declare_parameter<std::vector<std::string>>("exclude_nodes", std::vector<std::string>{});
+  include_only_nodes_ =
+      declare_parameter<std::vector<std::string>>("include_only_nodes", std::vector<std::string>{});
+}
+
+void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg) {
+  // Never promote our own logs (avoids any self-referential loop).
+  if (msg->name == own_node_name_ || msg->name == "log_bridge") {
+    return;
+  }
+  if (!node_is_eligible(msg->name)) {
+    return;
+  }
+
+  uint8_t severity = 0;
+  if (!map_level_to_severity(msg->level, severity_floor_, &severity)) {
+    return;  // below floor / INFO / DEBUG -> dropped
+  }
+
+  const std::string fault_code = generate_fault_code(msg->name, msg->msg);
+  // Attribute to the node FQN so the fault associates with the gateway's
+  // runtime-discovered entity (and its snapshots/rosbag become reachable).
+  auto * reporter = reporter_for(node_source_id(msg->name));
+  if (reporter == nullptr) {
+    return;
+  }
+  reporter->report(fault_code, severity, msg->msg);
+  RCLCPP_DEBUG(get_logger(), "Log %s [lvl=%u] '%s' -> fault %s (severity=%u)", msg->name.c_str(),
+               static_cast<unsigned>(msg->level), msg->msg.c_str(), fault_code.c_str(),
+               static_cast<unsigned>(severity));
+}
+
+std::string LogBridgeNode::node_source_id(const std::string & log_name) {
+  // The logger name is the node name, optionally with a sub-logger suffix after
+  // '.' (node names themselves cannot contain '.'), so the first dotted segment
+  // is the node. Prefix '/' to form the FQN the gateway's entity discovery uses.
+  std::string node = log_name.substr(0, log_name.find('.'));
+  if (node.empty()) {
+    node = log_name;
+  }
+  if (node.empty() || node.front() != '/') {
+    node = "/" + node;
+  }
+  return node;
+}
+
+bool LogBridgeNode::node_is_eligible(const std::string & node_name) const {
+  if (!include_only_nodes_.empty() && !contains_substr(include_only_nodes_, node_name)) {
+    return false;
+  }
+  if (contains_substr(exclude_nodes_, node_name)) {
+    return false;
+  }
+  return true;
+}
+
+ros2_medkit_fault_reporter::FaultReporter * LogBridgeNode::reporter_for(const std::string & node_name) {
+  std::lock_guard<std::mutex> lock(reporters_mutex_);
+  auto it = reporters_.find(node_name);
+  if (it != reporters_.end()) {
+    return it->second.get();
+  }
+  // source_id is the ORIGINATING node so faults are attributed correctly.
+  // Multiple FaultReporters on one node are safe: the ctor guards parameter
+  // declaration with has_parameter().
+  auto reporter =
+      std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), node_name);
+  auto * raw = reporter.get();
+  reporters_.emplace(node_name, std::move(reporter));
+  return raw;
+}
+
+bool LogBridgeNode::map_level_to_severity(uint8_t log_level, uint8_t severity_floor, uint8_t * severity_out) {
+  using Fault = ros2_medkit_msgs::msg::Fault;
+  if (log_level < severity_floor || log_level <= kLevelInfo) {
+    return false;
+  }
+  switch (log_level) {
+    case kLevelWarn:
+      *severity_out = Fault::SEVERITY_WARN;
+      return true;
+    case kLevelError:
+      *severity_out = Fault::SEVERITY_ERROR;
+      return true;
+    case kLevelFatal:
+      *severity_out = Fault::SEVERITY_CRITICAL;
+      return true;
+    default:
+      // Unknown level >= floor and above INFO: treat as ERROR rather than drop.
+      *severity_out = Fault::SEVERITY_ERROR;
+      return true;
+  }
+}
+
+std::string LogBridgeNode::normalize_message(const std::string & message) {
+  // Collapse anything that varies per-occurrence (numbers, hex, paths) so the
+  // same logical message hashes to the same code. Keep only lowercase letters
+  // and single spaces between word runs.
+  std::string out;
+  out.reserve(message.size());
+  bool last_space = true;
+  for (char c : message) {
+    const auto uc = static_cast<unsigned char>(c);
+    if (std::isalpha(uc)) {
+      out += static_cast<char>(std::tolower(uc));
+      last_space = false;
+    } else {
+      // digits, punctuation, slashes, whitespace -> a single separator space
+      if (!last_space) {
+        out += ' ';
+        last_space = true;
+      }
+    }
+  }
+  // trim trailing space
+  if (!out.empty() && out.back() == ' ') {
+    out.pop_back();
+  }
+  return out;
+}
+
+std::string LogBridgeNode::to_upper_snake(const std::string & in, size_t max_len) {
+  std::string result;
+  result.reserve(in.size());
+  bool last_sep = true;
+  for (char c : in) {
+    const auto uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc)) {
+      result += static_cast<char>(std::toupper(uc));
+      last_sep = false;
+    } else if (!last_sep) {
+      result += '_';
+      last_sep = true;
+    }
+  }
+  while (!result.empty() && result.back() == '_') {
+    result.pop_back();
+  }
+  if (result.size() > max_len) {
+    result.resize(max_len);
+    while (!result.empty() && result.back() == '_') {
+      result.pop_back();
+    }
+  }
+  return result;
+}
+
+std::string LogBridgeNode::generate_fault_code(const std::string & node_name, const std::string & message) const {
+  // Node basename (drop namespace), upper-snake, length-capped.
+  std::string base = node_name;
+  const auto slash = base.find_last_of('/');
+  if (slash != std::string::npos) {
+    base = base.substr(slash + 1);
+  }
+  const std::string node_part = to_upper_snake(base, 32);
+
+  // Stable 8-hex-char hash of the normalized message template.
+  const std::string templ = normalize_message(message);
+  const std::size_t h = std::hash<std::string>{}(templ);
+  char hashbuf[9];
+  std::snprintf(hashbuf, sizeof(hashbuf), "%08X", static_cast<unsigned>(h & 0xFFFFFFFFu));
+
+  std::string code = code_prefix_;
+  if (!node_part.empty()) {
+    code += '_';
+    code += node_part;
+  }
+  code += '_';
+  code += hashbuf;
+
+  if (code.size() > 64) {
+    code.resize(64);
+  }
+  return code;
+}
+
+}  // namespace ros2_medkit_log_bridge

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -17,7 +17,9 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
-#include <functional>
+#include <cstdio>
+#include <iterator>
+#include <utility>
 
 #include "ros2_medkit_msgs/msg/fault.hpp"
 
@@ -50,8 +52,9 @@ LogBridgeNode::LogBridgeNode(const rclcpp::NodeOptions & options) : Node("log_br
   // /rosout is published reliable+volatile; keep a deep queue so log bursts at
   // fault time are not dropped before the bridge processes them.
   log_sub_ = create_subscription<rcl_interfaces::msg::Log>(
-      rosout_topic_, rclcpp::QoS(rclcpp::KeepLast(1000)),
-      [this](const rcl_interfaces::msg::Log::ConstSharedPtr & msg) { log_callback(msg); });
+      rosout_topic_, rclcpp::QoS(rclcpp::KeepLast(1000)), [this](const rcl_interfaces::msg::Log::ConstSharedPtr & msg) {
+        log_callback(msg);
+      });
 
   RCLCPP_INFO(get_logger(), "LogBridge started (topic=%s, severity_floor=%u, prefix=%s)", rosout_topic_.c_str(),
               static_cast<unsigned>(severity_floor_), code_prefix_.c_str());
@@ -59,22 +62,44 @@ LogBridgeNode::LogBridgeNode(const rclcpp::NodeOptions & options) : Node("log_br
 
 void LogBridgeNode::load_parameters() {
   rosout_topic_ = declare_parameter<std::string>("rosout_topic", "/rosout");
-  // Default floor is WARN: WARN lands as PREFAILED (with a low FaultManager
-  // confirmation_threshold), ERROR/FATAL confirm. Raise to 40 (ERROR) on
-  // chatty / constrained targets to cut volume.
-  severity_floor_ = static_cast<uint8_t>(declare_parameter<int>("severity_floor", kLevelWarn));
-  code_prefix_ = declare_parameter<std::string>("code_prefix", "LOG");
+  // Default floor is WARN. WARN passes through each node's FaultReporter
+  // LocalFilter (threshold/window debounce); ERROR/FATAL bypass it. Raise to 40
+  // (ERROR) on chatty / constrained targets to cut volume.
+  const int floor = declare_parameter<int>("severity_floor", kLevelWarn);
+  // int -> uint8_t silently wraps; clamp so a bad value cannot pass everything.
+  if (floor < 0 || floor > kLevelFatal) {
+    RCLCPP_WARN(get_logger(), "severity_floor=%d out of range [0,%u], clamping", floor,
+                static_cast<unsigned>(kLevelFatal));
+  }
+  severity_floor_ = static_cast<uint8_t>(std::clamp(floor, 0, static_cast<int>(kLevelFatal)));
+  // Normalize the prefix so a non-conforming value cannot yield a fault_code
+  // violating medkit's [A-Z0-9_] charset.
+  code_prefix_ = to_upper_snake(declare_parameter<std::string>("code_prefix", "LOG"), 32);
+  if (code_prefix_.empty()) {
+    code_prefix_ = "LOG";
+  }
   exclude_nodes_ = declare_parameter<std::vector<std::string>>("exclude_nodes", std::vector<std::string>{});
-  include_only_nodes_ =
-      declare_parameter<std::vector<std::string>>("include_only_nodes", std::vector<std::string>{});
+  include_only_nodes_ = declare_parameter<std::vector<std::string>>("include_only_nodes", std::vector<std::string>{});
+  max_tracked_nodes_ = declare_parameter<int>("max_tracked_nodes", 512);
+  if (max_tracked_nodes_ < 1) {
+    max_tracked_nodes_ = 1;
+  }
+  report_cooldown_sec_ = declare_parameter<double>("report_cooldown_sec", 5.0);
+  if (report_cooldown_sec_ < 0.0) {
+    report_cooldown_sec_ = 0.0;
+  }
 }
 
 void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg) {
+  // Resolve the FQN once and use it for code-gen, eligibility, self-exclusion,
+  // and reporter source_id so they cannot disagree.
+  const std::string source_id = node_source_id(msg->name);
+
   // Never promote our own logs (avoids any self-referential loop).
-  if (msg->name == own_node_name_ || msg->name == "log_bridge") {
+  if (source_id == own_node_name_ || source_id == "/log_bridge") {
     return;
   }
-  if (!node_is_eligible(msg->name)) {
+  if (!node_is_eligible(source_id)) {
     return;
   }
 
@@ -83,10 +108,19 @@ void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr 
     return;  // below floor / INFO / DEBUG -> dropped
   }
 
-  const std::string fault_code = generate_fault_code(msg->name, msg->msg);
+  const std::string fault_code = generate_fault_code(source_id, msg->msg);
+
+  // ERROR/FATAL bypass each node's LocalFilter and forward immediately, so bound
+  // a same-code flood here. WARN is left to the LocalFilter (cooling it would
+  // starve its threshold counting). Keyed by severity so a WARN never suppresses
+  // a same-message ERROR escalation.
+  if (severity >= ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR && !cooldown_allows(fault_code, severity, now())) {
+    return;
+  }
+
   // Attribute to the node FQN so the fault associates with the gateway's
   // runtime-discovered entity (and its snapshots/rosbag become reachable).
-  auto * reporter = reporter_for(node_source_id(msg->name));
+  auto * reporter = reporter_for(source_id);
   if (reporter == nullptr) {
     return;
   }
@@ -100,6 +134,9 @@ std::string LogBridgeNode::node_source_id(const std::string & log_name) {
   // The logger name is the node name, optionally with a sub-logger suffix after
   // '.' (node names themselves cannot contain '.'), so the first dotted segment
   // is the node. Prefix '/' to form the FQN the gateway's entity discovery uses.
+  // Caveat: a namespaced node dots its namespace too (robot1.planner_server),
+  // indistinguishable from a sub-logger, so this collapses it to '/robot1'.
+  // See README (namespaced-node limitation).
   std::string node = log_name.substr(0, log_name.find('.'));
   if (node.empty()) {
     node = log_name;
@@ -110,33 +147,70 @@ std::string LogBridgeNode::node_source_id(const std::string & log_name) {
   return node;
 }
 
-bool LogBridgeNode::node_is_eligible(const std::string & node_name) const {
-  if (!include_only_nodes_.empty() && !contains_substr(include_only_nodes_, node_name)) {
+bool LogBridgeNode::node_is_eligible(const std::string & source_id) const {
+  if (!include_only_nodes_.empty() && !contains_substr(include_only_nodes_, source_id)) {
     return false;
   }
-  if (contains_substr(exclude_nodes_, node_name)) {
+  if (contains_substr(exclude_nodes_, source_id)) {
     return false;
   }
   return true;
 }
 
-ros2_medkit_fault_reporter::FaultReporter * LogBridgeNode::reporter_for(const std::string & node_name) {
+bool LogBridgeNode::cooldown_allows(const std::string & fault_code, uint8_t severity, rclcpp::Time now) {
+  if (report_cooldown_sec_ <= 0.0) {
+    return true;
+  }
+  const std::string key = fault_code + ":" + std::to_string(static_cast<unsigned>(severity));
+  const auto window = rclcpp::Duration::from_seconds(report_cooldown_sec_);
+  std::lock_guard<std::mutex> lock(cooldown_mutex_);
+  auto it = last_forward_.find(key);
+  if (it != last_forward_.end() && (now - it->second) < window) {
+    return false;
+  }
+  // Drop entries past their window so the map stays bounded by active codes.
+  for (auto e = last_forward_.begin(); e != last_forward_.end();) {
+    e = (e->first != key && (now - e->second) >= window) ? last_forward_.erase(e) : std::next(e);
+  }
+  last_forward_[key] = now;
+  return true;
+}
+
+ros2_medkit_fault_reporter::FaultReporter * LogBridgeNode::reporter_for(const std::string & source_id) {
   std::lock_guard<std::mutex> lock(reporters_mutex_);
-  auto it = reporters_.find(node_name);
+  auto it = reporters_.find(source_id);
   if (it != reporters_.end()) {
-    return it->second.get();
+    // Touch: move to the back (most-recently-used).
+    reporters_lru_.splice(reporters_lru_.end(), reporters_lru_, it->second);
+    return it->second->reporter.get();
   }
   // source_id is the ORIGINATING node so faults are attributed correctly.
   // Multiple FaultReporters on one node are safe: the ctor guards parameter
   // declaration with has_parameter().
-  auto reporter =
-      std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), node_name);
+  auto reporter = std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), source_id);
   auto * raw = reporter.get();
-  reporters_.emplace(node_name, std::move(reporter));
+  reporters_lru_.push_back(ReporterEntry{source_id, std::move(reporter)});
+  reporters_[source_id] = std::prev(reporters_lru_.end());
+
+  // Cap the map: evict the least-recently-used node to bound growth under churn.
+  if (static_cast<int>(reporters_lru_.size()) > max_tracked_nodes_) {
+    RCLCPP_WARN_ONCE(get_logger(), "max_tracked_nodes (%d) reached; evicting least-recently-used reporters",
+                     max_tracked_nodes_);
+    reporters_.erase(reporters_lru_.front().source_id);
+    reporters_lru_.pop_front();
+  }
   return raw;
 }
 
+size_t LogBridgeNode::tracked_reporter_count() {
+  std::lock_guard<std::mutex> lock(reporters_mutex_);
+  return reporters_.size();
+}
+
 bool LogBridgeNode::map_level_to_severity(uint8_t log_level, uint8_t severity_floor, uint8_t * severity_out) {
+  if (severity_out == nullptr) {
+    return false;
+  }
   using Fault = ros2_medkit_msgs::msg::Fault;
   if (log_level < severity_floor || log_level <= kLevelInfo) {
     return false;
@@ -182,7 +256,38 @@ std::string LogBridgeNode::normalize_message(const std::string & message) {
   if (!out.empty() && out.back() == ' ') {
     out.pop_back();
   }
-  return out;
+
+  // Drop isolated single-letter tokens (e.g. "host A" / "host B" enumerations)
+  // so an otherwise-identical message does not fragment into many codes.
+  std::string filtered;
+  filtered.reserve(out.size());
+  size_t i = 0;
+  while (i < out.size()) {
+    size_t j = out.find(' ', i);
+    if (j == std::string::npos) {
+      j = out.size();
+    }
+    if (j - i > 1) {
+      if (!filtered.empty()) {
+        filtered += ' ';
+      }
+      filtered.append(out, i, j - i);
+    }
+    i = j + 1;
+  }
+  return filtered;
+}
+
+std::string LogBridgeNode::fnv1a_hex(const std::string & in) {
+  // FNV-1a 32-bit, fixed spec: offset basis 2166136261, prime 16777619.
+  uint32_t h = 2166136261u;
+  for (char c : in) {
+    h ^= static_cast<uint8_t>(c);
+    h *= 16777619u;
+  }
+  char buf[9];
+  std::snprintf(buf, sizeof(buf), "%08x", h);
+  return std::string(buf);
 }
 
 std::string LogBridgeNode::to_upper_snake(const std::string & in, size_t max_len) {
@@ -211,32 +316,44 @@ std::string LogBridgeNode::to_upper_snake(const std::string & in, size_t max_len
   return result;
 }
 
-std::string LogBridgeNode::generate_fault_code(const std::string & node_name, const std::string & message) const {
-  // Node basename (drop namespace), upper-snake, length-capped.
-  std::string base = node_name;
-  const auto slash = base.find_last_of('/');
-  if (slash != std::string::npos) {
-    base = base.substr(slash + 1);
+std::string LogBridgeNode::generate_fault_code(const std::string & source_id, const std::string & message) const {
+  // Node part: fold the namespace into one token so /robot1/planner_server and
+  // /robot2/planner_server do not collide. Leading '/' is dropped by
+  // to_upper_snake (treated as a separator), '/'-separated segments join with '_'.
+  std::string node_part = to_upper_snake(source_id, 48);
+
+  // Stable 8-hex-char hash of the normalized message template. An all-punct /
+  // all-digit / empty message normalizes to "" -> substitute a sentinel so such
+  // entries do not all collapse onto one hash-of-"" code.
+  std::string templ = normalize_message(message);
+  if (templ.empty()) {
+    templ = "_NOMSG";
   }
-  const std::string node_part = to_upper_snake(base, 32);
+  const std::string hashpart = fnv1a_hex(templ);
 
-  // Stable 8-hex-char hash of the normalized message template.
-  const std::string templ = normalize_message(message);
-  const std::size_t h = std::hash<std::string>{}(templ);
-  char hashbuf[9];
-  std::snprintf(hashbuf, sizeof(hashbuf), "%08X", static_cast<unsigned>(h & 0xFFFFFFFFu));
-
+  // Budget from the hash inward: the 8-hex hash and its '_' separators are
+  // sacred (never truncated); trim the node part to fit 64 chars.
+  // 64 - prefix - '_' - '_' - 8(hash)
   std::string code = code_prefix_;
+  const size_t fixed = code.size() + 2 + hashpart.size();  // prefix + 2 separators + hash
+  if (fixed >= 64) {
+    // Prefix alone (plus hash) already at budget; keep prefix + hash only.
+    return code + '_' + hashpart;
+  }
+  const size_t node_budget = 64 - fixed;
+  if (node_part.size() > node_budget) {
+    node_part.resize(node_budget);
+    while (!node_part.empty() && node_part.back() == '_') {
+      node_part.pop_back();
+    }
+  }
+
   if (!node_part.empty()) {
     code += '_';
     code += node_part;
   }
   code += '_';
-  code += hashbuf;
-
-  if (code.size() > 64) {
-    code.resize(64);
-  }
+  code += hashpart;
   return code;
 }
 

--- a/src/ros2_medkit_log_bridge/src/main.cpp
+++ b/src/ros2_medkit_log_bridge/src/main.cpp
@@ -1,0 +1,24 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_medkit_log_bridge/log_bridge_node.hpp"
+
+int main(int argc, char * argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ros2_medkit_log_bridge::LogBridgeNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/ros2_medkit_log_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_log_bridge/test/test_integration.test.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end integration tests for ros2_medkit_log_bridge (/rosout -> fault)."""
+
+import time
+import unittest
+
+from launch import LaunchDescription
+import launch_ros.actions
+import launch_testing.actions
+import launch_testing.markers
+from rcl_interfaces.msg import Log
+import rclpy
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ListFaults
+
+# rcl_interfaces/msg/Log levels are 'byte'-typed constants (Python bytes in
+# rclpy), so use plain ints for the uint8 'level' field.
+LOG_INFO = 20
+LOG_WARN = 30
+LOG_ERROR = 40
+
+
+def generate_test_description():
+    """Launch description with fault_manager and log_bridge nodes."""
+    fault_manager_node = launch_ros.actions.Node(
+        package='ros2_medkit_fault_manager',
+        executable='fault_manager_node',
+        name='fault_manager',
+        output='screen',
+        parameters=[{
+            'storage_type': 'memory',
+            'confirmation_threshold': -1,  # immediate confirmation
+            'healing_enabled': True,
+            'healing_threshold': 1,
+        }],
+    )
+
+    log_bridge_node = launch_ros.actions.Node(
+        package='ros2_medkit_log_bridge',
+        executable='log_bridge_node',
+        name='log_bridge',
+        output='screen',
+        parameters=[{
+            'rosout_topic': '/rosout',
+            'report_cooldown_sec': 0.0,  # no bridge cooldown in the test
+        }],
+    )
+
+    return (
+        LaunchDescription([
+            fault_manager_node,
+            log_bridge_node,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'fault_manager_node': fault_manager_node,
+            'log_bridge_node': log_bridge_node,
+        },
+    )
+
+
+class TestLogBridgeIntegration(unittest.TestCase):
+    """End-to-end /rosout -> fault tests."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node('test_log_bridge_client')
+        cls.rosout_pub = cls.node.create_publisher(Log, '/rosout', 10)
+        cls.list_faults_client = cls.node.create_client(
+            ListFaults, '/fault_manager/list_faults'
+        )
+        assert cls.list_faults_client.wait_for_service(timeout_sec=10.0), \
+            'ListFaults service not available'
+        time.sleep(1.0)  # let the bridge connect
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def list_faults(self, statuses=None):
+        request = ListFaults.Request()
+        request.filter_by_severity = False
+        request.statuses = statuses or []
+        future = self.list_faults_client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=5.0)
+        return future.result().faults
+
+    def publish_log(self, node_name, level, message):
+        msg = Log()
+        msg.stamp = self.node.get_clock().now().to_msg()
+        msg.level = level
+        msg.name = node_name
+        msg.msg = message
+        self.rosout_pub.publish(msg)
+        time.sleep(0.4)
+
+    def find_fault(self, faults, code_prefix):
+        return next((f for f in faults if f.fault_code.startswith(code_prefix)), None)
+
+    def wait_for_fault(self, code_prefix, timeout=12.0):
+        """Poll list_faults until a fault with the given code prefix appears."""
+        deadline = time.time() + timeout
+        fault = None
+        while time.time() < deadline:
+            fault = self.find_fault(self.list_faults(), code_prefix)
+            if fault is not None:
+                return fault
+            time.sleep(0.5)
+        return fault
+
+    def test_01_error_log_creates_attributed_fault(self):
+        """An ERROR log becomes a CONFIRMED fault attributed to the node FQN."""
+        self.publish_log('planner_server', LOG_ERROR, 'failed to compute path')
+
+        fault = self.wait_for_fault('LOG_PLANNER_SERVER_')
+        self.assertIsNotNone(fault, 'expected a LOG_PLANNER_SERVER_* fault')
+        self.assertEqual(fault.severity, Fault.SEVERITY_ERROR)
+        # The fault must associate with the node FQN, not the raw logger name.
+        self.assertIn('/planner_server', list(fault.reporting_sources))
+
+    def test_02_warn_log_needs_threshold(self):
+        """A single WARN is held by the LocalFilter; repeats promote it."""
+        self.publish_log('controller', LOG_WARN, 'goal tolerance exceeded')
+        time.sleep(1.0)
+        self.assertIsNone(
+            self.find_fault(self.list_faults(), 'LOG_CONTROLLER_'),
+            'a single WARN should be held by the LocalFilter')
+
+        # default_threshold is 3 within default_window_sec; send enough repeats.
+        for _ in range(3):
+            self.publish_log('controller', LOG_WARN, 'goal tolerance exceeded')
+
+        fault = self.wait_for_fault('LOG_CONTROLLER_')
+        self.assertIsNotNone(fault, 'repeated WARN should promote to a fault')
+        self.assertEqual(fault.severity, Fault.SEVERITY_WARN)
+
+    def test_03_info_log_dropped(self):
+        """INFO is below the floor and never becomes a fault."""
+        self.publish_log('chatter', LOG_INFO, 'all good')
+        time.sleep(1.5)  # settle; a promoted fault would have appeared by now
+        self.assertIsNone(self.find_fault(self.list_faults(), 'LOG_CHATTER_'))
+
+
+@launch_testing.post_shutdown_test()
+class TestLogBridgeShutdown(unittest.TestCase):
+    """Test clean shutdown."""
+
+    def test_exit_code(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
+++ b/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
@@ -1,0 +1,151 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_log_bridge/log_bridge_node.hpp"
+#include "ros2_medkit_msgs/msg/fault.hpp"
+
+using Fault = ros2_medkit_msgs::msg::Fault;
+using ros2_medkit_log_bridge::LogBridgeNode;
+
+namespace {
+constexpr uint8_t kDebug = 10;
+constexpr uint8_t kInfo = 20;
+constexpr uint8_t kWarn = 30;
+constexpr uint8_t kError = 40;
+constexpr uint8_t kFatal = 50;
+}  // namespace
+
+class LogBridgeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+  }
+  void TearDown() override {
+    rclcpp::shutdown();
+  }
+};
+
+// --- Level -> severity mapping (default floor WARN) ---
+
+TEST_F(LogBridgeTest, MapLevel_DebugAndInfoDropped) {
+  uint8_t sev = 255;
+  EXPECT_FALSE(LogBridgeNode::map_level_to_severity(kDebug, kWarn, &sev));
+  EXPECT_FALSE(LogBridgeNode::map_level_to_severity(kInfo, kWarn, &sev));
+}
+
+TEST_F(LogBridgeTest, MapLevel_WarnErrorFatal) {
+  uint8_t sev = 255;
+  ASSERT_TRUE(LogBridgeNode::map_level_to_severity(kWarn, kWarn, &sev));
+  EXPECT_EQ(sev, Fault::SEVERITY_WARN);
+  ASSERT_TRUE(LogBridgeNode::map_level_to_severity(kError, kWarn, &sev));
+  EXPECT_EQ(sev, Fault::SEVERITY_ERROR);
+  ASSERT_TRUE(LogBridgeNode::map_level_to_severity(kFatal, kWarn, &sev));
+  EXPECT_EQ(sev, Fault::SEVERITY_CRITICAL);
+}
+
+TEST_F(LogBridgeTest, MapLevel_FloorRaisedToError) {
+  // With floor=ERROR, WARN is dropped, ERROR/FATAL still pass.
+  uint8_t sev = 255;
+  EXPECT_FALSE(LogBridgeNode::map_level_to_severity(kWarn, kError, &sev));
+  ASSERT_TRUE(LogBridgeNode::map_level_to_severity(kError, kError, &sev));
+  EXPECT_EQ(sev, Fault::SEVERITY_ERROR);
+}
+
+TEST_F(LogBridgeTest, MapLevel_UnknownAboveFloorTreatedAsError) {
+  uint8_t sev = 255;
+  ASSERT_TRUE(LogBridgeNode::map_level_to_severity(45, kWarn, &sev));
+  EXPECT_EQ(sev, Fault::SEVERITY_ERROR);
+}
+
+// --- Message normalization (stable template across varying numbers) ---
+
+TEST_F(LogBridgeTest, NormalizeMessage_StripsNumbersAndPunctuation) {
+  // Same logical message with different numbers must normalize identically.
+  const auto a = LogBridgeNode::normalize_message("worldToMap failed: mx,my: 2200,2200");
+  const auto b = LogBridgeNode::normalize_message("worldToMap failed: mx,my: 1500,1500");
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a, "worldtomap failed mx my");
+}
+
+TEST_F(LogBridgeTest, NormalizeMessage_CollapsesNumbersAndHex) {
+  // Same device, differing only in the trailing index and the hex errno:
+  // both collapse to the same template.
+  const auto a = LogBridgeNode::normalize_message("Failed to open /dev/ttyACM0 (errno 0x19)");
+  const auto b = LogBridgeNode::normalize_message("Failed to open /dev/ttyACM5 (errno 0x05)");
+  EXPECT_EQ(a, b);
+  // A genuinely different device name stays distinct (ACM vs USB are not noise).
+  const auto c = LogBridgeNode::normalize_message("Failed to open /dev/ttyUSB0 (errno 0x19)");
+  EXPECT_NE(a, c);
+}
+
+// --- Fault-code generation ---
+
+TEST_F(LogBridgeTest, GenerateFaultCode_StableAndWellFormed) {
+  auto node = std::make_shared<LogBridgeNode>();
+  const auto c1 = node->generate_fault_code("/planner_server", "failed to create plan to (100.0, 100.0)");
+  const auto c2 = node->generate_fault_code("/planner_server", "failed to create plan to (5.0, 5.0)");
+  // Same node + same template -> same code regardless of the coordinates.
+  EXPECT_EQ(c1, c2);
+  // Prefix + node basename present, charset respected, length bounded.
+  EXPECT_EQ(c1.rfind("LOG_PLANNER_SERVER_", 0), 0u);
+  EXPECT_LE(c1.size(), 64u);
+  for (char ch : c1) {
+    const bool ok = (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_';
+    EXPECT_TRUE(ok) << "bad char in fault_code: " << ch;
+  }
+}
+
+TEST_F(LogBridgeTest, GenerateFaultCode_DifferentMessagesDiffer) {
+  auto node = std::make_shared<LogBridgeNode>();
+  const auto a = node->generate_fault_code("/ctrl", "command interface not available");
+  const auto b = node->generate_fault_code("/ctrl", "could not find controller");
+  EXPECT_NE(a, b);
+}
+
+// --- Node eligibility (include/exclude) ---
+
+TEST_F(LogBridgeTest, NodeEligibility_DefaultAllows) {
+  auto node = std::make_shared<LogBridgeNode>();
+  EXPECT_TRUE(node->node_is_eligible("/any_node"));
+}
+
+// --- source_id normalization to node FQN (entity association) ---
+
+TEST_F(LogBridgeTest, NodeSourceId_PrependsLeadingSlash) {
+  EXPECT_EQ(LogBridgeNode::node_source_id("bt_navigator"), "/bt_navigator");
+  EXPECT_EQ(LogBridgeNode::node_source_id("planner_server"), "/planner_server");
+}
+
+TEST_F(LogBridgeTest, NodeSourceId_KeepsExistingSlash) {
+  EXPECT_EQ(LogBridgeNode::node_source_id("/amcl"), "/amcl");
+}
+
+TEST_F(LogBridgeTest, NodeSourceId_StripsSubLoggerSuffix) {
+  // A logger name with a sub-logger suffix maps to the node FQN.
+  EXPECT_EQ(LogBridgeNode::node_source_id("controller_manager.resource_manager"),
+            "/controller_manager");
+}
+
+TEST_F(LogBridgeTest, NodeCreation) {
+  auto node = std::make_shared<LogBridgeNode>();
+  EXPECT_NE(node, nullptr);
+  EXPECT_STREQ(node->get_name(), "log_bridge");
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
+++ b/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
@@ -26,6 +26,24 @@ constexpr uint8_t kInfo = 20;
 constexpr uint8_t kWarn = 30;
 constexpr uint8_t kError = 40;
 constexpr uint8_t kFatal = 50;
+
+// The trailing "_<8 hex>" hash segment is lowercase hex by spec; the prefix and
+// node parts must be [A-Z0-9_]. Validate accordingly.
+void ExpectWellFormed(const std::string & code) {
+  ASSERT_GE(code.size(), 9u);  // at least "_<8hex>"
+  const size_t hash_start = code.size() - 8;
+  ASSERT_EQ(code[hash_start - 1], '_');
+  for (size_t i = 0; i < hash_start - 1; ++i) {
+    const char ch = code[i];
+    const bool ok = (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_';
+    EXPECT_TRUE(ok) << "bad char in fault_code prefix/node: " << ch;
+  }
+  for (size_t i = hash_start; i < code.size(); ++i) {
+    const char ch = code[i];
+    const bool ok = (ch >= 'a' && ch <= 'f') || (ch >= '0' && ch <= '9');
+    EXPECT_TRUE(ok) << "bad char in fault_code hash: " << ch;
+  }
+}
 }  // namespace
 
 class LogBridgeTest : public ::testing::Test {
@@ -35,6 +53,13 @@ class LogBridgeTest : public ::testing::Test {
   }
   void TearDown() override {
     rclcpp::shutdown();
+  }
+
+  // Build a node with parameter overrides (declare_parameter reads these).
+  static std::shared_ptr<LogBridgeNode> make_node_with(const std::vector<rclcpp::Parameter> & overrides) {
+    rclcpp::NodeOptions opts;
+    opts.parameter_overrides(overrides);
+    return std::make_shared<LogBridgeNode>(opts);
   }
 };
 
@@ -77,6 +102,7 @@ TEST_F(LogBridgeTest, NormalizeMessage_StripsNumbersAndPunctuation) {
   const auto a = LogBridgeNode::normalize_message("worldToMap failed: mx,my: 2200,2200");
   const auto b = LogBridgeNode::normalize_message("worldToMap failed: mx,my: 1500,1500");
   EXPECT_EQ(a, b);
+  // mx/my are two-char tokens, kept; numbers and punctuation gone.
   EXPECT_EQ(a, "worldtomap failed mx my");
 }
 
@@ -91,6 +117,29 @@ TEST_F(LogBridgeTest, NormalizeMessage_CollapsesNumbersAndHex) {
   EXPECT_NE(a, c);
 }
 
+TEST_F(LogBridgeTest, NormalizeMessage_DropsIsolatedSingleLetters) {
+  // "host A" vs "host B" must normalize to the same template (single letters dropped).
+  const auto a = LogBridgeNode::normalize_message("connection lost to host A");
+  const auto b = LogBridgeNode::normalize_message("connection lost to host B");
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a, "connection lost to host");
+}
+
+TEST_F(LogBridgeTest, NormalizeMessage_EmptyForAllPunctOrDigits) {
+  EXPECT_EQ(LogBridgeNode::normalize_message(""), "");
+  EXPECT_EQ(LogBridgeNode::normalize_message("12345"), "");
+  EXPECT_EQ(LogBridgeNode::normalize_message("--- 0x1f ::"), "");
+}
+
+// --- Stable hash (fixed FNV-1a spec, known constant) ---
+
+TEST_F(LogBridgeTest, Fnv1aHex_KnownConstants) {
+  // Fixed FNV-1a 32-bit, 8 lowercase hex. Constants are part of the contract.
+  EXPECT_EQ(LogBridgeNode::fnv1a_hex(""), "811c9dc5");
+  EXPECT_EQ(LogBridgeNode::fnv1a_hex("a"), "e40c292c");
+  EXPECT_EQ(LogBridgeNode::fnv1a_hex("foobar"), "bf9cf968");
+}
+
 // --- Fault-code generation ---
 
 TEST_F(LogBridgeTest, GenerateFaultCode_StableAndWellFormed) {
@@ -102,10 +151,15 @@ TEST_F(LogBridgeTest, GenerateFaultCode_StableAndWellFormed) {
   // Prefix + node basename present, charset respected, length bounded.
   EXPECT_EQ(c1.rfind("LOG_PLANNER_SERVER_", 0), 0u);
   EXPECT_LE(c1.size(), 64u);
-  for (char ch : c1) {
-    const bool ok = (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_';
-    EXPECT_TRUE(ok) << "bad char in fault_code: " << ch;
-  }
+  ExpectWellFormed(c1);
+}
+
+TEST_F(LogBridgeTest, GenerateFaultCode_KnownConstant) {
+  auto node = std::make_shared<LogBridgeNode>();
+  // Pin the full code for a fixed input: hash of normalize_message("oops 42") =
+  // hash of "oops" since the digits drop. fnv1a_hex("oops") asserted below.
+  const std::string expected_hash = LogBridgeNode::fnv1a_hex("oops");
+  EXPECT_EQ(node->generate_fault_code("/ctrl", "oops 42"), "LOG_CTRL_" + expected_hash);
 }
 
 TEST_F(LogBridgeTest, GenerateFaultCode_DifferentMessagesDiffer) {
@@ -115,11 +169,54 @@ TEST_F(LogBridgeTest, GenerateFaultCode_DifferentMessagesDiffer) {
   EXPECT_NE(a, b);
 }
 
+TEST_F(LogBridgeTest, GenerateFaultCode_EmptyMessageGetsSentinel) {
+  auto node = std::make_shared<LogBridgeNode>();
+  // All-punct and empty messages share the _NOMSG sentinel hash, but two
+  // genuinely different real messages must not collide with it.
+  const auto a = node->generate_fault_code("/ctrl", "");
+  const auto b = node->generate_fault_code("/ctrl", "!!!");
+  const auto real = node->generate_fault_code("/ctrl", "actual failure");
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, real);
+}
+
+TEST_F(LogBridgeTest, GenerateFaultCode_NamespaceDisambiguates) {
+  auto node = std::make_shared<LogBridgeNode>();
+  // Same node name under different namespaces must not collide.
+  const auto a = node->generate_fault_code("/robot1/planner_server", "no plan");
+  const auto b = node->generate_fault_code("/robot2/planner_server", "no plan");
+  EXPECT_NE(a, b);
+  EXPECT_EQ(a.rfind("LOG_ROBOT1_PLANNER_SERVER_", 0), 0u);
+  EXPECT_EQ(b.rfind("LOG_ROBOT2_PLANNER_SERVER_", 0), 0u);
+}
+
+TEST_F(LogBridgeTest, GenerateFaultCode_NeverTruncatesHash_LongNode) {
+  auto node = std::make_shared<LogBridgeNode>();
+  const std::string long_ns = "/" + std::string(200, 'x') + "/planner_server";
+  const auto code = node->generate_fault_code(long_ns, "boom");
+  EXPECT_LE(code.size(), 64u);
+  ExpectWellFormed(code);
+  // The full 8-hex hash survives intact at the tail.
+  EXPECT_EQ(code.substr(code.size() - 8), LogBridgeNode::fnv1a_hex("boom"));
+}
+
 // --- Node eligibility (include/exclude) ---
 
 TEST_F(LogBridgeTest, NodeEligibility_DefaultAllows) {
   auto node = std::make_shared<LogBridgeNode>();
   EXPECT_TRUE(node->node_is_eligible("/any_node"));
+}
+
+TEST_F(LogBridgeTest, NodeEligibility_ExcludeSubstring) {
+  auto node = make_node_with({rclcpp::Parameter("exclude_nodes", std::vector<std::string>{"chatty"})});
+  EXPECT_FALSE(node->node_is_eligible("/chatty_logger"));
+  EXPECT_TRUE(node->node_is_eligible("/planner_server"));
+}
+
+TEST_F(LogBridgeTest, NodeEligibility_IncludeOnlySubstring) {
+  auto node = make_node_with({rclcpp::Parameter("include_only_nodes", std::vector<std::string>{"planner"})});
+  EXPECT_TRUE(node->node_is_eligible("/planner_server"));
+  EXPECT_FALSE(node->node_is_eligible("/amcl"));
 }
 
 // --- source_id normalization to node FQN (entity association) ---
@@ -135,8 +232,71 @@ TEST_F(LogBridgeTest, NodeSourceId_KeepsExistingSlash) {
 
 TEST_F(LogBridgeTest, NodeSourceId_StripsSubLoggerSuffix) {
   // A logger name with a sub-logger suffix maps to the node FQN.
-  EXPECT_EQ(LogBridgeNode::node_source_id("controller_manager.resource_manager"),
-            "/controller_manager");
+  EXPECT_EQ(LogBridgeNode::node_source_id("controller_manager.resource_manager"), "/controller_manager");
+}
+
+// --- Per-code forward cooldown ---
+
+TEST_F(LogBridgeTest, Cooldown_FirstPassesThenSuppressedThenReopens) {
+  auto node = std::make_shared<LogBridgeNode>();
+  const rclcpp::Time t0(0, 0, RCL_ROS_TIME);
+  // First occurrence forwarded; same code+severity within the 5s window suppressed.
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0));
+  EXPECT_FALSE(
+      node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0 + rclcpp::Duration::from_seconds(1.0)));
+  // A different code is independent.
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_bbbb2222", Fault::SEVERITY_ERROR, t0 + rclcpp::Duration::from_seconds(1.0)));
+  // After the window the original code reopens.
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0 + rclcpp::Duration::from_seconds(6.0)));
+}
+
+TEST_F(LogBridgeTest, Cooldown_KeyedBySeverity_EscalationNotSuppressed) {
+  auto node = std::make_shared<LogBridgeNode>();
+  const rclcpp::Time t0(0, 0, RCL_ROS_TIME);
+  // A same-code escalation to a higher severity is a distinct (code, severity)
+  // and must pass even within the window.
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0));
+  EXPECT_TRUE(
+      node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_CRITICAL, t0 + rclcpp::Duration::from_seconds(1.0)));
+  // ...but a repeat of the same (code, severity) is still bounded.
+  EXPECT_FALSE(
+      node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0 + rclcpp::Duration::from_seconds(1.0)));
+}
+
+TEST_F(LogBridgeTest, Cooldown_ZeroDisables) {
+  auto node = make_node_with({rclcpp::Parameter("report_cooldown_sec", 0.0)});
+  const rclcpp::Time t0(0, 0, RCL_ROS_TIME);
+  // With cooldown disabled, every occurrence passes.
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0));
+  EXPECT_TRUE(node->cooldown_allows("LOG_X_aaaa1111", Fault::SEVERITY_ERROR, t0));
+}
+
+// --- Per-node reporter lifecycle (reuse + bounded LRU eviction) ---
+
+TEST_F(LogBridgeTest, ReporterReuse_SameSourceReturnsSameInstance) {
+  auto node = std::make_shared<LogBridgeNode>();
+  auto * a = node->reporter_for("/planner_server");
+  auto * b = node->reporter_for("/planner_server");
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(node->tracked_reporter_count(), 1u);
+  auto * c = node->reporter_for("/amcl");
+  EXPECT_NE(a, c);
+  EXPECT_EQ(node->tracked_reporter_count(), 2u);
+}
+
+TEST_F(LogBridgeTest, ReporterBound_LruEviction) {
+  auto node = make_node_with({rclcpp::Parameter("max_tracked_nodes", 2)});
+  node->reporter_for("/n1");
+  node->reporter_for("/n2");
+  // Touch n1 so n2 becomes least-recently-used.
+  node->reporter_for("/n1");
+  node->reporter_for("/n3");  // evicts n2
+  EXPECT_EQ(node->tracked_reporter_count(), 2u);
+  // n1 survived the eviction: fetching it again returns the cached reporter
+  // without growing the count.
+  auto * n1_again = node->reporter_for("/n1");
+  EXPECT_NE(n1_again, nullptr);
+  EXPECT_EQ(node->tracked_reporter_count(), 2u);
 }
 
 TEST_F(LogBridgeTest, NodeCreation) {


### PR DESCRIPTION
Adds `ros2_medkit_log_bridge`, a drop-in compatibility adapter (same category as `ros2_medkit_diagnostic_bridge`) that subscribes to `/rosout` and promotes `WARN`+/`ERROR`/`FATAL` log entries to FaultManager faults.

- Each fault is attributed to the originating node via a per-node `FaultReporter`, so `source_id` is the node FQN and the fault associates with the runtime-discovered entity (snapshot/rosbag included).
- `fault_code` is auto-generated and stable across occurrences (hash over a normalized message template: digits/hex/paths stripped).
- Configurable severity floor, code prefix, and node include/exclude lists. No changes to the user's nodes.

Native `ros2_medkit_fault_reporter` instrumentation stays the canonical path; this bridge is the fallback for nodes that only log.

Unit tests cover level-to-severity mapping, fault_code generation/stability, and source_id normalization.

Closes #420
