### PR TITLE
fix(log_bridge): skip the medkit stack's own nodes by default

### DIFF
--- a/src/ros2_medkit_log_bridge/README.md
+++ b/src/ros2_medkit_log_bridge/README.md
@@ -100,3 +100,10 @@ ros2 launch ros2_medkit_log_bridge log_bridge.launch.py
 against the node FQN: `planner` matches `/planner_server` and
 `/robot1/planner_server`. Use a longer, more specific substring (e.g.
 `/planner_server`) to avoid accidental matches.
+
+`exclude_medkit_stack` likewise matches **unanchored substrings** (on the raw
+logger name, so a namespaced `robot1.fault_manager` is still caught). A user
+node whose name contains one of these tokens - e.g. `fault_manager` or
+`diagnostic_bridge` - is therefore also skipped; set `exclude_medkit_stack:
+false` (and use `exclude_nodes` for the real medkit nodes) if that collides
+with your naming.

--- a/src/ros2_medkit_log_bridge/README.md
+++ b/src/ros2_medkit_log_bridge/README.md
@@ -94,6 +94,7 @@ ros2 launch ros2_medkit_log_bridge log_bridge.launch.py
 | `include_only_nodes` | `[]` | if set, only promote nodes whose FQN matches |
 | `max_tracked_nodes` | `512` | cap on per-node reporters; least-recently-used nodes evicted past this |
 | `report_cooldown_sec` | `5.0` | per-fault_code forward debounce; `0.0` disables |
+| `exclude_medkit_stack` | `true` | skip medkit's own infrastructure nodes (`fault_manager`, gateway, the other bridges) so their logs do not feed back as faults; set `false` to debug medkit's own logs |
 
 `exclude_nodes` / `include_only_nodes` match as **unanchored substrings**
 against the node FQN: `planner` matches `/planner_server` and

--- a/src/ros2_medkit_log_bridge/config/log_bridge.yaml
+++ b/src/ros2_medkit_log_bridge/config/log_bridge.yaml
@@ -21,3 +21,7 @@ log_bridge:
     # forwarded immediately; the same code within the window is suppressed.
     # 0.0 disables. Tames ERROR/FATAL floods, which bypass the per-node filter.
     report_cooldown_sec: 5.0
+    # Skip the medkit stack's own infrastructure nodes (fault_manager, gateway,
+    # the other bridges). Their /rosout lines would otherwise feed back as
+    # faults about medkit itself. Set false only to debug medkit's own logs.
+    exclude_medkit_stack: true

--- a/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
+++ b/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
@@ -68,6 +68,11 @@ class LogBridgeNode : public rclcpp::Node {
   /// name so namespaced nodes are caught. Exposed for unit testing.
   static bool is_medkit_stack_logger(const std::string & logger_name);
 
+  /// Whether this log should be skipped because it comes from the medkit stack
+  /// itself - applies the exclude_medkit_stack toggle to is_medkit_stack_logger.
+  /// Exposed for unit testing the toggle.
+  bool skips_medkit_stack(const std::string & logger_name) const;
+
   /// Map an rcl_interfaces/msg/Log.name (a logger name, e.g. "bt_navigator" or
   /// "controller_manager.resource_manager") to the originating node's
   /// fully-qualified name ("/bt_navigator", "/controller_manager"). The gateway

--- a/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
+++ b/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
@@ -121,6 +121,10 @@ class LogBridgeNode : public rclcpp::Node {
   int max_tracked_nodes_;
   double report_cooldown_sec_;
   std::string own_node_name_;
+  // When true (default), never promote logs from the medkit stack's own
+  // infrastructure nodes (fault_manager, gateway, the other bridges) - else
+  // their /rosout lines feed back into faults about medkit itself.
+  bool exclude_medkit_stack_;
 };
 
 }  // namespace ros2_medkit_log_bridge

--- a/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
+++ b/src/ros2_medkit_log_bridge/include/ros2_medkit_log_bridge/log_bridge_node.hpp
@@ -63,6 +63,11 @@ class LogBridgeNode : public rclcpp::Node {
   /// include/exclude lists. Exposed for unit testing.
   bool node_is_eligible(const std::string & source_id) const;
 
+  /// Whether a logger name belongs to the medkit stack's own infrastructure
+  /// (fault_manager, gateway, the other bridges). Matched on the raw logger
+  /// name so namespaced nodes are caught. Exposed for unit testing.
+  static bool is_medkit_stack_logger(const std::string & logger_name);
+
   /// Map an rcl_interfaces/msg/Log.name (a logger name, e.g. "bt_navigator" or
   /// "controller_manager.resource_manager") to the originating node's
   /// fully-qualified name ("/bt_navigator", "/controller_manager"). The gateway

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -88,6 +88,7 @@ void LogBridgeNode::load_parameters() {
   if (report_cooldown_sec_ < 0.0) {
     report_cooldown_sec_ = 0.0;
   }
+  exclude_medkit_stack_ = declare_parameter<bool>("exclude_medkit_stack", true);
 }
 
 void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr & msg) {
@@ -148,6 +149,16 @@ std::string LogBridgeNode::node_source_id(const std::string & log_name) {
 }
 
 bool LogBridgeNode::node_is_eligible(const std::string & source_id) const {
+  // Skip the medkit stack's own infrastructure nodes by default: promoting
+  // their /rosout lines would report faults about medkit itself (e.g. the
+  // fault_manager logging a confirmed fault feeds back as a new fault).
+  if (exclude_medkit_stack_) {
+    static const std::vector<std::string> kMedkitStack = {"fault_manager", "ros2_medkit_gateway", "diagnostic_bridge",
+                                                          "action_status_bridge"};
+    if (contains_substr(kMedkitStack, source_id)) {
+      return false;
+    }
+  }
   if (!include_only_nodes_.empty() && !contains_substr(include_only_nodes_, source_id)) {
     return false;
   }

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -103,7 +103,7 @@ void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr 
   // Skip the medkit stack's own infrastructure nodes (else fault_manager's own
   // /rosout lines feed back as faults about medkit). Matched on the raw logger
   // name, which keeps the namespace (node_source_id collapses it to the ns).
-  if (exclude_medkit_stack_ && is_medkit_stack_logger(msg->name)) {
+  if (skips_medkit_stack(msg->name)) {
     return;
   }
   if (!node_is_eligible(source_id)) {
@@ -161,6 +161,10 @@ bool LogBridgeNode::is_medkit_stack_logger(const std::string & logger_name) {
   static const std::vector<std::string> kMedkitStack = {"fault_manager", "ros2_medkit_gateway", "diagnostic_bridge",
                                                         "action_status_bridge"};
   return contains_substr(kMedkitStack, logger_name);
+}
+
+bool LogBridgeNode::skips_medkit_stack(const std::string & logger_name) const {
+  return exclude_medkit_stack_ && is_medkit_stack_logger(logger_name);
 }
 
 bool LogBridgeNode::node_is_eligible(const std::string & source_id) const {

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -100,6 +100,12 @@ void LogBridgeNode::log_callback(const rcl_interfaces::msg::Log::ConstSharedPtr 
   if (source_id == own_node_name_ || source_id == "/log_bridge") {
     return;
   }
+  // Skip the medkit stack's own infrastructure nodes (else fault_manager's own
+  // /rosout lines feed back as faults about medkit). Matched on the raw logger
+  // name, which keeps the namespace (node_source_id collapses it to the ns).
+  if (exclude_medkit_stack_ && is_medkit_stack_logger(msg->name)) {
+    return;
+  }
   if (!node_is_eligible(source_id)) {
     return;
   }
@@ -148,17 +154,16 @@ std::string LogBridgeNode::node_source_id(const std::string & log_name) {
   return node;
 }
 
+bool LogBridgeNode::is_medkit_stack_logger(const std::string & logger_name) {
+  // Match medkit's own infrastructure against the raw logger name so a
+  // namespaced node (e.g. "robot1.fault_manager") is still caught, even though
+  // node_source_id would collapse its FQN to the namespace.
+  static const std::vector<std::string> kMedkitStack = {"fault_manager", "ros2_medkit_gateway", "diagnostic_bridge",
+                                                        "action_status_bridge"};
+  return contains_substr(kMedkitStack, logger_name);
+}
+
 bool LogBridgeNode::node_is_eligible(const std::string & source_id) const {
-  // Skip the medkit stack's own infrastructure nodes by default: promoting
-  // their /rosout lines would report faults about medkit itself (e.g. the
-  // fault_manager logging a confirmed fault feeds back as a new fault).
-  if (exclude_medkit_stack_) {
-    static const std::vector<std::string> kMedkitStack = {"fault_manager", "ros2_medkit_gateway", "diagnostic_bridge",
-                                                          "action_status_bridge"};
-    if (contains_substr(kMedkitStack, source_id)) {
-      return false;
-    }
-  }
   if (!include_only_nodes_.empty() && !contains_substr(include_only_nodes_, source_id)) {
     return false;
   }

--- a/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
+++ b/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
@@ -219,6 +219,23 @@ TEST_F(LogBridgeTest, NodeEligibility_IncludeOnlySubstring) {
   EXPECT_FALSE(node->node_is_eligible("/amcl"));
 }
 
+TEST_F(LogBridgeTest, NodeEligibility_ExcludesMedkitStackByDefault) {
+  auto node = make_node_with({});
+  // medkit's own infrastructure must not feed its own logs back as faults
+  EXPECT_FALSE(node->node_is_eligible("/fault_manager"));
+  EXPECT_FALSE(node->node_is_eligible("/robot1/fault_manager"));
+  EXPECT_FALSE(node->node_is_eligible("/ros2_medkit_gateway"));
+  EXPECT_FALSE(node->node_is_eligible("/diagnostic_bridge"));
+  EXPECT_FALSE(node->node_is_eligible("/action_status_bridge"));
+  // ordinary application nodes are still promoted
+  EXPECT_TRUE(node->node_is_eligible("/bt_navigator"));
+}
+
+TEST_F(LogBridgeTest, NodeEligibility_MedkitStackExclusionDisablable) {
+  auto node = make_node_with({rclcpp::Parameter("exclude_medkit_stack", false)});
+  EXPECT_TRUE(node->node_is_eligible("/fault_manager"));
+}
+
 // --- source_id normalization to node FQN (entity association) ---
 
 TEST_F(LogBridgeTest, NodeSourceId_PrependsLeadingSlash) {

--- a/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
+++ b/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
@@ -236,6 +236,20 @@ TEST_F(LogBridgeTest, MedkitStackLogger_AllowsApplicationNodes) {
   EXPECT_FALSE(LogBridgeNode::is_medkit_stack_logger("amcl"));
 }
 
+// The exclude_medkit_stack toggle gates the skip in log_callback (mirrors
+// Cooldown_ZeroDisables for the param path).
+TEST_F(LogBridgeTest, MedkitStack_SkippedByDefault) {
+  auto node = make_node_with({});
+  EXPECT_TRUE(node->skips_medkit_stack("fault_manager"));
+  EXPECT_TRUE(node->skips_medkit_stack("robot1.fault_manager"));
+  EXPECT_FALSE(node->skips_medkit_stack("bt_navigator"));
+}
+
+TEST_F(LogBridgeTest, MedkitStack_ToggleDisables) {
+  auto node = make_node_with({rclcpp::Parameter("exclude_medkit_stack", false)});
+  EXPECT_FALSE(node->skips_medkit_stack("fault_manager"));
+}
+
 // --- source_id normalization to node FQN (entity association) ---
 
 TEST_F(LogBridgeTest, NodeSourceId_PrependsLeadingSlash) {

--- a/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
+++ b/src/ros2_medkit_log_bridge/test/test_log_bridge.cpp
@@ -219,21 +219,21 @@ TEST_F(LogBridgeTest, NodeEligibility_IncludeOnlySubstring) {
   EXPECT_FALSE(node->node_is_eligible("/amcl"));
 }
 
-TEST_F(LogBridgeTest, NodeEligibility_ExcludesMedkitStackByDefault) {
-  auto node = make_node_with({});
-  // medkit's own infrastructure must not feed its own logs back as faults
-  EXPECT_FALSE(node->node_is_eligible("/fault_manager"));
-  EXPECT_FALSE(node->node_is_eligible("/robot1/fault_manager"));
-  EXPECT_FALSE(node->node_is_eligible("/ros2_medkit_gateway"));
-  EXPECT_FALSE(node->node_is_eligible("/diagnostic_bridge"));
-  EXPECT_FALSE(node->node_is_eligible("/action_status_bridge"));
-  // ordinary application nodes are still promoted
-  EXPECT_TRUE(node->node_is_eligible("/bt_navigator"));
+// Matched on the raw logger name (msg->name), which is what log_callback feeds
+// it - including the namespaced form "robot1.fault_manager" that node_source_id
+// would otherwise collapse to "/robot1".
+TEST_F(LogBridgeTest, MedkitStackLogger_MatchesOwnInfra) {
+  EXPECT_TRUE(LogBridgeNode::is_medkit_stack_logger("fault_manager"));
+  EXPECT_TRUE(LogBridgeNode::is_medkit_stack_logger("robot1.fault_manager"));
+  EXPECT_TRUE(LogBridgeNode::is_medkit_stack_logger("ros2_medkit_gateway"));
+  EXPECT_TRUE(LogBridgeNode::is_medkit_stack_logger("diagnostic_bridge"));
+  EXPECT_TRUE(LogBridgeNode::is_medkit_stack_logger("action_status_bridge"));
 }
 
-TEST_F(LogBridgeTest, NodeEligibility_MedkitStackExclusionDisablable) {
-  auto node = make_node_with({rclcpp::Parameter("exclude_medkit_stack", false)});
-  EXPECT_TRUE(node->node_is_eligible("/fault_manager"));
+TEST_F(LogBridgeTest, MedkitStackLogger_AllowsApplicationNodes) {
+  EXPECT_FALSE(LogBridgeNode::is_medkit_stack_logger("bt_navigator"));
+  EXPECT_FALSE(LogBridgeNode::is_medkit_stack_logger("robot1.controller_server"));
+  EXPECT_FALSE(LogBridgeNode::is_medkit_stack_logger("amcl"));
 }
 
 // --- source_id normalization to node FQN (entity association) ---


### PR DESCRIPTION
Part 2 of #458 (part 1 is #459).

`log_bridge` only self-excluded its own node and `/log_bridge` (`log_bridge_node.cpp`), so when the rest of the medkit stack logs to `/rosout` - notably `fault_manager` logging a confirmed fault - log_bridge promotes those lines into new faults about medkit itself, a self-noise feedback loop.

This skips the medkit stack's own infrastructure nodes (`fault_manager`, `ros2_medkit_gateway`, `diagnostic_bridge`, `action_status_bridge`) by default, gated by a new `exclude_medkit_stack` param (default `true`; set `false` only to debug medkit's own logs). Substring match, so namespaced nodes (`/robot1/fault_manager`) are covered. Ordinary application nodes are unaffected.

Verified: `colcon build` clean, clang-format-18 clean, and 2 new regression tests pass (`NodeEligibility_ExcludesMedkitStackByDefault`, `NodeEligibility_MedkitStackExclusionDisablable`) alongside the existing eligibility tests (5/5).

Addresses #458 (part 2). Together with #459 this resolves #458.
