### PR TITLE
build(image): bundle CycloneDDS RMW as opt-in

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,10 +97,14 @@ ENV ROS_DISTRO=${ROS_DISTRO}
 ENV COLCON_WS=/home/medkit/ws
 
 # Runtime dependencies only (nlohmann-json and cpp-httplib are compiled into
-# the binaries at build time, no need to install here)
+# the binaries at build time, no need to install here).
+# CycloneDDS RMW is bundled so the gateway can attach to a stack running
+# CycloneDDS (e.g. Autoware) without rebuilding. FastDDS stays the default;
+# switch with RMW_IMPLEMENTATION=rmw_cyclonedds_cpp at runtime.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-${ROS_DISTRO}-yaml-cpp-vendor \
     ros-${ROS_DISTRO}-example-interfaces \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     libsqlite3-0 \
     libsystemd0 \
     libssl3 \


### PR DESCRIPTION
The prebuilt Docker image is built on `ros-base`, which ships FastDDS only. A containerized gateway attached to an external stack running CycloneDDS (Autoware and others) does not load at all. Note this is image-only: apt installs from rosdistro use the host's RMW and are unaffected (no medkit `package.xml` pins an RMW).

This bundles `rmw_cyclonedds_cpp` in the runtime stage. FastDDS stays the default; switch with `RMW_IMPLEMENTATION=rmw_cyclonedds_cpp`.

Verified: the package installs on `ros:jazzy-ros-base` (~8 MB delta incl. iceoryx) and Cyclone loads + publishes on a stock host (`net.core.rmem_max` 208 KB) with no tuned config. Full official image not rebuilt (single additive runtime apt line).

Closes #447
