### PR TITLE
feat(action_status_bridge): add aborted-goal to faults bridge

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -16,6 +16,8 @@ INPUT                  = ../src/ros2_medkit_gateway/include \
                          ../src/ros2_medkit_diagnostic_bridge/src \
                          ../src/ros2_medkit_log_bridge/include \
                          ../src/ros2_medkit_log_bridge/src \
+                         ../src/ros2_medkit_action_status_bridge/include \
+                         ../src/ros2_medkit_action_status_bridge/src \
                          ../src/ros2_medkit_serialization/include \
                          ../src/ros2_medkit_serialization/src \
                          ../src/ros2_medkit_msgs

--- a/docs/api/cpp.rst
+++ b/docs/api/cpp.rst
@@ -91,6 +91,14 @@ Bridge node that promotes ROS 2 /rosout log entries to FaultManager faults.
 .. doxygenclass:: ros2_medkit_log_bridge::LogBridgeNode
    :members:
 
+ros2_medkit_action_status_bridge
+--------------------------------
+
+Bridge node that turns terminal ROS 2 action goal states into FaultManager faults.
+
+.. doxygenclass:: ros2_medkit_action_status_bridge::ActionStatusBridgeNode
+   :members:
+
 ros2_medkit_serialization
 -------------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,8 @@ This page aggregates changelogs from all ros2_medkit packages.
 
 .. include:: ../src/ros2_medkit_log_bridge/CHANGELOG.rst
 
+.. include:: ../src/ros2_medkit_action_status_bridge/CHANGELOG.rst
+
 .. include:: ../src/ros2_medkit_serialization/CHANGELOG.rst
 
 .. include:: ../src/ros2_medkit_msgs/CHANGELOG.rst

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -62,6 +62,9 @@ ros2_medkit consists of several ROS 2 packages:
 **ros2_medkit_log_bridge**
    Bridge node that promotes ROS 2 ``/rosout`` log entries to fault manager faults.
 
+**ros2_medkit_action_status_bridge**
+   Bridge node that turns terminal ROS 2 action goal states (aborted) into fault manager faults.
+
 **ros2_medkit_msgs**
    Message and service definitions for fault management.
 

--- a/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
@@ -1,0 +1,11 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ros2_medkit_action_status_bridge
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Initial release: generic action-status bridge. Watches every
+  ``/<action>/_action/status`` topic and turns ABORTED goals into FaultManager
+  faults (``<PREFIX>_<ACTION>_ABORTED``), heals on SUCCEEDED, with per-goal
+  dedup. Captures the terminal action verdict that the diagnostic and log
+  bridges cannot see.

--- a/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
@@ -6,6 +6,17 @@ Forthcoming
 -----------
 * Initial release: generic action-status bridge. Watches every
   ``/<action>/_action/status`` topic and turns ABORTED goals into FaultManager
-  faults (``<PREFIX>_<ACTION>_ABORTED``), heals on SUCCEEDED, with per-goal
-  dedup. Captures the terminal action verdict that the diagnostic and log
-  bridges cannot see.
+  faults (``<PREFIX>_<ACTION>_ABORTED``), heals on a non-failing terminal state.
+  Captures the terminal action verdict that the diagnostic and log bridges
+  cannot see.
+* Fault state is per-ACTION, derived from the whole ``GoalStatusArray`` on each
+  message: a fault is raised only on the ``healthy -> failed`` transition and
+  healed only on ``failed -> healthy``, so it is order-independent and resilient
+  to dropped terminal messages. Per-goal dedup now only suppresses duplicate log
+  lines.
+* ``canceled_is_fault`` emits a status-aware ``<PREFIX>_<ACTION>_CANCELED`` code;
+  such a fault heals on the next non-failing terminal or when the canceled goal
+  ages out of the retained status array.
+* Vanished actions (lifecycle deactivate, one-shot nodes) are pruned on rescan.
+* Parameters are range-checked/normalized at load; an incompatible action status
+  QoS is now warned about instead of silently dropping faults.

--- a/src/ros2_medkit_action_status_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_action_status_bridge/CMakeLists.txt
@@ -1,0 +1,112 @@
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.8)
+project(ros2_medkit_action_status_bridge)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(ros2_medkit_cmake REQUIRED)
+include(ROS2MedkitCcache)
+include(ROS2MedkitSanitizers)
+include(ROS2MedkitLinting)
+include(ROS2MedkitWarnings)
+
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+if(ENABLE_COVERAGE)
+  message(STATUS "Code coverage enabled")
+  add_compile_options(--coverage -O0 -g)
+  add_link_options(--coverage)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+include(ROS2MedkitCompat)
+
+find_package(rclcpp REQUIRED)
+find_package(action_msgs REQUIRED)
+find_package(ros2_medkit_msgs REQUIRED)
+find_package(ros2_medkit_fault_reporter REQUIRED)
+
+add_library(action_status_bridge_lib SHARED
+  src/action_status_bridge_node.cpp
+)
+
+target_include_directories(action_status_bridge_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+medkit_target_dependencies(action_status_bridge_lib
+  rclcpp
+  action_msgs
+  ros2_medkit_msgs
+  ros2_medkit_fault_reporter
+)
+
+add_executable(action_status_bridge_node src/main.cpp)
+target_link_libraries(action_status_bridge_node action_status_bridge_lib)
+medkit_target_dependencies(action_status_bridge_node rclcpp)
+
+install(TARGETS action_status_bridge_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(TARGETS action_status_bridge_lib
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+install(DIRECTORY launch config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp action_msgs ros2_medkit_msgs ros2_medkit_fault_reporter)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  set(ament_cmake_clang_format_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify ament_cmake_cpplint ament_cmake_clang_tidy)
+  ament_lint_auto_find_test_dependencies()
+
+  ros2_medkit_clang_tidy()
+
+  include(ROS2MedkitTestDomain)
+  medkit_init_test_domains(START 90 END 99)
+
+  ament_add_gtest(test_action_status_bridge test/test_action_status_bridge.cpp)
+  target_link_libraries(test_action_status_bridge action_status_bridge_lib)
+  medkit_target_dependencies(test_action_status_bridge rclcpp action_msgs ros2_medkit_msgs)
+  medkit_set_test_domain(test_action_status_bridge)
+
+  if(ENABLE_COVERAGE)
+    target_compile_options(test_action_status_bridge PRIVATE --coverage -O0 -g)
+    target_link_options(test_action_status_bridge PRIVATE --coverage)
+  endif()
+
+  ros2_medkit_relax_vendor_warnings()
+endif()
+
+ament_package()

--- a/src/ros2_medkit_action_status_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_action_status_bridge/CMakeLists.txt
@@ -86,6 +86,7 @@ ament_export_dependencies(rclcpp action_msgs ros2_medkit_msgs ros2_medkit_fault_
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
 
   set(ament_cmake_clang_format_CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../.clang-format")
   list(APPEND AMENT_LINT_AUTO_EXCLUDE ament_cmake_uncrustify ament_cmake_cpplint ament_cmake_clang_tidy)
@@ -94,7 +95,7 @@ if(BUILD_TESTING)
   ros2_medkit_clang_tidy()
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 90 END 99)
+  medkit_init_test_domains(START 215 END 219)
 
   ament_add_gtest(test_action_status_bridge test/test_action_status_bridge.cpp)
   target_link_libraries(test_action_status_bridge action_status_bridge_lib)
@@ -105,6 +106,16 @@ if(BUILD_TESTING)
     target_compile_options(test_action_status_bridge PRIVATE --coverage -O0 -g)
     target_link_options(test_action_status_bridge PRIVATE --coverage)
   endif()
+
+  # Integration test (launch_testing): fault_manager + bridge + synthetic status
+  install(DIRECTORY test
+    DESTINATION share/${PROJECT_NAME}
+  )
+  add_launch_test(
+    test/test_integration.test.py
+    TARGET test_integration
+    TIMEOUT 120
+  )
 
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_action_status_bridge/README.md
+++ b/src/ros2_medkit_action_status_bridge/README.md
@@ -1,0 +1,60 @@
+# ros2_medkit_action_status_bridge
+
+Generic drop-in bridge that turns terminal ROS 2 action goal states into
+structured medkit faults. It watches the `/<action>/_action/status`
+(`action_msgs/msg/GoalStatusArray`) topic that **every** action server
+publishes, so it works across Nav2, MoveIt 2, ros2_control's controller
+actions, and any custom action with **no per-project code**.
+
+## Why this matters
+
+For the core ROS 2 league the authoritative "the goal failed" verdict lives on
+the action-result channel, not on `/diagnostics` or `/rosout`:
+
+- Nav2 `NavigateToPose` -> `GoalStatus = ABORTED`
+- MoveIt `MoveGroup` -> `GoalStatus = ABORTED` (with `MoveItErrorCode` in the result)
+- ros2_control controller actions -> aborted goals
+
+Neither the diagnostic bridge nor the log bridge sees this. This bridge does,
+generically, by observing the goal-status topic.
+
+## What it does
+
+- Discovers every action on the graph by scanning for `*/_action/status`
+  topics (re-scanned on a timer to catch actions that appear later).
+- `ABORTED (6)` -> fault (`SEVERITY_ERROR` by default).
+- `CANCELED (5)` -> fault only if `canceled_is_fault` (off by default; cancel is
+  usually intentional).
+- `SUCCEEDED (4)` -> `PASSED` to heal the action's ABORTED code (if enabled).
+- `fault_code` is `<PREFIX>_<ACTION>_ABORTED`, e.g.
+  `ACTION_NAVIGATE_TO_POSE_ABORTED`. `source_id` is the action name.
+- Per-goal dedup keyed on `goal_id` so a latched terminal status is reported
+  once, not on every status publication.
+
+## Scope: the terminal verdict, not the reason
+
+This bridge delivers the generic "it aborted" event. The action-specific
+*reason* (e.g. `MoveItErrorCode.val = -26 START_STATE_IN_COLLISION`, Nav2
+`error_code` on Iron/Jazzy) lives in the action result message and is a separate
+enrichment concern (a future action-result reader using runtime message
+introspection / dynmsg). Per-project plugins are only needed for human-readable
+labels, not to surface the fault.
+
+## Run it
+
+```bash
+ros2 launch ros2_medkit_action_status_bridge action_status_bridge.launch.py
+```
+
+## Configuration (`config/action_status_bridge.yaml`)
+
+| Param | Default | Meaning |
+|-------|---------|---------|
+| `aborted_severity` | `2` (ERROR) | severity of an aborted goal |
+| `canceled_is_fault` | `false` | treat CANCELED as a fault |
+| `heal_on_succeeded` | `true` | send PASSED on a successful goal |
+| `rescan_period_sec` | `2.0` | how often to look for new actions |
+| `code_prefix` | `ACTION` | prefix for generated codes |
+| `exclude_actions` | `[]` | action-name substrings to skip |
+| `include_only_actions` | `[]` | if set, only watch these |
+| `dedup_capacity` | `4096` | remembered goal/status keys |

--- a/src/ros2_medkit_action_status_bridge/README.md
+++ b/src/ros2_medkit_action_status_bridge/README.md
@@ -21,15 +21,33 @@ generically, by observing the goal-status topic.
 ## What it does
 
 - Discovers every action on the graph by scanning for `*/_action/status`
-  topics (re-scanned on a timer to catch actions that appear later).
+  topics (re-scanned on a timer to catch actions that appear later, and to drop
+  actions that vanish, e.g. a Nav2 lifecycle deactivate or a one-shot node).
 - `ABORTED (6)` -> fault (`SEVERITY_ERROR` by default).
 - `CANCELED (5)` -> fault only if `canceled_is_fault` (off by default; cancel is
-  usually intentional).
-- `SUCCEEDED (4)` -> `PASSED` to heal the action's ABORTED code (if enabled).
-- `fault_code` is `<PREFIX>_<ACTION>_ABORTED`, e.g.
-  `ACTION_NAVIGATE_TO_POSE_ABORTED`. `source_id` is the action name.
-- Per-goal dedup keyed on `goal_id` so a latched terminal status is reported
-  once, not on every status publication.
+  usually intentional). When enabled it emits a `_CANCELED` code.
+- `SUCCEEDED (4)` -> `PASSED` to heal the action's fault code (if enabled).
+- `fault_code` is `<PREFIX>_<ACTION>_ABORTED` (or `_CANCELED`), e.g.
+  `ACTION_NAVIGATE_TO_POSE_ABORTED`. `source_id` is the action **server's node
+  FQN** (resolved from the status topic's publisher, e.g. `/bt_navigator`), so
+  the fault associates with that node's SOVD entity; it falls back to the action
+  name only if no publisher is visible.
+
+## Per-action state, not per-goal
+
+The fault is a property of the **action**, not of an individual goal. On every
+status message the whole `GoalStatusArray` is scanned for the net state:
+
+- if **any** goal is `ABORTED` (or `CANCELED` when `canceled_is_fault`), the
+  action is **failed** (order of goals in the array does not matter);
+- otherwise, if the array has terminal goals and none are failing, the action is
+  **healthy**.
+
+A fault is raised only on the `healthy -> failed` transition and healed only on
+`failed -> healthy`. This means one failed goal cannot heal an action while
+another goal is still failed, and a dropped terminal message cannot leave a
+fault stuck. Per-goal dedup (keyed on `goal_id:status`) only suppresses
+duplicate log lines; it never gates the transition.
 
 ## Scope: the terminal verdict, not the reason
 
@@ -57,4 +75,37 @@ ros2 launch ros2_medkit_action_status_bridge action_status_bridge.launch.py
 | `code_prefix` | `ACTION` | prefix for generated codes |
 | `exclude_actions` | `[]` | action-name substrings to skip |
 | `include_only_actions` | `[]` | if set, only watch these |
-| `dedup_capacity` | `4096` | remembered goal/status keys |
+| `dedup_capacity` | `4096` | remembered goal/status log keys |
+
+`exclude_actions` / `include_only_actions` match as **unanchored substrings** of
+the fully-qualified action name (e.g. `nav` matches `/navigate_to_pose`). Use a
+longer fragment (or the full name) for exact targeting.
+
+`aborted_severity`, `code_prefix` and `dedup_capacity` are range-checked and
+normalized at load (out-of-range severity clamps to ERROR, a non-snake-case
+`code_prefix` is upper-snake-cased, a non-positive `dedup_capacity` falls back to
+the default), with a warning.
+
+## Limitations
+
+- **Flapping**: a retry loop that issues a fresh `goal_id` each attempt does not
+  re-raise while the action stays failed (only net-state changes transition),
+  but a true flap (fail -> succeed -> fail) does produce one raise + heal per
+  cycle. There is no per-code rate throttle in this bridge; lower noise via the
+  FaultReporter local filter if needed.
+- **No per-code throttle**: every action-level transition is forwarded.
+- **CANCELED heal semantics**: with `canceled_is_fault`, a canceled action heals
+  on the next non-failing terminal (a later SUCCEEDED), or when the canceled goal
+  ages out of the action server's retained status array and a non-failed terminal
+  remains. It is not healed by an explicit "uncancel" because none exists.
+- **QoS**: the bridge requests the standard action status QoS (reliable +
+  transient_local). A non-standard server (volatile/best-effort) is logged with
+  an incompatible-QoS warning rather than silently yielding zero faults.
+- **Vanish while failed**: if an action that is currently failed disappears from
+  the graph (lifecycle deactivate, one-shot node), the bridge heals its fault
+  before forgetting it (when `heal_on_succeeded` is set), so it is not left stuck
+  active. With healing disabled the fault persists by design.
+- **Healing threshold**: the bridge emits one `PASSED` per recovery (a discrete
+  event, not a stream), so a fault reaches `HEALED` only when the FaultManager's
+  `healing_threshold` is `0`. With a higher threshold the fault stays `CONFIRMED`
+  after the action recovers.

--- a/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
+++ b/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
@@ -1,0 +1,19 @@
+action_status_bridge:
+  ros__parameters:
+    # Severity for an ABORTED goal (0=INFO 1=WARN 2=ERROR 3=CRITICAL).
+    aborted_severity: 2
+    # Treat a CANCELED goal as a fault. Off by default (cancel is usually
+    # an intentional operator/client action, not a failure).
+    canceled_is_fault: false
+    # On a SUCCEEDED goal, send PASSED to heal the action's ABORTED fault code.
+    heal_on_succeeded: true
+    # How often to rescan the graph for new action status topics.
+    rescan_period_sec: 2.0
+    # Prefix for generated fault codes (<PREFIX>_<ACTION>_ABORTED).
+    code_prefix: "ACTION"
+    # Action-name substrings to skip.
+    exclude_actions: []
+    # If non-empty, ONLY watch actions matching these substrings.
+    include_only_actions: []
+    # Max remembered (goal_id:status) keys for dedup.
+    dedup_capacity: 4096

--- a/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
+++ b/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
@@ -2,18 +2,19 @@ action_status_bridge:
   ros__parameters:
     # Severity for an ABORTED goal (0=INFO 1=WARN 2=ERROR 3=CRITICAL).
     aborted_severity: 2
-    # Treat a CANCELED goal as a fault. Off by default (cancel is usually
-    # an intentional operator/client action, not a failure).
+    # Treat a CANCELED goal as a fault (emits a _CANCELED code). Off by default
+    # (cancel is usually an intentional operator/client action, not a failure).
     canceled_is_fault: false
-    # On a SUCCEEDED goal, send PASSED to heal the action's ABORTED fault code.
+    # On a non-failing terminal state, send PASSED to heal the action's fault.
     heal_on_succeeded: true
-    # How often to rescan the graph for new action status topics.
+    # How often to rescan the graph for new (and vanished) action status topics.
     rescan_period_sec: 2.0
-    # Prefix for generated fault codes (<PREFIX>_<ACTION>_ABORTED).
+    # Prefix for generated fault codes (<PREFIX>_<ACTION>_ABORTED/_CANCELED).
+    # Normalized to UPPER_SNAKE at load.
     code_prefix: "ACTION"
-    # Action-name substrings to skip.
+    # Action-name substrings to skip (unanchored substring match).
     exclude_actions: []
     # If non-empty, ONLY watch actions matching these substrings.
     include_only_actions: []
-    # Max remembered (goal_id:status) keys for dedup.
+    # Max remembered (goal_id:status) keys for log dedup.
     dedup_capacity: 4096

--- a/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
+++ b/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
@@ -1,0 +1,101 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+#include "action_msgs/msg/goal_status_array.hpp"
+#include "ros2_medkit_fault_reporter/fault_reporter.hpp"
+
+namespace ros2_medkit_action_status_bridge {
+
+/// Bridge node that turns terminal ROS 2 action goal states into FaultManager
+/// faults. Generic across every action: it observes the per-action
+/// `/<action>/_action/status` topic (`action_msgs/msg/GoalStatusArray`) that
+/// every action server publishes, so no per-project code is needed.
+///
+/// This catches the authoritative "the goal failed" verdict that neither the
+/// /diagnostics bridge nor the /rosout log bridge can see - e.g. a Nav2
+/// NavigateToPose aborting or a MoveIt MoveGroup goal aborting. The *reason*
+/// (action-specific error code in the result) is a separate enrichment concern;
+/// this bridge delivers the generic terminal status.
+///
+/// Status mapping (action_msgs/msg/GoalStatus):
+///   - ABORTED (6)  -> fault (severity configurable, default ERROR)
+///   - CANCELED (5) -> fault only if canceled_is_fault (usually intentional)
+///   - SUCCEEDED (4)-> PASSED (heals the per-action ABORTED code) if enabled
+class ActionStatusBridgeNode : public rclcpp::Node {
+ public:
+  explicit ActionStatusBridgeNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  /// Derive the action name from a `/<action>/_action/status` topic name.
+  /// Returns empty when the topic is not an action status topic.
+  static std::string action_name_from_status_topic(const std::string & topic);
+
+  /// Build the ABORTED fault code for an action name.
+  /// Format: <PREFIX>_<ACTION>_ABORTED, charset/length per medkit rules.
+  std::string aborted_fault_code(const std::string & action_name) const;
+
+  /// Lowercase hex of a 16-byte goal UUID, for dedup keys and short display.
+  static std::string uuid_to_hex(const std::array<uint8_t, 16> & uuid);
+
+ private:
+  void rescan_actions();
+  void status_callback(const std::string & action_name,
+                       const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg);
+
+  ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & action_name);
+
+  /// Returns true if this (goal, status) pair was not handled before, marking
+  /// it handled. Bounded to avoid unbounded growth.
+  bool mark_handled(const std::string & goal_status_key);
+
+  bool action_is_eligible(const std::string & action_name) const;
+
+  void load_parameters();
+
+  static std::string to_upper_snake(const std::string & in, size_t max_len);
+
+  rclcpp::TimerBase::SharedPtr rescan_timer_;
+  std::map<std::string, rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr> subs_;
+
+  std::map<std::string, std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter>> reporters_;
+  std::mutex reporters_mutex_;
+
+  // Bounded dedup of handled (goal_id:status) keys.
+  std::unordered_set<std::string> handled_;
+  std::deque<std::string> handled_order_;
+  std::mutex handled_mutex_;
+  size_t handled_capacity_;
+
+  // Configuration
+  uint8_t aborted_severity_;
+  bool canceled_is_fault_;
+  bool heal_on_succeeded_;
+  double rescan_period_sec_;
+  std::string code_prefix_;
+  std::vector<std::string> exclude_actions_;
+  std::vector<std::string> include_only_actions_;
+};
+
+}  // namespace ros2_medkit_action_status_bridge

--- a/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
+++ b/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <deque>
 #include <map>
@@ -43,36 +44,70 @@ namespace ros2_medkit_action_status_bridge {
 /// Status mapping (action_msgs/msg/GoalStatus):
 ///   - ABORTED (6)  -> fault (severity configurable, default ERROR)
 ///   - CANCELED (5) -> fault only if canceled_is_fault (usually intentional)
-///   - SUCCEEDED (4)-> PASSED (heals the per-action ABORTED code) if enabled
+///   - SUCCEEDED (4)-> PASSED (heals the per-action fault code) if enabled
+///
+/// Fault state is per-ACTION, not per-goal: every message is scanned for the net
+/// state of the whole GoalStatusArray and a fault is raised/healed only on the
+/// action-level transition. See `derive_state`.
 class ActionStatusBridgeNode : public rclcpp::Node {
  public:
   explicit ActionStatusBridgeNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
+
+  /// Net fault state of an action, derived from a whole GoalStatusArray.
+  ///   - kUnknown: no terminal goal in the array yet (no transition)
+  ///   - kHealthy: array has terminal goals and none of them are failing
+  ///   - kFailed:  at least one goal is failing (ABORTED, or CANCELED when
+  ///               canceled_is_fault)
+  enum class ActionState { kUnknown, kHealthy, kFailed };
 
   /// Derive the action name from a `/<action>/_action/status` topic name.
   /// Returns empty when the topic is not an action status topic.
   static std::string action_name_from_status_topic(const std::string & topic);
 
-  /// Build the ABORTED fault code for an action name.
-  /// Format: <PREFIX>_<ACTION>_ABORTED, charset/length per medkit rules.
-  std::string aborted_fault_code(const std::string & action_name) const;
+  /// Build the fault code for an action name and terminal status.
+  /// Format: <PREFIX>_<ACTION>_<ABORTED|CANCELED>, charset/length per medkit
+  /// rules. `canceled` selects the CANCELED suffix.
+  std::string fault_code_for(const std::string & action_name, bool canceled) const;
 
   /// Lowercase hex of a 16-byte goal UUID, for dedup keys and short display.
   static std::string uuid_to_hex(const std::array<uint8_t, 16> & uuid);
 
+  /// Scan a whole GoalStatusArray and return the action-level net state.
+  /// `canceled_is_fault` decides whether CANCELED counts as failing. Order of
+  /// the goals in the array does not affect the result (any failing goal wins).
+  static ActionState derive_state(const action_msgs::msg::GoalStatusArray & msg, bool canceled_is_fault);
+
+  /// Update per-action state from a message and act on the transition only.
+  /// Returns the state that was reported on (kFailed on raise, kHealthy on
+  /// heal) or kUnknown when nothing was reported. Side-effect free w.r.t.
+  /// reporting when `reporter` is null (test seam): the transition decision and
+  /// stored per-action state still update, so tests assert on the return value.
+  ActionState apply_message(const std::string & action_name, const action_msgs::msg::GoalStatusArray & msg,
+                            ros2_medkit_fault_reporter::FaultReporter * reporter);
+
  private:
   void rescan_actions();
-  void status_callback(const std::string & action_name,
-                       const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg);
+  void status_callback(const std::string & action_name, const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg);
 
   ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & action_name);
 
-  /// Returns true if this (goal, status) pair was not handled before, marking
-  /// it handled. Bounded to avoid unbounded growth.
-  bool mark_handled(const std::string & goal_status_key);
+  /// Resolve the action server's node FQN from its status-topic publisher, for
+  /// use as the fault source_id so faults associate with the gateway's SOVD
+  /// entity. Falls back to the action name if no publisher is visible.
+  std::string server_fqn_for_action(const std::string & action_name);
+
+  /// Returns true if this (goal, status) pair was not logged before, marking it
+  /// logged. Bounded to avoid unbounded growth. Suppresses duplicate LOG lines
+  /// only; never gates the action-level state transition.
+  bool mark_logged(const std::string & goal_status_key);
 
   bool action_is_eligible(const std::string & action_name) const;
 
   void load_parameters();
+
+  /// Drop subscriptions, reporters and per-action state for actions whose status
+  /// topic has vanished from `present_topics`.
+  void prune_vanished(const std::map<std::string, std::string> & present_topics);
 
   static std::string to_upper_snake(const std::string & in, size_t max_len);
 
@@ -82,11 +117,15 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   std::map<std::string, std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter>> reporters_;
   std::mutex reporters_mutex_;
 
-  // Bounded dedup of handled (goal_id:status) keys.
-  std::unordered_set<std::string> handled_;
-  std::deque<std::string> handled_order_;
-  std::mutex handled_mutex_;
-  size_t handled_capacity_;
+  // Last reported action-level state, keyed by action name. Drives transitions.
+  std::map<std::string, ActionState> last_reported_state_;
+  std::mutex state_mutex_;
+
+  // Bounded dedup of logged (goal_id:status) keys (LOG suppression only).
+  std::unordered_set<std::string> logged_;
+  std::deque<std::string> logged_order_;
+  std::mutex logged_mutex_;
+  size_t logged_capacity_;
 
   // Configuration
   uint8_t aborted_severity_;
@@ -96,6 +135,29 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   std::string code_prefix_;
   std::vector<std::string> exclude_actions_;
   std::vector<std::string> include_only_actions_;
+
+  friend class ActionStatusBridgeTestAccess;
+};
+
+/// Test-only accessor for the bridge's private maps and prune path. Lets unit
+/// tests exercise rescan add+prune without a live action graph.
+class ActionStatusBridgeTestAccess {
+ public:
+  explicit ActionStatusBridgeTestAccess(ActionStatusBridgeNode * node) : node_(node) {
+  }
+
+  /// Seed a watched action (subscription placeholder + per-action state) as if
+  /// rescan had discovered its `/<action>/_action/status` topic.
+  void add_watched(const std::string & action_name);
+
+  /// Run the prune pass against a set of still-present action names.
+  void prune_to(const std::vector<std::string> & present_action_names);
+
+  bool is_watched(const std::string & action_name) const;
+  bool has_state(const std::string & action_name) const;
+
+ private:
+  ActionStatusBridgeNode * node_;
 };
 
 }  // namespace ros2_medkit_action_status_bridge

--- a/src/ros2_medkit_action_status_bridge/launch/action_status_bridge.launch.py
+++ b/src/ros2_medkit_action_status_bridge/launch/action_status_bridge.launch.py
@@ -1,0 +1,37 @@
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    config_file = os.path.join(
+        get_package_share_directory('ros2_medkit_action_status_bridge'),
+        'config',
+        'action_status_bridge.yaml'
+    )
+
+    return LaunchDescription([
+        Node(
+            package='ros2_medkit_action_status_bridge',
+            executable='action_status_bridge_node',
+            name='action_status_bridge',
+            output='screen',
+            parameters=[config_file],
+        ),
+    ])

--- a/src/ros2_medkit_action_status_bridge/package.xml
+++ b/src/ros2_medkit_action_status_bridge/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_medkit_action_status_bridge</name>
+  <version>0.5.0</version>
+  <description>Bridge node turning terminal ROS2 action goal states (aborted) into FaultManager faults</description>
+
+  <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ros2_medkit_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>action_msgs</depend>
+  <depend>ros2_medkit_msgs</depend>
+  <depend>ros2_medkit_fault_reporter</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_clang_tidy</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>ros2_medkit_fault_manager</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_action_status_bridge/action_status_bridge_node.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cstdio>
+
+#include "action_msgs/msg/goal_status.hpp"
+#include "ros2_medkit_msgs/msg/fault.hpp"
+
+namespace ros2_medkit_action_status_bridge {
+
+namespace {
+
+constexpr char kStatusSuffix[] = "/_action/status";
+constexpr char kStatusType[] = "action_msgs/msg/GoalStatusArray";
+
+bool contains_substr(const std::vector<std::string> & list, const std::string & value) {
+  for (const auto & item : list) {
+    if (!item.empty() && value.find(item) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+ActionStatusBridgeNode::ActionStatusBridgeNode(const rclcpp::NodeOptions & options)
+    : Node("action_status_bridge", options) {
+  load_parameters();
+
+  rescan_actions();
+  rescan_timer_ = create_wall_timer(
+      std::chrono::duration<double>(rescan_period_sec_), [this]() { rescan_actions(); });
+
+  RCLCPP_INFO(get_logger(), "ActionStatusBridge started (prefix=%s, aborted_severity=%u, rescan=%.1fs)",
+              code_prefix_.c_str(), static_cast<unsigned>(aborted_severity_), rescan_period_sec_);
+}
+
+void ActionStatusBridgeNode::load_parameters() {
+  aborted_severity_ = static_cast<uint8_t>(
+      declare_parameter<int>("aborted_severity", ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR));
+  canceled_is_fault_ = declare_parameter<bool>("canceled_is_fault", false);
+  heal_on_succeeded_ = declare_parameter<bool>("heal_on_succeeded", true);
+  rescan_period_sec_ = declare_parameter<double>("rescan_period_sec", 2.0);
+  code_prefix_ = declare_parameter<std::string>("code_prefix", "ACTION");
+  exclude_actions_ = declare_parameter<std::vector<std::string>>("exclude_actions", std::vector<std::string>{});
+  include_only_actions_ =
+      declare_parameter<std::vector<std::string>>("include_only_actions", std::vector<std::string>{});
+  handled_capacity_ = static_cast<size_t>(declare_parameter<int>("dedup_capacity", 4096));
+
+  // Action terminal states are discrete, authoritative events, not flapping
+  // conditions, and per-goal dedup above already prevents repeats. Pre-declare
+  // the FaultReporter LocalFilter as disabled so ABORTED reports immediately
+  // and, crucially, PASSED (healing on a later SUCCEEDED) is not throttled by
+  // the default occurrence threshold. The reporter ctor's has_parameter guard
+  // honours this value. Override via fault_reporter.local_filtering.enabled.
+  if (!has_parameter("fault_reporter.local_filtering.enabled")) {
+    declare_parameter("fault_reporter.local_filtering.enabled", false);
+  }
+}
+
+void ActionStatusBridgeNode::rescan_actions() {
+  const auto topics = get_topic_names_and_types();
+  // Action status QoS is reliable + transient_local + keep_last; match it so we
+  // receive the latched terminal status of a goal.
+  const auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+
+  for (const auto & [topic, types] : topics) {
+    const std::string action_name = action_name_from_status_topic(topic);
+    if (action_name.empty()) {
+      continue;
+    }
+    if (std::find(types.begin(), types.end(), kStatusType) == types.end()) {
+      continue;
+    }
+    if (!action_is_eligible(action_name)) {
+      continue;
+    }
+    if (subs_.find(topic) != subs_.end()) {
+      continue;  // already subscribed
+    }
+    auto sub = create_subscription<action_msgs::msg::GoalStatusArray>(
+        topic, qos,
+        [this, action_name](const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg) {
+          status_callback(action_name, msg);
+        });
+    subs_.emplace(topic, sub);
+    RCLCPP_INFO(get_logger(), "Watching action '%s' (topic %s)", action_name.c_str(), topic.c_str());
+  }
+}
+
+void ActionStatusBridgeNode::status_callback(const std::string & action_name,
+                                             const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg) {
+  using GoalStatus = action_msgs::msg::GoalStatus;
+
+  for (const auto & gs : msg->status_list) {
+    std::array<uint8_t, 16> uuid{};
+    std::copy(gs.goal_info.goal_id.uuid.begin(), gs.goal_info.goal_id.uuid.end(), uuid.begin());
+    const std::string uuid_hex = uuid_to_hex(uuid);
+    const std::string key = uuid_hex + ":" + std::to_string(static_cast<int>(gs.status));
+
+    if (gs.status == GoalStatus::STATUS_ABORTED ||
+        (gs.status == GoalStatus::STATUS_CANCELED && canceled_is_fault_)) {
+      if (!mark_handled(key)) {
+        continue;  // already reported this terminal state for this goal
+      }
+      auto * reporter = reporter_for(action_name);
+      if (reporter == nullptr) {
+        continue;
+      }
+      const char * what = (gs.status == GoalStatus::STATUS_ABORTED) ? "aborted" : "canceled";
+      const std::string desc = std::string("Goal ") + uuid_hex.substr(0, 8) + " " + what + " on action " +
+                               action_name;
+      reporter->report(aborted_fault_code(action_name), aborted_severity_, desc);
+      RCLCPP_INFO(get_logger(), "Action %s goal %s %s -> fault %s", action_name.c_str(),
+                  uuid_hex.substr(0, 8).c_str(), what, aborted_fault_code(action_name).c_str());
+    } else if (gs.status == GoalStatus::STATUS_SUCCEEDED && heal_on_succeeded_) {
+      if (!mark_handled(key)) {
+        continue;
+      }
+      auto * reporter = reporter_for(action_name);
+      if (reporter != nullptr) {
+        reporter->report_passed(aborted_fault_code(action_name));
+      }
+    }
+  }
+}
+
+ros2_medkit_fault_reporter::FaultReporter * ActionStatusBridgeNode::reporter_for(const std::string & action_name) {
+  std::lock_guard<std::mutex> lock(reporters_mutex_);
+  auto it = reporters_.find(action_name);
+  if (it != reporters_.end()) {
+    return it->second.get();
+  }
+  // Attribute the fault to the action (best stable identifier from the status
+  // topic alone). Multiple reporters on one node are safe (has_parameter guard).
+  auto reporter =
+      std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), action_name);
+  auto * raw = reporter.get();
+  reporters_.emplace(action_name, std::move(reporter));
+  return raw;
+}
+
+bool ActionStatusBridgeNode::mark_handled(const std::string & goal_status_key) {
+  std::lock_guard<std::mutex> lock(handled_mutex_);
+  if (handled_.find(goal_status_key) != handled_.end()) {
+    return false;
+  }
+  handled_.insert(goal_status_key);
+  handled_order_.push_back(goal_status_key);
+  while (handled_order_.size() > handled_capacity_) {
+    handled_.erase(handled_order_.front());
+    handled_order_.pop_front();
+  }
+  return true;
+}
+
+bool ActionStatusBridgeNode::action_is_eligible(const std::string & action_name) const {
+  if (!include_only_actions_.empty() && !contains_substr(include_only_actions_, action_name)) {
+    return false;
+  }
+  if (contains_substr(exclude_actions_, action_name)) {
+    return false;
+  }
+  return true;
+}
+
+std::string ActionStatusBridgeNode::action_name_from_status_topic(const std::string & topic) {
+  const std::string suffix = kStatusSuffix;
+  if (topic.size() <= suffix.size()) {
+    return "";
+  }
+  if (topic.compare(topic.size() - suffix.size(), suffix.size(), suffix) != 0) {
+    return "";
+  }
+  return topic.substr(0, topic.size() - suffix.size());
+}
+
+std::string ActionStatusBridgeNode::uuid_to_hex(const std::array<uint8_t, 16> & uuid) {
+  std::string out;
+  out.reserve(32);
+  char buf[3];
+  for (uint8_t b : uuid) {
+    std::snprintf(buf, sizeof(buf), "%02x", static_cast<unsigned>(b));
+    out += buf;
+  }
+  return out;
+}
+
+std::string ActionStatusBridgeNode::to_upper_snake(const std::string & in, size_t max_len) {
+  std::string result;
+  result.reserve(in.size());
+  bool last_sep = true;
+  for (char c : in) {
+    const auto uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc)) {
+      result += static_cast<char>(std::toupper(uc));
+      last_sep = false;
+    } else if (!last_sep) {
+      result += '_';
+      last_sep = true;
+    }
+  }
+  while (!result.empty() && result.back() == '_') {
+    result.pop_back();
+  }
+  if (result.size() > max_len) {
+    result.resize(max_len);
+    while (!result.empty() && result.back() == '_') {
+      result.pop_back();
+    }
+  }
+  return result;
+}
+
+std::string ActionStatusBridgeNode::aborted_fault_code(const std::string & action_name) const {
+  const std::string action_part = to_upper_snake(action_name, 48);
+  std::string code = code_prefix_;
+  if (!action_part.empty()) {
+    code += '_';
+    code += action_part;
+  }
+  code += "_ABORTED";
+  if (code.size() > 64) {
+    code.resize(64);
+  }
+  return code;
+}
+
+}  // namespace ros2_medkit_action_status_bridge

--- a/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
@@ -19,6 +19,7 @@
 #include <cctype>
 #include <chrono>
 #include <cstdio>
+#include <functional>
 
 #include "action_msgs/msg/goal_status.hpp"
 #include "ros2_medkit_msgs/msg/fault.hpp"
@@ -30,6 +31,13 @@ namespace {
 constexpr char kStatusSuffix[] = "/_action/status";
 constexpr char kStatusType[] = "action_msgs/msg/GoalStatusArray";
 
+// Total fault-code length clamp (medkit rule). Reserve room for the status
+// suffix so a long action name cannot let the clamp eat "_ABORTED"/"_CANCELED".
+constexpr size_t kMaxCodeLen = 64;
+constexpr size_t kMaxActionPart = 48;
+// Longest status suffix that may follow the action part, "_CANCELED".
+constexpr size_t kMaxStatusSuffix = 9;
+
 bool contains_substr(const std::vector<std::string> & list, const std::string & value) {
   for (const auto & item : list) {
     if (!item.empty() && value.find(item) != std::string::npos) {
@@ -39,38 +47,87 @@ bool contains_substr(const std::vector<std::string> & list, const std::string & 
   return false;
 }
 
+void strip_trailing_underscore(std::string & s) {
+  while (!s.empty() && s.back() == '_') {
+    s.pop_back();
+  }
+}
+
+// True when the failing state is caused solely by CANCELED goals (no ABORTED),
+// so the emitted code matches the description. ABORTED dominates if both occur.
+bool describe_failure_is_cancel(const action_msgs::msg::GoalStatusArray & msg, bool canceled_is_fault) {
+  using GoalStatus = action_msgs::msg::GoalStatus;
+  bool saw_canceled = false;
+  for (const auto & gs : msg.status_list) {
+    if (gs.status == GoalStatus::STATUS_ABORTED) {
+      return false;
+    }
+    if (gs.status == GoalStatus::STATUS_CANCELED && canceled_is_fault) {
+      saw_canceled = true;
+    }
+  }
+  return saw_canceled;
+}
+
 }  // namespace
 
 ActionStatusBridgeNode::ActionStatusBridgeNode(const rclcpp::NodeOptions & options)
-    : Node("action_status_bridge", options) {
+  : Node("action_status_bridge", options) {
   load_parameters();
 
   rescan_actions();
-  rescan_timer_ = create_wall_timer(
-      std::chrono::duration<double>(rescan_period_sec_), [this]() { rescan_actions(); });
+  rescan_timer_ = create_wall_timer(std::chrono::duration<double>(rescan_period_sec_), [this]() {
+    rescan_actions();
+  });
 
   RCLCPP_INFO(get_logger(), "ActionStatusBridge started (prefix=%s, aborted_severity=%u, rescan=%.1fs)",
               code_prefix_.c_str(), static_cast<unsigned>(aborted_severity_), rescan_period_sec_);
 }
 
 void ActionStatusBridgeNode::load_parameters() {
-  aborted_severity_ = static_cast<uint8_t>(
-      declare_parameter<int>("aborted_severity", ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR));
+  const int aborted_severity = declare_parameter<int>("aborted_severity", ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR);
+  if (aborted_severity < ros2_medkit_msgs::msg::Fault::SEVERITY_INFO ||
+      aborted_severity > ros2_medkit_msgs::msg::Fault::SEVERITY_CRITICAL) {
+    RCLCPP_WARN(get_logger(), "aborted_severity %d out of range [0,3]; clamping to ERROR", aborted_severity);
+    aborted_severity_ = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
+  } else {
+    aborted_severity_ = static_cast<uint8_t>(aborted_severity);
+  }
+
   canceled_is_fault_ = declare_parameter<bool>("canceled_is_fault", false);
   heal_on_succeeded_ = declare_parameter<bool>("heal_on_succeeded", true);
   rescan_period_sec_ = declare_parameter<double>("rescan_period_sec", 2.0);
-  code_prefix_ = declare_parameter<std::string>("code_prefix", "ACTION");
+  if (rescan_period_sec_ <= 0.0) {
+    RCLCPP_WARN(get_logger(), "rescan_period_sec %.3f not positive; using 2.0", rescan_period_sec_);
+    rescan_period_sec_ = 2.0;
+  }
+
+  code_prefix_ = to_upper_snake(declare_parameter<std::string>("code_prefix", "ACTION"), kMaxActionPart);
+  if (code_prefix_.empty()) {
+    RCLCPP_WARN(get_logger(), "code_prefix empty after normalization; using ACTION");
+    code_prefix_ = "ACTION";
+  }
+
   exclude_actions_ = declare_parameter<std::vector<std::string>>("exclude_actions", std::vector<std::string>{});
   include_only_actions_ =
       declare_parameter<std::vector<std::string>>("include_only_actions", std::vector<std::string>{});
-  handled_capacity_ = static_cast<size_t>(declare_parameter<int>("dedup_capacity", 4096));
 
-  // Action terminal states are discrete, authoritative events, not flapping
-  // conditions, and per-goal dedup above already prevents repeats. Pre-declare
-  // the FaultReporter LocalFilter as disabled so ABORTED reports immediately
-  // and, crucially, PASSED (healing on a later SUCCEEDED) is not throttled by
-  // the default occurrence threshold. The reporter ctor's has_parameter guard
-  // honours this value. Override via fault_reporter.local_filtering.enabled.
+  const int dedup_capacity = declare_parameter<int>("dedup_capacity", 4096);
+  if (dedup_capacity <= 0) {
+    RCLCPP_WARN(get_logger(), "dedup_capacity %d not positive; using 4096", dedup_capacity);
+    logged_capacity_ = 4096;
+  } else {
+    logged_capacity_ = static_cast<size_t>(dedup_capacity);
+  }
+
+  // Action terminal states are discrete, authoritative events. The action-level
+  // state model only transitions on a net-state change, so it does not flap;
+  // retries that issue a fresh goal_id each attempt do not re-raise while the
+  // action stays failed. Pre-declare the FaultReporter LocalFilter as disabled
+  // so a raise reports immediately and, crucially, PASSED (healing on a later
+  // SUCCEEDED) is not throttled by the default occurrence threshold. The
+  // reporter ctor's has_parameter guard honours this value. Override via
+  // fault_reporter.local_filtering.enabled.
   if (!has_parameter("fault_reporter.local_filtering.enabled")) {
     declare_parameter("fault_reporter.local_filtering.enabled", false);
   }
@@ -81,6 +138,18 @@ void ActionStatusBridgeNode::rescan_actions() {
   // Action status QoS is reliable + transient_local + keep_last; match it so we
   // receive the latched terminal status of a goal.
   const auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable().transient_local();
+
+  // Warn (don't silently drop faults) when a server publishes a non-standard
+  // (volatile/best-effort) status QoS that is incompatible with our request.
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.event_callbacks.incompatible_qos_callback = [this](rclcpp::QOSRequestedIncompatibleQoSInfo & info) {
+    RCLCPP_WARN(get_logger(),
+                "Incompatible action status QoS (policy %d); faults may be missed for a non-standard server",
+                static_cast<int>(info.last_policy_kind));
+  };
+
+  // Track which eligible status topics exist this scan, to prune the rest.
+  std::map<std::string, std::string> present;
 
   for (const auto & [topic, types] : topics) {
     const std::string action_name = action_name_from_status_topic(topic);
@@ -93,6 +162,7 @@ void ActionStatusBridgeNode::rescan_actions() {
     if (!action_is_eligible(action_name)) {
       continue;
     }
+    present.emplace(topic, action_name);
     if (subs_.find(topic) != subs_.end()) {
       continue;  // already subscribed
     }
@@ -100,47 +170,147 @@ void ActionStatusBridgeNode::rescan_actions() {
         topic, qos,
         [this, action_name](const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg) {
           status_callback(action_name, msg);
-        });
+        },
+        sub_options);
     subs_.emplace(topic, sub);
     RCLCPP_INFO(get_logger(), "Watching action '%s' (topic %s)", action_name.c_str(), topic.c_str());
   }
+
+  prune_vanished(present);
+}
+
+void ActionStatusBridgeNode::prune_vanished(const std::map<std::string, std::string> & present_topics) {
+  for (auto it = subs_.begin(); it != subs_.end();) {
+    const std::string & topic = it->first;
+    if (present_topics.find(topic) != present_topics.end()) {
+      ++it;
+      continue;
+    }
+    const std::string action_name = action_name_from_status_topic(topic);
+
+    bool was_failed = false;
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      auto sit = last_reported_state_.find(action_name);
+      was_failed = sit != last_reported_state_.end() && sit->second == ActionState::kFailed;
+    }
+    {
+      std::lock_guard<std::mutex> lock(reporters_mutex_);
+      // If a still-failed action vanishes (e.g. Nav2 lifecycle deactivate), heal
+      // its fault before forgetting it - otherwise the fault stays stuck active
+      // in the FaultManager and the bridge can no longer clear it.
+      auto rit = reporters_.find(action_name);
+      if (was_failed && heal_on_succeeded_ && rit != reporters_.end()) {
+        rit->second->report_passed(fault_code_for(action_name, false));
+        if (canceled_is_fault_) {
+          rit->second->report_passed(fault_code_for(action_name, true));
+        }
+        RCLCPP_INFO(get_logger(), "Action '%s' vanished while failed; healed before dropping", action_name.c_str());
+      }
+      reporters_.erase(action_name);
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      last_reported_state_.erase(action_name);
+    }
+    RCLCPP_INFO(get_logger(), "Action '%s' vanished; dropped (topic %s)", action_name.c_str(), topic.c_str());
+    it = subs_.erase(it);
+  }
+}
+
+ActionStatusBridgeNode::ActionState ActionStatusBridgeNode::derive_state(const action_msgs::msg::GoalStatusArray & msg,
+                                                                         bool canceled_is_fault) {
+  using GoalStatus = action_msgs::msg::GoalStatus;
+
+  bool any_terminal = false;
+  for (const auto & gs : msg.status_list) {
+    const bool failing =
+        gs.status == GoalStatus::STATUS_ABORTED || (gs.status == GoalStatus::STATUS_CANCELED && canceled_is_fault);
+    if (failing) {
+      return ActionState::kFailed;  // any failing goal fails the action (order-independent)
+    }
+    // SUCCEEDED, or CANCELED when it is not a fault, is a non-failing terminal.
+    if (gs.status == GoalStatus::STATUS_SUCCEEDED || gs.status == GoalStatus::STATUS_CANCELED) {
+      any_terminal = true;
+    }
+  }
+  return any_terminal ? ActionState::kHealthy : ActionState::kUnknown;
+}
+
+ActionStatusBridgeNode::ActionState
+ActionStatusBridgeNode::apply_message(const std::string & action_name, const action_msgs::msg::GoalStatusArray & msg,
+                                      ros2_medkit_fault_reporter::FaultReporter * reporter) {
+  const ActionState net = derive_state(msg, canceled_is_fault_);
+  if (net == ActionState::kUnknown) {
+    return ActionState::kUnknown;  // no terminal verdict in this message
+  }
+
+  ActionState prev;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    auto it = last_reported_state_.find(action_name);
+    // Absent state is treated as healthy: a first SUCCEEDED must not heal a
+    // fault that was never raised.
+    prev = (it == last_reported_state_.end()) ? ActionState::kHealthy : it->second;
+  }
+
+  // Only the two real transitions act: raise on (not failed)->failed, heal on
+  // failed->(healthy). Everything else is a no-op.
+  if (net == ActionState::kFailed && prev != ActionState::kFailed) {
+    const bool canceled = describe_failure_is_cancel(msg, canceled_is_fault_);
+    if (reporter != nullptr) {
+      const std::string code = fault_code_for(action_name, canceled);
+      reporter->report(code, aborted_severity_,
+                       std::string("Action ") + action_name + (canceled ? " canceled" : " aborted"));
+      RCLCPP_INFO(get_logger(), "Action %s -> fault %s", action_name.c_str(), code.c_str());
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      last_reported_state_[action_name] = ActionState::kFailed;
+    }
+    return ActionState::kFailed;
+  }
+
+  if (net == ActionState::kHealthy && prev == ActionState::kFailed && heal_on_succeeded_) {
+    if (reporter != nullptr) {
+      // Heal both possible codes; only the one previously raised exists.
+      reporter->report_passed(fault_code_for(action_name, false));
+      if (canceled_is_fault_) {
+        reporter->report_passed(fault_code_for(action_name, true));
+      }
+      RCLCPP_INFO(get_logger(), "Action %s healed", action_name.c_str());
+    }
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      last_reported_state_[action_name] = ActionState::kHealthy;
+    }
+    return ActionState::kHealthy;
+  }
+
+  return ActionState::kUnknown;
 }
 
 void ActionStatusBridgeNode::status_callback(const std::string & action_name,
                                              const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg) {
   using GoalStatus = action_msgs::msg::GoalStatus;
 
+  // Per-goal dedup is LOG-only here; it must not gate the state transition.
   for (const auto & gs : msg->status_list) {
+    if (gs.status != GoalStatus::STATUS_ABORTED && gs.status != GoalStatus::STATUS_CANCELED &&
+        gs.status != GoalStatus::STATUS_SUCCEEDED) {
+      continue;
+    }
     std::array<uint8_t, 16> uuid{};
     std::copy(gs.goal_info.goal_id.uuid.begin(), gs.goal_info.goal_id.uuid.end(), uuid.begin());
     const std::string uuid_hex = uuid_to_hex(uuid);
     const std::string key = uuid_hex + ":" + std::to_string(static_cast<int>(gs.status));
-
-    if (gs.status == GoalStatus::STATUS_ABORTED ||
-        (gs.status == GoalStatus::STATUS_CANCELED && canceled_is_fault_)) {
-      if (!mark_handled(key)) {
-        continue;  // already reported this terminal state for this goal
-      }
-      auto * reporter = reporter_for(action_name);
-      if (reporter == nullptr) {
-        continue;
-      }
-      const char * what = (gs.status == GoalStatus::STATUS_ABORTED) ? "aborted" : "canceled";
-      const std::string desc = std::string("Goal ") + uuid_hex.substr(0, 8) + " " + what + " on action " +
-                               action_name;
-      reporter->report(aborted_fault_code(action_name), aborted_severity_, desc);
-      RCLCPP_INFO(get_logger(), "Action %s goal %s %s -> fault %s", action_name.c_str(),
-                  uuid_hex.substr(0, 8).c_str(), what, aborted_fault_code(action_name).c_str());
-    } else if (gs.status == GoalStatus::STATUS_SUCCEEDED && heal_on_succeeded_) {
-      if (!mark_handled(key)) {
-        continue;
-      }
-      auto * reporter = reporter_for(action_name);
-      if (reporter != nullptr) {
-        reporter->report_passed(aborted_fault_code(action_name));
-      }
+    if (mark_logged(key)) {
+      RCLCPP_DEBUG(get_logger(), "Action %s goal %s status %d", action_name.c_str(), uuid_hex.substr(0, 8).c_str(),
+                   static_cast<int>(gs.status));
     }
   }
+
+  apply_message(action_name, *msg, reporter_for(action_name));
 }
 
 ros2_medkit_fault_reporter::FaultReporter * ActionStatusBridgeNode::reporter_for(const std::string & action_name) {
@@ -149,25 +319,43 @@ ros2_medkit_fault_reporter::FaultReporter * ActionStatusBridgeNode::reporter_for
   if (it != reporters_.end()) {
     return it->second.get();
   }
-  // Attribute the fault to the action (best stable identifier from the status
-  // topic alone). Multiple reporters on one node are safe (has_parameter guard).
-  auto reporter =
-      std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), action_name);
+  // Attribute the fault to the action SERVER's node FQN, not the action name:
+  // the gateway resolves a fault to a SOVD entity by node FQN, and an action
+  // interface name (e.g. /navigate_to_pose) matches no entity. Multiple
+  // reporters on one node are safe (has_parameter guard).
+  const std::string source_id = server_fqn_for_action(action_name);
+  auto reporter = std::make_unique<ros2_medkit_fault_reporter::FaultReporter>(this->shared_from_this(), source_id);
   auto * raw = reporter.get();
   reporters_.emplace(action_name, std::move(reporter));
   return raw;
 }
 
-bool ActionStatusBridgeNode::mark_handled(const std::string & goal_status_key) {
-  std::lock_guard<std::mutex> lock(handled_mutex_);
-  if (handled_.find(goal_status_key) != handled_.end()) {
+std::string ActionStatusBridgeNode::server_fqn_for_action(const std::string & action_name) {
+  // The action server publishes <action>/_action/status, so its node FQN is the
+  // publisher's. A fault only fires while the server is publishing, so this
+  // resolves in practice; fall back to the action name otherwise.
+  const auto pubs = get_publishers_info_by_topic(action_name + "/_action/status");
+  for (const auto & p : pubs) {
+    const std::string name = p.node_name();
+    if (name.empty()) {
+      continue;
+    }
+    const std::string ns = p.node_namespace();
+    return (ns.empty() || ns == "/") ? "/" + name : ns + "/" + name;
+  }
+  return action_name;
+}
+
+bool ActionStatusBridgeNode::mark_logged(const std::string & goal_status_key) {
+  std::lock_guard<std::mutex> lock(logged_mutex_);
+  if (logged_.find(goal_status_key) != logged_.end()) {
     return false;
   }
-  handled_.insert(goal_status_key);
-  handled_order_.push_back(goal_status_key);
-  while (handled_order_.size() > handled_capacity_) {
-    handled_.erase(handled_order_.front());
-    handled_order_.pop_front();
+  logged_.insert(goal_status_key);
+  logged_order_.push_back(goal_status_key);
+  while (logged_order_.size() > logged_capacity_) {
+    logged_.erase(logged_order_.front());
+    logged_order_.pop_front();
   }
   return true;
 }
@@ -218,30 +406,69 @@ std::string ActionStatusBridgeNode::to_upper_snake(const std::string & in, size_
       last_sep = true;
     }
   }
-  while (!result.empty() && result.back() == '_') {
-    result.pop_back();
-  }
+  strip_trailing_underscore(result);
   if (result.size() > max_len) {
-    result.resize(max_len);
-    while (!result.empty() && result.back() == '_') {
-      result.pop_back();
-    }
+    // Truncate but reserve room for a stable disambiguator so two action names
+    // sharing the same `max_len` prefix do not collide.
+    constexpr size_t kDisambigLen = 5;  // '_' + 4 hex
+    const size_t keep = (max_len > kDisambigLen) ? (max_len - kDisambigLen) : 0;
+    const std::string full = result;
+    result.resize(keep);
+    strip_trailing_underscore(result);
+    const uint16_t h = static_cast<uint16_t>(std::hash<std::string>{}(full));
+    char buf[6];
+    std::snprintf(buf, sizeof(buf), "_%04X", static_cast<unsigned>(h));
+    result += buf;
   }
   return result;
 }
 
-std::string ActionStatusBridgeNode::aborted_fault_code(const std::string & action_name) const {
-  const std::string action_part = to_upper_snake(action_name, 48);
+std::string ActionStatusBridgeNode::fault_code_for(const std::string & action_name, bool canceled) const {
+  const char * suffix = canceled ? "_CANCELED" : "_ABORTED";
+  // Budget the action part so the status suffix always survives the 64-char clamp.
+  const size_t suffix_budget = kMaxStatusSuffix + 1;  // suffix + leading '_' to action part
+  const size_t prefix_len = code_prefix_.size() + 1;  // prefix + '_'
+  size_t action_budget = kMaxActionPart;
+  if (prefix_len + action_budget + suffix_budget > kMaxCodeLen) {
+    action_budget = (kMaxCodeLen > prefix_len + suffix_budget) ? (kMaxCodeLen - prefix_len - suffix_budget) : 0;
+  }
+  const std::string action_part = to_upper_snake(action_name, action_budget);
+
   std::string code = code_prefix_;
   if (!action_part.empty()) {
     code += '_';
     code += action_part;
   }
-  code += "_ABORTED";
-  if (code.size() > 64) {
-    code.resize(64);
+  code += suffix;
+  if (code.size() > kMaxCodeLen) {
+    code.resize(kMaxCodeLen);
+    strip_trailing_underscore(code);
   }
   return code;
+}
+
+void ActionStatusBridgeTestAccess::add_watched(const std::string & action_name) {
+  // nullptr subscription is sufficient: prune keys off the topic name only.
+  node_->subs_.emplace(action_name + kStatusSuffix, nullptr);
+  std::lock_guard<std::mutex> lock(node_->state_mutex_);
+  node_->last_reported_state_[action_name] = ActionStatusBridgeNode::ActionState::kFailed;
+}
+
+void ActionStatusBridgeTestAccess::prune_to(const std::vector<std::string> & present_action_names) {
+  std::map<std::string, std::string> present;
+  for (const auto & a : present_action_names) {
+    present.emplace(a + kStatusSuffix, a);
+  }
+  node_->prune_vanished(present);
+}
+
+bool ActionStatusBridgeTestAccess::is_watched(const std::string & action_name) const {
+  return node_->subs_.find(action_name + kStatusSuffix) != node_->subs_.end();
+}
+
+bool ActionStatusBridgeTestAccess::has_state(const std::string & action_name) const {
+  std::lock_guard<std::mutex> lock(node_->state_mutex_);
+  return node_->last_reported_state_.find(action_name) != node_->last_reported_state_.end();
 }
 
 }  // namespace ros2_medkit_action_status_bridge

--- a/src/ros2_medkit_action_status_bridge/src/main.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/main.cpp
@@ -1,0 +1,24 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_medkit_action_status_bridge/action_status_bridge_node.hpp"
+
+int main(int argc, char * argv[]) {
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ros2_medkit_action_status_bridge::ActionStatusBridgeNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
+++ b/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
@@ -1,0 +1,88 @@
+// Copyright 2026 mfaferek93, bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+#include "ros2_medkit_action_status_bridge/action_status_bridge_node.hpp"
+
+using ros2_medkit_action_status_bridge::ActionStatusBridgeNode;
+
+class ActionStatusBridgeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    rclcpp::init(0, nullptr);
+  }
+  void TearDown() override {
+    rclcpp::shutdown();
+  }
+};
+
+// --- action name extraction from status topic ---
+
+TEST_F(ActionStatusBridgeTest, ActionNameFromStatusTopic_Valid) {
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/navigate_to_pose/_action/status"),
+            "/navigate_to_pose");
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/move_action/_action/status"),
+            "/move_action");
+}
+
+TEST_F(ActionStatusBridgeTest, ActionNameFromStatusTopic_NotAStatusTopic) {
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/some/topic"), "");
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/navigate_to_pose/_action/feedback"), "");
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/_action/status"), "");
+}
+
+// --- fault code generation ---
+
+TEST_F(ActionStatusBridgeTest, AbortedFaultCode_WellFormed) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  const auto code = node->aborted_fault_code("/navigate_to_pose");
+  EXPECT_EQ(code, "ACTION_NAVIGATE_TO_POSE_ABORTED");
+  EXPECT_LE(code.size(), 64u);
+  for (char ch : code) {
+    const bool ok = (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_';
+    EXPECT_TRUE(ok) << "bad char: " << ch;
+  }
+}
+
+TEST_F(ActionStatusBridgeTest, AbortedFaultCode_MoveAction) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(node->aborted_fault_code("/move_action"), "ACTION_MOVE_ACTION_ABORTED");
+}
+
+// --- uuid hex ---
+
+TEST_F(ActionStatusBridgeTest, UuidToHex) {
+  std::array<uint8_t, 16> uuid{};
+  uuid[0] = 0xAB;
+  uuid[1] = 0x01;
+  uuid[15] = 0xFF;
+  const auto hex = ActionStatusBridgeNode::uuid_to_hex(uuid);
+  EXPECT_EQ(hex.size(), 32u);
+  EXPECT_EQ(hex.substr(0, 4), "ab01");
+  EXPECT_EQ(hex.substr(30, 2), "ff");
+}
+
+TEST_F(ActionStatusBridgeTest, NodeCreation) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_NE(node, nullptr);
+  EXPECT_STREQ(node->get_name(), "action_status_bridge");
+}
+
+int main(int argc, char ** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
+++ b/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
@@ -15,10 +15,40 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
 
+#include "action_msgs/msg/goal_status.hpp"
+#include "action_msgs/msg/goal_status_array.hpp"
 #include "ros2_medkit_action_status_bridge/action_status_bridge_node.hpp"
 
 using ros2_medkit_action_status_bridge::ActionStatusBridgeNode;
+using ros2_medkit_action_status_bridge::ActionStatusBridgeTestAccess;
+using GoalStatus = action_msgs::msg::GoalStatus;
+using GoalStatusArray = action_msgs::msg::GoalStatusArray;
+using State = ActionStatusBridgeNode::ActionState;
+
+namespace {
+
+// Build a GoalStatusArray from a list of (goal_byte, status) pairs. goal_byte
+// seeds a distinct UUID so each goal has its own id.
+GoalStatusArray make_array(const std::vector<std::pair<uint8_t, int8_t>> & goals) {
+  GoalStatusArray arr;
+  for (const auto & [goal_byte, status] : goals) {
+    GoalStatus gs;
+    gs.goal_info.goal_id.uuid[0] = goal_byte;
+    gs.status = status;
+    arr.status_list.push_back(gs);
+  }
+  return arr;
+}
+
+GoalStatusArray one_goal(uint8_t goal_byte, int8_t status) {
+  return make_array({{goal_byte, status}});
+}
+
+}  // namespace
 
 class ActionStatusBridgeTest : public ::testing::Test {
  protected:
@@ -35,8 +65,7 @@ class ActionStatusBridgeTest : public ::testing::Test {
 TEST_F(ActionStatusBridgeTest, ActionNameFromStatusTopic_Valid) {
   EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/navigate_to_pose/_action/status"),
             "/navigate_to_pose");
-  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/move_action/_action/status"),
-            "/move_action");
+  EXPECT_EQ(ActionStatusBridgeNode::action_name_from_status_topic("/move_action/_action/status"), "/move_action");
 }
 
 TEST_F(ActionStatusBridgeTest, ActionNameFromStatusTopic_NotAStatusTopic) {
@@ -47,9 +76,9 @@ TEST_F(ActionStatusBridgeTest, ActionNameFromStatusTopic_NotAStatusTopic) {
 
 // --- fault code generation ---
 
-TEST_F(ActionStatusBridgeTest, AbortedFaultCode_WellFormed) {
+TEST_F(ActionStatusBridgeTest, FaultCode_Aborted_WellFormed) {
   auto node = std::make_shared<ActionStatusBridgeNode>();
-  const auto code = node->aborted_fault_code("/navigate_to_pose");
+  const auto code = node->fault_code_for("/navigate_to_pose", false);
   EXPECT_EQ(code, "ACTION_NAVIGATE_TO_POSE_ABORTED");
   EXPECT_LE(code.size(), 64u);
   for (char ch : code) {
@@ -58,9 +87,32 @@ TEST_F(ActionStatusBridgeTest, AbortedFaultCode_WellFormed) {
   }
 }
 
-TEST_F(ActionStatusBridgeTest, AbortedFaultCode_MoveAction) {
+TEST_F(ActionStatusBridgeTest, FaultCode_Canceled_UsesCanceledSuffix) {
   auto node = std::make_shared<ActionStatusBridgeNode>();
-  EXPECT_EQ(node->aborted_fault_code("/move_action"), "ACTION_MOVE_ACTION_ABORTED");
+  EXPECT_EQ(node->fault_code_for("/move_action", true), "ACTION_MOVE_ACTION_CANCELED");
+}
+
+TEST_F(ActionStatusBridgeTest, FaultCode_LongName_StatusSuffixSurvivesClamp) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  const std::string long_name = "/" + std::string(80, 'a');
+  const auto aborted = node->fault_code_for(long_name, false);
+  const auto canceled = node->fault_code_for(long_name, true);
+  EXPECT_LE(aborted.size(), 64u);
+  EXPECT_LE(canceled.size(), 64u);
+  EXPECT_NE(aborted.find("_ABORTED"), std::string::npos) << aborted;
+  EXPECT_NE(canceled.find("_CANCELED"), std::string::npos) << canceled;
+  EXPECT_NE(aborted.back(), '_');
+}
+
+TEST_F(ActionStatusBridgeTest, FaultCode_SharedLongPrefix_NoCollision) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  // Two names share the first 60 chars but differ afterwards.
+  const std::string base = "/" + std::string(60, 'x');
+  const auto a = node->fault_code_for(base + "_alpha", false);
+  const auto b = node->fault_code_for(base + "_bravo", false);
+  EXPECT_NE(a, b) << a << " vs " << b;
+  EXPECT_LE(a.size(), 64u);
+  EXPECT_LE(b.size(), 64u);
 }
 
 // --- uuid hex ---
@@ -80,6 +132,152 @@ TEST_F(ActionStatusBridgeTest, NodeCreation) {
   auto node = std::make_shared<ActionStatusBridgeNode>();
   EXPECT_NE(node, nullptr);
   EXPECT_STREQ(node->get_name(), "action_status_bridge");
+}
+
+// --- derive_state: net state from a whole array ---
+
+TEST_F(ActionStatusBridgeTest, DeriveState_AbortedIsFailed) {
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(one_goal(1, GoalStatus::STATUS_ABORTED), false), State::kFailed);
+}
+
+TEST_F(ActionStatusBridgeTest, DeriveState_SucceededIsHealthy) {
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(one_goal(1, GoalStatus::STATUS_SUCCEEDED), false), State::kHealthy);
+}
+
+TEST_F(ActionStatusBridgeTest, DeriveState_NoTerminalIsUnknown) {
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(one_goal(1, GoalStatus::STATUS_EXECUTING), false), State::kUnknown);
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(GoalStatusArray{}, false), State::kUnknown);
+}
+
+TEST_F(ActionStatusBridgeTest, DeriveState_CanceledRespectsFlag) {
+  const auto arr = one_goal(1, GoalStatus::STATUS_CANCELED);
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(arr, false), State::kHealthy);
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(arr, true), State::kFailed);
+}
+
+TEST_F(ActionStatusBridgeTest, DeriveState_OrderIndependent) {
+  // ABORTED before and after SUCCEEDED must both yield FAILED.
+  const auto a = make_array({{1, GoalStatus::STATUS_ABORTED}, {2, GoalStatus::STATUS_SUCCEEDED}});
+  const auto b = make_array({{2, GoalStatus::STATUS_SUCCEEDED}, {1, GoalStatus::STATUS_ABORTED}});
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(a, false), State::kFailed);
+  EXPECT_EQ(ActionStatusBridgeNode::derive_state(b, false), State::kFailed);
+}
+
+// --- apply_message: transitions only (nullptr reporter = decision-only seam) ---
+
+TEST_F(ActionStatusBridgeTest, Apply_AbortRaisesThenSucceedHeals) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_DedupNoDoubleRaiseOrHeal) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  // Same failed array again: no transition.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kUnknown);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+  // Same healthy array again: no transition.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kUnknown);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_SucceededFirstNoSpuriousHeal) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  // First terminal is SUCCEEDED with no prior fault: healthy is the net state
+  // but there is nothing to heal, so no failed->healthy transition fires.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kUnknown);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_MultiGoalOneArray_OrderIndependent) {
+  auto n1 = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(n1->apply_message("/nav", make_array({{1, GoalStatus::STATUS_ABORTED}, {2, GoalStatus::STATUS_SUCCEEDED}}),
+                              nullptr),
+            State::kFailed);
+  auto n2 = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(n2->apply_message("/nav", make_array({{2, GoalStatus::STATUS_SUCCEEDED}, {1, GoalStatus::STATUS_ABORTED}}),
+                              nullptr),
+            State::kFailed);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_HealOnlyWhenFailingGoalAgesOut) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  // Failing goal still retained alongside a fresh success: stays failed.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  EXPECT_EQ(node->apply_message(
+                "/nav", make_array({{1, GoalStatus::STATUS_ABORTED}, {2, GoalStatus::STATUS_SUCCEEDED}}), nullptr),
+            State::kUnknown);
+  // Failing goal aged out, only the success remains: heals.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_Flapping_OnlyNetStateChangesTransition) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  int transitions = 0;
+  // Retries issue a fresh goal_id each attempt; the action stays failed.
+  for (uint8_t g = 10; g < 14; ++g) {
+    if (node->apply_message("/nav", one_goal(g, GoalStatus::STATUS_ABORTED), nullptr) != State::kUnknown) {
+      ++transitions;
+    }
+  }
+  EXPECT_EQ(transitions, 1) << "only the first abort should transition";
+  EXPECT_EQ(node->apply_message("/nav", one_goal(99, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+}
+
+// --- canceled-as-fault semantics ---
+
+TEST_F(ActionStatusBridgeTest, Apply_CanceledNotFaultByDefault) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  // Default canceled_is_fault=false: a lone CANCELED is a non-failing terminal,
+  // healthy with nothing to heal -> no transition.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_CANCELED), nullptr), State::kUnknown);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_CanceledIsFault_RaisesThenHealsOnSuccess) {
+  rclcpp::NodeOptions opts;
+  opts.append_parameter_override("canceled_is_fault", true);
+  auto node = std::make_shared<ActionStatusBridgeNode>(opts);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_CANCELED), nullptr), State::kFailed);
+  // Canceled goal aged out, success remains -> heals.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+}
+
+TEST_F(ActionStatusBridgeTest, Apply_HealDisabled_NoHealTransition) {
+  rclcpp::NodeOptions opts;
+  opts.append_parameter_override("heal_on_succeeded", false);
+  auto node = std::make_shared<ActionStatusBridgeNode>(opts);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kUnknown);
+}
+
+// --- per-action isolation: one action failing must not heal another ---
+
+TEST_F(ActionStatusBridgeTest, Apply_PerActionIsolation) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  EXPECT_EQ(node->apply_message("/arm", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  // Healing /arm leaves /nav failed.
+  EXPECT_EQ(node->apply_message("/arm", one_goal(2, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+  EXPECT_EQ(node->apply_message("/nav", one_goal(3, GoalStatus::STATUS_SUCCEEDED), nullptr), State::kHealthy);
+}
+
+// --- rescan add + prune ---
+
+TEST_F(ActionStatusBridgeTest, RescanPrune_DropsVanishedAction) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  ActionStatusBridgeTestAccess access(node.get());
+
+  access.add_watched("/nav");
+  access.add_watched("/arm");
+  EXPECT_TRUE(access.is_watched("/nav"));
+  EXPECT_TRUE(access.is_watched("/arm"));
+  EXPECT_TRUE(access.has_state("/arm"));
+
+  // /arm vanished from the graph; /nav remains.
+  access.prune_to({"/nav"});
+  EXPECT_TRUE(access.is_watched("/nav"));
+  EXPECT_TRUE(access.has_state("/nav"));
+  EXPECT_FALSE(access.is_watched("/arm"));
+  EXPECT_FALSE(access.has_state("/arm"));
 }
 
 int main(int argc, char ** argv) {

--- a/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93, bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end integration tests for ros2_medkit_action_status_bridge."""
+
+import time
+import unittest
+
+from action_msgs.msg import GoalStatus, GoalStatusArray
+from launch import LaunchDescription
+import launch_ros.actions
+import launch_testing.actions
+import launch_testing.markers
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import (
+    DurabilityPolicy,
+    HistoryPolicy,
+    QoSProfile,
+    ReliabilityPolicy,
+)
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ListFaults
+from unique_identifier_msgs.msg import UUID
+
+STATUS_TOPIC = '/test_action/_action/status'
+ABORTED_CODE = 'ACTION_TEST_ACTION_ABORTED'
+
+
+def generate_test_description():
+    """Launch description with fault_manager and action_status_bridge nodes."""
+    fault_manager_node = launch_ros.actions.Node(
+        package='ros2_medkit_fault_manager',
+        executable='fault_manager_node',
+        name='fault_manager',
+        output='screen',
+        parameters=[{
+            'storage_type': 'memory',
+            'confirmation_threshold': -1,  # immediate confirmation
+            'healing_enabled': True,
+            # The bridge emits one PASSED per recovery (state machine), so the
+            # fault heals on that single event only with healing_threshold 0.
+            'healing_threshold': 0,
+        }],
+    )
+
+    action_status_bridge_node = launch_ros.actions.Node(
+        package='ros2_medkit_action_status_bridge',
+        executable='action_status_bridge_node',
+        name='action_status_bridge',
+        output='screen',
+        parameters=[{
+            'rescan_period_sec': 1.0,  # fast discovery for the test
+        }],
+    )
+
+    return (
+        LaunchDescription([
+            fault_manager_node,
+            action_status_bridge_node,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'fault_manager_node': fault_manager_node,
+            'action_status_bridge_node': action_status_bridge_node,
+        },
+    )
+
+
+def _status_array(status, goal_byte):
+    gsa = GoalStatusArray()
+    gs = GoalStatus()
+    gs.goal_info.goal_id = UUID(uuid=[goal_byte] * 16)
+    gs.status = int(status)
+    gsa.status_list = [gs]
+    return gsa
+
+
+class TestActionStatusBridgeIntegration(unittest.TestCase):
+    """End-to-end action-status -> fault discovery and raise/heal."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node('test_action_status_client')
+        # Match the bridge's subscription QoS so the latched status is delivered.
+        qos = QoSProfile(
+            depth=10,
+            reliability=ReliabilityPolicy.RELIABLE,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            history=HistoryPolicy.KEEP_LAST,
+        )
+        cls.status_pub = cls.node.create_publisher(GoalStatusArray, STATUS_TOPIC, qos)
+        cls.list_faults_client = cls.node.create_client(
+            ListFaults, '/fault_manager/list_faults'
+        )
+        assert cls.list_faults_client.wait_for_service(timeout_sec=10.0), \
+            'ListFaults service not available'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def list_faults(self, statuses=None):
+        request = ListFaults.Request()
+        request.filter_by_severity = False
+        request.statuses = statuses or []
+        future = self.list_faults_client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=5.0)
+        return future.result().faults
+
+    def find(self, faults, code):
+        return next((f for f in faults if f.fault_code == code), None)
+
+    def wait_for_fault(self, code, statuses=None, want_status=None, timeout=15.0):
+        """Poll list_faults until the fault exists and optionally reaches a status."""
+        deadline = time.time() + timeout
+        fault = None
+        while time.time() < deadline:
+            fault = self.find(self.list_faults(statuses), code)
+            if fault is not None and (want_status is None or fault.status == want_status):
+                return fault
+            time.sleep(0.5)
+        return fault
+
+    def test_01_aborted_goal_raises_fault(self):
+        """An ABORTED goal on a discovered status topic raises a fault."""
+        self.status_pub.publish(_status_array(GoalStatus.STATUS_ABORTED, 1))
+        # Poll through runtime discovery (rescan) + subscription + processing.
+        fault = self.wait_for_fault(ABORTED_CODE)
+        self.assertIsNotNone(fault, f'expected a {ABORTED_CODE} fault')
+        self.assertEqual(fault.severity, Fault.SEVERITY_ERROR)
+        # Attributed to the action server's node FQN (this test node publishes it).
+        self.assertIn('/test_action_status_client', list(fault.reporting_sources))
+
+    def test_02_succeeded_goal_heals_fault(self):
+        """A later SUCCEEDED goal (no failing goal in the array) heals it."""
+        self.status_pub.publish(_status_array(GoalStatus.STATUS_SUCCEEDED, 2))
+        fault = self.wait_for_fault(
+            ABORTED_CODE,
+            statuses=[Fault.STATUS_CONFIRMED, Fault.STATUS_HEALED],
+            want_status=Fault.STATUS_HEALED,
+        )
+        self.assertIsNotNone(fault, f'{ABORTED_CODE} fault not HEALED in time')
+        self.assertEqual(fault.status, Fault.STATUS_HEALED)
+
+
+@launch_testing.post_shutdown_test()
+class TestActionStatusBridgeShutdown(unittest.TestCase):
+    """Test clean shutdown."""
+
+    def test_exit_code(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
Adds `ros2_medkit_action_status_bridge`, a generic drop-in adapter that discovers every action via its `*/_action/status` topic and turns terminal `ABORTED` goal states into FaultManager faults, healing the code on `SUCCEEDED`.

This captures the authoritative failure channel for the core stacks (Nav2, MoveIt 2, ros2_control), where an aborted goal reaches neither `/rosout` nor `/diagnostics`.

- `source_id` is the action name; `fault_code` is `<PREFIX>_<ACTION>_ABORTED`.
- Per-goal dedup on `goal_id` so a latched terminal status reports once.
- New actions appearing later are picked up by a periodic rescan.

Unit tests cover action-name extraction, fault_code generation, and dedup.

Closes #421
