### PR TITLE
test(diagnostic_bridge): label test_integration as an integration test

### DIFF
--- a/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
@@ -122,11 +122,20 @@ if(BUILD_TESTING)
     DESTINATION share/${PROJECT_NAME}
   )
 
+  # add_launch_test() defaults the test's ctest LABELS to "launch_test", which
+  # the unit selector (colcon test -LE 'linter|integration') does not exclude,
+  # so the launch test ran in the unit phase together with all other unit tests
+  # in one colcon invocation. Under that load the node could miss the launch
+  # SIGINT shutdown window and get killed with SIGTERM, failing the
+  # post-shutdown exit-code check. Override the label to "integration" via
+  # set_tests_properties (the repo convention) so it runs only in the
+  # integration phase.
   add_launch_test(
     test/test_integration.test.py
     TARGET test_integration
     TIMEOUT 60
   )
+  set_tests_properties(test_integration PROPERTIES LABELS "integration")
   ros2_medkit_relax_vendor_warnings()
 endif()
 


### PR DESCRIPTION
## Summary

`test/test_integration.test.py` in `ros2_medkit_diagnostic_bridge` is a launch test registered with `add_launch_test`, which defaults its ctest `LABELS` to `launch_test`. The Pixi unit task runs `colcon test --ctest-args -LE 'linter|integration'`, which does not exclude the `launch_test` label, so this launch test ran in the unit phase together with all other unit tests in a single colcon invocation. Under that load the node sometimes did not handle the launch SIGINT within the 5s shutdown window, so launch escalated to SIGTERM and the post-shutdown `assertExitCodes` check failed with exit code -15.

This overrides the label to `integration` via `set_tests_properties` (the pattern used by `ros2_medkit_fault_manager` and `ros2_medkit_integration_tests`), so the test runs in the integration phase and is excluded from the unit phase. The node shutdown code is unchanged.

## Issue

No separate tracking issue - small CI test-categorization fix.

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

## Testing

`ctest -N -L integration` lists `test_integration` and `ctest -V` shows `Labels: integration`; `ctest -N -LE 'linter|integration'` no longer lists it. The package unit test (`test_diagnostic_bridge`) still passes.

## Checklist

- [x] Breaking changes are clearly described (none)
- [x] Tests were added or updated if needed (test categorization only)
- [x] Docs were updated if behavior or public API changed (no behavior or API change)