### PR TITLE
feat(gateway): SOVD entity status and lifecycle control endpoints

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -566,6 +566,67 @@ Execute Operations
    - **204:** Execution cancelled
    - **404:** Execution not found
 
+Lifecycle Endpoints
+-------------------
+
+Read the lifecycle status of an entity and request lifecycle transitions.
+Available for apps and components only.
+
+Lifecycle control is delegated to a ``LifecycleProvider`` registered by a
+substrate-owning plugin (ROS 2 lifecycle nodes, process/container/systemd, host
+reboot). When no provider is registered for the entity, the status read returns
+a value derived from runtime state and the transitions return ``501``.
+
+Read Status
+~~~~~~~~~~~
+
+``GET /api/v1/apps/{app_id}/status``
+
+``GET /api/v1/components/{component_id}/status``
+   Return the current lifecycle status of the entity.
+
+   The response ``status`` is ``ready`` or ``notReady``. Each supported
+   transition is advertised as a URI field (``start``, ``restart``,
+   ``force-restart``, ``shutdown``, ``force-shutdown``), present only when the
+   entity's provider supports it. Without a provider, status is derived from
+   runtime state (an App is ``ready`` while its node is online; the host
+   Component is ``ready`` while reachable, any other Component is ``ready`` while
+   at least one hosted App is online) and no transition URIs are returned.
+
+   - **200:** Lifecycle status
+   - **404:** Entity not found
+
+   .. code-block:: json
+
+      {
+        "status": "ready",
+        "restart": "/api/v1/apps/temp_sensor/status/restart"
+      }
+
+Request Transition
+~~~~~~~~~~~~~~~~~~~
+
+``PUT /api/v1/apps/{app_id}/status/{transition}``
+
+``PUT /api/v1/components/{component_id}/status/{transition}``
+   Request a lifecycle transition. ``{transition}`` is one of ``start``,
+   ``restart``, ``force-restart``, ``shutdown``, ``force-shutdown``. The call is
+   asynchronous: it returns on acceptance and the client polls the status read.
+
+   RBAC: ``start`` / ``restart`` / ``force-restart`` require the ``operator``
+   role; the destructive ``shutdown`` / ``force-shutdown`` require
+   ``configurator``.
+
+   - **202:** Transition accepted (the ``Location`` header points to the status URI)
+   - **403:** Caller lacks the required role (``insufficient-access-rights``)
+   - **404:** Entity not found
+   - **409:** A precondition was not fulfilled (``precondition-not-fulfilled``)
+   - **501:** No lifecycle provider is registered for the entity (``not-implemented``)
+
+   .. code-block:: bash
+
+      curl -X PUT http://localhost:8080/api/v1/apps/temp_sensor/status/restart
+
 Configurations Endpoints
 ------------------------
 

--- a/docs/requirements/specs/lifecycle.rst
+++ b/docs/requirements/specs/lifecycle.rst
@@ -3,7 +3,7 @@ Lifecycle
 
 .. req:: GET /{entity}/status
    :id: REQ_INTEROP_076
-   :status: open
+   :status: verified
    :tags: Lifecycle
 
    The endpoint shall return the current lifecycle status of the addressed entity.
@@ -42,4 +42,3 @@ Lifecycle
    :tags: Lifecycle
 
    The endpoint shall request a forced shutdown of the addressed entity, bypassing normal procedures.
-

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -647,6 +647,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_dto_contract test/test_dto_contract.cpp)
   target_link_libraries(test_dto_contract gateway_core)
 
+  # Lifecycle DTO (pure C++17, no ROS node)
+  ament_add_gtest(test_lifecycle_dto test/test_lifecycle_dto.cpp)
+  target_link_libraries(test_lifecycle_dto gateway_core)
+
   # DTO Collection<T, XMedkit> template + fan-out observability fields
   ament_add_gtest(test_collection test/test_collection.cpp)
   target_link_libraries(test_collection gateway_core)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -182,6 +182,7 @@ add_library(gateway_ros2 STATIC
   src/http/handlers/fault_handlers.cpp
   src/http/handlers/handler_context.cpp
   src/http/handlers/health_handlers.cpp
+  src/http/handlers/lifecycle_handlers.cpp
   src/http/handlers/lock_handlers.cpp
   src/http/handlers/log_handlers.cpp
   src/http/handlers/operation_handlers.cpp
@@ -760,6 +761,12 @@ if(BUILD_TESTING)
   ament_add_gtest(test_health_handlers test/test_health_handlers.cpp)
   target_link_libraries(test_health_handlers gateway_ros2)
   medkit_set_test_domain(test_health_handlers)
+
+  # Add lifecycle handler tests
+  ament_add_gtest(test_lifecycle_handlers test/test_lifecycle_handlers.cpp)
+  target_link_libraries(test_lifecycle_handlers gateway_ros2)
+  medkit_target_dependencies(test_lifecycle_handlers rclcpp)
+  medkit_set_test_domain(test_lifecycle_handlers)
 
   # Add operation handler tests
   ament_add_gtest(test_operation_handlers test/test_operation_handlers.cpp)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -826,6 +826,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_plugin_entity_routing test/test_plugin_entity_routing.cpp)
   target_link_libraries(test_plugin_entity_routing gateway_ros2)
 
+  # Lifecycle provider routing tests
+  ament_add_gtest(test_lifecycle_provider_routing test/test_lifecycle_provider_routing.cpp)
+  target_link_libraries(test_lifecycle_provider_routing gateway_ros2)
+
   # Plugin HTTP types tests
   ament_add_gtest(test_plugin_http_types test/test_plugin_http_types.cpp)
   target_link_libraries(test_plugin_http_types gateway_ros2)

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -114,6 +114,23 @@ All endpoints are prefixed with `/api/v1` for API versioning.
 - `GET /api/v1/{entity_type}/{id}/docs` - Entity-scoped OpenAPI spec
 - `GET /api/v1/swagger-ui` - Interactive Swagger UI (requires build with `-DENABLE_SWAGGER_UI=ON`)
 
+### Status and Lifecycle Endpoints
+
+- `GET /api/v1/apps/{app_id}/status` - Read app lifecycle status (`ready` or `notReady`)
+- `PUT /api/v1/apps/{app_id}/status/start` - Request app start transition
+- `PUT /api/v1/apps/{app_id}/status/restart` - Request controlled app restart
+- `PUT /api/v1/apps/{app_id}/status/force-restart` - Request forced app restart
+- `PUT /api/v1/apps/{app_id}/status/shutdown` - Request controlled app shutdown
+- `PUT /api/v1/apps/{app_id}/status/force-shutdown` - Request forced app shutdown
+- `GET /api/v1/components/{component_id}/status` - Read component lifecycle status
+- `PUT /api/v1/components/{component_id}/status/start` - Request component start transition
+- `PUT /api/v1/components/{component_id}/status/restart` - Request controlled component restart
+- `PUT /api/v1/components/{component_id}/status/force-restart` - Request forced component restart
+- `PUT /api/v1/components/{component_id}/status/shutdown` - Request controlled component shutdown
+- `PUT /api/v1/components/{component_id}/status/force-shutdown` - Request forced component shutdown
+
+`GET /status` always returns a response (derived from the entity cache when no lifecycle plugin is registered). `PUT /status/{action}` returns `501 Not Implemented` until a substrate plugin registers a `LifecycleProvider` for the entity. Accepted transitions return `202` with a `Location` header pointing back to `GET /status`.
+
 ### Vendor Extension Endpoints
 
 - `GET /api/v1/{entity}/{id}/x-medkit-topic-beacon` - Topic beacon metadata
@@ -1639,6 +1656,19 @@ Five legacy call sites are currently on the allowlist
 (`sse_fault_handler.cpp`, `trigger_fault_subscriber.cpp`,
 `trigger_topic_subscriber.cpp`, `operation_manager.cpp`,
 `log_manager.cpp`) pending migration to the slot pattern.
+
+## SOVD Compliance
+
+| Requirement     | Status   | Notes                                                                  |
+|-----------------|----------|------------------------------------------------------------------------|
+| REQ_INTEROP_076 | verified | `GET /status` - returns entity lifecycle status from cache or provider |
+| REQ_INTEROP_077 | open (route registered, returns 501) | `PUT /status/start` route registered; returns 501 until a `LifecycleProvider` plugin registers for the entity |
+| REQ_INTEROP_078 | open (route registered, returns 501) | `PUT /status/restart` - same as above                                  |
+| REQ_INTEROP_079 | open (route registered, returns 501) | `PUT /status/force-restart` - same as above                            |
+| REQ_INTEROP_080 | open (route registered, returns 501) | `PUT /status/shutdown` - same as above                                 |
+| REQ_INTEROP_081 | open (route registered, returns 501) | `PUT /status/force-shutdown` - same as above                           |
+
+Requirements 077-081 will be fully verified when a substrate plugin (ROS 2 lifecycle node manager, process supervisor, or container manager) implements the `LifecycleProvider` interface and registers it via the plugin manager.
 
 ## License
 

--- a/src/ros2_medkit_gateway/design/index.rst
+++ b/src/ros2_medkit_gateway/design/index.rst
@@ -673,5 +673,6 @@ Additional Design Documents
 
    aggregation
    dto_contract
+   lifecycle
    plugin_entity_notifications
    ros2_subscription_architecture

--- a/src/ros2_medkit_gateway/design/lifecycle.rst
+++ b/src/ros2_medkit_gateway/design/lifecycle.rst
@@ -1,0 +1,295 @@
+Status and Lifecycle Endpoints
+==============================
+
+This document describes the design of the SOVD status/lifecycle endpoints
+in ros2_medkit_gateway. It covers the six REST routes, the status read
+semantics for each entity type, the ``LifecycleProvider`` plugin seam,
+error mapping, and SOVD requirement coverage.
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 3
+
+Overview
+--------
+
+SOVD ISO 17978-3 defines a lifecycle model for software entities. A client
+reads the current lifecycle state via a GET and drives transitions via PUT
+sub-resources. The gateway implements these routes for **Apps** and
+**Components** only (Areas and Functions do not carry lifecycle state in the
+current SOVD profile).
+
+The six routes are:
+
++-------------------------------------------+--------+--------------------------------------+
+| Path                                      | Method | Description                          |
++===========================================+========+======================================+
+| ``/{entity}/{id}/status``                 | GET    | Read current lifecycle status        |
++-------------------------------------------+--------+--------------------------------------+
+| ``/{entity}/{id}/status/start``           | PUT    | Request transition to started state  |
++-------------------------------------------+--------+--------------------------------------+
+| ``/{entity}/{id}/status/restart``         | PUT    | Request controlled restart           |
++-------------------------------------------+--------+--------------------------------------+
+| ``/{entity}/{id}/status/force-restart``   | PUT    | Request forced restart               |
++-------------------------------------------+--------+--------------------------------------+
+| ``/{entity}/{id}/status/shutdown``        | PUT    | Request controlled shutdown          |
++-------------------------------------------+--------+--------------------------------------+
+| ``/{entity}/{id}/status/force-shutdown``  | PUT    | Request forced shutdown              |
++-------------------------------------------+--------+--------------------------------------+
+
+where ``{entity}`` is either ``apps`` or ``components``.
+
+Route Registration
+------------------
+
+The lifecycle routes are registered **outside** the four-entity-type loop in
+``rest_server.cpp::setup_routes()``, covering only ``apps`` and
+``components``:
+
+.. code-block:: cpp
+
+   for (const auto & et_lc :
+        std::vector<std::pair<const char *, const char *>>{
+            {"apps", "app"}, {"components", "component"}}) {
+     const std::string base_lc = "/" + et_lc.first + "/{" + et_lc.second + "_id}";
+
+     // PUT routes registered BEFORE GET /status to avoid the shorter path
+     // shadowing the more-specific fixed segments.
+     for (const auto & action :
+          {"start", "restart", "force-restart", "shutdown", "force-shutdown"}) {
+       reg.put<http::NoContent>(base_lc + "/status/" + action, ...);
+     }
+     reg.get<dto::LifecycleStatusResponse>(base_lc + "/status", ...);
+   }
+
+The PUT routes must be registered before the GET route. The typed
+``RouteRegistry`` matches fixed path segments (``/status/start``) before
+parameterized ones (``/status``), but registration order also affects the
+matching priority inside cpp-httplib's internal routing table.
+
+Status Read Semantics
+---------------------
+
+``GET /{entity}/{id}/status`` returns a ``LifecycleStatusResponse`` DTO:
+
+.. code-block:: text
+
+   {
+     "status": "ready" | "notReady",
+     "start":          "/api/v1/{entity}/{id}/status/start",    // optional
+     "restart":        "/api/v1/{entity}/{id}/status/restart",  // optional
+     "force-restart":  "/api/v1/{entity}/{id}/status/force-restart", // optional
+     "shutdown":       "/api/v1/{entity}/{id}/status/shutdown",       // optional
+     "force-shutdown": "/api/v1/{entity}/{id}/status/force-shutdown"  // optional
+   }
+
+The optional transition URI fields are only present when the registered
+``LifecycleProvider`` signals support for that transition. Each field value
+is the absolute path the client should call to trigger the transition.
+
+**App status (no provider registered):** derived from ``App::is_online`` in
+the entity cache. The entity cache marks an App online when it has at least
+one node in the ROS 2 graph. ``is_online = true`` maps to ``"ready"``;
+``false`` maps to ``"notReady"``.
+
+**Component status (no provider registered):** derived from
+``Component::host_metadata``. A Component populated by ``HostInfoProvider``
+carries OS, hostname, and architecture metadata. Presence of
+``host_metadata`` maps to ``"ready"``; absence maps to ``"notReady"``.
+Components created by runtime namespace grouping (``source: "synthetic"``)
+do not carry host metadata and therefore report ``"notReady"`` by default.
+
+When a ``LifecycleProvider`` is registered for the entity the provider's
+response takes precedence over the cache-derived default. The handler also
+fills absolute transition URIs from the provider-supplied optional fields.
+
+LifecycleProvider Interface
+---------------------------
+
+``LifecycleProvider`` is a per-entity plugin interface defined in
+``include/ros2_medkit_gateway/core/providers/lifecycle_provider.hpp``.
+It follows the same typed-DTO style as ``OperationProvider``.
+
+.. plantuml::
+   :caption: LifecycleProvider and handler relationships
+
+   @startuml lifecycle_provider
+
+   skinparam linetype ortho
+   skinparam classAttributeIconSize 0
+
+   package "core/providers/" {
+       class LifecycleProvider <<interface>> {
+           + get_status(entity_id): expected<LifecycleStatusResponse, LifecycleProviderErrorInfo>
+           + request_transition(entity_id, transition): expected<monostate, LifecycleProviderErrorInfo>
+       }
+   }
+
+   package "core/http/handlers/" {
+       class LifecycleHandlers {
+           + handle_get_status(req): Result<LifecycleStatusResponse>
+           + handle_transition(req, transition): Result<pair<NoContent, ResponseAttachments>>
+           - ctx_: HandlerContext
+           - plugin_mgr_: PluginManager*
+       }
+   }
+
+   package "core/plugins/" {
+       class PluginManager {
+           + get_lifecycle_provider_for_entity(entity_id): LifecycleProvider*
+       }
+   }
+
+   LifecycleHandlers --> PluginManager : queries for provider
+   LifecycleHandlers --> LifecycleProvider : calls get_status / request_transition
+   PluginManager ..> LifecycleProvider : returns registered instance
+
+   @enduml
+
+A substrate plugin (ROS 2 lifecycle node manager, process/container
+supervisor, host-level service manager) registers a ``LifecycleProvider``
+implementation via ``PluginManager``. The handler looks up the provider per
+entity at request time via ``plugin_mgr_->get_lifecycle_provider_for_entity(entity_id)``.
+
+**Fallback behavior when no provider is registered:**
+
+- ``GET /status`` returns a cache-derived ``LifecycleStatusResponse`` with
+  no transition URI fields (no actuation capability advertised).
+- ``PUT /status/{action}`` returns ``501 Not Implemented`` with error code
+  ``not-implemented``.
+
+Control remains ``501`` for all five PUT transitions until a plugin
+registers a provider for the entity.
+
+Error Mapping
+-------------
+
+``LifecycleProviderErrorInfo`` carries a typed error code, a message string,
+and an optional HTTP status hint. The handler maps it to a gateway
+``ErrorInfo`` via the file-local ``to_error_info`` helper:
+
++-----------------------------------+---------+----------------------------------+
+| ``LifecycleProviderError``        | HTTP    | SOVD error code                  |
++===================================+=========+==================================+
+| ``AccessDenied``                  | 403     | ``insufficient-access-rights``   |
++-----------------------------------+---------+----------------------------------+
+| ``PreconditionFailed``            | 409     | ``precondition-not-fulfilled``   |
++-----------------------------------+---------+----------------------------------+
+| ``Unsupported``                   | 501     | ``not-implemented``              |
++-----------------------------------+---------+----------------------------------+
+| ``EntityNotFound``,               | *hint*  | ``x-medkit-plugin-error``        |
+| ``TransportError``, ``Internal``  |         |                                  |
++-----------------------------------+---------+----------------------------------+
+
+The HTTP status from ``LifecycleProviderErrorInfo::http_status`` is clamped
+to the range 400-599. Plugin exceptions are caught; unknown exceptions map
+to ``500 / x-medkit-plugin-error``.
+
+There are two distinct 403 paths. The auth middleware returns 403 before the
+handler runs when the client's RBAC role is insufficient (for example a viewer
+calling a PUT transition). Separately, the provider error table's
+``AccessDenied`` row maps to 403 when a registered ``LifecycleProvider`` itself
+refuses the operation for a substrate-level reason, unrelated to the gateway
+RBAC check.
+
+Transition Flow
+---------------
+
+.. plantuml::
+   :caption: PUT lifecycle transition - full request flow
+
+   @startuml lifecycle_transition_flow
+
+   participant Client
+   participant RouteRegistry as reg
+   participant LifecycleHandlers as handler
+   participant PluginManager as pm
+   participant LifecycleProvider as provider
+
+   Client -> reg : PUT /api/v1/apps/{id}/status/restart
+   reg -> handler : handle_transition(req, "restart")
+   handler -> handler : validate_entity_for_route(req, entity_id)
+
+   alt entity not found
+       handler --> reg : 404 GenericError
+       reg --> Client : 404
+   end
+
+   handler -> pm : get_lifecycle_provider_for_entity(entity_id)
+
+   alt no provider registered
+       handler --> reg : 501 not-implemented
+       reg --> Client : 501 Not Implemented
+   end
+
+   pm --> handler : LifecycleProvider*
+   handler -> provider : request_transition(entity_id, "restart")
+
+   alt provider error
+       provider --> handler : unexpected(LifecycleProviderErrorInfo)
+       handler -> handler : to_error_info(e) -> ErrorInfo
+       handler --> reg : ErrorInfo (403 / 409 / 501 / 5xx)
+       reg --> Client : error response
+   end
+
+   provider --> handler : expected<monostate, ...> (success)
+   handler -> handler : build ResponseAttachments (202, Location header)
+   handler --> reg : pair<NoContent, ResponseAttachments>
+   reg --> Client : 202 Accepted\nLocation: /api/v1/apps/{id}/status
+
+   @enduml
+
+The transition is **async**: the PUT returns 202 with a ``Location`` header
+pointing to ``GET /{entity}/{id}/status``. The client polls that endpoint to
+observe the state change. The provider is responsible for initiating the
+substrate-level operation (e.g., calling a ROS 2 lifecycle service or
+sending a signal to a process manager); it returns immediately on acceptance.
+
+SOVD Requirement Coverage
+--------------------------
+
++----------------+--------+-------------------------------------+
+| Requirement    | Status | Notes                               |
++================+========+=====================================+
+| REQ_INTEROP_076| verified| GET /status implemented; default   |
+|                |        | status derived from entity cache    |
+|                |        | when no provider is registered.     |
++----------------+--------+-------------------------------------+
+| REQ_INTEROP_077| open   | Route registered; returns 501 until |
+|                |        | a LifecycleProvider registers.      |
++----------------+--------+-------------------------------------+
+| REQ_INTEROP_078| open   | Same as REQ_INTEROP_077.            |
++----------------+--------+-------------------------------------+
+| REQ_INTEROP_079| open   | Same as REQ_INTEROP_077.            |
++----------------+--------+-------------------------------------+
+| REQ_INTEROP_080| open   | Same as REQ_INTEROP_077.            |
++----------------+--------+-------------------------------------+
+| REQ_INTEROP_081| open   | Same as REQ_INTEROP_077.            |
++----------------+--------+-------------------------------------+
+
+REQ_INTEROP_076 is verified by the lifecycle integration tests. Requirements
+077-081 remain open because they require actuation at the substrate level
+(process/container/ROS 2 lifecycle node). They will be closed when a
+plugin implementing ``LifecycleProvider::request_transition`` ships.
+
+Key Files
+---------
+
+``include/ros2_medkit_gateway/dto/lifecycle.hpp``
+    ``LifecycleStatusResponse`` DTO with ``dto_fields`` and ``dto_name``
+    specializations. Wire keys ``force-restart`` and ``force-shutdown`` use
+    hyphen as required by the SOVD spec.
+
+``include/ros2_medkit_gateway/core/providers/lifecycle_provider.hpp``
+    ``LifecycleProvider`` pure virtual interface and
+    ``LifecycleProviderErrorInfo`` error struct.
+
+``include/ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp``
+    ``LifecycleHandlers`` class declaration.
+
+``src/http/handlers/lifecycle_handlers.cpp``
+    Handler implementations for GET status and PUT transition, including
+    the ``to_error_info`` mapping helper.
+
+``src/http/rest_server.cpp``
+    Route registration (search for ``// === Lifecycle``).

--- a/src/ros2_medkit_gateway/design/lifecycle.rst
+++ b/src/ros2_medkit_gateway/design/lifecycle.rst
@@ -91,12 +91,14 @@ the entity cache. The entity cache marks an App online when it has at least
 one node in the ROS 2 graph. ``is_online = true`` maps to ``"ready"``;
 ``false`` maps to ``"notReady"``.
 
-**Component status (no provider registered):** derived from
-``Component::host_metadata``. A Component populated by ``HostInfoProvider``
-carries OS, hostname, and architecture metadata. Presence of
-``host_metadata`` maps to ``"ready"``; absence maps to ``"notReady"``.
-Components created by runtime namespace grouping (``source: "synthetic"``)
-do not carry host metadata and therefore report ``"notReady"`` by default.
+**Component status (no provider registered):** derived from a real liveness
+signal, because ``Component`` has no online flag of its own. The synthetic host
+Component populated by ``HostInfoProvider`` (the one carrying ``host_metadata``)
+is ``"ready"`` while the gateway is reachable - if the client can reach this
+endpoint, the host is up. Any other Component is ``"ready"`` when at least one of
+its hosted Apps is online (``App::is_online`` over the Component's hosted apps),
+and ``"notReady"`` otherwise. ``host_metadata`` is only used to identify the host
+Component; it is not itself a liveness signal.
 
 When a ``LifecycleProvider`` is registered for the entity the provider's
 response takes precedence over the cache-derived default. The handler also

--- a/src/ros2_medkit_gateway/design/lifecycle.rst
+++ b/src/ros2_medkit_gateway/design/lifecycle.rst
@@ -53,8 +53,8 @@ The lifecycle routes are registered **outside** the four-entity-type loop in
             {"apps", "app"}, {"components", "component"}}) {
      const std::string base_lc = "/" + et_lc.first + "/{" + et_lc.second + "_id}";
 
-     // PUT routes registered BEFORE GET /status to avoid the shorter path
-     // shadowing the more-specific fixed segments.
+     // GET and PUT use different HTTP methods so neither can shadow the
+     // other; registration order within the loop is arbitrary.
      for (const auto & action :
           {"start", "restart", "force-restart", "shutdown", "force-shutdown"}) {
        reg.put<http::NoContent>(base_lc + "/status/" + action, ...);
@@ -62,10 +62,9 @@ The lifecycle routes are registered **outside** the four-entity-type loop in
      reg.get<dto::LifecycleStatusResponse>(base_lc + "/status", ...);
    }
 
-The PUT routes must be registered before the GET route. The typed
-``RouteRegistry`` matches fixed path segments (``/status/start``) before
-parameterized ones (``/status``), but registration order also affects the
-matching priority inside cpp-httplib's internal routing table.
+The GET ``/status`` route and the PUT ``/status/{action}`` routes use
+different HTTP methods, so neither can shadow the other. cpp-httplib keeps a
+separate handler list per method, so registration order does not matter.
 
 Status Read Semantics
 ---------------------
@@ -269,7 +268,7 @@ SOVD Requirement Coverage
 
 REQ_INTEROP_076 is verified by the lifecycle integration tests. Requirements
 077-081 remain open because they require actuation at the substrate level
-(process/container/ROS 2 lifecycle node). They will be closed when a
+(process/container/ROS 2 lifecycle node). They will be marked verified when a
 plugin implementing ``LifecycleProvider::request_transition`` ships.
 
 Key Files

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/error_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/error_codes.hpp
@@ -141,6 +141,12 @@ constexpr const char * ERR_X_MEDKIT_UNSUPPORTED_PROTOCOL = "x-medkit-unsupported
 /// SOVD standard: client's lock was broken by another client (409)
 constexpr const char * ERR_LOCK_BROKEN = "lock-broken";
 
+/// SOVD standard: caller lacks the required access rights for this operation (403)
+constexpr const char * ERR_INSUFFICIENT_ACCESS_RIGHTS = "insufficient-access-rights";
+
+/// SOVD standard: a required precondition was not fulfilled (409)
+constexpr const char * ERR_PRECONDITION_NOT_FULFILLED = "precondition-not-fulfilled";
+
 // Script error codes (vendor-specific only; generic cases use ERR_RESOURCE_NOT_FOUND / ERR_INVALID_PARAMETER)
 constexpr const char * ERR_SCRIPT_ALREADY_EXISTS = "x-medkit-script-already-exists";
 constexpr const char * ERR_SCRIPT_MANAGED = "x-medkit-managed-script";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/capability_builder.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/capability_builder.hpp
@@ -59,7 +59,8 @@ class CapabilityBuilder {
     CYCLIC_SUBSCRIPTIONS,  ///< Entity has cyclic subscription endpoints
     LOCKS,                 ///< Entity has lock endpoints (components and apps only)
     SCRIPTS,               ///< Entity has diagnostic script endpoints
-    TRIGGERS               ///< Entity has trigger endpoints (x-medkit extension)
+    TRIGGERS,              ///< Entity has trigger endpoints (x-medkit extension)
+    STATUS                 ///< Entity has lifecycle status endpoint (components and apps only)
   };
 
   /**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/handlers.hpp
@@ -33,6 +33,7 @@
 #include "ros2_medkit_gateway/core/http/handlers/config_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/docs_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/health_handlers.hpp"
+#include "ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/lock_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/log_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/operation_handlers.hpp"

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
+#include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
+#include "ros2_medkit_gateway/http/response_types.hpp"
+#include "ros2_medkit_gateway/http/typed_router.hpp"
+
+namespace ros2_medkit_gateway {
+
+class PluginManager;
+
+namespace handlers {
+
+/**
+ * @brief Handlers for SOVD status/lifecycle endpoints.
+ *
+ * Handlers:
+ * - GET /{entity}/status            - Read entity lifecycle status
+ * - PUT /{entity}/status/{action}   - Request a lifecycle transition (async, 202)
+ *
+ * Routes are registered outside the 4-type entity loop (apps + components only).
+ * Control is delegated to a LifecycleProvider when one is registered for the
+ * entity; otherwise GET returns a default status from the entity cache and PUT
+ * returns 501 Not Implemented.
+ */
+class LifecycleHandlers {
+ public:
+  /// Construct lifecycle handlers with shared context and optional plugin manager.
+  LifecycleHandlers(HandlerContext & ctx, PluginManager * plugin_mgr) : ctx_(ctx), plugin_mgr_(plugin_mgr) {
+  }
+
+  /// GET /{entity}/status - read lifecycle status.
+  http::Result<dto::LifecycleStatusResponse> handle_get_status(const http::TypedRequest & req);
+
+  /// PUT /{entity}/status/{action} - request a lifecycle transition.
+  /// Returns 202 + Location on acceptance, or 501 when no provider is registered.
+  http::Result<std::pair<http::NoContent, http::ResponseAttachments>> handle_transition(const http::TypedRequest & req,
+                                                                                        std::string transition);
+
+ private:
+  HandlerContext & ctx_;
+  PluginManager * plugin_mgr_;
+};
+
+}  // namespace handlers
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp
@@ -52,7 +52,7 @@ class LifecycleHandlers {
   /// PUT /{entity}/status/{action} - request a lifecycle transition.
   /// Returns 202 + Location on acceptance, or 501 when no provider is registered.
   http::Result<std::pair<http::NoContent, http::ResponseAttachments>> handle_transition(const http::TypedRequest & req,
-                                                                                        std::string transition);
+                                                                                        std::string_view transition);
 
  private:
   HandlerContext & ctx_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/rest_server.hpp
@@ -120,6 +120,7 @@ class RESTServer {
   std::unique_ptr<handlers::HealthHandlers> health_handlers_;
   std::unique_ptr<handlers::DiscoveryHandlers> discovery_handlers_;
   std::unique_ptr<handlers::DataHandlers> data_handlers_;
+  std::unique_ptr<handlers::LifecycleHandlers> lifecycle_handlers_;
   std::unique_ptr<handlers::OperationHandlers> operation_handlers_;
   std::unique_ptr<handlers::ConfigHandlers> config_handlers_;
   std::unique_ptr<handlers::FaultHandlers> fault_handlers_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_loader.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_loader.hpp
@@ -30,6 +30,7 @@ class ScriptProvider;
 class DataProvider;
 class FaultProvider;
 class OperationProvider;
+class LifecycleProvider;
 
 /**
  * @brief Result of loading a gateway plugin.
@@ -76,6 +77,9 @@ struct GatewayPluginLoadResult {
   /// Non-owning pointer to FaultProvider interface (null if not provided).
   FaultProvider * fault_provider = nullptr;
 
+  /// Non-owning pointer to LifecycleProvider interface (null if not provided).
+  LifecycleProvider * lifecycle_provider = nullptr;
+
   /// Get the dlopen handle (for dlsym queries by PluginManager)
   void * dl_handle() const {
     return handle_;
@@ -101,6 +105,7 @@ struct GatewayPluginLoadResult {
  *   extern "C" DataProvider* get_data_provider(GatewayPlugin* plugin);
  *   extern "C" OperationProvider* get_operation_provider(GatewayPlugin* plugin);
  *   extern "C" FaultProvider* get_fault_provider(GatewayPlugin* plugin);
+ *   extern "C" LifecycleProvider* get_lifecycle_provider(GatewayPlugin* plugin);
  *
  * Path requirements: must be absolute, have .so extension, and resolve to a real file.
  */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
@@ -22,6 +22,7 @@
 #include "ros2_medkit_gateway/core/providers/data_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/fault_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_gateway/core/providers/lifecycle_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/log_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/log_provider_registry.hpp"
 #include "ros2_medkit_gateway/core/providers/operation_provider.hpp"
@@ -206,6 +207,11 @@ class PluginManager : public LogProviderRegistry {
   ///         or owning plugin doesn't implement OperationProvider
   OperationProvider * get_operation_provider_for_entity(const std::string & entity_id) const;
 
+  /// Get LifecycleProvider for a specific entity (if plugin-owned)
+  /// @return Non-owning pointer, or nullptr if entity is not plugin-owned
+  ///         or owning plugin doesn't implement LifecycleProvider
+  LifecycleProvider * get_lifecycle_provider_for_entity(const std::string & entity_id) const;
+
   /// Get FaultProvider for a specific entity (if plugin-owned)
   FaultProvider * get_fault_provider_for_entity(const std::string & entity_id) const;
 
@@ -229,6 +235,7 @@ class PluginManager : public LogProviderRegistry {
     ScriptProvider * script_provider = nullptr;
     DataProvider * data_provider = nullptr;
     OperationProvider * operation_provider = nullptr;
+    LifecycleProvider * lifecycle_provider = nullptr;
     FaultProvider * fault_provider = nullptr;
   };
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/lifecycle_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/lifecycle_provider.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <variant>
+
+#include <tl/expected.hpp>
+
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
+
+namespace ros2_medkit_gateway {
+
+enum class LifecycleProviderError {
+  EntityNotFound,
+  Unsupported,
+  PreconditionFailed,
+  AccessDenied,
+  TransportError,
+  Internal
+};
+
+struct LifecycleProviderErrorInfo {
+  LifecycleProviderError code;
+  std::string message;
+  int http_status{500};
+};
+
+/// Per-entity provider for SOVD status/lifecycle control. A substrate-owning
+/// plugin (ROS lifecycle, process/container, host) implements this; the
+/// lifecycle handler routes to it. Mirrors OperationProvider's typed-DTO +
+/// per-provider-error-struct style.
+class LifecycleProvider {
+ public:
+  virtual ~LifecycleProvider() = default;
+
+  virtual tl::expected<dto::LifecycleStatusResponse, LifecycleProviderErrorInfo>
+  get_status(const std::string & entity_id) = 0;
+
+  /// Initiate a transition ("start"|"restart"|"force-restart"|"shutdown"|
+  /// "force-shutdown"). Async: returns on accept; the client polls GET status.
+  virtual tl::expected<std::monostate, LifecycleProviderErrorInfo> request_transition(const std::string & entity_id,
+                                                                                      std::string_view transition) = 0;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/entities.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/entities.hpp
@@ -142,7 +142,7 @@ inline constexpr std::string_view dto_name<ComponentListItem> = "ComponentListIt
 //
 // Wire keys:
 //   id, name, description?, tags?,
-//   data, operations, configurations, faults, subcomponents, hosts, logs,
+//   status, data, operations, configurations, faults, subcomponents, hosts, logs,
 //   bulk-data, cyclic-subscriptions, triggers,
 //   scripts? (conditional on script backend), depends-on? (conditional),
 //   belongs-to? (conditional on area), is-located-on? (not present here - app only),
@@ -157,6 +157,7 @@ struct ComponentDetail {
   std::optional<std::string> description;
   std::optional<std::vector<std::string>> tags;
   // Always-present resource collection URIs
+  std::string status;
   std::string data;
   std::string operations;
   std::string configurations;
@@ -181,11 +182,11 @@ template <>
 inline constexpr auto dto_fields<ComponentDetail> = std::make_tuple(
     field("id", &ComponentDetail::id), field("name", &ComponentDetail::name),
     field_enum("type", &ComponentDetail::type, kEntityTypeValues), field("description", &ComponentDetail::description),
-    field("tags", &ComponentDetail::tags), field("data", &ComponentDetail::data),
-    field("operations", &ComponentDetail::operations), field("configurations", &ComponentDetail::configurations),
-    field("faults", &ComponentDetail::faults), field("subcomponents", &ComponentDetail::subcomponents),
-    field("hosts", &ComponentDetail::hosts), field("logs", &ComponentDetail::logs),
-    field("bulk-data", &ComponentDetail::bulk_data),
+    field("tags", &ComponentDetail::tags), field("status", &ComponentDetail::status),
+    field("data", &ComponentDetail::data), field("operations", &ComponentDetail::operations),
+    field("configurations", &ComponentDetail::configurations), field("faults", &ComponentDetail::faults),
+    field("subcomponents", &ComponentDetail::subcomponents), field("hosts", &ComponentDetail::hosts),
+    field("logs", &ComponentDetail::logs), field("bulk-data", &ComponentDetail::bulk_data),
     field("cyclic-subscriptions", &ComponentDetail::cyclic_subscriptions),
     field("triggers", &ComponentDetail::triggers), field("scripts", &ComponentDetail::scripts),
     field("depends-on", &ComponentDetail::depends_on), field("belongs-to", &ComponentDetail::belongs_to),
@@ -229,7 +230,7 @@ inline constexpr std::string_view dto_name<AppListItem> = "AppListItem";
 //
 // Wire keys:
 //   id, name, description?, translation_id?, tags?,
-//   data, operations, configurations, faults, logs, bulk-data,
+//   status, data, operations, configurations, faults, logs, bulk-data,
 //   cyclic-subscriptions, triggers,
 //   scripts? (conditional on script backend),
 //   is-located-on? (conditional on component_id),
@@ -247,6 +248,7 @@ struct AppDetail {
   std::optional<std::string> translation_id;
   std::optional<std::vector<std::string>> tags;
   // Always-present resource collection URIs
+  std::string status;
   std::string data;
   std::string operations;
   std::string configurations;
@@ -271,10 +273,10 @@ inline constexpr auto dto_fields<AppDetail> =
     std::make_tuple(field("id", &AppDetail::id), field("name", &AppDetail::name),
                     field_enum("type", &AppDetail::type, kEntityTypeValues),
                     field("description", &AppDetail::description), field("translation_id", &AppDetail::translation_id),
-                    field("tags", &AppDetail::tags), field("data", &AppDetail::data),
-                    field("operations", &AppDetail::operations), field("configurations", &AppDetail::configurations),
-                    field("faults", &AppDetail::faults), field("logs", &AppDetail::logs),
-                    field("bulk-data", &AppDetail::bulk_data),
+                    field("tags", &AppDetail::tags), field("status", &AppDetail::status),
+                    field("data", &AppDetail::data), field("operations", &AppDetail::operations),
+                    field("configurations", &AppDetail::configurations), field("faults", &AppDetail::faults),
+                    field("logs", &AppDetail::logs), field("bulk-data", &AppDetail::bulk_data),
                     field("cyclic-subscriptions", &AppDetail::cyclic_subscriptions),
                     field("triggers", &AppDetail::triggers), field("scripts", &AppDetail::scripts),
                     field("is-located-on", &AppDetail::is_located_on), field("belongs-to", &AppDetail::belongs_to),

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
@@ -62,5 +62,8 @@ inline constexpr std::string_view kLogSeverityFilterValues[] = {"debug", "info",
 /// Execution control capability (execution_update_request_schema).
 inline constexpr std::string_view kExecutionCapabilityValues[] = {"stop", "execute", "freeze", "reset"};
 
+/// Lifecycle status (LifecycleStatusResponse.status).
+inline constexpr std::string_view kLifecycleStatusValues[] = {"ready", "notReady"};
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
@@ -14,12 +14,10 @@
 
 #pragma once
 
-#include <optional>
 #include <string>
-#include <string_view>
-#include <tuple>
 
 #include "ros2_medkit_gateway/dto/contract.hpp"
+#include "ros2_medkit_gateway/dto/enums.hpp"
 
 namespace ros2_medkit_gateway {
 namespace dto {
@@ -35,8 +33,6 @@ struct LifecycleStatusResponse {
   std::optional<std::string> shutdown;
   std::optional<std::string> force_shutdown;  // wire key "force-shutdown"
 };
-
-inline constexpr std::string_view kLifecycleStatusValues[] = {"ready", "notReady"};
 
 template <>
 inline constexpr auto dto_fields<LifecycleStatusResponse> =

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
@@ -1,0 +1,54 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+
+#include "ros2_medkit_gateway/dto/contract.hpp"
+
+namespace ros2_medkit_gateway {
+namespace dto {
+
+/// Response body for GET /{entity}/status. `status` is "ready"|"notReady";
+/// each transition field is the URI for that action, present only when the
+/// entity supports it.
+struct LifecycleStatusResponse {
+  std::string status;
+  std::optional<std::string> start;
+  std::optional<std::string> restart;
+  std::optional<std::string> force_restart;  // wire key "force-restart"
+  std::optional<std::string> shutdown;
+  std::optional<std::string> force_shutdown;  // wire key "force-shutdown"
+};
+
+inline constexpr std::string_view kLifecycleStatusValues[] = {"ready", "notReady"};
+
+template <>
+inline constexpr auto dto_fields<LifecycleStatusResponse> =
+    std::make_tuple(field_enum("status", &LifecycleStatusResponse::status, kLifecycleStatusValues),
+                    field("start", &LifecycleStatusResponse::start),
+                    field("restart", &LifecycleStatusResponse::restart),
+                    field("force-restart", &LifecycleStatusResponse::force_restart),
+                    field("shutdown", &LifecycleStatusResponse::shutdown),
+                    field("force-shutdown", &LifecycleStatusResponse::force_shutdown));
+
+template <>
+inline constexpr std::string_view dto_name<LifecycleStatusResponse> = "LifecycleStatusResponse";
+
+}  // namespace dto
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/lifecycle.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "ros2_medkit_gateway/dto/contract.hpp"

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
@@ -30,6 +30,7 @@
 #include "ros2_medkit_gateway/dto/errors.hpp"
 #include "ros2_medkit_gateway/dto/faults.hpp"
 #include "ros2_medkit_gateway/dto/health.hpp"
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
 #include "ros2_medkit_gateway/dto/locks.hpp"
 #include "ros2_medkit_gateway/dto/logs.hpp"
 #include "ros2_medkit_gateway/dto/operations.hpp"
@@ -82,7 +83,9 @@ using AllDtos =
                AuthCredentials, AuthTokenResponse, AuthRevokeRequest, AuthRevokeResponse,
                // Health / Root domain DTOs
                HealthDiscoveryLinking, HealthDiscovery, HealthAggregationWarning, Health, VersionInfoVendor,
-               VersionInfoEntry, XMedkitVersionInfo, VersionInfo, RootCapabilities, RootAuth, RootTls, RootOverview>;
+               VersionInfoEntry, XMedkitVersionInfo, VersionInfo, RootCapabilities, RootAuth, RootTls, RootOverview,
+               // Lifecycle domain DTOs
+               LifecycleStatusResponse>;
 
 namespace detail {
 template <class T>

--- a/src/ros2_medkit_gateway/src/core/auth/auth_config.cpp
+++ b/src/ros2_medkit_gateway/src/core/auth/auth_config.cpp
@@ -161,6 +161,9 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
+           // Status: all entity types (read-only)
+           "GET:/api/v1/apps/*/status",
+           "GET:/api/v1/components/*/status",
            // Docs
            "GET:/api/v1/docs",
        }},
@@ -302,6 +305,9 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
+           // Status: all entity types (read-only, inherited from VIEWER)
+           "GET:/api/v1/apps/*/status",
+           "GET:/api/v1/components/*/status",
            // Docs
            "GET:/api/v1/docs",
            // --- Operator-specific write permissions ---
@@ -365,6 +371,9 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "PUT:/api/v1/apps/*/scripts/*/executions/*",
            "DELETE:/api/v1/components/*/scripts/*/executions/*",
            "DELETE:/api/v1/apps/*/scripts/*/executions/*",
+           // Lifecycle control: apps and components (PUT)
+           "PUT:/api/v1/apps/*/status/*",
+           "PUT:/api/v1/components/*/status/*",
        }},
       {UserRole::CONFIGURATOR,
        {
@@ -504,6 +513,9 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
+           // Status: all entity types (read-only, inherited from VIEWER)
+           "GET:/api/v1/apps/*/status",
+           "GET:/api/v1/components/*/status",
            // Docs
            "GET:/api/v1/docs",
            // Inherited from OPERATOR - write permissions
@@ -567,6 +579,9 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "PUT:/api/v1/apps/*/scripts/*/executions/*",
            "DELETE:/api/v1/components/*/scripts/*/executions/*",
            "DELETE:/api/v1/apps/*/scripts/*/executions/*",
+           // Lifecycle control: apps and components (PUT, inherited from OPERATOR)
+           "PUT:/api/v1/apps/*/status/*",
+           "PUT:/api/v1/components/*/status/*",
            // --- Configurator-specific write permissions ---
            // Modify configurations: all entity types (PUT)
            "PUT:/api/v1/components/*/configurations/*",

--- a/src/ros2_medkit_gateway/src/core/auth/auth_config.cpp
+++ b/src/ros2_medkit_gateway/src/core/auth/auth_config.cpp
@@ -161,7 +161,7 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
-           // Status: all entity types (read-only)
+           // Status: apps and components (read-only)
            "GET:/api/v1/apps/*/status",
            "GET:/api/v1/components/*/status",
            // Docs
@@ -305,7 +305,7 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
-           // Status: all entity types (read-only, inherited from VIEWER)
+           // Status: apps and components (read-only, inherited from VIEWER)
            "GET:/api/v1/apps/*/status",
            "GET:/api/v1/components/*/status",
            // Docs
@@ -371,9 +371,15 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "PUT:/api/v1/apps/*/scripts/*/executions/*",
            "DELETE:/api/v1/components/*/scripts/*/executions/*",
            "DELETE:/api/v1/apps/*/scripts/*/executions/*",
-           // Lifecycle control: apps and components (PUT)
-           "PUT:/api/v1/apps/*/status/*",
-           "PUT:/api/v1/components/*/status/*",
+           // Lifecycle control (non-destructive): apps and components.
+           // shutdown / force-shutdown tear an entity down and are gated
+           // behind CONFIGURATOR, so OPERATOR gets only start/restart/force-restart.
+           "PUT:/api/v1/apps/*/status/start",
+           "PUT:/api/v1/apps/*/status/restart",
+           "PUT:/api/v1/apps/*/status/force-restart",
+           "PUT:/api/v1/components/*/status/start",
+           "PUT:/api/v1/components/*/status/restart",
+           "PUT:/api/v1/components/*/status/force-restart",
        }},
       {UserRole::CONFIGURATOR,
        {
@@ -513,7 +519,7 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "GET:/api/v1/apps/*/scripts/*",
            "GET:/api/v1/components/*/scripts/*/executions/*",
            "GET:/api/v1/apps/*/scripts/*/executions/*",
-           // Status: all entity types (read-only, inherited from VIEWER)
+           // Status: apps and components (read-only, inherited from VIEWER)
            "GET:/api/v1/apps/*/status",
            "GET:/api/v1/components/*/status",
            // Docs
@@ -579,9 +585,18 @@ const std::unordered_map<UserRole, std::unordered_set<std::string>> & AuthConfig
            "PUT:/api/v1/apps/*/scripts/*/executions/*",
            "DELETE:/api/v1/components/*/scripts/*/executions/*",
            "DELETE:/api/v1/apps/*/scripts/*/executions/*",
-           // Lifecycle control: apps and components (PUT, inherited from OPERATOR)
-           "PUT:/api/v1/apps/*/status/*",
-           "PUT:/api/v1/components/*/status/*",
+           // Lifecycle control: apps and components, including the destructive
+           // shutdown / force-shutdown teardown transitions (CONFIGURATOR and above).
+           "PUT:/api/v1/apps/*/status/start",
+           "PUT:/api/v1/apps/*/status/restart",
+           "PUT:/api/v1/apps/*/status/force-restart",
+           "PUT:/api/v1/apps/*/status/shutdown",
+           "PUT:/api/v1/apps/*/status/force-shutdown",
+           "PUT:/api/v1/components/*/status/start",
+           "PUT:/api/v1/components/*/status/restart",
+           "PUT:/api/v1/components/*/status/force-restart",
+           "PUT:/api/v1/components/*/status/shutdown",
+           "PUT:/api/v1/components/*/status/force-shutdown",
            // --- Configurator-specific write permissions ---
            // Modify configurations: all entity types (PUT)
            "PUT:/api/v1/components/*/configurations/*",

--- a/src/ros2_medkit_gateway/src/core/http/handlers/capability_builder.cpp
+++ b/src/ros2_medkit_gateway/src/core/http/handlers/capability_builder.cpp
@@ -57,6 +57,8 @@ std::string CapabilityBuilder::capability_to_name(Capability cap) {
       return "scripts";
     case Capability::TRIGGERS:
       return "triggers";
+    case Capability::STATUS:
+      return "status";
     default:
       return "unknown";
   }

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -614,6 +614,7 @@ http::Result<dto::ComponentDetail> DiscoveryHandlers::get_component(const http::
     }
 
     std::string base = "/api/v1/components/" + comp.id;
+    detail.status = base + "/status";
     detail.data = base + "/data";
     detail.operations = base + "/operations";
     detail.configurations = base + "/configurations";
@@ -1027,6 +1028,7 @@ http::Result<dto::AppDetail> DiscoveryHandlers::get_app(const http::TypedRequest
     }
 
     std::string base_uri = "/api/v1/apps/" + app.id;
+    detail.status = base_uri + "/status";
     detail.data = base_uri + "/data";
     detail.operations = base_uri + "/operations";
     detail.configurations = base_uri + "/configurations";

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -688,8 +688,8 @@ http::Result<dto::ComponentDetail> DiscoveryHandlers::get_component(const http::
 
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {
-        Cap::DATA,  Cap::OPERATIONS, Cap::CONFIGURATIONS,       Cap::FAULTS,  Cap::LOGS, Cap::SUBCOMPONENTS,
-        Cap::HOSTS, Cap::BULK_DATA,  Cap::CYCLIC_SUBSCRIPTIONS, Cap::TRIGGERS};
+        Cap::STATUS,        Cap::DATA,  Cap::OPERATIONS, Cap::CONFIGURATIONS,       Cap::FAULTS,  Cap::LOGS,
+        Cap::SUBCOMPONENTS, Cap::HOSTS, Cap::BULK_DATA,  Cap::CYCLIC_SUBSCRIPTIONS, Cap::TRIGGERS};
     if (ctx_.node()->get_script_manager() && ctx_.node()->get_script_manager()->has_backend()) {
       caps.push_back(Cap::SCRIPTS);
     }
@@ -1052,8 +1052,8 @@ http::Result<dto::AppDetail> DiscoveryHandlers::get_app(const http::TypedRequest
     }
 
     using Cap = CapabilityBuilder::Capability;
-    std::vector<Cap> caps = {Cap::DATA, Cap::OPERATIONS, Cap::CONFIGURATIONS,       Cap::FAULTS,
-                             Cap::LOGS, Cap::BULK_DATA,  Cap::CYCLIC_SUBSCRIPTIONS, Cap::TRIGGERS};
+    std::vector<Cap> caps = {Cap::STATUS, Cap::DATA,      Cap::OPERATIONS,           Cap::CONFIGURATIONS, Cap::FAULTS,
+                             Cap::LOGS,   Cap::BULK_DATA, Cap::CYCLIC_SUBSCRIPTIONS, Cap::TRIGGERS};
     // Relationship endpoints are gated the same way as the top-level URI keys
     // above so the three advertising surfaces (top-level URIs, `_links`,
     // `capabilities` array) describe the same set of available collections.

--- a/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp"
+
+#include <string>
+#include <utility>
+
+#include <tl/expected.hpp>
+
+#include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/core/providers/lifecycle_provider.hpp"
+#include "ros2_medkit_gateway/gateway_node.hpp"
+#include "ros2_medkit_gateway/http/handlers/handler_support.hpp"
+
+namespace ros2_medkit_gateway {
+namespace handlers {
+
+namespace {
+
+/// Map a LifecycleProviderErrorInfo to a gateway ErrorInfo.
+/// Modeled on operation_handlers' make_provider_error; NOT reused from there
+/// because that helper is typed for OperationProviderErrorInfo and is
+/// file-local to operation_handlers.cpp.
+ErrorInfo to_error_info(const LifecycleProviderErrorInfo & e) {
+  static constexpr size_t kMaxMsg = 512;
+  int status = e.http_status < 400 ? 400 : (e.http_status > 599 ? 599 : e.http_status);
+  std::string msg = e.message.size() > kMaxMsg ? e.message.substr(0, kMaxMsg) + "..." : e.message;
+
+  switch (e.code) {
+    case LifecycleProviderError::AccessDenied:
+      return make_error(403, ERR_INSUFFICIENT_ACCESS_RIGHTS, std::move(msg));
+    case LifecycleProviderError::PreconditionFailed:
+      return make_error(409, ERR_PRECONDITION_NOT_FULFILLED, std::move(msg));
+    case LifecycleProviderError::Unsupported:
+      return make_error(501, ERR_NOT_IMPLEMENTED, std::move(msg));
+    case LifecycleProviderError::EntityNotFound:
+    case LifecycleProviderError::TransportError:
+    case LifecycleProviderError::Internal:
+      return make_error(status, ERR_PLUGIN_ERROR, std::move(msg));
+  }
+  return make_error(status, ERR_PLUGIN_ERROR, std::move(msg));
+}
+
+}  // namespace
+
+// =============================================================================
+// GET /{entity}/status
+// =============================================================================
+
+http::Result<dto::LifecycleStatusResponse> LifecycleHandlers::handle_get_status(const http::TypedRequest & req) {
+  auto id_raw = req.path_param("1");
+  if (!id_raw) {
+    return tl::make_unexpected(make_error(400, ERR_INVALID_REQUEST, "Invalid request"));
+  }
+  const std::string entity_id = *id_raw;
+
+  auto entity_result = ctx_.validate_entity_for_route(req, entity_id);
+  if (!entity_result) {
+    return tl::make_unexpected(flatten_validator_error(entity_result.error()));
+  }
+  const auto & entity = *entity_result;
+
+  const std::string base =
+      std::string("/api/v1/") + (entity.type == EntityType::APP ? "apps/" : "components/") + entity.id;
+
+  // Delegate to LifecycleProvider when one is registered for this entity.
+  if (plugin_mgr_) {
+    auto * provider = plugin_mgr_->get_lifecycle_provider_for_entity(entity_id);
+    if (provider) {
+      try {
+        auto result = provider->get_status(entity_id);
+        if (!result) {
+          return tl::make_unexpected(to_error_info(result.error()));
+        }
+        auto resp = *result;
+        // Fill absolute transition URIs for each present field.
+        if (resp.start.has_value()) {
+          resp.start = base + "/status/start";
+        }
+        if (resp.restart.has_value()) {
+          resp.restart = base + "/status/restart";
+        }
+        if (resp.force_restart.has_value()) {
+          resp.force_restart = base + "/status/force-restart";
+        }
+        if (resp.shutdown.has_value()) {
+          resp.shutdown = base + "/status/shutdown";
+        }
+        if (resp.force_shutdown.has_value()) {
+          resp.force_shutdown = base + "/status/force-shutdown";
+        }
+        return resp;
+      } catch (const std::exception & e) {
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, e.what()));
+      } catch (...) {
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw unknown exception"));
+      }
+    }
+  }
+
+  // No provider registered - build default status from the entity cache.
+  const auto & cache = ctx_.node()->get_thread_safe_cache();
+  dto::LifecycleStatusResponse resp;
+
+  if (entity.type == EntityType::APP) {
+    auto app = cache.get_app(entity_id);
+    resp.status = (app && app->is_online) ? "ready" : "notReady";
+  } else {
+    // Component: ready only when host_metadata is present.
+    auto component = cache.get_component(entity_id);
+    resp.status = (component && component->host_metadata.has_value()) ? "ready" : "notReady";
+  }
+
+  // No transition URIs for the default (no-provider) path.
+  return resp;
+}
+
+// =============================================================================
+// PUT /{entity}/status/{action}
+// =============================================================================
+
+http::Result<std::pair<http::NoContent, http::ResponseAttachments>>
+LifecycleHandlers::handle_transition(const http::TypedRequest & req, std::string transition) {
+  auto id_raw = req.path_param("1");
+  if (!id_raw) {
+    return tl::make_unexpected(make_error(400, ERR_INVALID_REQUEST, "Invalid request"));
+  }
+  const std::string entity_id = *id_raw;
+
+  auto entity_result = ctx_.validate_entity_for_route(req, entity_id);
+  if (!entity_result) {
+    return tl::make_unexpected(flatten_validator_error(entity_result.error()));
+  }
+  const auto & entity = *entity_result;
+
+  const std::string base =
+      std::string("/api/v1/") + (entity.type == EntityType::APP ? "apps/" : "components/") + entity.id;
+
+  if (plugin_mgr_) {
+    auto * provider = plugin_mgr_->get_lifecycle_provider_for_entity(entity_id);
+    if (provider) {
+      try {
+        auto result = provider->request_transition(entity_id, transition);
+        if (!result) {
+          return tl::make_unexpected(to_error_info(result.error()));
+        }
+        http::NoContent resp;
+        http::ResponseAttachments att;
+        att.with_status(202).with_header("Location", base + "/status");
+        return std::pair{std::move(resp), std::move(att)};
+      } catch (const std::exception & e) {
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, e.what()));
+      } catch (...) {
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw unknown exception"));
+      }
+    }
+  }
+
+  // No provider - lifecycle control not available.
+  return tl::make_unexpected(make_error(501, ERR_NOT_IMPLEMENTED, "Lifecycle control not available for this entity"));
+}
+
+}  // namespace handlers
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
@@ -133,7 +133,7 @@ http::Result<dto::LifecycleStatusResponse> LifecycleHandlers::handle_get_status(
 // =============================================================================
 
 http::Result<std::pair<http::NoContent, http::ResponseAttachments>>
-LifecycleHandlers::handle_transition(const http::TypedRequest & req, std::string transition) {
+LifecycleHandlers::handle_transition(const http::TypedRequest & req, std::string_view transition) {
   auto id_raw = req.path_param("1");
   if (!id_raw) {
     return tl::make_unexpected(make_error(400, ERR_INVALID_REQUEST, "Invalid request"));
@@ -157,10 +157,9 @@ LifecycleHandlers::handle_transition(const http::TypedRequest & req, std::string
         if (!result) {
           return tl::make_unexpected(to_error_info(result.error()));
         }
-        http::NoContent resp;
         http::ResponseAttachments att;
         att.with_status(202).with_header("Location", base + "/status");
-        return std::pair{std::move(resp), std::move(att)};
+        return std::make_pair(http::NoContent{}, std::move(att));
       } catch (const std::exception & e) {
         return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, e.what()));
       } catch (...) {

--- a/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
@@ -47,6 +47,7 @@ ErrorInfo to_error_info(const LifecycleProviderErrorInfo & e) {
     case LifecycleProviderError::Unsupported:
       return make_error(501, ERR_NOT_IMPLEMENTED, std::move(msg));
     case LifecycleProviderError::EntityNotFound:
+      return make_error(404, ERR_ENTITY_NOT_FOUND, std::move(msg));
     case LifecycleProviderError::TransportError:
     case LifecycleProviderError::Internal:
       return make_error(status, ERR_PLUGIN_ERROR, std::move(msg));
@@ -86,6 +87,13 @@ http::Result<dto::LifecycleStatusResponse> LifecycleHandlers::handle_get_status(
           return tl::make_unexpected(to_error_info(result.error()));
         }
         auto resp = *result;
+        // The JSON writer only validates the status enum on read, not on write,
+        // so guard the SOVD ready/notReady contract against a misbehaving plugin.
+        if (resp.status != "ready" && resp.status != "notReady") {
+          RCLCPP_ERROR(HandlerContext::logger(), "LifecycleProvider returned invalid status '%s' for entity '%s'",
+                       resp.status.c_str(), entity_id.c_str());
+          return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin returned invalid lifecycle status"));
+        }
         // Fill absolute transition URIs for each present field.
         if (resp.start.has_value()) {
           resp.start = base + "/status/start";
@@ -123,9 +131,26 @@ http::Result<dto::LifecycleStatusResponse> LifecycleHandlers::handle_get_status(
     auto app = cache.get_app(entity_id);
     resp.status = (app && app->is_online) ? "ready" : "notReady";
   } else {
-    // Component: ready only when host_metadata is present.
+    // Component readiness from a real liveness signal: the synthetic host
+    // component is ready while the gateway is reachable (we are serving this
+    // request); any other component is ready when at least one of its hosted
+    // Apps is online. host_metadata alone is not a liveness signal.
     auto component = cache.get_component(entity_id);
-    resp.status = (component && component->host_metadata.has_value()) ? "ready" : "notReady";
+    bool ready = false;
+    if (component) {
+      if (component->host_metadata.has_value()) {
+        ready = true;
+      } else {
+        for (const auto & app_id : cache.get_apps_for_component(entity_id)) {
+          auto app = cache.get_app(app_id);
+          if (app && app->is_online) {
+            ready = true;
+            break;
+          }
+        }
+      }
+    }
+    resp.status = ready ? "ready" : "notReady";
   }
 
   // No transition URIs for the default (no-provider) path.

--- a/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/lifecycle_handlers.cpp
@@ -104,8 +104,12 @@ http::Result<dto::LifecycleStatusResponse> LifecycleHandlers::handle_get_status(
         }
         return resp;
       } catch (const std::exception & e) {
-        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, e.what()));
+        RCLCPP_ERROR(HandlerContext::logger(), "Plugin LifecycleProvider threw for entity '%s': %s", entity_id.c_str(),
+                     e.what());
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw exception"));
       } catch (...) {
+        RCLCPP_ERROR(HandlerContext::logger(), "Plugin LifecycleProvider threw unknown exception for entity '%s'",
+                     entity_id.c_str());
         return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw unknown exception"));
       }
     }
@@ -161,8 +165,12 @@ LifecycleHandlers::handle_transition(const http::TypedRequest & req, std::string
         att.with_status(202).with_header("Location", base + "/status");
         return std::make_pair(http::NoContent{}, std::move(att));
       } catch (const std::exception & e) {
-        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, e.what()));
+        RCLCPP_ERROR(HandlerContext::logger(), "Plugin LifecycleProvider threw for entity '%s': %s", entity_id.c_str(),
+                     e.what());
+        return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw exception"));
       } catch (...) {
+        RCLCPP_ERROR(HandlerContext::logger(), "Plugin LifecycleProvider threw unknown exception for entity '%s'",
+                     entity_id.c_str());
         return tl::make_unexpected(make_error(500, ERR_PLUGIN_ERROR, "Plugin threw unknown exception"));
       }
     }

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -125,6 +125,7 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   health_handlers_ = std::make_unique<handlers::HealthHandlers>(*handler_ctx_, route_registry_.get());
   discovery_handlers_ = std::make_unique<handlers::DiscoveryHandlers>(*handler_ctx_);
   data_handlers_ = std::make_unique<handlers::DataHandlers>(*handler_ctx_);
+  lifecycle_handlers_ = std::make_unique<handlers::LifecycleHandlers>(*handler_ctx_, node_->get_plugin_manager());
   operation_handlers_ = std::make_unique<handlers::OperationHandlers>(*handler_ctx_);
   config_handlers_ = std::make_unique<handlers::ConfigHandlers>(*handler_ctx_);
   fault_handlers_ = std::make_unique<handlers::FaultHandlers>(*handler_ctx_);
@@ -1591,6 +1592,32 @@ void RESTServer::setup_routes() {
       .request_body("Token to revoke", SB::ref("AuthRevokeRequest"))
       .operation_id("revokeToken")
       .error_renderer(openapi::ErrorRenderer::kOAuth2Error);
+
+  // === Lifecycle (status) - apps and components only, outside the 4-type loop ===
+  // PUT /status/{action} MUST be registered before GET /status to avoid the
+  // more-specific fixed segment being shadowed by the shorter path.
+  for (const auto & et_lc :
+       std::vector<std::pair<const char *, const char *>>{{"apps", "app"}, {"components", "component"}}) {
+    const std::string base_lc = std::string("/") + et_lc.first + "/{" + et_lc.second + "_id}";
+
+    for (const auto & action : {"start", "restart", "force-restart", "shutdown", "force-shutdown"}) {
+      std::string action_str = action;
+      reg.put<http::NoContent>(base_lc + "/status/" + action,
+                               [this, action_str](http::TypedRequest req)
+                                   -> http::Result<std::pair<http::NoContent, http::ResponseAttachments>> {
+                                 return lifecycle_handlers_->handle_transition(req, action_str);
+                               })
+          .tag("Lifecycle")
+          .summary(std::string("Request lifecycle transition '") + action + "'");
+    }
+
+    reg.get<dto::LifecycleStatusResponse>(base_lc + "/status",
+                                          [this](http::TypedRequest req) -> http::Result<dto::LifecycleStatusResponse> {
+                                            return lifecycle_handlers_->handle_get_status(req);
+                                          })
+        .tag("Lifecycle")
+        .summary(std::string("Get ") + et_lc.second + " lifecycle status");
+  }
 
   // Register all routes with cpp-httplib
   route_registry_->register_all(*srv, API_BASE_PATH);

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -1594,21 +1594,36 @@ void RESTServer::setup_routes() {
       .error_renderer(openapi::ErrorRenderer::kOAuth2Error);
 
   // === Lifecycle (status) - apps and components only, outside the 4-type loop ===
-  // PUT /status/{action} MUST be registered before GET /status to avoid the
-  // more-specific fixed segment being shadowed by the shorter path.
+  // GET and PUT use different HTTP methods so neither can shadow the other.
+  // Registration order within the loop is arbitrary from the router's perspective.
   for (const auto & et_lc :
        std::vector<std::pair<const char *, const char *>>{{"apps", "app"}, {"components", "component"}}) {
     const std::string base_lc = std::string("/") + et_lc.first + "/{" + et_lc.second + "_id}";
+    // e.g. "Apps" / "Components" for operation ID construction
+    const std::string entity_cap = capitalize(std::string(et_lc.first));
 
     for (const auto & action : {"start", "restart", "force-restart", "shutdown", "force-shutdown"}) {
       std::string action_str = action;
+      // Capitalise action for operation ID: "force-restart" -> "ForceRestart"
+      std::string action_cap;
+      bool cap_next = true;
+      for (char c : action_str) {
+        if (c == '-') {
+          cap_next = true;
+        } else {
+          action_cap += cap_next ? static_cast<char>(std::toupper(static_cast<unsigned char>(c))) : c;
+          cap_next = false;
+        }
+      }
       reg.put<http::NoContent>(base_lc + "/status/" + action,
                                [this, action_str](http::TypedRequest req)
                                    -> http::Result<std::pair<http::NoContent, http::ResponseAttachments>> {
                                  return lifecycle_handlers_->handle_transition(req, action_str);
                                })
           .tag("Lifecycle")
-          .summary(std::string("Request lifecycle transition '") + action + "'");
+          .summary(std::string("Request lifecycle transition '") + action + "'")
+          .response(202, "Lifecycle transition accepted")
+          .operation_id(std::string("put").append(entity_cap).append("Status").append(action_cap));
     }
 
     reg.get<dto::LifecycleStatusResponse>(base_lc + "/status",
@@ -1616,7 +1631,8 @@ void RESTServer::setup_routes() {
                                             return lifecycle_handlers_->handle_get_status(req);
                                           })
         .tag("Lifecycle")
-        .summary(std::string("Get ") + et_lc.second + " lifecycle status");
+        .summary(std::string("Get ") + et_lc.second + " lifecycle status")
+        .operation_id(std::string("get") + entity_cap + "Status");
   }
 
   // Register all routes with cpp-httplib

--- a/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
@@ -121,6 +121,7 @@ nlohmann::json CapabilityGenerator::generate_root() const {
           {"Locking", "Entity lock management for exclusive access"},
           {"Scripts", "Diagnostic script upload, execution, and management"},
           {"Updates", "Software update management"},
+          {"Lifecycle", "Entity status and lifecycle control (start, restart, shutdown)"},
           {"Authentication", "JWT-based authentication"},
       });
 

--- a/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_loader.cpp
@@ -18,6 +18,7 @@
 #include "ros2_medkit_gateway/core/providers/data_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/fault_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_gateway/core/providers/lifecycle_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/operation_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/script_provider.hpp"
 #include "ros2_medkit_gateway/core/providers/update_provider.hpp"
@@ -39,6 +40,7 @@ GatewayPluginLoadResult::~GatewayPluginLoadResult() {
   data_provider = nullptr;
   operation_provider = nullptr;
   fault_provider = nullptr;
+  lifecycle_provider = nullptr;
   plugin.reset();
   if (handle_) {
     dlclose(handle_);
@@ -54,6 +56,7 @@ GatewayPluginLoadResult::GatewayPluginLoadResult(GatewayPluginLoadResult && othe
   , data_provider(other.data_provider)
   , operation_provider(other.operation_provider)
   , fault_provider(other.fault_provider)
+  , lifecycle_provider(other.lifecycle_provider)
   , handle_(other.handle_) {
   other.update_provider = nullptr;
   other.introspection_provider = nullptr;
@@ -62,6 +65,7 @@ GatewayPluginLoadResult::GatewayPluginLoadResult(GatewayPluginLoadResult && othe
   other.data_provider = nullptr;
   other.operation_provider = nullptr;
   other.fault_provider = nullptr;
+  other.lifecycle_provider = nullptr;
   other.handle_ = nullptr;
 }
 
@@ -75,6 +79,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     data_provider = nullptr;
     operation_provider = nullptr;
     fault_provider = nullptr;
+    lifecycle_provider = nullptr;
     plugin.reset();
     if (handle_) {
       dlclose(handle_);
@@ -89,6 +94,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     data_provider = other.data_provider;
     operation_provider = other.operation_provider;
     fault_provider = other.fault_provider;
+    lifecycle_provider = other.lifecycle_provider;
     handle_ = other.handle_;
 
     other.update_provider = nullptr;
@@ -98,6 +104,7 @@ GatewayPluginLoadResult & GatewayPluginLoadResult::operator=(GatewayPluginLoadRe
     other.data_provider = nullptr;
     other.operation_provider = nullptr;
     other.fault_provider = nullptr;
+    other.lifecycle_provider = nullptr;
     other.handle_ = nullptr;
   }
   return *this;
@@ -286,6 +293,20 @@ tl::expected<GatewayPluginLoadResult, std::string> PluginLoader::load(const std:
                   e.what());
     } catch (...) {
       RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_fault_provider threw unknown exception in %s",
+                  plugin_path.c_str());
+    }
+  }
+
+  using LifecycleProviderFn = LifecycleProvider * (*)(GatewayPlugin *);
+  auto lifecycle_fn = reinterpret_cast<LifecycleProviderFn>(dlsym(handle, "get_lifecycle_provider"));
+  if (lifecycle_fn) {
+    try {
+      result.lifecycle_provider = lifecycle_fn(raw_plugin);
+    } catch (const std::exception & e) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_lifecycle_provider threw in %s: %s", plugin_path.c_str(),
+                  e.what());
+    } catch (...) {
+      RCLCPP_WARN(rclcpp::get_logger("plugin_loader"), "get_lifecycle_provider threw unknown exception in %s",
                   plugin_path.c_str());
     }
   }

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -66,6 +66,7 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   lp.script_provider = dynamic_cast<ScriptProvider *>(plugin.get());
   lp.data_provider = dynamic_cast<DataProvider *>(plugin.get());
   lp.operation_provider = dynamic_cast<OperationProvider *>(plugin.get());
+  lp.lifecycle_provider = dynamic_cast<LifecycleProvider *>(plugin.get());
   lp.fault_provider = dynamic_cast<FaultProvider *>(plugin.get());
 
   // Cache first UpdateProvider, warn on duplicates
@@ -120,6 +121,7 @@ size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
       lp.script_provider = result->script_provider;
       lp.data_provider = result->data_provider;
       lp.operation_provider = result->operation_provider;
+      lp.lifecycle_provider = dynamic_cast<LifecycleProvider *>(result->plugin.get());
       lp.fault_provider = result->fault_provider;
 
       // Cache first UpdateProvider, warn on duplicates
@@ -207,6 +209,7 @@ void PluginManager::disable_plugin(LoadedPlugin & lp) {
   lp.script_provider = nullptr;
   lp.data_provider = nullptr;
   lp.operation_provider = nullptr;
+  lp.lifecycle_provider = nullptr;
   lp.fault_provider = nullptr;
   lp.load_result.update_provider = nullptr;
   lp.load_result.introspection_provider = nullptr;
@@ -477,6 +480,20 @@ OperationProvider * PluginManager::get_operation_provider_for_entity(const std::
   for (const auto & lp : plugins_) {
     if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
       return lp.operation_provider;
+    }
+  }
+  return nullptr;
+}
+
+LifecycleProvider * PluginManager::get_lifecycle_provider_for_entity(const std::string & entity_id) const {
+  std::shared_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto own_it = entity_ownership_.find(entity_id);
+  if (own_it == entity_ownership_.end()) {
+    return nullptr;
+  }
+  for (const auto & lp : plugins_) {
+    if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
+      return lp.lifecycle_provider;
     }
   }
   return nullptr;

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -121,7 +121,10 @@ size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
       lp.script_provider = result->script_provider;
       lp.data_provider = result->data_provider;
       lp.operation_provider = result->operation_provider;
-      lp.lifecycle_provider = dynamic_cast<LifecycleProvider *>(result->plugin.get());
+      // LifecycleProvider: discovered via extern "C" query function - dynamic_cast
+      // is unreliable across the dlopen boundary (typeinfo can differ between the
+      // plugin and the host, casting a real provider to null).
+      lp.lifecycle_provider = result->lifecycle_provider;
       lp.fault_provider = result->fault_provider;
 
       // Cache first UpdateProvider, warn on duplicates

--- a/src/ros2_medkit_gateway/test/test_auth_config.cpp
+++ b/src/ros2_medkit_gateway/test/test_auth_config.cpp
@@ -94,6 +94,56 @@ TEST(AuthConfigRolePermissionsTest, AdminHasWildcardAccess) {
 }
 
 // =============================================================================
+// Status and lifecycle RBAC tests
+// =============================================================================
+
+TEST(AuthConfigRolePermissionsTest, ViewerCanReadStatus) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & viewer_perms = permissions.at(UserRole::VIEWER);
+  EXPECT_TRUE(viewer_perms.count("GET:/api/v1/apps/*/status") > 0);
+  EXPECT_TRUE(viewer_perms.count("GET:/api/v1/components/*/status") > 0);
+}
+
+TEST(AuthConfigRolePermissionsTest, OperatorCanReadStatusAndControlLifecycle) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & operator_perms = permissions.at(UserRole::OPERATOR);
+  EXPECT_TRUE(operator_perms.count("GET:/api/v1/apps/*/status") > 0);
+  EXPECT_TRUE(operator_perms.count("GET:/api/v1/components/*/status") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/*") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/*") > 0);
+}
+
+TEST(AuthConfigRolePermissionsTest, ConfiguratorCanReadStatusAndControlLifecycle) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & config_perms = permissions.at(UserRole::CONFIGURATOR);
+  EXPECT_TRUE(config_perms.count("GET:/api/v1/apps/*/status") > 0);
+  EXPECT_TRUE(config_perms.count("GET:/api/v1/components/*/status") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/apps/*/status/*") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/components/*/status/*") > 0);
+}
+
+TEST(AuthConfigRolePermissionsTest, ViewerCannotControlLifecycle) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & viewer_perms = permissions.at(UserRole::VIEWER);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/apps/*/status/*") == 0);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/components/*/status/*") == 0);
+}
+
+TEST(AuthConfigRolePermissionsTest, AdminStatusCoveredByWildcard) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & admin_perms = permissions.at(UserRole::ADMIN);
+  // Admin is covered by PUT:/api/v1/** - no specific status entries needed
+  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/**") > 0);
+  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/apps/*/status/*") == 0);
+  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/components/*/status/*") == 0);
+}
+
+// =============================================================================
 // AuthConfigBuilder additional tests
 // =============================================================================
 

--- a/src/ros2_medkit_gateway/test/test_auth_config.cpp
+++ b/src/ros2_medkit_gateway/test/test_auth_config.cpp
@@ -105,32 +105,56 @@ TEST(AuthConfigRolePermissionsTest, ViewerCanReadStatus) {
   EXPECT_TRUE(viewer_perms.count("GET:/api/v1/components/*/status") > 0);
 }
 
-TEST(AuthConfigRolePermissionsTest, OperatorCanReadStatusAndControlLifecycle) {
+TEST(AuthConfigRolePermissionsTest, OperatorCanReadStatusAndControlNonDestructiveLifecycle) {
   const auto & permissions = AuthConfig::get_role_permissions();
 
   const auto & operator_perms = permissions.at(UserRole::OPERATOR);
   EXPECT_TRUE(operator_perms.count("GET:/api/v1/apps/*/status") > 0);
   EXPECT_TRUE(operator_perms.count("GET:/api/v1/components/*/status") > 0);
-  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/*") > 0);
-  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/*") > 0);
+  // Non-destructive transitions are allowed for OPERATOR.
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/start") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/restart") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/force-restart") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/start") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/restart") > 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/force-restart") > 0);
 }
 
-TEST(AuthConfigRolePermissionsTest, ConfiguratorCanReadStatusAndControlLifecycle) {
+TEST(AuthConfigRolePermissionsTest, OperatorCannotPerformDestructiveTransitions) {
+  const auto & permissions = AuthConfig::get_role_permissions();
+
+  const auto & operator_perms = permissions.at(UserRole::OPERATOR);
+  // shutdown / force-shutdown tear an entity down and are gated behind CONFIGURATOR.
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/shutdown") == 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/force-shutdown") == 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/shutdown") == 0);
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/components/*/status/force-shutdown") == 0);
+  // The old broad wildcard must not be present.
+  EXPECT_TRUE(operator_perms.count("PUT:/api/v1/apps/*/status/*") == 0);
+}
+
+TEST(AuthConfigRolePermissionsTest, ConfiguratorCanControlDestructiveLifecycle) {
   const auto & permissions = AuthConfig::get_role_permissions();
 
   const auto & config_perms = permissions.at(UserRole::CONFIGURATOR);
   EXPECT_TRUE(config_perms.count("GET:/api/v1/apps/*/status") > 0);
   EXPECT_TRUE(config_perms.count("GET:/api/v1/components/*/status") > 0);
-  EXPECT_TRUE(config_perms.count("PUT:/api/v1/apps/*/status/*") > 0);
-  EXPECT_TRUE(config_perms.count("PUT:/api/v1/components/*/status/*") > 0);
+  // CONFIGURATOR has the non-destructive transitions plus the teardown ones.
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/apps/*/status/restart") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/apps/*/status/shutdown") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/apps/*/status/force-shutdown") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/components/*/status/shutdown") > 0);
+  EXPECT_TRUE(config_perms.count("PUT:/api/v1/components/*/status/force-shutdown") > 0);
 }
 
 TEST(AuthConfigRolePermissionsTest, ViewerCannotControlLifecycle) {
   const auto & permissions = AuthConfig::get_role_permissions();
 
   const auto & viewer_perms = permissions.at(UserRole::VIEWER);
-  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/apps/*/status/*") == 0);
-  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/components/*/status/*") == 0);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/apps/*/status/start") == 0);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/apps/*/status/restart") == 0);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/apps/*/status/shutdown") == 0);
+  EXPECT_TRUE(viewer_perms.count("PUT:/api/v1/components/*/status/restart") == 0);
 }
 
 TEST(AuthConfigRolePermissionsTest, AdminStatusCoveredByWildcard) {
@@ -139,8 +163,8 @@ TEST(AuthConfigRolePermissionsTest, AdminStatusCoveredByWildcard) {
   const auto & admin_perms = permissions.at(UserRole::ADMIN);
   // Admin is covered by PUT:/api/v1/** - no specific status entries needed
   EXPECT_TRUE(admin_perms.count("PUT:/api/v1/**") > 0);
-  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/apps/*/status/*") == 0);
-  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/components/*/status/*") == 0);
+  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/apps/*/status/shutdown") == 0);
+  EXPECT_TRUE(admin_perms.count("PUT:/api/v1/components/*/status/force-shutdown") == 0);
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_capability_builder.cpp
+++ b/src/ros2_medkit_gateway/test/test_capability_builder.cpp
@@ -64,6 +64,7 @@ TEST(CapabilityBuilderTest, CapabilityToNameReturnsCorrectStrings) {
   EXPECT_EQ(CapabilityBuilder::capability_to_name(Cap::RELATED_APPS), "related-apps");
   EXPECT_EQ(CapabilityBuilder::capability_to_name(Cap::HOSTS), "hosts");
   EXPECT_EQ(CapabilityBuilder::capability_to_name(Cap::LOGS), "logs");
+  EXPECT_EQ(CapabilityBuilder::capability_to_name(Cap::STATUS), "status");
 }
 
 TEST(CapabilityBuilderTest, CapabilityToPathMatchesName) {

--- a/src/ros2_medkit_gateway/test/test_lifecycle_dto.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_dto.cpp
@@ -1,0 +1,40 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_gateway/dto/json_writer.hpp"
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
+
+namespace ros2_medkit_gateway::dto {
+
+TEST(LifecycleDto, WritesStatusOnlyWhenNoTransitions) {
+  LifecycleStatusResponse r;
+  r.status = "ready";
+  const nlohmann::json j = JsonWriter<LifecycleStatusResponse>::write(r);
+  EXPECT_EQ(j.at("status"), "ready");
+  EXPECT_FALSE(j.contains("start"));
+  EXPECT_FALSE(j.contains("force-restart"));
+}
+
+TEST(LifecycleDto, EmitsHyphenatedTransitionKeys) {
+  LifecycleStatusResponse r;
+  r.status = "ready";
+  r.force_restart = "/api/v1/apps/x/status/force-restart";
+  const nlohmann::json j = JsonWriter<LifecycleStatusResponse>::write(r);
+  EXPECT_EQ(j.at("force-restart"), "/api/v1/apps/x/status/force-restart");
+  EXPECT_FALSE(j.contains("force_restart"));
+}
+
+}  // namespace ros2_medkit_gateway::dto

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -1,0 +1,231 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <regex>
+#include <string>
+#include <thread>
+
+#include "ros2_medkit_gateway/core/discovery/models/app.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/component.hpp"
+#include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp"
+#include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
+#include "ros2_medkit_gateway/gateway_node.hpp"
+#include "ros2_medkit_gateway/http/typed_router.hpp"
+
+using json = nlohmann::json;
+using ros2_medkit_gateway::App;
+using ros2_medkit_gateway::AuthConfig;
+using ros2_medkit_gateway::Component;
+using ros2_medkit_gateway::CorsConfig;
+using ros2_medkit_gateway::GatewayNode;
+using ros2_medkit_gateway::ThreadSafeEntityCache;
+using ros2_medkit_gateway::TlsConfig;
+using ros2_medkit_gateway::handlers::HandlerContext;
+using ros2_medkit_gateway::handlers::LifecycleHandlers;
+namespace dto = ros2_medkit_gateway::dto;
+namespace http = ros2_medkit_gateway::http;
+
+namespace {
+
+httplib::Request make_request_with_match(const std::string & path, const std::string & pattern) {
+  httplib::Request req;
+  req.path = path;
+  std::regex re(pattern);
+  std::regex_match(req.path, req.matches, re);
+  return req;
+}
+
+}  // namespace
+
+// =============================================================================
+// Fixture-based tests against a live GatewayNode.
+// =============================================================================
+
+class LifecycleHandlersTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    std::vector<std::string> args = {"test_lifecycle_handlers", "--ros-args", "-p", "refresh_interval_ms:=60000"};
+    std::vector<char *> argv;
+    argv.reserve(args.size());
+    for (auto & arg : args) {
+      argv.push_back(arg.data());
+    }
+    rclcpp::init(static_cast<int>(argv.size()), argv.data());
+  }
+
+  static void TearDownTestSuite() {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override {
+    gateway_node_ = std::make_shared<GatewayNode>();
+    ASSERT_NE(gateway_node_, nullptr);
+
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(gateway_node_);
+    spin_thread_ = std::thread([this]() {
+      executor_->spin();
+    });
+
+    ctx_ = std::make_unique<HandlerContext>(gateway_node_.get(), cors_, auth_, tls_, nullptr);
+    handlers_ = std::make_unique<LifecycleHandlers>(*ctx_, nullptr);  // no plugin manager
+
+    // Give the executor a moment to start before seeding cache.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    seed_cache();
+  }
+
+  void TearDown() override {
+    if (executor_) {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    handlers_.reset();
+    ctx_.reset();
+    executor_.reset();
+    gateway_node_.reset();
+  }
+
+  void seed_cache() {
+    // Online app
+    App online_app;
+    online_app.id = "online_sensor";
+    online_app.name = "OnlineSensor";
+    online_app.is_online = true;
+
+    // Offline app
+    App offline_app;
+    offline_app.id = "offline_sensor";
+    offline_app.name = "OfflineSensor";
+    offline_app.is_online = false;
+
+    // Component with host_metadata (host component -> "ready")
+    Component host_comp;
+    host_comp.id = "host_controller";
+    host_comp.name = "HostController";
+    host_comp.host_metadata = json{{"hostname", "robot-main"}};
+
+    // Component without host_metadata (non-host -> "notReady")
+    Component non_host_comp;
+    non_host_comp.id = "bridge_component";
+    non_host_comp.name = "BridgeComponent";
+    // host_metadata left as nullopt
+
+    auto & cache = const_cast<ThreadSafeEntityCache &>(gateway_node_->get_thread_safe_cache());
+    cache.update_all({}, {host_comp, non_host_comp}, {online_app, offline_app}, {});
+  }
+
+  CorsConfig cors_{};
+  AuthConfig auth_{};
+  TlsConfig tls_{};
+  std::shared_ptr<GatewayNode> gateway_node_;
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::unique_ptr<HandlerContext> ctx_;
+  std::unique_ptr<LifecycleHandlers> handlers_;
+};
+
+// GET /apps/{online_sensor}/status -> 200, status == "ready", no restart URI
+TEST_F(LifecycleHandlersTest, GetStatusOnlineAppReturnsReady) {
+  auto raw = make_request_with_match("/api/v1/apps/online_sensor/status", R"(/api/v1/apps/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "ready");
+  EXPECT_FALSE(result->restart.has_value());
+}
+
+// GET /apps/{offline_sensor}/status -> 200, status == "notReady"
+TEST_F(LifecycleHandlersTest, GetStatusOfflineAppReturnsNotReady) {
+  auto raw = make_request_with_match("/api/v1/apps/offline_sensor/status", R"(/api/v1/apps/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "notReady");
+}
+
+// GET /components/{host_controller}/status -> 200, status == "ready" (has host_metadata)
+TEST_F(LifecycleHandlersTest, GetStatusHostComponentReturnsReady) {
+  auto raw =
+      make_request_with_match("/api/v1/components/host_controller/status", R"(/api/v1/components/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "ready");
+}
+
+// GET /components/{bridge_component}/status -> 200, status == "notReady" (no host_metadata, no provider)
+TEST_F(LifecycleHandlersTest, GetStatusNonHostComponentReturnsNotReady) {
+  auto raw =
+      make_request_with_match("/api/v1/components/bridge_component/status", R"(/api/v1/components/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "notReady");
+}
+
+// PUT /apps/{online_sensor}/status/restart -> 501 (no provider registered)
+TEST_F(LifecycleHandlersTest, TransitionRestartWithNoProviderReturns501) {
+  // Route regex: the action is captured as param "1" = entity_id from /apps/{id}/status/restart
+  // We register a route with {app_id} as capture group 1. In the handler, path_param("1") gives entity_id.
+  auto raw =
+      make_request_with_match("/api/v1/apps/online_sensor/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 501);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_NOT_IMPLEMENTED);
+}
+
+// PUT /apps/{online_sensor}/status/force-shutdown -> 501 (no provider registered)
+TEST_F(LifecycleHandlersTest, TransitionForceShutdownWithNoProviderReturns501) {
+  auto raw = make_request_with_match("/api/v1/apps/online_sensor/status/force-shutdown",
+                                     R"(/api/v1/apps/([^/]+)/status/force-shutdown)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "force-shutdown");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 501);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_NOT_IMPLEMENTED);
+}
+
+// PUT /apps/{unknown}/status/restart -> 404 (validate_entity_for_route before provider)
+TEST_F(LifecycleHandlersTest, TransitionUnknownEntityReturns404) {
+  auto raw =
+      make_request_with_match("/api/v1/apps/does_not_exist/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 404);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_ENTITY_NOT_FOUND);
+}

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -243,7 +243,10 @@ namespace {
 
 template <class T>
 json detail_body_json(const ros2_medkit_gateway::http::Result<T> & result) {
-  EXPECT_TRUE(result.has_value());
+  if (!result.has_value()) {
+    ADD_FAILURE() << "Expected result to have value but it was empty";
+    return json{};
+  }
   return JsonWriter<T>::write(result.value());
 }
 

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -140,14 +140,35 @@ class LifecycleHandlersTest : public ::testing::Test {
     host_comp.name = "HostController";
     host_comp.host_metadata = json{{"hostname", "robot-main"}};
 
-    // Component without host_metadata (non-host -> "notReady")
+    // Component without host_metadata and without hosted apps (non-host -> "notReady")
     Component non_host_comp;
     non_host_comp.id = "bridge_component";
     non_host_comp.name = "BridgeComponent";
     // host_metadata left as nullopt
 
+    // Non-host component with one online hosted app -> liveness "ready".
+    Component live_comp;
+    live_comp.id = "live_subsystem";
+    live_comp.name = "LiveSubsystem";
+    App hosted_online_app;
+    hosted_online_app.id = "hosted_online_node";
+    hosted_online_app.name = "HostedOnlineNode";
+    hosted_online_app.is_online = true;
+    hosted_online_app.component_id = "live_subsystem";
+
+    // Non-host component whose only hosted app is offline -> "notReady".
+    Component dead_comp;
+    dead_comp.id = "dead_subsystem";
+    dead_comp.name = "DeadSubsystem";
+    App hosted_offline_app;
+    hosted_offline_app.id = "hosted_offline_node";
+    hosted_offline_app.name = "HostedOfflineNode";
+    hosted_offline_app.is_online = false;
+    hosted_offline_app.component_id = "dead_subsystem";
+
     auto & cache = const_cast<ThreadSafeEntityCache &>(gateway_node_->get_thread_safe_cache());
-    cache.update_all({}, {host_comp, non_host_comp}, {online_app, offline_app}, {});
+    cache.update_all({}, {host_comp, non_host_comp, live_comp, dead_comp},
+                     {online_app, offline_app, hosted_online_app, hosted_offline_app}, {});
   }
 
   CorsConfig cors_{};
@@ -196,6 +217,28 @@ TEST_F(LifecycleHandlersTest, GetStatusHostComponentReturnsReady) {
 TEST_F(LifecycleHandlersTest, GetStatusNonHostComponentReturnsNotReady) {
   auto raw =
       make_request_with_match("/api/v1/components/bridge_component/status", R"(/api/v1/components/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "notReady");
+}
+
+// GET /components/{live_subsystem}/status -> "ready" (a hosted App is online)
+TEST_F(LifecycleHandlersTest, GetStatusComponentWithOnlineHostedAppReturnsReady) {
+  auto raw =
+      make_request_with_match("/api/v1/components/live_subsystem/status", R"(/api/v1/components/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "ready");
+}
+
+// GET /components/{dead_subsystem}/status -> "notReady" (its only hosted App is offline)
+TEST_F(LifecycleHandlersTest, GetStatusComponentWithOnlyOfflineHostedAppReturnsNotReady) {
+  auto raw =
+      make_request_with_match("/api/v1/components/dead_subsystem/status", R"(/api/v1/components/([^/]+)/status)");
   http::TypedRequest req(raw);
 
   auto result = handlers_->handle_get_status(req);
@@ -583,4 +626,31 @@ TEST_F(LifecycleHandlersWithProviderTest, GetStatusProviderErrorReturnsMappedCod
   ASSERT_FALSE(result.has_value());
   EXPECT_EQ(result.error().http_status, 403);
   EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_INSUFFICIENT_ACCESS_RIGHTS);
+}
+
+// PUT with provider reporting EntityNotFound -> 404 entity-not-found (not a 500 plugin-error).
+TEST_F(LifecycleHandlersWithProviderTest, TransitionEntityNotFoundReturns404) {
+  mock_->transition_error =
+      LifecycleProviderErrorInfo{LifecycleProviderError::EntityNotFound, "no such substrate unit", 500};
+  auto raw =
+      make_request_with_match("/api/v1/apps/plugin_app/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 404);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_ENTITY_NOT_FOUND);
+}
+
+// GET with a provider returning a status outside {ready, notReady} -> 500 (contract guard).
+TEST_F(LifecycleHandlersWithProviderTest, GetStatusProviderInvalidStatusReturns500) {
+  mock_->status_response.status = "running";  // not a valid SOVD lifecycle status
+
+  auto raw = make_request_with_match("/api/v1/apps/plugin_app/status", R"(/api/v1/apps/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 500);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_PLUGIN_ERROR);
 }

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -26,8 +26,10 @@
 #include "ros2_medkit_gateway/core/discovery/models/app.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/component.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/core/http/handlers/discovery_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp"
 #include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+#include "ros2_medkit_gateway/dto/json_writer.hpp"
 #include "ros2_medkit_gateway/dto/lifecycle.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/typed_router.hpp"
@@ -40,6 +42,8 @@ using ros2_medkit_gateway::CorsConfig;
 using ros2_medkit_gateway::GatewayNode;
 using ros2_medkit_gateway::ThreadSafeEntityCache;
 using ros2_medkit_gateway::TlsConfig;
+using ros2_medkit_gateway::dto::JsonWriter;
+using ros2_medkit_gateway::handlers::DiscoveryHandlers;
 using ros2_medkit_gateway::handlers::HandlerContext;
 using ros2_medkit_gateway::handlers::LifecycleHandlers;
 namespace dto = ros2_medkit_gateway::dto;
@@ -228,4 +232,113 @@ TEST_F(LifecycleHandlersTest, TransitionUnknownEntityReturns404) {
   ASSERT_FALSE(result.has_value());
   EXPECT_EQ(result.error().http_status, 404);
   EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_ENTITY_NOT_FOUND);
+}
+
+// =============================================================================
+// Entity detail status link advertisement tests.
+// Verify GET /apps/{id} and GET /components/{id} include "status" URI field.
+// =============================================================================
+
+namespace {
+
+template <class T>
+json detail_body_json(const ros2_medkit_gateway::http::Result<T> & result) {
+  EXPECT_TRUE(result.has_value());
+  return JsonWriter<T>::write(result.value());
+}
+
+}  // namespace
+
+class EntityDetailStatusLinkTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      std::vector<std::string> args = {"test_lifecycle_handlers", "--ros-args", "-p", "refresh_interval_ms:=60000"};
+      std::vector<char *> argv;
+      argv.reserve(args.size());
+      for (auto & arg : args) {
+        argv.push_back(arg.data());
+      }
+      rclcpp::init(static_cast<int>(argv.size()), argv.data());
+    }
+  }
+
+  static void TearDownTestSuite() {
+  }
+
+  void SetUp() override {
+    gateway_node_ = std::make_shared<GatewayNode>();
+    ASSERT_NE(gateway_node_, nullptr);
+
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(gateway_node_);
+    spin_thread_ = std::thread([this]() {
+      executor_->spin();
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    App app;
+    app.id = "online_sensor";
+    app.name = "OnlineSensor";
+    app.is_online = true;
+
+    Component comp;
+    comp.id = "host_controller";
+    comp.name = "HostController";
+
+    auto & cache = const_cast<ThreadSafeEntityCache &>(gateway_node_->get_thread_safe_cache());
+    cache.update_all({}, {comp}, {app}, {});
+
+    ctx_ = std::make_unique<HandlerContext>(gateway_node_.get(), cors_, auth_, tls_, nullptr);
+    discovery_ = std::make_unique<DiscoveryHandlers>(*ctx_);
+  }
+
+  void TearDown() override {
+    if (executor_) {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    discovery_.reset();
+    ctx_.reset();
+    executor_.reset();
+    gateway_node_.reset();
+  }
+
+  CorsConfig cors_{};
+  AuthConfig auth_{};
+  TlsConfig tls_{};
+  std::shared_ptr<GatewayNode> gateway_node_;
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::unique_ptr<HandlerContext> ctx_;
+  std::unique_ptr<DiscoveryHandlers> discovery_;
+};
+
+// GET /apps/{id} must include "status" -> "/api/v1/apps/{id}/status"
+TEST_F(EntityDetailStatusLinkTest, AppDetailAdvertisesStatusLink) {
+  httplib::Request req;
+  req.path = "/api/v1/apps/online_sensor";
+  std::regex re(R"(/api/v1/apps/([^/]+))");
+  std::regex_match(req.path, req.matches, re);
+  http::TypedRequest typed_req(req);
+
+  auto result = discovery_->get_app(typed_req);
+  auto body = detail_body_json(result);
+  EXPECT_EQ(body["status"], "/api/v1/apps/online_sensor/status");
+}
+
+// GET /components/{id} must include "status" -> "/api/v1/components/{id}/status"
+TEST_F(EntityDetailStatusLinkTest, ComponentDetailAdvertisesStatusLink) {
+  httplib::Request req;
+  req.path = "/api/v1/components/host_controller";
+  std::regex re(R"(/api/v1/components/([^/]+))");
+  std::regex_match(req.path, req.matches, re);
+  http::TypedRequest typed_req(req);
+
+  auto result = discovery_->get_component(typed_req);
+  auto body = detail_body_json(result);
+  EXPECT_EQ(body["status"], "/api/v1/components/host_controller/status");
 }

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -528,3 +528,59 @@ TEST_F(LifecycleHandlersWithProviderTest, TransitionPreconditionFailedReturns409
   EXPECT_EQ(result.error().http_status, 409);
   EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_PRECONDITION_NOT_FULFILLED);
 }
+
+// PUT /apps/{plugin_app}/status/restart with provider returning AccessDenied -> 403.
+TEST_F(LifecycleHandlersWithProviderTest, TransitionAccessDeniedReturns403) {
+  mock_->transition_error =
+      LifecycleProviderErrorInfo{LifecycleProviderError::AccessDenied, "operator role required", 403};
+  auto raw =
+      make_request_with_match("/api/v1/apps/plugin_app/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 403);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_INSUFFICIENT_ACCESS_RIGHTS);
+}
+
+// PUT /apps/{plugin_app}/status/force-restart with provider returning Unsupported -> 501.
+// Distinct from the no-provider 501: here a provider exists but rejects this transition.
+TEST_F(LifecycleHandlersWithProviderTest, TransitionUnsupportedReturns501) {
+  mock_->transition_error =
+      LifecycleProviderErrorInfo{LifecycleProviderError::Unsupported, "force-restart not supported", 501};
+  auto raw = make_request_with_match("/api/v1/apps/plugin_app/status/force-restart",
+                                     R"(/api/v1/apps/([^/]+)/status/force-restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "force-restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 501);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_NOT_IMPLEMENTED);
+}
+
+// PUT with provider returning Internal and an out-of-range status -> clamped to 599, plugin-error.
+TEST_F(LifecycleHandlersWithProviderTest, TransitionInternalErrorClampsStatus) {
+  mock_->transition_error = LifecycleProviderErrorInfo{LifecycleProviderError::Internal, "boom", 650};
+  auto raw =
+      make_request_with_match("/api/v1/apps/plugin_app/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 599);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_PLUGIN_ERROR);
+}
+
+// GET /apps/{plugin_app}/status with provider returning an error -> handler maps it.
+// Covers the GET provider-error branch (the no-error path is covered above).
+TEST_F(LifecycleHandlersWithProviderTest, GetStatusProviderErrorReturnsMappedCode) {
+  mock_->get_status_error =
+      LifecycleProviderErrorInfo{LifecycleProviderError::AccessDenied, "viewer cannot read status", 403};
+  auto raw = make_request_with_match("/api/v1/apps/plugin_app/status", R"(/api/v1/apps/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 403);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_INSUFFICIENT_ACCESS_RIGHTS);
+}

--- a/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_handlers.cpp
@@ -29,6 +29,9 @@
 #include "ros2_medkit_gateway/core/http/handlers/discovery_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/lifecycle_handlers.hpp"
 #include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+#include "ros2_medkit_gateway/core/plugins/gateway_plugin.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/core/providers/lifecycle_provider.hpp"
 #include "ros2_medkit_gateway/dto/json_writer.hpp"
 #include "ros2_medkit_gateway/dto/lifecycle.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -40,6 +43,10 @@ using ros2_medkit_gateway::AuthConfig;
 using ros2_medkit_gateway::Component;
 using ros2_medkit_gateway::CorsConfig;
 using ros2_medkit_gateway::GatewayNode;
+using ros2_medkit_gateway::LifecycleProvider;
+using ros2_medkit_gateway::LifecycleProviderError;
+using ros2_medkit_gateway::LifecycleProviderErrorInfo;
+using ros2_medkit_gateway::PluginManager;
 using ros2_medkit_gateway::ThreadSafeEntityCache;
 using ros2_medkit_gateway::TlsConfig;
 using ros2_medkit_gateway::dto::JsonWriter;
@@ -344,4 +351,180 @@ TEST_F(EntityDetailStatusLinkTest, ComponentDetailAdvertisesStatusLink) {
   auto result = discovery_->get_component(typed_req);
   auto body = detail_body_json(result);
   EXPECT_EQ(body["status"], "/api/v1/components/host_controller/status");
+}
+
+// =============================================================================
+// Provider-present handler path tests.
+// Wire a mock LifecycleProvider into the handler via PluginManager and verify
+// the handler correctly delegates, fills transition URIs, returns 202, and maps
+// provider errors to the right HTTP codes.
+// =============================================================================
+
+namespace {
+
+/// Configurable mock plugin implementing LifecycleProvider.
+/// Set `status_to_return` for get_status(), or `error_to_return` for failures.
+/// Set `transition_error` for request_transition() failures.
+class MockLifecyclePlugin : public ros2_medkit_gateway::GatewayPlugin, public LifecycleProvider {
+ public:
+  std::string name() const override {
+    return "mock_lifecycle";
+  }
+  void configure(const json & /*cfg*/) override {
+  }
+  void shutdown() override {
+  }
+
+  // LifecycleProvider
+
+  tl::expected<dto::LifecycleStatusResponse, LifecycleProviderErrorInfo>
+  get_status(const std::string & /*entity_id*/) override {
+    if (get_status_error) {
+      return tl::make_unexpected(*get_status_error);
+    }
+    return status_response;
+  }
+
+  tl::expected<std::monostate, LifecycleProviderErrorInfo>
+  request_transition(const std::string & /*entity_id*/, std::string_view /*transition*/) override {
+    if (transition_error) {
+      return tl::make_unexpected(*transition_error);
+    }
+    return std::monostate{};
+  }
+
+  // Configurable state
+  dto::LifecycleStatusResponse status_response;
+  std::optional<LifecycleProviderErrorInfo> get_status_error;
+  std::optional<LifecycleProviderErrorInfo> transition_error;
+};
+
+}  // namespace
+
+class LifecycleHandlersWithProviderTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      std::vector<std::string> args = {"test_lifecycle_handlers", "--ros-args", "-p", "refresh_interval_ms:=60000"};
+      std::vector<char *> argv;
+      argv.reserve(args.size());
+      for (auto & arg : args) {
+        argv.push_back(arg.data());
+      }
+      rclcpp::init(static_cast<int>(argv.size()), argv.data());
+    }
+  }
+
+  static void TearDownTestSuite() {
+  }
+
+  void SetUp() override {
+    gateway_node_ = std::make_shared<GatewayNode>();
+    ASSERT_NE(gateway_node_, nullptr);
+
+    executor_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(gateway_node_);
+    spin_thread_ = std::thread([this]() {
+      executor_->spin();
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Seed cache with one online app.
+    App app;
+    app.id = "plugin_app";
+    app.name = "PluginApp";
+    app.is_online = true;
+    auto & cache = const_cast<ThreadSafeEntityCache &>(gateway_node_->get_thread_safe_cache());
+    cache.update_all({}, {}, {app}, {});
+
+    // Wire plugin manager: add mock plugin and register entity ownership.
+    plugin_mgr_ = std::make_unique<PluginManager>();
+    auto mock = std::make_unique<MockLifecyclePlugin>();
+    mock_ = mock.get();
+    plugin_mgr_->add_plugin(std::move(mock));
+    plugin_mgr_->register_entity_ownership("mock_lifecycle", {"plugin_app"});
+
+    ctx_ = std::make_unique<HandlerContext>(gateway_node_.get(), cors_, auth_, tls_, nullptr);
+    handlers_ = std::make_unique<LifecycleHandlers>(*ctx_, plugin_mgr_.get());
+  }
+
+  void TearDown() override {
+    if (executor_) {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    handlers_.reset();
+    ctx_.reset();
+    plugin_mgr_.reset();
+    executor_.reset();
+    gateway_node_.reset();
+  }
+
+  CorsConfig cors_{};
+  AuthConfig auth_{};
+  TlsConfig tls_{};
+  std::shared_ptr<GatewayNode> gateway_node_;
+  std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::unique_ptr<PluginManager> plugin_mgr_;
+  MockLifecyclePlugin * mock_{nullptr};
+  std::unique_ptr<HandlerContext> ctx_;
+  std::unique_ptr<LifecycleHandlers> handlers_;
+};
+
+// GET /apps/{plugin_app}/status with provider returning "ready" + restart transition:
+// - status == "ready"
+// - restart field filled with absolute URI "/api/v1/apps/plugin_app/status/restart"
+TEST_F(LifecycleHandlersWithProviderTest, GetStatusProviderReadyFillsTransitionURI) {
+  mock_->status_response.status = "ready";
+  mock_->status_response.restart = "";  // non-nullopt signals provider supports it
+
+  auto raw = make_request_with_match("/api/v1/apps/plugin_app/status", R"(/api/v1/apps/([^/]+)/status)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_get_status(req);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "ready");
+  ASSERT_TRUE(result->restart.has_value());
+  EXPECT_EQ(*result->restart, "/api/v1/apps/plugin_app/status/restart");
+  // start was not set by provider, so it should remain absent.
+  EXPECT_FALSE(result->start.has_value());
+}
+
+// PUT /apps/{plugin_app}/status/restart with provider accepting -> 202 + Location header.
+TEST_F(LifecycleHandlersWithProviderTest, TransitionAcceptedReturns202WithLocation) {
+  auto raw =
+      make_request_with_match("/api/v1/apps/plugin_app/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_TRUE(result.has_value());
+  const auto & att = result->second;
+  ASSERT_TRUE(att.status_override.has_value());
+  EXPECT_EQ(*att.status_override, 202);
+  bool found_location = false;
+  for (const auto & [name, value] : att.headers) {
+    if (name == "Location") {
+      EXPECT_EQ(value, "/api/v1/apps/plugin_app/status");
+      found_location = true;
+    }
+  }
+  EXPECT_TRUE(found_location);
+}
+
+// PUT /apps/{plugin_app}/status/restart with provider returning PreconditionFailed -> 409.
+TEST_F(LifecycleHandlersWithProviderTest, TransitionPreconditionFailedReturns409) {
+  mock_->transition_error =
+      LifecycleProviderErrorInfo{LifecycleProviderError::PreconditionFailed, "not in correct state", 409};
+  auto raw =
+      make_request_with_match("/api/v1/apps/plugin_app/status/restart", R"(/api/v1/apps/([^/]+)/status/restart)");
+  http::TypedRequest req(raw);
+
+  auto result = handlers_->handle_transition(req, "restart");
+  ASSERT_FALSE(result.has_value());
+  EXPECT_EQ(result.error().http_status, 409);
+  EXPECT_EQ(result.error().code, ros2_medkit_gateway::ERR_PRECONDITION_NOT_FULFILLED);
 }

--- a/src/ros2_medkit_gateway/test/test_lifecycle_provider_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_lifecycle_provider_routing.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_gateway/core/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/core/providers/lifecycle_provider.hpp"
+#include "ros2_medkit_gateway/dto/lifecycle.hpp"
+
+using namespace ros2_medkit_gateway;
+
+// --- Mock plugin implementing LifecycleProvider ---
+
+class MockLifecyclePlugin : public GatewayPlugin, public LifecycleProvider {
+ public:
+  std::string name() const override {
+    return "lifecycle_plugin";
+  }
+  void configure(const json & /*config*/) override {
+  }
+  void shutdown() override {
+  }
+
+  // LifecycleProvider
+  tl::expected<dto::LifecycleStatusResponse, LifecycleProviderErrorInfo>
+  get_status(const std::string & /*entity_id*/) override {
+    dto::LifecycleStatusResponse resp;
+    resp.status = "ready";
+    return resp;
+  }
+
+  tl::expected<std::monostate, LifecycleProviderErrorInfo>
+  request_transition(const std::string & /*entity_id*/, std::string_view /*transition*/) override {
+    return std::monostate{};
+  }
+};
+
+// --- Mock plugin without LifecycleProvider ---
+
+class MockBarePlugin : public GatewayPlugin {
+ public:
+  std::string name() const override {
+    return "bare_plugin";
+  }
+  void configure(const json & /*config*/) override {
+  }
+  void shutdown() override {
+  }
+};
+
+// =============================================================================
+// LifecycleProvider Routing Tests
+// =============================================================================
+
+TEST(LifecycleProviderRouting, UnownedEntityReturnsNull) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockLifecyclePlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  // No ownership registered - entity is not owned by any plugin
+  EXPECT_EQ(mgr.get_lifecycle_provider_for_entity("unowned"), nullptr);
+}
+
+TEST(LifecycleProviderRouting, LifecycleProviderResolvedForOwnedEntity) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockLifecyclePlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("lifecycle_plugin", {"my_node"});
+
+  auto * lp = mgr.get_lifecycle_provider_for_entity("my_node");
+  ASSERT_NE(lp, nullptr);
+  EXPECT_EQ(lp, static_cast<LifecycleProvider *>(raw));
+
+  auto result = lp->get_status("my_node");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->status, "ready");
+}
+
+TEST(LifecycleProviderRouting, BarePluginReturnsNullLifecycleProvider) {
+  PluginManager mgr;
+
+  auto plugin = std::make_unique<MockBarePlugin>();
+  mgr.add_plugin(std::move(plugin));
+
+  mgr.register_entity_ownership("bare_plugin", {"entity1"});
+
+  // Entity is owned, but plugin doesn't implement LifecycleProvider
+  EXPECT_EQ(mgr.get_lifecycle_provider_for_entity("entity1"), nullptr);
+}
+
+TEST(LifecycleProviderRouting, OwnershipForNonLoadedPluginReturnsNull) {
+  PluginManager mgr;
+  mgr.register_entity_ownership("ghost_plugin", {"entity1"});
+
+  EXPECT_EQ(mgr.get_lifecycle_provider_for_entity("entity1"), nullptr);
+}

--- a/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Feature tests for lifecycle status endpoints (GET /status, PUT /status/{action}).
+
+Validates the default (no-provider) lifecycle status path:
+- GET /{entity}/status returns 200 with status == "ready" for online entities.
+- PUT /{entity}/status/{action} returns 501 when no lifecycle provider is registered.
+
+"""
+
+import unittest
+
+import launch_testing
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor'],
+        fault_manager=False,
+    )
+
+
+# @verifies REQ_INTEROP_076
+class TestLifecycleStatus(GatewayTestCase):
+    """Lifecycle status endpoint tests for apps and components."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {'temp_sensor'}
+
+    # Cache for the dynamically-discovered host component ID.
+    _host_component_id = None
+
+    def _get_host_component_id(self):
+        """Get the host component ID (cached after first lookup)."""
+        if TestLifecycleStatus._host_component_id is not None:
+            return TestLifecycleStatus._host_component_id
+
+        data = self.get_json('/components')
+        components = data.get('items', [])
+        self.assertGreater(
+            len(components), 0,
+            'Expected at least 1 host component, got none'
+        )
+        TestLifecycleStatus._host_component_id = components[0]['id']
+        return TestLifecycleStatus._host_component_id
+
+    def test_app_status_ready(self):
+        """GET /apps/{app_id}/status returns 200 with status == "ready" for an online app.
+
+        @verifies REQ_INTEROP_076
+        """
+        data = self.poll_endpoint_until(
+            '/apps/temp_sensor/status',
+            condition=lambda d: d if d.get('status') == 'ready' else None,
+            timeout=15.0,
+        )
+        self.assertEqual(data.get('status'), 'ready')
+
+    def test_component_status_ready(self):
+        """GET /components/{component_id}/status returns 200 with status == "ready".
+
+        @verifies REQ_INTEROP_076
+        """
+        host_id = self._get_host_component_id()
+        data = self.poll_endpoint_until(
+            f'/components/{host_id}/status',
+            condition=lambda d: d if d.get('status') == 'ready' else None,
+            timeout=15.0,
+        )
+        self.assertEqual(data.get('status'), 'ready')
+
+    def test_app_status_restart_returns_501(self):
+        """PUT /apps/{app_id}/status/restart returns 501 when no lifecycle provider is registered.
+
+        @verifies REQ_INTEROP_076
+        """
+        response = requests.put(
+            f'{self.BASE_URL}/apps/temp_sensor/status/restart',
+            json={},
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 501)
+        data = response.json()
+        self.assertIn('error_code', data)
+
+    def test_app_status_structure(self):
+        """GET /apps/{app_id}/status response has required 'status' field.
+
+        @verifies REQ_INTEROP_076
+        """
+        data = self.poll_endpoint_until(
+            '/apps/temp_sensor/status',
+            condition=lambda d: d if 'status' in d else None,
+            timeout=15.0,
+        )
+        self.assertIn('status', data)
+        self.assertIn(data['status'], ['ready', 'notReady'])
+
+    def test_app_status_nonexistent_returns_404(self):
+        """GET /apps/{app_id}/status returns 404 for a nonexistent app.
+
+        @verifies REQ_INTEROP_076
+        """
+        response = self.get_raw('/apps/nonexistent_app/status', expected_status=404)
+        data = response.json()
+        self.assertIn('error_code', data)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check all processes exited cleanly (SIGTERM allowed)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
@@ -55,9 +55,11 @@ class TestLifecycleStatus(GatewayTestCase):
 
         data = self.get_json('/components')
         components = data.get('items', [])
-        self.assertGreater(
-            len(components), 0,
-            'Expected at least 1 host component, got none'
+        # Runtime discovery exposes exactly one host Component (the host machine),
+        # matching the other feature tests. Picking [0] is only safe because of this.
+        self.assertEqual(
+            len(components), 1,
+            f'Expected exactly 1 host component, got {len(components)}'
         )
         TestLifecycleStatus._host_component_id = components[0]['id']
         return TestLifecycleStatus._host_component_id

--- a/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_lifecycle.test.py
@@ -99,7 +99,7 @@ class TestLifecycleStatus(GatewayTestCase):
         )
         self.assertEqual(response.status_code, 501)
         data = response.json()
-        self.assertIn('error_code', data)
+        self.assertEqual(data.get('error_code'), 'not-implemented')
 
     def test_app_status_structure(self):
         """GET /apps/{app_id}/status response has required 'status' field.
@@ -121,7 +121,7 @@ class TestLifecycleStatus(GatewayTestCase):
         """
         response = self.get_raw('/apps/nonexistent_app/status', expected_status=404)
         data = response.json()
-        self.assertIn('error_code', data)
+        self.assertEqual(data.get('error_code'), 'entity-not-found')
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Summary

Adds the SOVD ISO 17978-3 entity status and lifecycle endpoints to the gateway core:

- `GET /{apps|components}/{id}/status` - returns `ready` / `notReady` plus the URIs of the
  transitions the entity supports.
- `PUT /{apps|components}/{id}/status/{start,restart,force-restart,shutdown,force-shutdown}`.

This is the core contract only. Status read works from runtime state: an App is `ready` when its
node is online, and the host Component is `ready` while it is reachable. The five control
transitions are routed to a new per-entity `LifecycleProvider` interface that has no implementation
in this PR, so control returns `501` until a substrate-owning plugin registers a provider. The
actuation work (ROS lifecycle nodes, process / container / systemd, host reboot) is out of scope
here and is tracked in follow-up issues #434, #435, #436.

Also in this PR:

- New `LifecycleProvider` interface plus a `LifecycleProviderErrorInfo` error struct, routed through
  `PluginManager` like the existing operation provider.
- `LifecycleStatusResponse` DTO, and a `status` link advertised on the app and component detail
  responses.
- RBAC: `GET` status is allowed for the viewer role and above; the PUT transitions for operator and
  above.
- Design doc, README, and `REQ_INTEROP_076` marked verified (077-081 stay open since control is a
  `501` stub).

Making the required role per endpoint configurable is tracked separately in #432. The version bump
is left to a maintainer at release time. No breaking changes; everything here is additive.

## Issue

- closes #433

## Type

- [x] New feature or tests

## Testing

Unit (GTest):

- DTO serialization, including the hyphenated wire keys (`force-restart`, `force-shutdown`).
- Provider routing in `PluginManager` (owned vs unowned entity).
- The status / lifecycle handlers: status read (`ready` / `notReady` for apps and the host
  component), 404 before 501 for an unknown entity, the five PUT transitions returning `501` with no
  provider, and the provider-present path via a mock provider (filled transition URIs, `202` +
  `Location`, and `precondition-not-fulfilled` -> 409).
- The new RBAC permissions, including a viewer-denied-PUT case.

Integration (launch_testing): `GET /apps/{id}/status` and `GET /components/{host}/status` return
`ready`, and `PUT /apps/{id}/status/restart` returns `501`. Tagged `@verifies REQ_INTEROP_076`.

clang-tidy is clean on the changed files.

## Checklist

- [x] Breaking changes are clearly described (none - additive)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
