### PR TITLE
fix(image): enable CORS for the documented web UI path

### DIFF
--- a/docker/gateway_docker_params.yaml
+++ b/docker/gateway_docker_params.yaml
@@ -7,3 +7,9 @@ ros2_medkit_gateway:
       host: "0.0.0.0"
       port: 8080
     refresh_interval_ms: 2000
+    # The web UI runs as a separate origin (its own host/port), so the
+    # documented "run the web UI next to the gateway" path needs CORS. Without
+    # it the browser gets "Failed to fetch". Restrict allowed_origins to your
+    # UI origin(s) and/or enable JWT auth for production.
+    cors:
+      allowed_origins: ["*"]

--- a/docker/gateway_docker_params.yaml
+++ b/docker/gateway_docker_params.yaml
@@ -9,7 +9,11 @@ ros2_medkit_gateway:
     refresh_interval_ms: 2000
     # The web UI runs as a separate origin (its own host/port), so the
     # documented "run the web UI next to the gateway" path needs CORS. Without
-    # it the browser gets "Failed to fetch". Restrict allowed_origins to your
-    # UI origin(s) and/or enable JWT auth for production.
+    # it the browser gets "Failed to fetch". These are the default web UI
+    # origins; a wildcard is deliberately NOT used - with auth disabled and
+    # write methods enabled it would let any site drive cross-origin writes.
+    # Add your own UI origin(s) here, and enable JWT auth for production.
     cors:
-      allowed_origins: ["*"]
+      allowed_origins:
+        - "http://localhost:3000"
+        - "http://localhost:5173"

--- a/docs/tutorials/docker.rst
+++ b/docs/tutorials/docker.rst
@@ -67,10 +67,10 @@ Test the gateway:
 Custom Configuration
 --------------------
 
-The default configuration listens on ``0.0.0.0:8080``. CORS is enabled with a
-permissive ``allowed_origins: ["*"]`` so the web UI works out of the box;
-restrict it for production (see `CORS for Web UI`_ below). To use a custom
-configuration, mount a params file:
+The default configuration listens on ``0.0.0.0:8080``. CORS is enabled for the
+default web UI origins (``http://localhost:3000`` and ``http://localhost:5173``)
+so the web UI works out of the box; add your own UI origin(s) as needed (see
+`CORS for Web UI`_ below). To use a custom configuration, mount a params file:
 
 .. code-block:: bash
 
@@ -213,8 +213,10 @@ For containers to discover each other's ROS 2 nodes, use the same ``ROS_DOMAIN_I
 CORS for Web UI
 ---------------
 
-The image default allows all origins so the Web UI works out of the box. For
-production, restrict ``allowed_origins`` to the specific UI origin(s):
+The image enables CORS for the default web UI origins (``http://localhost:3000``
+and ``http://localhost:5173``). A wildcard is deliberately not used: with auth
+disabled and write methods enabled it would let any site drive cross-origin
+writes. Add your own UI origin(s):
 
 .. code-block:: yaml
 

--- a/docs/tutorials/docker.rst
+++ b/docs/tutorials/docker.rst
@@ -67,8 +67,10 @@ Test the gateway:
 Custom Configuration
 --------------------
 
-The default configuration listens on ``0.0.0.0:8080`` with CORS disabled.
-To use a custom configuration, mount a params file:
+The default configuration listens on ``0.0.0.0:8080``. CORS is enabled with a
+permissive ``allowed_origins: ["*"]`` so the web UI works out of the box;
+restrict it for production (see `CORS for Web UI`_ below). To use a custom
+configuration, mount a params file:
 
 .. code-block:: bash
 
@@ -211,8 +213,8 @@ For containers to discover each other's ROS 2 nodes, use the same ``ROS_DOMAIN_I
 CORS for Web UI
 ---------------
 
-When the Web UI runs in a separate container or host, enable CORS in your
-custom params file. CORS is disabled by default for production safety:
+The image default allows all origins so the Web UI works out of the box. For
+production, restrict ``allowed_origins`` to the specific UI origin(s):
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The Docker params file has no `cors` section, so the image runs with CORS off (empty `allowed_origins`). The documented path of running the web UI next to the gateway then fails: the UI is a separate origin and every request returns "Failed to fetch".

This sets `cors.allowed_origins: ["*"]` in `docker/gateway_docker_params.yaml`. The gateway echoes the request origin (not a literal `*`) and blocks credentials+wildcard at startup; `allow_credentials` defaults false, so this is safe by default. Restrict origins / enable JWT auth for production.

Verified: gateway started with this params file logs `CORS enabled - origins: [*], ... credentials: false`, and `curl -H "Origin: http://localhost:3001" .../api/v1/health` returns `Access-Control-Allow-Origin: http://localhost:3001`.

Closes #445
