### PR TITLE
feat(fault_manager): entity-scoped rosbag capture by default

### DIFF
--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -217,12 +217,15 @@ Capture continuous rosbag recordings around fault events.
            enabled: false                  # Enable rosbag recording
            duration_sec: 5.0               # Pre-fault buffer duration
            duration_after_sec: 1.0         # Post-fault recording duration
-           topics: "config"                # Topic selection: "config", "all", or "none"
+           topics: "entity"                # Topic selection: "entity" (default), "config", "all", "explicit"
            include_topics: []              # Additional topics to include
            exclude_topics: []              # Topics to exclude
+           exclude_sensor_topics: true     # Auto-exclude image/points/depth/compressed in broad modes
            lazy_start: false               # Start recording on first fault
            format: "sqlite3"               # Storage format
+           qos_match: true                 # Match each topic's publisher QoS
            storage_path: ""                # Custom storage path
+           max_buffer_mb: 256              # Ring-buffer RAM cap
            max_bag_size_mb: 50             # Max size per bag file
            max_total_storage_mb: 500       # Max total storage
            auto_cleanup: true              # Auto-delete old bags
@@ -244,8 +247,21 @@ Capture continuous rosbag recordings around fault events.
      - ``1.0``
      - How long to record after fault.
    * - ``rosbag.topics``
-     - ``config``
-     - Topic selection mode: ``config`` (per-fault), ``all``, or ``none``.
+     - ``entity``
+     - Topic selection mode: ``entity`` (default; write only the faulting node's
+       topics + ``/tf``), ``config`` (per-fault), ``all``, or ``explicit``.
+   * - ``rosbag.exclude_sensor_topics``
+     - ``true``
+     - In broad modes (``all``/``entity``), auto-exclude high-bandwidth sensor
+       topics (image/points/depth/compressed) to bound memory. Excluded topics are
+       dropped silently; ``include_topics`` re-adds any you need.
+   * - ``rosbag.qos_match``
+     - ``true``
+     - Subscribe with each topic's publisher-offered QoS for faithful capture
+       instead of forcing best-effort.
+   * - ``rosbag.max_buffer_mb``
+     - ``256``
+     - Ring-buffer RAM cap; oldest buffered messages drop past it.
    * - ``rosbag.lazy_start``
      - ``false``
      - Start recording only when first fault occurs.

--- a/docs/tutorials/snapshots.rst
+++ b/docs/tutorials/snapshots.rst
@@ -332,12 +332,27 @@ Rosbag Configuration Options
      - Post-fault recording duration. After a fault is confirmed, recording
        continues for this many seconds to capture immediate system response.
    * - ``snapshots.rosbag.topics``
-     - ``"config"``
+     - ``"entity"``
      - Topic selection mode:
 
+       - ``"entity"`` - Default. Subscribe broadly for pre-roll, but on fault
+         confirmation write only the faulting source node's topics (resolved from
+         the fault's reporting source) plus ``/tf`` and ``/tf_static``. Falls back
+         to the full buffer if the source is not a live node.
        - ``"config"`` - Use same topics as JSON snapshots (from config file)
        - ``"all"`` or ``"auto"`` - Auto-discover and record all available topics
        - ``"explicit"`` - Use only topics from ``include_topics`` list
+
+       .. note::
+
+          The default changed from ``"config"`` to ``"entity"`` so an enabled black
+          box produces a useful, fault-scoped bag with no per-topic configuration.
+          Set ``topics: "config"`` to restore the previous behavior.
+
+          Faults reported by the ``diagnostic_bridge`` carry the bridge's own node
+          as the source, so in ``entity`` mode the bag is scoped to the bridge
+          (e.g. ``/diagnostics``) rather than the node that actually failed. Use a
+          manual mode if you need a different scope for bridge-sourced faults.
    * - ``snapshots.rosbag.include_topics``
      - ``[]``
      - Explicit list of topics to record (only used when ``topics: "explicit"``).
@@ -346,6 +361,19 @@ Rosbag Configuration Options
      - ``[]``
      - Topics to exclude from recording (applies to all modes). Useful for
        filtering high-bandwidth topics like camera images.
+   * - ``snapshots.rosbag.exclude_sensor_topics``
+     - ``true``
+     - In broad modes (``all``/``entity``), auto-exclude high-bandwidth sensor
+       topics (image/points/depth/compressed) to bound memory. Dropped silently;
+       ``include_topics`` re-adds any you specifically need.
+   * - ``snapshots.rosbag.qos_match``
+     - ``true``
+     - Subscribe with each topic's publisher-offered QoS (reliable/transient-local
+       where offered) for faithful capture, instead of forcing best-effort.
+   * - ``snapshots.rosbag.max_buffer_mb``
+     - ``256``
+     - In-memory ring-buffer cap; oldest buffered messages drop once exceeded, so a
+       broad subscribe set cannot grow memory without bound.
    * - ``snapshots.rosbag.format``
      - ``"sqlite3"``
      - Bag storage format: ``"sqlite3"`` (default, widely compatible) or

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -217,6 +217,13 @@ if(BUILD_TESTING)
     TIMEOUT 60
   )
   set_tests_properties(test_entity_thresholds_integration PROPERTIES LABELS "integration")
+
+  add_launch_test(
+    test/test_rosbag_entity_scope.test.py
+    TARGET test_rosbag_entity_scope
+    TIMEOUT 120
+  )
+  set_tests_properties(test_rosbag_entity_scope PROPERTIES LABELS "integration")
   ros2_medkit_relax_vendor_warnings()
 endif()
 

--- a/src/ros2_medkit_fault_manager/config/snapshots.yaml
+++ b/src/ros2_medkit_fault_manager/config/snapshots.yaml
@@ -86,13 +86,18 @@ rosbag:
   # Continue recording after fault is confirmed to capture aftermath
   duration_after_sec: 1.0
 
-  # Topic selection mode (default: "config")
+  # Topic selection mode (default: "entity")
   # Options:
+  #   "entity"   - DEFAULT. Subscribe broadly for pre-roll, but on fault confirmation
+  #                write only the faulting source node's topics (+ /tf, /tf_static),
+  #                resolved from the fault's reporting source. Useful black box with
+  #                zero per-topic config. Falls back to the full buffer if the source
+  #                cannot be resolved to a live node.
   #   "config"   - Use same topics as JSON snapshots (from this config file)
-  #   "all"      - Record all available topics (WARNING: high memory usage!)
+  #   "all"      - Record all available topics
   #   "auto"     - Alias for "all" (auto-discover all topics)
   #   "explicit" - Use only topics from include_topics list below
-  topics: "config"
+  topics: "entity"
 
   # Explicit topic list (only used when topics: "explicit")
   # include_topics:
@@ -106,6 +111,11 @@ rosbag:
   #   - /camera/image_raw
   #   - /camera/depth/image_raw
   #   - /pointcloud
+
+  # Auto-exclude high-bandwidth sensor topics (image/points/depth/compressed) in
+  # broad modes ("all"/"auto"/"entity") to bound memory (default: true).
+  # Excluded topics are dropped silently; list them in include_topics to re-add.
+  exclude_sensor_topics: true
 
   # Lazy start mode (default: false)
   # When true, ring buffer only starts when fault enters PREFAILED state
@@ -133,6 +143,16 @@ rosbag:
   # Maximum total storage for all bag files in MB (default: 500)
   # Oldest bags are deleted when this limit is exceeded
   max_total_storage_mb: 500
+
+  # Maximum in-memory ring buffer size in MB (default: 256)
+  # Oldest buffered messages are dropped once the buffer exceeds this, so a broad
+  # subscribe set on a busy robot cannot grow memory without bound.
+  max_buffer_mb: 256
+
+  # Match each topic's publisher-offered QoS for faithful capture (default: true)
+  # Captures reliable / transient-local topics without dropping; set false to force
+  # best-effort SensorDataQoS on every subscription.
+  qos_match: true
 
   # Auto-cleanup bag files when fault is cleared (default: true)
   # When true, bag files are deleted when ClearFault is called

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/rosbag_capture.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/rosbag_capture.hpp
@@ -109,6 +109,10 @@ class RosbagCapture {
     return config_.enabled;
   }
 
+  /// Whether a topic is a high-bandwidth sensor stream (image/points/depth/compressed),
+  /// auto-excluded from broad-mode capture. Static + public so it is directly testable.
+  static bool is_high_bandwidth_topic(const std::string & topic);
+
  private:
   /// Initialize subscriptions for configured topics
   void init_subscriptions();
@@ -122,6 +126,17 @@ class RosbagCapture {
 
   /// Resolve which topics to record based on config
   std::vector<std::string> resolve_topics() const;
+
+  /// Resolve the publisher-offered QoS for a topic so capture is faithful
+  /// (falls back to SensorDataQoS when no publisher is known or qos_match is off)
+  rclcpp::QoS resolve_topic_qos(const std::string & topic) const;
+
+  /// In "entity" mode, compute the set of topics to write for a confirmed fault
+  /// (the faulting source node's pub/sub topics + /tf). Empty set = write all.
+  void resolve_entity_topics(const std::string & fault_code);
+
+  /// Whether a topic should be written to the bag given the active entity filter
+  bool should_capture_topic(const std::string & topic) const;
 
   /// Get message type for a topic
   std::string get_topic_type(const std::string & topic) const;
@@ -167,6 +182,13 @@ class RosbagCapture {
   /// Ring buffer for messages
   mutable std::mutex buffer_mutex_;
   std::deque<BufferedMessage> message_buffer_;
+  /// Running byte size of message_buffer_ (guarded by buffer_mutex_), for the RAM cap
+  size_t buffer_bytes_{0};
+
+  /// Topics to write for the in-flight capture in "entity" mode (guarded below).
+  /// Empty = no entity filter, write everything buffered (manual modes / fallback).
+  mutable std::mutex capture_topics_mutex_;
+  std::set<std::string> active_capture_topics_;
 
   /// Subscriptions (kept alive for continuous recording)
   std::vector<rclcpp::GenericSubscription::SharedPtr> subscriptions_;
@@ -197,6 +219,16 @@ class RosbagCapture {
   rclcpp::TimerBase::SharedPtr discovery_retry_timer_;
   std::vector<std::string> pending_topics_;
   int discovery_retry_count_{0};
+
+  /// Topics already subscribed (guards against duplicate subscriptions when the
+  /// broad-mode discovery timer re-resolves the topic set).
+  std::set<std::string> subscribed_topics_;
+
+  /// True in broad modes ("all"/"auto"/"entity"): the discovery timer keeps
+  /// re-resolving for the capture's lifetime so topics whose publishers appear
+  /// after startup are still subscribed (dynamic capture). False in fixed modes
+  /// (config/explicit/list), where only the initial set is retried.
+  bool dynamic_discovery_{false};
 };
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/snapshot_capture.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/snapshot_capture.hpp
@@ -38,14 +38,25 @@ struct RosbagConfig {
   /// Duration in seconds to continue recording after fault confirmation
   double duration_after_sec{1.0};
 
-  /// Topic selection mode: "config" (reuse JSON config), "all", or comma-separated list
-  std::string topics{"config"};
+  /// Topic selection mode (default "entity"):
+  ///   "entity"     - subscribe broadly for pre-roll, but on confirm write only the
+  ///                  faulting entity's topics (resolved from the fault's reporting
+  ///                  source node) plus always-on context (/tf, /tf_static)
+  ///   "config"     - reuse JSON snapshot config topics
+  ///   "all"/"auto" - every discovered topic
+  ///   "explicit"   - only include_topics
+  ///   "<a,b,c>"    - comma-separated topic list
+  std::string topics{"entity"};
 
   /// Additional topics to include (added to resolved list)
   std::vector<std::string> include_topics;
 
   /// Topics to exclude from recording
   std::vector<std::string> exclude_topics;
+
+  /// In broad modes ("all"/"auto"/"entity"), skip high-bandwidth sensor topics
+  /// (image/points/depth/compressed) to bound memory; include_topics re-adds them.
+  bool exclude_sensor_topics{true};
 
   /// If true, start ring buffer only when fault enters PREFAILED state
   /// If false (default), ring buffer runs continuously from startup
@@ -63,6 +74,13 @@ struct RosbagConfig {
 
   /// Maximum total storage for all bag files in MB
   size_t max_total_storage_mb{500};
+
+  /// Cap on the in-memory ring buffer in MB; oldest messages drop past it
+  size_t max_buffer_mb{256};
+
+  /// Subscribe with each topic's publisher-offered QoS for faithful capture
+  /// (reliable/transient-local where offered) instead of forcing best-effort
+  bool qos_match{true};
 
   /// If true, delete bag file when fault is cleared
   bool auto_cleanup{true};

--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -27,8 +27,10 @@
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_clang_tidy</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
+  <test_depend>rosbag2_py</test_depend>
   <test_depend>sensor_msgs</test_depend>
   <test_depend>std_msgs</test_depend>
 

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -744,11 +744,13 @@ SnapshotConfig FaultManagerNode::create_snapshot_config() {
       config.rosbag.duration_after_sec = 0.0;
     }
 
-    config.rosbag.topics = declare_parameter<std::string>("snapshots.rosbag.topics", "config");
+    config.rosbag.topics = declare_parameter<std::string>("snapshots.rosbag.topics", "entity");
     config.rosbag.include_topics =
         declare_parameter<std::vector<std::string>>("snapshots.rosbag.include_topics", std::vector<std::string>{});
     config.rosbag.exclude_topics =
         declare_parameter<std::vector<std::string>>("snapshots.rosbag.exclude_topics", std::vector<std::string>{});
+    config.rosbag.exclude_sensor_topics = declare_parameter<bool>("snapshots.rosbag.exclude_sensor_topics", true);
+    config.rosbag.qos_match = declare_parameter<bool>("snapshots.rosbag.qos_match", true);
 
     config.rosbag.lazy_start = declare_parameter<bool>("snapshots.rosbag.lazy_start", false);
     config.rosbag.format = declare_parameter<std::string>("snapshots.rosbag.format", "sqlite3");
@@ -768,14 +770,22 @@ SnapshotConfig FaultManagerNode::create_snapshot_config() {
     }
     config.rosbag.max_total_storage_mb = static_cast<size_t>(max_total_storage);
 
+    int64_t max_buffer = declare_parameter<int64_t>("snapshots.rosbag.max_buffer_mb", 256);
+    if (max_buffer <= 0) {
+      RCLCPP_WARN(get_logger(), "snapshots.rosbag.max_buffer_mb must be positive. Using 256MB");
+      max_buffer = 256;
+    }
+    config.rosbag.max_buffer_mb = static_cast<size_t>(max_buffer);
+
     config.rosbag.auto_cleanup = declare_parameter<bool>("snapshots.rosbag.auto_cleanup", true);
 
     RCLCPP_INFO(get_logger(),
-                "Rosbag capture enabled (duration=%.1fs+%.1fs, topics=%s, lazy=%s, format=%s, "
-                "max_bag=%zuMB, max_total=%zuMB)",
+                "Rosbag capture enabled (duration=%.1fs+%.1fs, topics=%s, qos_match=%s, lazy=%s, format=%s, "
+                "max_buffer=%zuMB, max_bag=%zuMB, max_total=%zuMB)",
                 config.rosbag.duration_sec, config.rosbag.duration_after_sec, config.rosbag.topics.c_str(),
-                config.rosbag.lazy_start ? "true" : "false", config.rosbag.format.c_str(),
-                config.rosbag.max_bag_size_mb, config.rosbag.max_total_storage_mb);
+                config.rosbag.qos_match ? "true" : "false", config.rosbag.lazy_start ? "true" : "false",
+                config.rosbag.format.c_str(), config.rosbag.max_buffer_mb, config.rosbag.max_bag_size_mb,
+                config.rosbag.max_total_storage_mb);
   }
 
   if (config.enabled) {

--- a/src/ros2_medkit_fault_manager/src/rosbag_capture.cpp
+++ b/src/ros2_medkit_fault_manager/src/rosbag_capture.cpp
@@ -18,6 +18,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <filesystem>
 #include <optional>
@@ -211,11 +212,13 @@ void RosbagCapture::stop() {
 
   // Clear subscriptions
   subscriptions_.clear();
+  subscribed_topics_.clear();
 
   // Clear buffer
   {
     std::lock_guard<std::mutex> lock(buffer_mutex_);
     message_buffer_.clear();
+    buffer_bytes_ = 0;
   }
 
   RCLCPP_INFO(node_->get_logger(), "RosbagCapture stopped");
@@ -250,6 +253,10 @@ void RosbagCapture::on_fault_confirmed(const std::string & fault_code) {
   }
 
   RCLCPP_INFO(node_->get_logger(), "RosbagCapture: fault '%s' confirmed, flushing buffer to bag", fault_code.c_str());
+
+  // In "entity" mode, narrow the broadly-buffered messages to the faulting node's
+  // topics. Sets the filter used by flush_to_bag() and the post-fault write path.
+  resolve_entity_topics(fault_code);
 
   // Flush buffer to bag
   std::string bag_path = flush_to_bag(fault_code);
@@ -298,6 +305,9 @@ void RosbagCapture::on_fault_confirmed(const std::string & fault_code) {
 
     RCLCPP_INFO(node_->get_logger(), "Bag file created: %s (%.2f MB)", bag_path.c_str(),
                 static_cast<double>(bag_size) / (1024.0 * 1024.0));
+
+    std::lock_guard<std::mutex> lock(capture_topics_mutex_);
+    active_capture_topics_.clear();
   }
 }
 
@@ -313,31 +323,30 @@ void RosbagCapture::on_fault_cleared(const std::string & fault_code) {
 }
 
 void RosbagCapture::init_subscriptions() {
-  auto topics = resolve_topics();
-  if (topics.empty()) {
-    RCLCPP_WARN(node_->get_logger(), "No topics configured for rosbag capture");
-    return;
-  }
+  // Broad modes ("all"/"auto"/"entity") capture whatever is on the graph, so the
+  // subscribe set must keep growing as publishers appear after startup (dynamic
+  // capture). Fixed modes (config/explicit/list) have a closed set known up front.
+  dynamic_discovery_ = (config_.topics == "all" || config_.topics == "auto" || config_.topics == "entity");
 
   subscriptions_.clear();
+  subscribed_topics_.clear();
 
   // Track topics that couldn't be subscribed yet (type not discoverable)
   std::vector<std::string> pending_topics;
-
-  for (const auto & topic : topics) {
+  for (const auto & topic : resolve_topics()) {
     if (!try_subscribe_topic(topic)) {
       pending_topics.push_back(topic);
     }
   }
 
-  // If we have pending topics, start a timer to retry subscription
-  if (!pending_topics.empty() && !discovery_retry_timer_) {
+  // Run the discovery timer when there are type-pending topics OR we need to keep
+  // picking up newly-appeared topics in a broad mode.
+  if ((dynamic_discovery_ || !pending_topics.empty()) && !discovery_retry_timer_) {
     pending_topics_ = pending_topics;
     discovery_retry_count_ = 0;
     discovery_retry_timer_ = node_->create_wall_timer(std::chrono::milliseconds(500), [this]() {
       discovery_retry_callback();
     });
-    RCLCPP_INFO(node_->get_logger(), "Will retry subscribing to %zu pending topics", pending_topics_.size());
   }
 }
 
@@ -355,7 +364,7 @@ bool RosbagCapture::try_subscribe_topic(const std::string & topic) {
   }
 
   try {
-    rclcpp::QoS qos = rclcpp::SensorDataQoS();
+    rclcpp::QoS qos = config_.qos_match ? resolve_topic_qos(topic) : rclcpp::QoS(rclcpp::SensorDataQoS());
 
     auto callback = [this, topic, msg_type](const std::shared_ptr<const rclcpp::SerializedMessage> & msg) {
       message_callback(topic, msg_type, msg);
@@ -363,6 +372,7 @@ bool RosbagCapture::try_subscribe_topic(const std::string & topic) {
 
     auto subscription = node_->create_generic_subscription(topic, msg_type, qos, callback);
     subscriptions_.push_back(subscription);
+    subscribed_topics_.insert(topic);
 
     RCLCPP_INFO(node_->get_logger(), "Subscribed to '%s' (%s) for rosbag capture", topic.c_str(), msg_type.c_str());
     return true;
@@ -374,7 +384,7 @@ bool RosbagCapture::try_subscribe_topic(const std::string & topic) {
 }
 
 void RosbagCapture::discovery_retry_callback() {
-  if (pending_topics_.empty() || !running_.load()) {
+  if (!running_.load()) {
     if (discovery_retry_timer_) {
       discovery_retry_timer_->cancel();
       discovery_retry_timer_.reset();
@@ -382,6 +392,19 @@ void RosbagCapture::discovery_retry_callback() {
     return;
   }
 
+  if (dynamic_discovery_) {
+    // Re-resolve the broad set every tick and subscribe to anything new, so topics
+    // whose publishers come up after startup are captured. Runs for the capture's
+    // lifetime; already-subscribed topics are skipped cheaply.
+    for (const auto & topic : resolve_topics()) {
+      if (subscribed_topics_.count(topic) == 0) {
+        try_subscribe_topic(topic);
+      }
+    }
+    return;
+  }
+
+  // Fixed modes: bounded retry of the initially type-pending topics only.
   discovery_retry_count_++;
   constexpr int max_retries = 20;  // 10 seconds total (20 * 500ms)
 
@@ -419,6 +442,10 @@ void RosbagCapture::message_callback(const std::string & topic, const std::strin
 
   // During post-fault recording, write directly to bag (no buffering)
   if (recording_post_fault_.load()) {
+    // Entity mode: keep the post-fault stream scoped to the same topics as the flush
+    if (!should_capture_topic(topic)) {
+      return;
+    }
     std::lock_guard<std::mutex> wlock(writer_mutex_);
     if (active_writer_) {
       try {
@@ -451,9 +478,11 @@ void RosbagCapture::message_callback(const std::string & topic, const std::strin
   buffered.message_type = msg_type;
   buffered.serialized_data = std::make_shared<rclcpp::SerializedMessage>(*msg);
   buffered.timestamp_ns = timestamp_ns;
+  const size_t msg_bytes = buffered.serialized_data->size();
 
   {
     std::lock_guard<std::mutex> lock(buffer_mutex_);
+    buffer_bytes_ += msg_bytes;
     message_buffer_.push_back(std::move(buffered));
   }
 
@@ -480,8 +509,30 @@ void RosbagCapture::prune_buffer() {
 
   // Remove messages older than cutoff
   while (!message_buffer_.empty() && message_buffer_.front().timestamp_ns < cutoff_ns) {
+    buffer_bytes_ -= message_buffer_.front().serialized_data->size();
     message_buffer_.pop_front();
   }
+
+  // RAM cap: drop the oldest messages once the buffer exceeds max_buffer_mb, so a
+  // broad subscribe set on a busy robot cannot grow the ring buffer without bound.
+  const size_t cap_bytes = config_.max_buffer_mb * 1024UL * 1024UL;
+  while (message_buffer_.size() > 1 && buffer_bytes_ > cap_bytes) {
+    buffer_bytes_ -= message_buffer_.front().serialized_data->size();
+    message_buffer_.pop_front();
+  }
+}
+
+bool RosbagCapture::is_high_bandwidth_topic(const std::string & topic) {
+  // Segment-anchored match (leading '/') so '/camera/image' and '/points' are caught
+  // but low-bandwidth lookalikes that merely contain the word - /waypoints,
+  // /setpoints, /keypoints, /image_quality on another node - are not.
+  static const std::array<const char *, 4> kSegments{"/image", "/points", "/depth", "/compressed"};
+  for (const char * seg : kSegments) {
+    if (topic.find(seg) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
 }
 
 std::vector<std::string> RosbagCapture::resolve_topics() const {
@@ -502,14 +553,19 @@ std::vector<std::string> RosbagCapture::resolve_topics() const {
         topics_set.insert(topic);
       }
     }
-  } else if (config_.topics == "all" || config_.topics == "auto") {
-    // Discover all available topics ("auto" is an alias for "all").
-    // Skip gracefully if the context is invalidated mid-call (shutdown race).
+  } else if (config_.topics == "all" || config_.topics == "auto" || config_.topics == "entity") {
+    // Broad discovery for the subscribe set ("auto" is an alias for "all"). "entity"
+    // also subscribes broadly for pre-roll and narrows to the faulting node's topics
+    // only at flush time. Skip gracefully if the context is invalidated mid-call.
     try {
       auto topic_names_and_types = node_->get_topic_names_and_types();
       for (const auto & [topic, types] : topic_names_and_types) {
         // Skip internal ROS topics
         if (topic.find("/parameter_events") != std::string::npos || topic.find("/rosout") != std::string::npos) {
+          continue;
+        }
+        // Skip high-bandwidth sensor topics in broad modes to bound memory
+        if (config_.exclude_sensor_topics && is_high_bandwidth_topic(topic)) {
           continue;
         }
         topics_set.insert(topic);
@@ -547,6 +603,141 @@ std::vector<std::string> RosbagCapture::resolve_topics() const {
   return {topics_set.begin(), topics_set.end()};
 }
 
+rclcpp::QoS RosbagCapture::resolve_topic_qos(const std::string & topic) const {
+  // QoS is resolved once, at subscribe time, from the publishers present then. It is
+  // not re-resolved later: if a best-effort publisher appears afterwards on a topic
+  // already subscribed as reliable, that publisher is QoS-incompatible and the
+  // subscription receives nothing from it. Acceptable for black-box capture, where
+  // the publisher set is stable by the time a fault occurs.
+  std::vector<rclcpp::TopicEndpointInfo> pubs;
+  try {
+    pubs = node_->get_publishers_info_by_topic(topic);
+  } catch (const std::exception &) {
+    return rclcpp::SensorDataQoS();
+  }
+  if (pubs.empty()) {
+    // No known publisher yet - best-effort default. Not upgraded once subscribed,
+    // but a topic discovered via get_topic_names_and_types already has a publisher,
+    // so this branch is a rare startup race rather than the steady state.
+    return rclcpp::SensorDataQoS();
+  }
+
+  // Build a subscriber QoS compatible with every publisher while staying as faithful
+  // as the offers allow: reliable only if ALL publishers offer reliable, transient-local
+  // only if ALL offer it (otherwise the sub would be incompatible and never connect).
+  bool all_reliable = true;
+  bool all_transient_local = true;
+  size_t depth = 10;
+  for (const auto & p : pubs) {
+    const auto & pq = p.qos_profile();
+    if (pq.reliability() != rclcpp::ReliabilityPolicy::Reliable) {
+      all_reliable = false;
+    }
+    if (pq.durability() != rclcpp::DurabilityPolicy::TransientLocal) {
+      all_transient_local = false;
+    }
+    depth = std::max(depth, std::min<size_t>(pq.depth(), 100));
+  }
+
+  rclcpp::QoS qos{rclcpp::KeepLast(depth)};
+  qos.reliability(all_reliable ? rclcpp::ReliabilityPolicy::Reliable : rclcpp::ReliabilityPolicy::BestEffort);
+  qos.durability(all_transient_local ? rclcpp::DurabilityPolicy::TransientLocal : rclcpp::DurabilityPolicy::Volatile);
+  return qos;
+}
+
+void RosbagCapture::resolve_entity_topics(const std::string & fault_code) {
+  std::set<std::string> topics;
+
+  if (config_.topics == "entity") {
+    // The whole resolution is guarded: this runs on a detached capture thread with
+    // no outer catch, and storage_->get_fault() can throw on the sqlite backend
+    // (e.g. SQLITE_BUSY). A throw here would terminate the process - the exact crash
+    // the crash-safety work removed - so any failure degrades to "write everything".
+    try {
+      auto fault = storage_->get_fault(fault_code);
+      if (fault && !fault->reporting_sources.empty()) {
+        // reporting_sources hold the reporting node's FQN (e.g. "/planner_server").
+        // Split each into (name, namespace) to match against topic endpoints.
+        std::set<std::pair<std::string, std::string>> wanted;
+        for (const auto & source : fault->reporting_sources) {
+          std::string ns = "/";
+          std::string name = source;
+          const auto slash = source.rfind('/');
+          if (slash != std::string::npos) {
+            name = source.substr(slash + 1);
+            ns = (slash == 0) ? "/" : source.substr(0, slash);
+          }
+          if (!name.empty()) {
+            wanted.emplace(name, ns);
+          }
+        }
+
+        // rclcpp does not expose per-node topic listing, so scan each topic's
+        // endpoints and keep the topics a wanted node publishes or subscribes to.
+        auto owned_by_wanted = [&wanted](const std::vector<rclcpp::TopicEndpointInfo> & eps) {
+          for (const auto & ep : eps) {
+            if (wanted.count({ep.node_name(), ep.node_namespace()})) {
+              return true;
+            }
+          }
+          return false;
+        };
+        for (const auto & [topic, types] : node_->get_topic_names_and_types()) {
+          if (owned_by_wanted(node_->get_publishers_info_by_topic(topic)) ||
+              owned_by_wanted(node_->get_subscriptions_info_by_topic(topic))) {
+            topics.insert(topic);
+          }
+        }
+
+        if (!topics.empty()) {
+          // Always-on context that makes a scoped bag useful for replay.
+          topics.insert("/tf");
+          topics.insert("/tf_static");
+        }
+
+        // Intersect with the actually-subscribed set so the filter never names a
+        // topic that was never buffered (an excluded/sensor topic, or one with no
+        // publisher) - which would otherwise be silently absent from the bag.
+        const auto subscribed_vec = resolve_topics();
+        const std::set<std::string> subscribed(subscribed_vec.begin(), subscribed_vec.end());
+        std::set<std::string> scoped;
+        for (const auto & t : topics) {
+          if (subscribed.count(t)) {
+            scoped.insert(t);
+          }
+        }
+        topics = std::move(scoped);
+      }
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(node_->get_logger(), "Entity scope resolution failed for fault '%s' (%s); writing full buffer",
+                  fault_code.c_str(), e.what());
+      topics.clear();
+    }
+
+    if (!topics.empty()) {
+      RCLCPP_INFO(node_->get_logger(), "Entity scope for fault '%s': %zu topic(s) from the faulting node(s) + /tf",
+                  fault_code.c_str(), topics.size());
+    } else {
+      RCLCPP_WARN(node_->get_logger(),
+                  "Entity scope unresolved for fault '%s' (source not a live node, or no buffered topics); "
+                  "writing the full buffer",
+                  fault_code.c_str());
+    }
+  }
+
+  std::lock_guard<std::mutex> lock(capture_topics_mutex_);
+  active_capture_topics_ = std::move(topics);
+}
+
+bool RosbagCapture::should_capture_topic(const std::string & topic) const {
+  std::lock_guard<std::mutex> lock(capture_topics_mutex_);
+  // Empty filter = manual modes, or entity resolution found nothing: write everything.
+  if (active_capture_topics_.empty()) {
+    return true;
+  }
+  return active_capture_topics_.count(topic) > 0;
+}
+
 std::string RosbagCapture::get_topic_type(const std::string & topic) const {
   // node_->get_topic_names_and_types() throws if the rcl context is
   // invalidated mid-call (e.g. SIGINT fires between the check and the rcl
@@ -575,6 +766,7 @@ std::string RosbagCapture::flush_to_bag(const std::string & fault_code) {
     }
     messages_to_write = std::move(message_buffer_);
     message_buffer_.clear();
+    buffer_bytes_ = 0;
   }
 
   std::string bag_path = generate_bag_path(fault_code);
@@ -600,9 +792,23 @@ std::string RosbagCapture::flush_to_bag(const std::string & fault_code) {
       active_writer_->open(storage_options);
     }
 
+    // Snapshot the entity filter once (empty = write everything) so the flush loop
+    // does not take capture_topics_mutex_ for every buffered message.
+    std::set<std::string> capture_filter;
+    {
+      std::lock_guard<std::mutex> lock(capture_topics_mutex_);
+      capture_filter = active_capture_topics_;
+    }
+    const bool entity_filtered = !capture_filter.empty();
+
     // Write messages (no buffer_mutex_ held, writer_mutex_ only for brief access)
     size_t msg_count = 0;
     for (const auto & msg : messages_to_write) {
+      // Entity mode: write only the faulting node's topics (+ /tf). No-op otherwise.
+      if (entity_filtered && capture_filter.count(msg.topic) == 0) {
+        continue;
+      }
+
       std::lock_guard<std::mutex> wlock(writer_mutex_);
       if (!active_writer_) {
         break;
@@ -757,6 +963,10 @@ void RosbagCapture::post_fault_timer_callback() {
 
   current_fault_code_.clear();
   current_bag_path_.clear();
+  {
+    std::lock_guard<std::mutex> lock(capture_topics_mutex_);
+    active_capture_topics_.clear();
+  }
 }
 
 std::optional<std::string> RosbagCapture::default_storage_probe(const std::string & format) const {

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_capture.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_capture.cpp
@@ -302,6 +302,45 @@ TEST_F(RosbagCaptureTest, ExcludeTopicsRespected) {
   EXPECT_NO_THROW(RosbagCapture(node_.get(), storage_.get(), rosbag_config, snapshot_config));
 }
 
+TEST_F(RosbagCaptureTest, EntityTopicsMode) {
+  auto rosbag_config = create_rosbag_config();
+  rosbag_config.topics = "entity";
+  auto snapshot_config = create_snapshot_config();
+  EXPECT_NO_THROW(RosbagCapture(node_.get(), storage_.get(), rosbag_config, snapshot_config));
+}
+
+TEST_F(RosbagCaptureTest, QosMatchDisabledFallsBackToSensorData) {
+  auto rosbag_config = create_rosbag_config();
+  rosbag_config.topics = "all";
+  rosbag_config.qos_match = false;
+  auto snapshot_config = create_snapshot_config();
+  EXPECT_NO_THROW(RosbagCapture(node_.get(), storage_.get(), rosbag_config, snapshot_config));
+}
+
+TEST_F(RosbagCaptureTest, SensorTopicsExcludedByDefaultInBroadMode) {
+  auto rosbag_config = create_rosbag_config();
+  rosbag_config.topics = "all";
+  rosbag_config.exclude_sensor_topics = true;
+  auto snapshot_config = create_snapshot_config();
+  EXPECT_NO_THROW(RosbagCapture(node_.get(), storage_.get(), rosbag_config, snapshot_config));
+}
+
+TEST(RosbagHighBandwidthTopicTest, MatchesSensorStreamsButNotLookalikes) {
+  // High-bandwidth sensor streams are classified as such.
+  EXPECT_TRUE(RosbagCapture::is_high_bandwidth_topic("/camera/image_raw"));
+  EXPECT_TRUE(RosbagCapture::is_high_bandwidth_topic("/image"));
+  EXPECT_TRUE(RosbagCapture::is_high_bandwidth_topic("/points"));
+  EXPECT_TRUE(RosbagCapture::is_high_bandwidth_topic("/camera/depth/points"));
+  EXPECT_TRUE(RosbagCapture::is_high_bandwidth_topic("/camera/image_raw/compressed"));
+
+  // Low-bandwidth lookalikes that merely contain the word must NOT be excluded.
+  EXPECT_FALSE(RosbagCapture::is_high_bandwidth_topic("/waypoints"));
+  EXPECT_FALSE(RosbagCapture::is_high_bandwidth_topic("/setpoints"));
+  EXPECT_FALSE(RosbagCapture::is_high_bandwidth_topic("/keypoints"));
+  EXPECT_FALSE(RosbagCapture::is_high_bandwidth_topic("/joint_states"));
+  EXPECT_FALSE(RosbagCapture::is_high_bandwidth_topic("/cmd_vel"));
+}
+
 // Fault lifecycle tests
 
 TEST_F(RosbagCaptureTest, OnFaultPrefailedWhileDisabled) {

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration test for entity-scoped rosbag capture (Issue #426)."""
+
+# The default "entity" topic mode subscribes broadly for pre-roll but, when a fault
+# is confirmed, writes only the topics of the faulting source node. This test runs
+# two publisher nodes and verifies a fault sourced at one node yields a bag holding
+# that node's topics and NOT the other node's topic.
+
+import os
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+import launch.actions
+import launch_ros.actions
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import GetRosbag, ReportFault
+
+ROSBAG_STORAGE_PATH = tempfile.mkdtemp(prefix='rosbag_entity_test_')
+PUBLISHER_SCRIPT_PATH = None
+
+# Two publisher nodes with distinct names so the gateway can resolve each entity's
+# topics via the ROS graph. "robot_planner" owns /plan + /cmd_vel; "robot_camera"
+# owns /telemetry. Default QoS (reliable) also exercises the qos_match path.
+PUBLISHER_SCRIPT = """
+import rclpy
+from rclpy.executors import SingleThreadedExecutor
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+class Planner(Node):
+    def __init__(self):
+        super().__init__('robot_planner')
+        self.plan_pub = self.create_publisher(String, '/plan', 10)
+        self.cmd_pub = self.create_publisher(String, '/cmd_vel', 10)
+        self.timer = self.create_timer(0.05, self.publish)
+        self.counter = 0
+
+    def publish(self):
+        msg = String()
+        msg.data = f'plan_{self.counter}'
+        self.plan_pub.publish(msg)
+        self.cmd_pub.publish(msg)
+        self.counter += 1
+
+
+class Camera(Node):
+    def __init__(self):
+        super().__init__('robot_camera')
+        self.tele_pub = self.create_publisher(String, '/telemetry', 10)
+        self.timer = self.create_timer(0.05, self.publish)
+        self.counter = 0
+
+    def publish(self):
+        msg = String()
+        msg.data = f'telemetry_{self.counter}'
+        self.tele_pub.publish(msg)
+        self.counter += 1
+
+
+def main():
+    rclpy.init()
+    executor = SingleThreadedExecutor()
+    planner = Planner()
+    camera = Camera()
+    executor.add_node(planner)
+    executor.add_node(camera)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        planner.destroy_node()
+        camera.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()
+"""
+
+
+def generate_test_description():
+    global PUBLISHER_SCRIPT_PATH
+    script_file = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False)
+    script_file.write(PUBLISHER_SCRIPT)
+    script_file.close()
+    PUBLISHER_SCRIPT_PATH = script_file.name
+
+    env = os.environ.copy()
+    env['ROS_DOMAIN_ID'] = '43'
+    env['ROS_LOCALHOST_ONLY'] = '1'
+
+    publishers = launch.actions.ExecuteProcess(
+        cmd=['python3', script_file.name],
+        output='screen',
+        name='entity_publishers',
+        env=env,
+    )
+
+    fault_manager_node = launch_ros.actions.Node(
+        package='ros2_medkit_fault_manager',
+        executable='fault_manager_node',
+        name='fault_manager',
+        output='screen',
+        additional_env={'ROS_DOMAIN_ID': '43', 'ROS_LOCALHOST_ONLY': '1'},
+        parameters=[{
+            'storage_type': 'memory',
+            'confirmation_threshold': -1,
+            'snapshots.rosbag.enabled': True,
+            'snapshots.rosbag.duration_sec': 2.0,
+            'snapshots.rosbag.duration_after_sec': 0.5,
+            # "entity" is the default; set explicitly to document the intent.
+            'snapshots.rosbag.topics': 'entity',
+            'snapshots.rosbag.format': 'sqlite3',
+            'snapshots.rosbag.storage_path': ROSBAG_STORAGE_PATH,
+            'snapshots.rosbag.lazy_start': False,
+        }],
+    )
+
+    delayed_fault_manager = launch.actions.TimerAction(
+        period=8.0,
+        actions=[fault_manager_node],
+    )
+
+    return (
+        LaunchDescription([
+            publishers,
+            delayed_fault_manager,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {'fault_manager_node': fault_manager_node, 'publishers': publishers},
+    )
+
+
+class TestRosbagEntityScope(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        os.environ['ROS_DOMAIN_ID'] = '43'
+        os.environ['ROS_LOCALHOST_ONLY'] = '1'
+        rclpy.init()
+        cls.node = Node('test_entity_scope_client')
+        cls.report_fault_client = cls.node.create_client(
+            ReportFault, '/fault_manager/report_fault')
+        cls.get_rosbag_client = cls.node.create_client(GetRosbag, '/fault_manager/get_rosbag')
+        assert cls.report_fault_client.wait_for_service(timeout_sec=20.0), \
+            'report_fault unavailable'
+        assert cls.get_rosbag_client.wait_for_service(timeout_sec=20.0), 'get_rosbag unavailable'
+        # Let dynamic discovery subscribe to the publisher topics and the ring buffer
+        # fill (needs > duration_sec of buffered messages before the fault is reported).
+        deadline = time.time() + 15.0
+        while time.time() < deadline:
+            rclpy.spin_once(cls.node, timeout_sec=0.2)
+            if cls.node.get_publishers_info_by_topic('/plan'):
+                break
+        time.sleep(5.0)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def _call(self, client, request, timeout_sec=10.0):
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=timeout_sec)
+        self.assertIsNotNone(future.result(), 'Service call timed out')
+        return future.result()
+
+    def _bag_topics(self, bag_path):
+        import rosbag2_py
+        reader = rosbag2_py.SequentialReader()
+        reader.open(
+            rosbag2_py.StorageOptions(uri=bag_path, storage_id='sqlite3'),
+            rosbag2_py.ConverterOptions('', ''),
+        )
+        return {t.name for t in reader.get_all_topics_and_types()}
+
+    def test_bag_scoped_to_faulting_entity(self):
+        """A fault sourced at /robot_planner yields a bag with the planner's topics only."""
+        request = ReportFault.Request()
+        request.fault_code = 'ENTITY_SCOPE_TEST'
+        request.event_type = ReportFault.Request.EVENT_FAILED
+        request.severity = Fault.SEVERITY_ERROR
+        request.description = 'entity scope test'
+        request.source_id = '/robot_planner'
+        response = self._call(self.report_fault_client, request)
+        self.assertTrue(response.accepted)
+
+        # Poll for the finished bag (post-fault recording + flush is asynchronous).
+        rosbag_request = GetRosbag.Request()
+        rosbag_request.fault_code = 'ENTITY_SCOPE_TEST'
+        rosbag_response = None
+        deadline = time.time() + 12.0
+        while time.time() < deadline:
+            rosbag_response = self._call(self.get_rosbag_client, rosbag_request)
+            if rosbag_response.success:
+                break
+            time.sleep(0.5)
+        self.assertTrue(rosbag_response.success,
+                        f'GetRosbag failed: {rosbag_response.error_message}')
+        self.assertTrue(os.path.exists(rosbag_response.file_path))
+
+        topics = self._bag_topics(rosbag_response.file_path)
+        print(f'Bag topics: {sorted(topics)}')
+
+        # Planner's own topics are captured.
+        self.assertIn('/plan', topics)
+        self.assertIn('/cmd_vel', topics)
+        # The other entity's topic is excluded even though it was buffered.
+        self.assertNotIn('/telemetry', topics)
+
+
+@launch_testing.post_shutdown_test()
+class TestRosbagEntityScopeShutdown(unittest.TestCase):
+
+    def test_exit_code(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, process='fault_manager_node')
+
+    def test_cleanup(self):
+        import shutil
+        if os.path.exists(ROSBAG_STORAGE_PATH):
+            shutil.rmtree(ROSBAG_STORAGE_PATH, ignore_errors=True)
+        if PUBLISHER_SCRIPT_PATH and os.path.exists(PUBLISHER_SCRIPT_PATH):
+            os.unlink(PUBLISHER_SCRIPT_PATH)

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -982,9 +982,12 @@ Rosbag capture is configured via FaultManager parameters. See `config/snapshots.
 | `snapshots.rosbag.enabled` | bool | `false` | Enable/disable rosbag capture |
 | `snapshots.rosbag.duration_sec` | double | `5.0` | Ring buffer duration (seconds before fault) |
 | `snapshots.rosbag.duration_after_sec` | double | `1.0` | Recording duration after fault confirmed |
-| `snapshots.rosbag.topics` | string | `"config"` | Topic selection: `"config"`, `"all"`, or `"explicit"` |
+| `snapshots.rosbag.topics` | string | `"entity"` | Topic selection: `"entity"` (default; faulting node's topics + `/tf`), `"config"`, `"all"`, or `"explicit"` |
+| `snapshots.rosbag.exclude_sensor_topics` | bool | `true` | Auto-exclude image/points/depth/compressed in broad modes (`include_topics` re-adds) |
+| `snapshots.rosbag.qos_match` | bool | `true` | Match each topic's publisher QoS for faithful capture |
 | `snapshots.rosbag.format` | string | `"sqlite3"` | Bag format: `"sqlite3"` or `"mcap"` |
 | `snapshots.rosbag.auto_cleanup` | bool | `true` | Delete bag when fault is cleared |
+| `snapshots.rosbag.max_buffer_mb` | int | `256` | Ring-buffer RAM cap (oldest messages drop past it) |
 | `snapshots.rosbag.max_bag_size_mb` | int | `50` | Max size per bag file |
 | `snapshots.rosbag.max_total_storage_mb` | int | `500` | Total storage limit |
 


### PR DESCRIPTION
Stacked on #430 (#425); the diff against `feat/425-rosbag-crash-safe` is only the #426 changes. Rebase to `main` once #430 merges.

Today the black-box rosbag's default `topics: "config"` mode captures nothing unless a YAML maps the fault code to topics, so an enabled black box often produces an empty bag. This makes it useful out of the box.

- **Entity-scoped capture, now the default (`topics: "entity"`)**: the ring buffer subscribes broadly for pre-roll, but on fault confirmation only the faulting source node's topics (resolved from the fault's reporting source via the ROS graph) plus `/tf` and `/tf_static` are written to the bag. If the source cannot be resolved to a live node, it falls back to writing the full buffer (a broad bag beats an empty one). Manual modes (`config`/`all`/`explicit`/comma-list) are unchanged and write exactly what they subscribe to.
- **Faithful QoS (`qos_match`, default on)**: each subscription matches the publisher-offered QoS (reliable / transient-local where all publishers offer it) instead of forcing best-effort `SensorDataQoS`, which silently dropped messages on reliable topics. Falls back to `SensorDataQoS` when no publisher is known yet.
- **Bounded memory**: a ring-buffer RAM cap (`max_buffer_mb`, default 256) drops the oldest buffered messages past the limit, and broad modes auto-exclude high-bandwidth sensor topics (image/points/depth/compressed); `include_topics` re-adds any you need.

New integration test `test_rosbag_entity_scope` runs two publisher nodes and asserts a fault sourced at one yields a bag with that node's topics and not the other's. Unit tests cover the new modes and flags.

Closes #426
