### PR TITLE
fix(log_bridge): start with the default config

### DIFF
--- a/src/ros2_medkit_log_bridge/config/log_bridge.yaml
+++ b/src/ros2_medkit_log_bridge/config/log_bridge.yaml
@@ -9,9 +9,11 @@ log_bridge:
     # Prefix for auto-generated fault codes (<PREFIX>_<NODE>_<HASH>).
     code_prefix: "LOG"
     # Originating-node FQN substrings to skip (e.g. noisy debug nodes).
-    exclude_nodes: []
+    # Defaults to empty; uncomment with a non-empty list to enable, e.g.:
+    # exclude_nodes: ["/debug_node"]
     # If non-empty, ONLY promote logs from nodes matching these substrings.
-    include_only_nodes: []
+    # Defaults to empty; uncomment with a non-empty list to enable, e.g.:
+    # include_only_nodes: ["/safety_monitor"]
     # Cap on per-node FaultReporters; least-recently-used nodes are evicted
     # past this to bound memory under transient-node churn.
     max_tracked_nodes: 512


### PR DESCRIPTION
The shipped `config/log_bridge.yaml` sets `exclude_nodes: []` and `include_only_nodes: []`. Empty YAML lists are untyped, so launching the node with this file aborts at startup:

```
terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterValueException'
  what():  parameter_value_from failed for parameter 'exclude_nodes': No parameter value set
[ros2run]: Aborted
```

The node code is correct (`declare_parameter<std::vector<std::string>>(..., {})`); only the shipped YAML breaks it. This comments out the two lines with non-empty examples, so the node's typed defaults apply.

Before: `ros2 run ros2_medkit_log_bridge log_bridge_node --ros-args --params-file config/log_bridge.yaml` -> Aborted.
After: `LogBridge started (topic=/rosout, severity_floor=30, prefix=LOG)`.

Closes #444
