### PR TITLE
fix(action_status_bridge): start with the default config

### DIFF
--- a/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
+++ b/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
@@ -13,8 +13,10 @@ action_status_bridge:
     # Normalized to UPPER_SNAKE at load.
     code_prefix: "ACTION"
     # Action-name substrings to skip (unanchored substring match).
-    exclude_actions: []
+    # Defaults to empty; uncomment with a non-empty list to enable, e.g.:
+    # exclude_actions: ["/some_action"]
     # If non-empty, ONLY watch actions matching these substrings.
-    include_only_actions: []
+    # Defaults to empty; uncomment with a non-empty list to enable, e.g.:
+    # include_only_actions: ["/navigate_to_pose"]
     # Max remembered (goal_id:status) keys for log dedup.
     dedup_capacity: 4096

--- a/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
@@ -15,10 +15,12 @@
 
 """End-to-end integration tests for ros2_medkit_action_status_bridge."""
 
+import os
 import time
 import unittest
 
 from action_msgs.msg import GoalStatus, GoalStatusArray
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 import launch_ros.actions
 import launch_testing.actions
@@ -56,12 +58,18 @@ def generate_test_description():
         }],
     )
 
+    # Load the packaged config first so assertExitCodes guards against the
+    # shipped action_status_bridge.yaml regressing the empty-untyped-list
+    # startup crash; the inline override only speeds up discovery for the test.
+    config_file = os.path.join(
+        get_package_share_directory('ros2_medkit_action_status_bridge'),
+        'config', 'action_status_bridge.yaml')
     action_status_bridge_node = launch_ros.actions.Node(
         package='ros2_medkit_action_status_bridge',
         executable='action_status_bridge_node',
         name='action_status_bridge',
         output='screen',
-        parameters=[{
+        parameters=[config_file, {
             'rescan_period_sec': 1.0,  # fast discovery for the test
         }],
     )


### PR DESCRIPTION
Part 1 of #458. Same empty-untyped-list crash as #444 (log_bridge), in `action_status_bridge` - the #444 fix did not cover this package.

`config/action_status_bridge.yaml` ships `exclude_actions: []` and `include_only_actions: []`. Empty YAML lists are untyped, so launching the node with this file aborts at startup:

```
terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterValueException'
  what():  parameter_value_from failed for parameter 'exclude_actions': No parameter value set
[ros2run]: Aborted
```

The node code is correct (`declare_parameter<std::vector<std::string>>(...)`); only the shipped YAML breaks it. This comments out the two lines with non-empty examples so the typed declared defaults apply.

Verified live: with the shipped config the node aborts (exit 250); with this fix it starts clean (`ActionStatusBridge started ... Watching action ...`).

Addresses #458 (part 1). The log_bridge self-noise item in #458 is left as a follow-up: its fix touches `log_bridge.yaml`, which #449 already modifies, so it is better done after #449 lands to avoid a conflict.
