### PR TITLE
feat: single-command bringup for the local medkit stack

### DIFF
--- a/docs/tutorials/bringup.rst
+++ b/docs/tutorials/bringup.rst
@@ -1,0 +1,115 @@
+Single-command bringup
+=======================
+
+``bringup.launch.py`` starts the full local medkit stack - the gateway, the
+fault_manager, and the generic fault bridges - as one process group, with no
+manual topic/service wiring. It ships a shared params file that turns on the
+headline value the conservative per-node defaults leave off (fault healing and
+crash-safe black-box rosbag capture).
+
+Install
+-------
+
+Build the workspace (the gateway brings the fault_manager and bridges in as
+runtime dependencies):
+
+.. code-block:: bash
+
+   colcon build --packages-up-to ros2_medkit_gateway
+   source install/setup.bash
+
+Run
+---
+
+One command starts the whole stack:
+
+.. code-block:: bash
+
+   ros2 launch ros2_medkit_gateway bringup.launch.py
+
+The gateway serves its REST API on ``http://127.0.0.1:8080`` by default. Common
+launch arguments:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 15 50
+
+   * - Argument
+     - Default
+     - Description
+   * - ``params_file``
+     - ``config/bringup_params.yaml``
+     - Shared params; each node reads its own named section. Point this at your
+       own file to override any value.
+   * - ``server_host``
+     - ``127.0.0.1``
+     - Host to bind the gateway REST server (use ``0.0.0.0`` to expose it).
+   * - ``server_port``
+     - ``8080``
+     - Gateway REST API port.
+   * - ``enable_fault_manager``
+     - ``true``
+     - Start the fault_manager node.
+   * - ``enable_log_bridge``
+     - ``true``
+     - Start the log_bridge (``/rosout`` -> faults).
+   * - ``enable_action_status_bridge``
+     - ``true``
+     - Start the action_status_bridge (aborted action goals -> faults).
+   * - ``enable_diagnostic_bridge``
+     - ``false``
+     - Start the diagnostic_bridge (``/diagnostics`` -> faults). Opt-in, for
+       legacy ``diagnostic_updater`` publishers.
+
+Verify
+------
+
+Induce a fault and see it surface through the gateway with a black-box bag, with
+no further wiring. Report a fault against any node on your stack:
+
+.. code-block:: bash
+
+   ros2 service call /fault_manager/report_fault ros2_medkit_msgs/srv/ReportFault \
+     "{fault_code: 'DEMO_FAULT', event_type: 0, severity: 2, description: 'bringup test', source_id: '/your_node'}"
+
+Then query the gateway and the black-box:
+
+.. code-block:: bash
+
+   # The fault is visible via the gateway REST API
+   curl http://127.0.0.1:8080/api/v1/faults
+
+   # A non-empty black-box bag was captured at confirmation
+   ros2 service call /fault_manager/get_rosbag ros2_medkit_msgs/srv/GetRosbag \
+     "{fault_code: 'DEMO_FAULT'}"
+
+With ``healing_enabled`` on, a recovery signal (e.g. an action transitioning to
+SUCCEEDED) clears the fault automatically. Log faults have no recovery signal, so
+``LOG_*`` faults do not auto-clear.
+
+Bridge runtime cost and tuning
+------------------------------
+
+The bridges are the first thing this bringup starts by default, so size them for
+your stack. Each bridge has ``include_only_*`` / ``exclude_*`` filters to scope
+what it watches, and these knobs for cost:
+
+- **log_bridge** subscribes ``/rosout`` and processes every log line, so its cost
+  scales with log volume. Keep ``severity_floor`` at WARN (20) by default; raise
+  it to ERROR (40) on chatty stacks. ``report_cooldown_sec`` already bounds
+  ERROR/FATAL floods.
+- **action_status_bridge** rescans the full ROS graph every ``rescan_period_sec``
+  (default 2.0s) plus low-volume per-status processing. Raise ``rescan_period_sec``
+  on large graphs.
+
+Opt a bridge out entirely with its ``enable_*`` launch argument, e.g.
+``ros2 launch ros2_medkit_gateway bringup.launch.py enable_log_bridge:=false``.
+
+Multi-domain topology
+---------------------
+
+A robot that spans several ``ROS_DOMAIN_ID`` / ``RMW_IMPLEMENTATION`` values runs
+**one bringup per domain**. The gateways are then federated into a single tree /
+API / UI by peer aggregation (set ``aggregation.enabled`` plus ``peer_urls`` or
+mDNS on the gateways). Each bringup must share its target stack's
+``ROS_DOMAIN_ID``, ``RMW_IMPLEMENTATION`` and network to see it.

--- a/docs/tutorials/bringup.rst
+++ b/docs/tutorials/bringup.rst
@@ -96,7 +96,7 @@ your stack. Each bridge has ``include_only_*`` / ``exclude_*`` filters to scope
 what it watches, and these knobs for cost:
 
 - **log_bridge** subscribes ``/rosout`` and processes every log line, so its cost
-  scales with log volume. Keep ``severity_floor`` at WARN (20) by default; raise
+  scales with log volume. Keep ``severity_floor`` at WARN (30) by default; raise
   it to ERROR (40) on chatty stacks. ``report_cooldown_sec`` already bounds
   ERROR/FATAL floods.
 - **action_status_bridge** rescans the full ROS graph every ``rescan_period_sec``

--- a/docs/tutorials/bringup.rst
+++ b/docs/tutorials/bringup.rst
@@ -39,8 +39,9 @@ launch arguments:
      - Description
    * - ``params_file``
      - ``config/bringup_params.yaml``
-     - Shared params; each node reads its own named section. Point this at your
-       own file to override any value.
+     - Parameter file applied to the fault_manager (healing + black-box rosbag).
+       Point this at your own file to override. The gateway and bridges run with
+       their own configs; tune those via their launch args.
    * - ``server_host``
      - ``127.0.0.1``
      - Host to bind the gateway REST server (use ``0.0.0.0`` to expose it).

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -6,6 +6,7 @@ Step-by-step guides for common use cases with ros2_medkit.
 .. toctree::
    :maxdepth: 1
 
+   bringup
    demos/index
    heuristic-apps
    manifest-discovery
@@ -28,6 +29,13 @@ Step-by-step guides for common use cases with ros2_medkit.
    linux-introspection
    triggers-use-cases
    multi-instance
+
+Getting Started
+---------------
+
+:doc:`bringup`
+   Start the full local stack - gateway, fault_manager and fault bridges - with
+   one command, then induce a fault and see it via the API with a black-box bag.
 
 Demos
 -----

--- a/src/ros2_medkit_fault_manager/config/fault_manager.yaml
+++ b/src/ros2_medkit_fault_manager/config/fault_manager.yaml
@@ -1,0 +1,21 @@
+# Default parameters for a standalone fault_manager_node.
+#
+# These are conservative single-node defaults: healing and black-box rosbag
+# capture are OFF. The integrated stack turns them on via the bringup params
+# (ros2_medkit_gateway/config/bringup_params.yaml). Override with
+# `ros2 launch ros2_medkit_fault_manager fault_manager.launch.py params_file:=<your.yaml>`.
+fault_manager:
+  ros__parameters:
+    # Fault confirmation: -1 confirms on the first FAILED report (DEM-style
+    # debounce disabled). Set to N to require N reports before CONFIRMED.
+    confirmation_threshold: -1
+
+    # Healing OFF by default: a recovery signal (e.g. action SUCCEEDED) does not
+    # auto-clear the fault until this is enabled.
+    healing_enabled: false
+    healing_threshold: 3
+
+    # Black-box rosbag capture OFF by default (opt-in). When enabled it defaults
+    # to entity-scoped capture and is crash-safe (falls back / self-disables if no
+    # storage backend is usable).
+    snapshots.rosbag.enabled: false

--- a/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
+++ b/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
@@ -12,16 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    default_params = os.path.join(
+        get_package_share_directory('ros2_medkit_fault_manager'),
+        'config',
+        'fault_manager.yaml',
+    )
+
     return LaunchDescription([
+        DeclareLaunchArgument(
+            'params_file',
+            default_value=default_params,
+            description='YAML parameter file for fault_manager_node (confirmation, healing, '
+                        'snapshots, black-box rosbag). Defaults to the conservative single-node '
+                        'config; the bringup passes shared params to turn on healing and capture.',
+        ),
         Node(
             package='ros2_medkit_fault_manager',
             executable='fault_manager_node',
             name='fault_manager',
             output='screen',
+            parameters=[LaunchConfiguration('params_file')],
         ),
     ])

--- a/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
+++ b/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
@@ -36,10 +36,18 @@ def generate_launch_description():
                         'snapshots, black-box rosbag). Defaults to the conservative single-node '
                         'config; the bringup passes shared params to turn on healing and capture.',
         ),
+        DeclareLaunchArgument(
+            'namespace',
+            default_value='',
+            description='Optional ROS 2 namespace for the fault_manager node (for example '
+                        'robot1 -> /robot1/fault_manager/...). Give the gateway a matching '
+                        'fault_manager.namespace parameter so it resolves the same paths.',
+        ),
         Node(
             package='ros2_medkit_fault_manager',
             executable='fault_manager_node',
             name='fault_manager',
+            namespace=LaunchConfiguration('namespace'),
             output='screen',
             parameters=[LaunchConfiguration('params_file')],
         ),

--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -19,6 +19,11 @@
   <depend>rosbag2_cpp</depend>
   <depend>rosbag2_storage</depend>
 
+  <!-- Runtime deps for the shipped launch file (fault_manager.launch.py) -->
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <!-- mcap is an opt-in storage backend (sqlite3 is the always-shipped default with

--- a/src/ros2_medkit_gateway/config/bringup_params.yaml
+++ b/src/ros2_medkit_gateway/config/bringup_params.yaml
@@ -1,6 +1,9 @@
-# Shared parameters for the medkit bringup stack (bringup.launch.py).
+# Parameters applied to the fault_manager in the medkit bringup stack
+# (bringup.launch.py passes this file to fault_manager_node).
 #
-# Each node reads its own named section. Override any value with
+# The gateway and the bridges are NOT configured from this file; they run with
+# their own config defaults (tune them via their launch args). Override these
+# fault_manager values with
 # `ros2 launch ros2_medkit_gateway bringup.launch.py params_file:=<your.yaml>`.
 #
 # The per-node defaults are conservative and leave the headline value off; this

--- a/src/ros2_medkit_gateway/config/bringup_params.yaml
+++ b/src/ros2_medkit_gateway/config/bringup_params.yaml
@@ -1,0 +1,27 @@
+# Shared parameters for the medkit bringup stack (bringup.launch.py).
+#
+# Each node reads its own named section. Override any value with
+# `ros2 launch ros2_medkit_gateway bringup.launch.py params_file:=<your.yaml>`.
+#
+# The per-node defaults are conservative and leave the headline value off; this
+# turns it on for a drop-in local stack.
+fault_manager:
+  ros__parameters:
+    # Confirm a fault on the first FAILED report (DEM-style debounce disabled).
+    confirmation_threshold: -1
+
+    # Heal on recovery so an action SUCCEEDED clears its fault (CONFIRMED -> HEALED).
+    # Note: log faults have no recovery signal, so LOG_* faults do not auto-clear.
+    healing_enabled: true
+    healing_threshold: 3
+
+    # Black-box rosbag capture: a crash-safe, entity-scoped ring buffer flushed on
+    # fault confirmation. Produces a non-empty bag on the happy path.
+    snapshots.rosbag.enabled: true
+
+# The bridges run with their own config/<bridge>.yaml defaults; they are toggled
+# on/off with the enable_* launch args. Tune their runtime cost in those configs
+# or via each bridge's launch args (see the bringup quickstart):
+#   - log_bridge:           severity_floor (WARN=20 default; raise to ERROR=40 on chatty stacks)
+#   - action_status_bridge: rescan_period_sec (2.0s default; raise on large graphs)
+#   - each bridge also has include_only_* / exclude_* filters to scope what it watches.

--- a/src/ros2_medkit_gateway/launch/bringup.launch.py
+++ b/src/ros2_medkit_gateway/launch/bringup.launch.py
@@ -55,8 +55,9 @@ def generate_launch_description():
     args = [
         DeclareLaunchArgument(
             'params_file', default_value=default_params,
-            description='Shared params for the stack (fault_manager healing + black-box rosbag). '
-                        'Each node reads its own named section.'),
+            description='Parameter file applied to the fault_manager (turns on healing + '
+                        'black-box rosbag). The gateway and bridges run with their own configs; '
+                        'tune those via their launch args.'),
         DeclareLaunchArgument(
             'server_host', default_value='127.0.0.1',
             description='Host to bind the gateway REST server (127.0.0.1 or 0.0.0.0).'),

--- a/src/ros2_medkit_gateway/launch/bringup.launch.py
+++ b/src/ros2_medkit_gateway/launch/bringup.launch.py
@@ -1,0 +1,101 @@
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-command bringup for the local medkit stack."""
+
+# Composes the gateway, the fault_manager and the generic fault bridges via
+# IncludeLaunchDescription so a user gets a fault-diagnosable stack with one
+# command and no manual topic/service wiring. Each component is individually
+# toggleable, and a shared params file turns on healing and black-box capture
+# that the conservative per-node defaults leave off.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def _include(package, launch_file, enable_arg=None, launch_arguments=None):
+    source = PythonLaunchDescriptionSource(
+        os.path.join(get_package_share_directory(package), 'launch', launch_file))
+    kwargs = {}
+    if launch_arguments is not None:
+        kwargs['launch_arguments'] = launch_arguments.items()
+    if enable_arg is not None:
+        kwargs['condition'] = IfCondition(LaunchConfiguration(enable_arg))
+    return IncludeLaunchDescription(source, **kwargs)
+
+
+def generate_launch_description():
+    default_params = os.path.join(
+        get_package_share_directory('ros2_medkit_gateway'),
+        'config',
+        'bringup_params.yaml',
+    )
+
+    params_file = LaunchConfiguration('params_file')
+    server_host = LaunchConfiguration('server_host')
+    server_port = LaunchConfiguration('server_port')
+
+    args = [
+        DeclareLaunchArgument(
+            'params_file', default_value=default_params,
+            description='Shared params for the stack (fault_manager healing + black-box rosbag). '
+                        'Each node reads its own named section.'),
+        DeclareLaunchArgument(
+            'server_host', default_value='127.0.0.1',
+            description='Host to bind the gateway REST server (127.0.0.1 or 0.0.0.0).'),
+        DeclareLaunchArgument(
+            'server_port', default_value='8080',
+            description='Gateway REST API port.'),
+        DeclareLaunchArgument(
+            'enable_fault_manager', default_value='true',
+            description='Start the fault_manager node.'),
+        DeclareLaunchArgument(
+            'enable_log_bridge', default_value='true',
+            description='Start the log_bridge (/rosout -> faults). Cost scales with log volume; '
+                        'raise log_bridge severity_floor on chatty stacks.'),
+        DeclareLaunchArgument(
+            'enable_action_status_bridge', default_value='true',
+            description='Start the action_status_bridge (aborted action goals -> faults). '
+                        'Rescans the ROS graph every rescan_period_sec (raise on large graphs).'),
+        DeclareLaunchArgument(
+            'enable_diagnostic_bridge', default_value='false',
+            description='Start the diagnostic_bridge (/diagnostics -> faults). Opt-in: for legacy '
+                        'diagnostic_updater publishers; new code should report faults natively.'),
+    ]
+
+    gateway = _include(
+        'ros2_medkit_gateway', 'gateway.launch.py',
+        launch_arguments={'server_host': server_host, 'server_port': server_port})
+    fault_manager = _include(
+        'ros2_medkit_fault_manager', 'fault_manager.launch.py',
+        enable_arg='enable_fault_manager',
+        launch_arguments={'params_file': params_file})
+    log_bridge = _include(
+        'ros2_medkit_log_bridge', 'log_bridge.launch.py',
+        enable_arg='enable_log_bridge')
+    action_status_bridge = _include(
+        'ros2_medkit_action_status_bridge', 'action_status_bridge.launch.py',
+        enable_arg='enable_action_status_bridge')
+    diagnostic_bridge = _include(
+        'ros2_medkit_diagnostic_bridge', 'diagnostic_bridge.launch.py',
+        enable_arg='enable_diagnostic_bridge')
+
+    return LaunchDescription(
+        args + [gateway, fault_manager, log_bridge, action_status_bridge, diagnostic_bridge])

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -33,6 +33,9 @@
   <exec_depend>rosidl_parser</exec_depend>
 
   <!-- bringup.launch.py composes the full local stack via IncludeLaunchDescription -->
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
   <exec_depend>ros2_medkit_fault_manager</exec_depend>
   <exec_depend>ros2_medkit_log_bridge</exec_depend>
   <exec_depend>ros2_medkit_action_status_bridge</exec_depend>

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -32,6 +32,12 @@
   <exec_depend>rosidl_runtime_py</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
 
+  <!-- bringup.launch.py composes the full local stack via IncludeLaunchDescription -->
+  <exec_depend>ros2_medkit_fault_manager</exec_depend>
+  <exec_depend>ros2_medkit_log_bridge</exec_depend>
+  <exec_depend>ros2_medkit_action_status_bridge</exec_depend>
+  <exec_depend>ros2_medkit_diagnostic_bridge</exec_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_clang_format</test_depend>


### PR DESCRIPTION
Today each medkit node ships its own single-node launch and nothing composes them: a user must run the gateway, the fault_manager and each bridge as separate processes and know the wiring between them. `fault_manager.launch.py` passed zero parameters, so the snapshot / black-box rosbag config was never loaded on the default path.

`bringup.launch.py` (in `ros2_medkit_gateway`) composes the full local stack in one command via `IncludeLaunchDescription`:
- gateway + fault_manager + the generic fault bridges (log / action_status; diagnostic is opt-in for legacy `/diagnostics` publishers).
- A shared `bringup_params.yaml` (per-node sections) turns on the headline value the conservative per-node defaults leave off: `healing_enabled` and crash-safe `snapshots.rosbag.enabled`.
- Per-component `enable_*` launch args (opt out of a bridge's overhead) plus `server_host` / `server_port` / `params_file`.

`fault_manager.launch.py` now accepts a `params_file` (default: a conservative `config/fault_manager.yaml`); the bringup passes the shared params. The gateway declares the composed packages as `exec_depend`.

Quickstart added (`docs/tutorials/bringup.rst`, Install / Run / Verify) documenting the bridge runtime cost + tuning knobs (`severity_floor`, `rescan_period_sec`, include/exclude filters) and the multi-domain topology (one bringup per domain, federated by peer aggregation).

Verified end to end: `ros2 launch ros2_medkit_gateway bringup.launch.py` starts the stack; a fault reported on a connected node is `CONFIRMED` via the gateway `/api/v1/faults` and `get_rosbag` returns a non-empty black-box bag, with no further wiring.

Closes #424
