### PR TITLE
feat(gateway): startup discovery summary + empty-graph warning

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -46,6 +46,12 @@ Possible causes:
 2. **Different ROS_DOMAIN_ID** - Ensure all nodes use the same domain
 3. **Discovery not complete** - Wait a few seconds and refresh
 
+The gateway logs a one-time **Discovery summary** a few seconds after startup
+with the peer node / topic / entity counts. When it sees no application nodes it
+also logs a warning that echoes the active ``ROS_DOMAIN_ID``,
+``RMW_IMPLEMENTATION`` and ``ROS_LOCALHOST_ONLY`` - check the gateway's console
+or logs first, as it names the most likely cause.
+
 Check with:
 
 .. code-block:: bash

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -245,6 +245,13 @@ class GatewayNode : public rclcpp::Node {
   void start_rest_server();
   void stop_rest_server();
 
+  /// Log a one-time discovery summary shortly after startup: discovered node /
+  /// topic / entity counts, the REST URL and a sample curl. When no application
+  /// nodes are visible, also warn loudly with the active ROS environment
+  /// (ROS_DOMAIN_ID / RMW_IMPLEMENTATION / ROS_LOCALHOST_ONLY) and likely causes,
+  /// so a misconfigured bringup is not a silent empty tree.
+  void log_startup_summary();
+
   // Configuration parameters
   std::string server_host_;
   int server_port_;
@@ -363,6 +370,10 @@ class GatewayNode : public rclcpp::Node {
 
   // Timer for periodic cleanup of old action goals
   rclcpp::TimerBase::SharedPtr cleanup_timer_;
+
+  // One-shot timer that fires the post-startup discovery summary (see
+  // log_startup_summary). Reset after it runs.
+  rclcpp::TimerBase::SharedPtr startup_summary_timer_;
 
   // Timer for periodic cleanup of expired cyclic subscriptions
   rclcpp::TimerBase::SharedPtr subscription_cleanup_timer_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -18,6 +18,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
@@ -65,6 +66,16 @@ class GatewayNode : public rclcpp::Node {
  public:
   explicit GatewayNode(const rclcpp::NodeOptions & options = rclcpp::NodeOptions{});
   ~GatewayNode() override;
+
+  /// Count application (peer) nodes from (name, namespace) pairs: excludes hidden
+  /// nodes and the gateway's own nodes (whose FQN starts with @p self_fqn). Static
+  /// and public so the startup-summary counting logic is unit-testable.
+  static size_t count_peer_nodes(const std::vector<std::pair<std::string, std::string>> & nodes_and_namespaces,
+                                 const std::string & self_fqn);
+
+  /// Translate a bind address into a connectable address for the sample curl
+  /// (bind-all "0.0.0.0"/"::"/"" -> loopback). Static and public for testing.
+  static std::string connectable_host(const std::string & bind_host);
   GatewayNode(const GatewayNode &) = delete;
   GatewayNode & operator=(const GatewayNode &) = delete;
   GatewayNode(GatewayNode &&) = delete;

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -18,8 +18,10 @@
 #include <cctype>
 #include <chrono>
 #include <cinttypes>
+#include <cstdlib>
 #include <mutex>
 #include <set>
+#include <string>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -1484,6 +1486,63 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   std::string protocol = tls_config_.enabled ? "HTTPS" : "HTTP";
   RCLCPP_INFO(get_logger(), "ROS 2 Medkit Gateway ready on %s://%s:%d", protocol.c_str(), server_host_.c_str(),
               server_port_);
+
+  // One-shot discovery summary a few seconds after startup. The delay lets DDS
+  // discovery settle so the counts (and any empty-graph warning) reflect a
+  // converged view rather than the cold-start moment.
+  startup_summary_timer_ = create_wall_timer(std::chrono::seconds(5), [this]() {
+    startup_summary_timer_->cancel();
+    startup_summary_timer_.reset();
+    log_startup_summary();
+  });
+}
+
+void GatewayNode::log_startup_summary() {
+  size_t topic_count = 0;
+  size_t peer_node_count = 0;
+  try {
+    const std::string self_fqn = get_fully_qualified_name();
+    for (const auto & entry : get_topic_names_and_types()) {
+      const std::string & topic = entry.first;
+      if (topic.find("/parameter_events") == std::string::npos && topic.find("/rosout") == std::string::npos) {
+        ++topic_count;
+      }
+    }
+    for (const auto & name : get_node_names()) {
+      // Count peers only: exclude the gateway's own nodes (the main node plus its
+      // internal helpers, which share the main node's FQN as a prefix, e.g.
+      // "<fqn>_sub") and hidden (_-prefixed) nodes.
+      if (name.rfind(self_fqn, 0) != 0 && name.rfind("/_", 0) != 0) {
+        ++peer_node_count;
+      }
+    }
+  } catch (const std::exception & e) {
+    RCLCPP_DEBUG(get_logger(), "Startup summary: graph query failed: %s", e.what());
+  }
+
+  const size_t entity_count = thread_safe_cache_.get_areas().size() + thread_safe_cache_.get_components().size() +
+                              thread_safe_cache_.get_apps().size() + thread_safe_cache_.get_functions().size();
+
+  const std::string protocol = tls_config_.enabled ? "https" : "http";
+  const std::string url = protocol + "://" + server_host_ + ":" + std::to_string(server_port_);
+
+  RCLCPP_INFO(get_logger(),
+              "Discovery summary: %zu peer node(s), %zu topic(s), %zu medkit entit%s. REST API: %s  Try: curl "
+              "%s/api/v1/areas",
+              peer_node_count, topic_count, entity_count, entity_count == 1 ? "y" : "ies", url.c_str(), url.c_str());
+
+  if (peer_node_count == 0) {
+    const char * domain = std::getenv("ROS_DOMAIN_ID");
+    const char * rmw = std::getenv("RMW_IMPLEMENTATION");
+    const char * localhost_only = std::getenv("ROS_LOCALHOST_ONLY");
+    RCLCPP_WARN(get_logger(),
+                "No application nodes are visible - the gateway sees only itself, so the entity tree is empty. "
+                "Active ROS environment: ROS_DOMAIN_ID=%s, RMW_IMPLEMENTATION=%s, ROS_LOCALHOST_ONLY=%s. Check that "
+                "the gateway shares the robot stack's ROS_DOMAIN_ID and RMW_IMPLEMENTATION and can reach it on the "
+                "network (in containers: matching domain/RMW and DDS discovery not blocked).",
+                domain ? domain : "0 (default)", rmw ? rmw : "(default)",
+                localhost_only ? localhost_only : "0 (default)");
+  }
 }
 
 GatewayNode::~GatewayNode() {
@@ -1554,6 +1613,10 @@ GatewayNode::~GatewayNode() {
   if (backstop_timer_) {
     backstop_timer_->cancel();
     backstop_timer_.reset();
+  }
+  if (startup_summary_timer_) {
+    startup_summary_timer_->cancel();
+    startup_summary_timer_.reset();
   }
   graph_event_.reset();
   // 10. Normal member destruction (managers safe - all transports stopped)

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1497,25 +1497,48 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   });
 }
 
+size_t GatewayNode::count_peer_nodes(const std::vector<std::pair<std::string, std::string>> & nodes_and_namespaces,
+                                     const std::string & self_fqn) {
+  size_t count = 0;
+  for (const auto & [name, ns] : nodes_and_namespaces) {
+    if (!name.empty() && name.front() == '_') {
+      continue;  // hidden node (name part starts with '_')
+    }
+    const std::string fqn = (ns == "/") ? ("/" + name) : (ns + "/" + name);
+    // Exclude the gateway's own nodes: the main node plus its internal helpers,
+    // which share the main node's FQN as a prefix (e.g. "<fqn>_sub").
+    if (fqn.rfind(self_fqn, 0) == 0) {
+      continue;
+    }
+    ++count;
+  }
+  return count;
+}
+
+std::string GatewayNode::connectable_host(const std::string & bind_host) {
+  // A bind-all address is not a valid connect target, so the sample curl must use
+  // a loopback address the operator can actually reach.
+  if (bind_host.empty() || bind_host == "0.0.0.0") {
+    return "127.0.0.1";
+  }
+  if (bind_host == "::" || bind_host == "[::]") {
+    return "::1";
+  }
+  return bind_host;
+}
+
 void GatewayNode::log_startup_summary() {
   size_t topic_count = 0;
   size_t peer_node_count = 0;
   try {
-    const std::string self_fqn = get_fully_qualified_name();
     for (const auto & entry : get_topic_names_and_types()) {
       const std::string & topic = entry.first;
       if (topic.find("/parameter_events") == std::string::npos && topic.find("/rosout") == std::string::npos) {
         ++topic_count;
       }
     }
-    for (const auto & name : get_node_names()) {
-      // Count peers only: exclude the gateway's own nodes (the main node plus its
-      // internal helpers, which share the main node's FQN as a prefix, e.g.
-      // "<fqn>_sub") and hidden (_-prefixed) nodes.
-      if (name.rfind(self_fqn, 0) != 0 && name.rfind("/_", 0) != 0) {
-        ++peer_node_count;
-      }
-    }
+    peer_node_count =
+        count_peer_nodes(get_node_graph_interface()->get_node_names_and_namespaces(), get_fully_qualified_name());
   } catch (const std::exception & e) {
     RCLCPP_DEBUG(get_logger(), "Startup summary: graph query failed: %s", e.what());
   }
@@ -1524,7 +1547,7 @@ void GatewayNode::log_startup_summary() {
                               thread_safe_cache_.get_apps().size() + thread_safe_cache_.get_functions().size();
 
   const std::string protocol = tls_config_.enabled ? "https" : "http";
-  const std::string url = protocol + "://" + server_host_ + ":" + std::to_string(server_port_);
+  const std::string url = protocol + "://" + connectable_host(server_host_) + ":" + std::to_string(server_port_);
 
   RCLCPP_INFO(get_logger(),
               "Discovery summary: %zu peer node(s), %zu topic(s), %zu medkit entit%s. REST API: %s  Try: curl "
@@ -1536,7 +1559,7 @@ void GatewayNode::log_startup_summary() {
     const char * rmw = std::getenv("RMW_IMPLEMENTATION");
     const char * localhost_only = std::getenv("ROS_LOCALHOST_ONLY");
     RCLCPP_WARN(get_logger(),
-                "No application nodes are visible - the gateway sees only itself, so the entity tree is empty. "
+                "No application nodes are visible on the ROS graph - the gateway sees only its own nodes. "
                 "Active ROS environment: ROS_DOMAIN_ID=%s, RMW_IMPLEMENTATION=%s, ROS_LOCALHOST_ONLY=%s. Check that "
                 "the gateway shares the robot stack's ROS_DOMAIN_ID and RMW_IMPLEMENTATION and can reach it on the "
                 "network (in containers: matching domain/RMW and DDS discovery not blocked).",

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1505,9 +1505,10 @@ size_t GatewayNode::count_peer_nodes(const std::vector<std::pair<std::string, st
       continue;  // hidden node (name part starts with '_')
     }
     const std::string fqn = (ns == "/") ? ("/" + name) : (ns + "/" + name);
-    // Exclude the gateway's own nodes: the main node plus its internal helpers,
-    // which share the main node's FQN as a prefix (e.g. "<fqn>_sub").
-    if (fqn.rfind(self_fqn, 0) == 0) {
+    // Exclude the gateway's own nodes by exact FQN: the main node and its known
+    // internal helpers. A plain prefix match would also drop a genuine peer whose
+    // name starts with the gateway name (e.g. "<fqn>_monitor" or "<fqn>2").
+    if (fqn == self_fqn || fqn == self_fqn + "_sub" || fqn == self_fqn + "_fault_clients") {
       continue;
     }
     ++count;
@@ -1522,7 +1523,11 @@ std::string GatewayNode::connectable_host(const std::string & bind_host) {
     return "127.0.0.1";
   }
   if (bind_host == "::" || bind_host == "[::]") {
-    return "::1";
+    return "[::1]";
+  }
+  // Bracket a bare IPv6 literal so "host:port" is a valid URL authority for curl.
+  if (bind_host.front() != '[' && bind_host.find(':') != std::string::npos) {
+    return "[" + bind_host + "]";
   }
   return bind_host;
 }
@@ -1563,8 +1568,7 @@ void GatewayNode::log_startup_summary() {
                 "Active ROS environment: ROS_DOMAIN_ID=%s, RMW_IMPLEMENTATION=%s, ROS_LOCALHOST_ONLY=%s. Check that "
                 "the gateway shares the robot stack's ROS_DOMAIN_ID and RMW_IMPLEMENTATION and can reach it on the "
                 "network (in containers: matching domain/RMW and DDS discovery not blocked).",
-                domain ? domain : "0 (default)", rmw ? rmw : "(default)",
-                localhost_only ? localhost_only : "0 (default)");
+                domain ? domain : "0 (default)", rmw ? rmw : "(default)", localhost_only ? localhost_only : "(unset)");
   }
 }
 

--- a/src/ros2_medkit_gateway/test/test_gateway_node.cpp
+++ b/src/ros2_medkit_gateway/test/test_gateway_node.cpp
@@ -27,6 +27,8 @@
 #include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
+#include <utility>
+#include <vector>
 
 #include "ros2_medkit_gateway/core/discovery/models/function.hpp"
 #include "ros2_medkit_gateway/core/http/http_utils.hpp"
@@ -960,6 +962,39 @@ TEST(ExtractEntityTypePath, unknown_routes) {
   EXPECT_EQ(extract_entity_type_from_path("/api/v1/applications"), SovdEntityType::UNKNOWN);
   EXPECT_EQ(extract_entity_type_from_path("/api/v1/areascan"), SovdEntityType::UNKNOWN);
   EXPECT_EQ(extract_entity_type_from_path("/api/v1/functional"), SovdEntityType::UNKNOWN);
+}
+
+// Startup-summary helper logic (no ROS graph needed - pure functions).
+
+TEST(GatewayStartupSummary, CountPeerNodesExcludesOwnAndHidden) {
+  const std::vector<std::pair<std::string, std::string>> nodes = {
+      {"ros2_medkit_gateway", "/"},                // the gateway's own node (self)
+      {"ros2_medkit_gateway_sub", "/"},            // own internal helper (FQN prefix)
+      {"ros2_medkit_gateway_fault_clients", "/"},  // own internal helper (FQN prefix)
+      {"_hidden_node", "/"},                       // hidden node
+      {"camera", "/sensors"},                      // peer (hidden node name check is on the name part)
+      {"robot_planner", "/"},                      // peer
+  };
+  // Two genuine peers: /sensors/camera and /robot_planner.
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::count_peer_nodes(nodes, "/ros2_medkit_gateway"), 2u);
+}
+
+TEST(GatewayStartupSummary, CountPeerNodesZeroWhenOnlyOwnNodes) {
+  const std::vector<std::pair<std::string, std::string>> nodes = {
+      {"ros2_medkit_gateway", "/"},
+      {"ros2_medkit_gateway_sub", "/"},
+      {"ros2_medkit_gateway_fault_clients", "/"},
+  };
+  // Zero peers is the condition that triggers the empty-graph warning.
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::count_peer_nodes(nodes, "/ros2_medkit_gateway"), 0u);
+}
+
+TEST(GatewayStartupSummary, ConnectableHostTranslatesBindAll) {
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("0.0.0.0"), "127.0.0.1");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host(""), "127.0.0.1");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("::"), "::1");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("192.168.1.5"), "192.168.1.5");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("127.0.0.1"), "127.0.0.1");
 }
 
 int main(int argc, char ** argv) {

--- a/src/ros2_medkit_gateway/test/test_gateway_node.cpp
+++ b/src/ros2_medkit_gateway/test/test_gateway_node.cpp
@@ -974,9 +974,11 @@ TEST(GatewayStartupSummary, CountPeerNodesExcludesOwnAndHidden) {
       {"_hidden_node", "/"},                       // hidden node
       {"camera", "/sensors"},                      // peer (hidden node name check is on the name part)
       {"robot_planner", "/"},                      // peer
+      {"ros2_medkit_gateway_monitor", "/"},        // peer that merely shares the gateway name prefix
   };
-  // Two genuine peers: /sensors/camera and /robot_planner.
-  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::count_peer_nodes(nodes, "/ros2_medkit_gateway"), 2u);
+  // Three genuine peers: /sensors/camera, /robot_planner and the prefix-sharing
+  // /ros2_medkit_gateway_monitor (only the exact self FQN and known helpers drop out).
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::count_peer_nodes(nodes, "/ros2_medkit_gateway"), 3u);
 }
 
 TEST(GatewayStartupSummary, CountPeerNodesZeroWhenOnlyOwnNodes) {
@@ -992,9 +994,13 @@ TEST(GatewayStartupSummary, CountPeerNodesZeroWhenOnlyOwnNodes) {
 TEST(GatewayStartupSummary, ConnectableHostTranslatesBindAll) {
   EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("0.0.0.0"), "127.0.0.1");
   EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host(""), "127.0.0.1");
-  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("::"), "::1");
   EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("192.168.1.5"), "192.168.1.5");
   EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("127.0.0.1"), "127.0.0.1");
+  // IPv6 bind addresses must be bracketed so host:port is a valid URL authority.
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("::"), "[::1]");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("[::]"), "[::1]");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("2001:db8::1"), "[2001:db8::1]");
+  EXPECT_EQ(ros2_medkit_gateway::GatewayNode::connectable_host("[2001:db8::1]"), "[2001:db8::1]");
 }
 
 int main(int argc, char ** argv) {


### PR DESCRIPTION
The gateway boots into a silent empty entity tree when it cannot see the target ROS graph (wrong `ROS_DOMAIN_ID`, mismatched `RMW_IMPLEMENTATION`, `ROS_LOCALHOST_ONLY`, container network isolation): the user gets a blank tree with no hint where to look.

This logs a one-time discovery summary a few seconds after startup (the delay lets DDS discovery settle): peer node / topic / medkit entity counts, the REST URL and a sample curl. When no application nodes are visible it additionally warns loudly with the active `ROS_DOMAIN_ID`, `RMW_IMPLEMENTATION` and `ROS_LOCALHOST_ONLY` and the likely causes, so a misconfigured bringup is diagnosable from the gateway's own console/logs.

The gateway's own nodes (the main node plus its internal helpers, which share the main node's FQN as a prefix, e.g. `<fqn>_sub`) and hidden nodes are excluded from the peer count, so "0 peer nodes" reliably means the gateway is isolated.

Verified at runtime: an empty domain logs the summary with 0 peers and the env-echo warning; a domain with one peer node logs 1 peer and no warning.

Scope: this is the startup-log diagnostic from #427. The `/health` diagnostic surface and the synthetic gateway self-entity are intentionally left out - the current web UI renders neither entity attributes nor `/health`, so they would not reach the user without separate UI work; a self-fault was considered but deferred to avoid empty-graph false positives at cold start.

Addresses #427.
