### PR TITLE
fix(launch): enable web UI CORS by default in the native gateway launch

### DIFF
--- a/src/ros2_medkit_gateway/launch/bringup.launch.py
+++ b/src/ros2_medkit_gateway/launch/bringup.launch.py
@@ -51,6 +51,7 @@ def generate_launch_description():
     params_file = LaunchConfiguration('params_file')
     server_host = LaunchConfiguration('server_host')
     server_port = LaunchConfiguration('server_port')
+    cors_allowed_origins = LaunchConfiguration('cors_allowed_origins')
 
     args = [
         DeclareLaunchArgument(
@@ -64,6 +65,11 @@ def generate_launch_description():
         DeclareLaunchArgument(
             'server_port', default_value='8080',
             description='Gateway REST API port.'),
+        DeclareLaunchArgument(
+            'cors_allowed_origins',
+            default_value='http://localhost:3000,http://localhost:5173',
+            description='Comma-separated CORS origins allowed to call the gateway from a browser, '
+                        'so the web UI works out of the box. Empty disables CORS.'),
         DeclareLaunchArgument(
             'enable_fault_manager', default_value='true',
             description='Start the fault_manager node.'),
@@ -83,7 +89,8 @@ def generate_launch_description():
 
     gateway = _include(
         'ros2_medkit_gateway', 'gateway.launch.py',
-        launch_arguments={'server_host': server_host, 'server_port': server_port})
+        launch_arguments={'server_host': server_host, 'server_port': server_port,
+                          'cors_allowed_origins': cors_allowed_origins})
     fault_manager = _include(
         'ros2_medkit_fault_manager', 'fault_manager.launch.py',
         enable_arg='enable_fault_manager',

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -18,7 +18,7 @@ from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
 from ament_index_python.packages import PackageNotFoundError
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
@@ -64,28 +64,44 @@ def generate_launch_description():
             'controls the periodic forced refresh. Must match the default '
             'in config/gateway_params.yaml.'))
 
-    # Build parameter overrides - only inject plugin path if found
-    param_overrides = {
-        'server.host': LaunchConfiguration('server_host'),
-        'server.port': LaunchConfiguration('server_port'),
-        'refresh_interval_ms': LaunchConfiguration('refresh_interval_ms'),
-    }
-    if graph_provider_path:
-        param_overrides['plugins'] = ['graph_provider']
-        param_overrides['plugins.graph_provider.path'] = graph_provider_path
+    declare_cors_arg = DeclareLaunchArgument(
+        'cors_allowed_origins',
+        default_value='http://localhost:3000,http://localhost:5173',
+        description='Comma-separated CORS origins allowed to call the REST API from a browser, so '
+                    'the bundled web UI (a different origin) works out of the box. Empty disables '
+                    'CORS. A wildcard is intentionally not the default: with auth off and write '
+                    'methods enabled it would let any site drive cross-origin writes.')
 
-    gateway_node = Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
-        name='ros2_medkit_gateway',
-        output='screen',
-        parameters=[default_config, LaunchConfiguration('config_file'), param_overrides],
-        arguments=['--ros-args', '--log-level', 'info'])
+    # Resolve the cors arg into a string list at launch time (a comma-separated
+    # LaunchConfiguration cannot be passed straight through as a string-array
+    # parameter). param_overrides is applied last, so cors_allowed_origins is the
+    # single override point for CORS; set it empty for the secure (off) default.
+    def _launch_setup(context, *_args, **_kwargs):
+        origins = [o.strip() for o in
+                   LaunchConfiguration('cors_allowed_origins').perform(context).split(',')
+                   if o.strip()]
+        param_overrides = {
+            'server.host': LaunchConfiguration('server_host'),
+            'server.port': LaunchConfiguration('server_port'),
+            'refresh_interval_ms': LaunchConfiguration('refresh_interval_ms'),
+            'cors.allowed_origins': origins,
+        }
+        if graph_provider_path:
+            param_overrides['plugins'] = ['graph_provider']
+            param_overrides['plugins.graph_provider.path'] = graph_provider_path
+        return [Node(
+            package='ros2_medkit_gateway',
+            executable='gateway_node',
+            name='ros2_medkit_gateway',
+            output='screen',
+            parameters=[default_config, LaunchConfiguration('config_file'), param_overrides],
+            arguments=['--ros-args', '--log-level', 'info'])]
 
     return LaunchDescription([
         declare_override_config_arg,
         declare_host_arg,
         declare_port_arg,
         declare_refresh_arg,
-        gateway_node,
+        declare_cors_arg,
+        OpaqueFunction(function=_launch_setup),
     ])

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -22,6 +22,35 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
+# Default web UI origins enabled when the user does not override CORS, so the
+# bundled web UI works out of the box. A wildcard is deliberately not used.
+CORS_DEFAULT = 'http://localhost:3000,http://localhost:5173'
+
+
+def cors_override(cors_arg, config_file, default_config):
+    """Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
+
+    The final overrides dict is applied after the config file, so anything in it
+    wins per key. To avoid silently overriding a user's ``config_file``:
+
+    - an explicit ``cors_allowed_origins`` arg always wins (empty -> [''], which
+      the gateway reads as CORS off);
+    - with no arg and a *custom* config file, inject nothing so the file's
+      ``cors.allowed_origins`` is respected;
+    - with no arg and the default config, apply the web UI origins so the bundled
+      UI works out of the box.
+
+    An empty list cannot be passed as a launch parameter (and is the untyped-empty
+    shape that aborts startup), so the off case uses [''] - the same placeholder
+    the gateway config ships; config.cpp filters the empty string.
+    """
+    if cors_arg.strip() != CORS_DEFAULT:
+        origins = [o.strip() for o in cors_arg.split(',') if o.strip()] or ['']
+        return {'cors.allowed_origins': origins}
+    if not config_file or config_file == default_config:
+        return {'cors.allowed_origins': CORS_DEFAULT.split(',')}
+    return {}
+
 
 def generate_launch_description():
     pkg_dir = get_package_share_directory('ros2_medkit_gateway')
@@ -66,35 +95,30 @@ def generate_launch_description():
 
     declare_cors_arg = DeclareLaunchArgument(
         'cors_allowed_origins',
-        default_value='http://localhost:3000,http://localhost:5173',
+        default_value=CORS_DEFAULT,
         description='Comma-separated CORS origins allowed to call the REST API from a browser, so '
-                    'the bundled web UI (a different origin) works out of the box. Empty disables '
-                    'CORS. A wildcard is intentionally not the default: with auth off and write '
-                    'methods enabled it would let any site drive cross-origin writes.')
+                    'the bundled web UI (a different origin) works out of the box. Pass an '
+                    'explicit value to override (empty disables CORS); when left at the default, '
+                    'a config_file that sets cors.allowed_origins is respected. A wildcard is '
+                    'intentionally not the default: with auth off and write methods enabled it '
+                    'would let any site drive cross-origin writes.')
 
-    # Resolve the cors arg into a string list at launch time (a comma-separated
-    # LaunchConfiguration cannot be passed straight through as a string-array
-    # parameter). param_overrides is applied last, so cors_allowed_origins is the
-    # single override point for CORS; the default is non-empty (CORS on for the
-    # web UI), and setting it empty disables CORS.
+    # The cors arg is resolved at launch time (a comma-separated LaunchConfiguration
+    # cannot be passed straight through as a string-array parameter) and folded in
+    # by cors_override, which keeps a config_file's CORS from being silently
+    # overridden by the launch default.
     def _launch_setup(context, *_args, **_kwargs):
-        # An empty Python list cannot be passed as a launch parameter, and bare
-        # [] would also be the untyped-empty-list shape that aborts node startup.
-        # When no origins are given, fall back to [''] - the same placeholder the
-        # gateway config uses; config.cpp filters the empty string, so CORS ends
-        # up off without the crash.
-        origins = [o.strip() for o in
-                   LaunchConfiguration('cors_allowed_origins').perform(context).split(',')
-                   if o.strip()] or ['']
         param_overrides = {
             'server.host': LaunchConfiguration('server_host'),
             'server.port': LaunchConfiguration('server_port'),
             'refresh_interval_ms': LaunchConfiguration('refresh_interval_ms'),
-            'cors.allowed_origins': origins,
         }
         if graph_provider_path:
             param_overrides['plugins'] = ['graph_provider']
             param_overrides['plugins.graph_provider.path'] = graph_provider_path
+        param_overrides.update(cors_override(
+            LaunchConfiguration('cors_allowed_origins').perform(context),
+            LaunchConfiguration('config_file').perform(context), default_config))
         return [Node(
             package='ros2_medkit_gateway',
             executable='gateway_node',

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -28,7 +28,8 @@ CORS_DEFAULT = 'http://localhost:3000,http://localhost:5173'
 
 
 def cors_override(cors_arg, config_file, default_config):
-    """Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
+    """
+    Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
 
     The final overrides dict is applied after the config file, so anything in it
     wins per key. To avoid silently overriding a user's ``config_file``:

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -75,7 +75,8 @@ def generate_launch_description():
     # Resolve the cors arg into a string list at launch time (a comma-separated
     # LaunchConfiguration cannot be passed straight through as a string-array
     # parameter). param_overrides is applied last, so cors_allowed_origins is the
-    # single override point for CORS; set it empty for the secure (off) default.
+    # single override point for CORS; the default is non-empty (CORS on for the
+    # web UI), and setting it empty disables CORS.
     def _launch_setup(context, *_args, **_kwargs):
         # An empty Python list cannot be passed as a launch parameter, and bare
         # [] would also be the untyped-empty-list shape that aborts node startup.

--- a/src/ros2_medkit_gateway/launch/gateway.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway.launch.py
@@ -77,9 +77,14 @@ def generate_launch_description():
     # parameter). param_overrides is applied last, so cors_allowed_origins is the
     # single override point for CORS; set it empty for the secure (off) default.
     def _launch_setup(context, *_args, **_kwargs):
+        # An empty Python list cannot be passed as a launch parameter, and bare
+        # [] would also be the untyped-empty-list shape that aborts node startup.
+        # When no origins are given, fall back to [''] - the same placeholder the
+        # gateway config uses; config.cpp filters the empty string, so CORS ends
+        # up off without the crash.
         origins = [o.strip() for o in
                    LaunchConfiguration('cors_allowed_origins').perform(context).split(',')
-                   if o.strip()]
+                   if o.strip()] or ['']
         param_overrides = {
             'server.host': LaunchConfiguration('server_host'),
             'server.port': LaunchConfiguration('server_port'),

--- a/src/ros2_medkit_gateway/launch/gateway_https.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway_https.launch.py
@@ -49,7 +49,8 @@ CORS_DEFAULT = 'http://localhost:3000,http://localhost:5173'
 
 
 def cors_override(cors_arg, config_file, default_config):
-    """Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
+    """
+    Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
 
     The final overrides dict wins per key, so to avoid silently overriding a
     user's ``config_file``: an explicit ``cors_allowed_origins`` arg always wins

--- a/src/ros2_medkit_gateway/launch/gateway_https.launch.py
+++ b/src/ros2_medkit_gateway/launch/gateway_https.launch.py
@@ -42,6 +42,28 @@ from launch.actions import DeclareLaunchArgument, LogInfo, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
+# Default web UI origins enabled when the user does not override CORS, so the
+# bundled web UI works over HTTPS out of the box (kept in sync with
+# gateway.launch.py; a wildcard is deliberately not used).
+CORS_DEFAULT = 'http://localhost:3000,http://localhost:5173'
+
+
+def cors_override(cors_arg, config_file, default_config):
+    """Return the ``cors.allowed_origins`` entry for the final overrides, or {}.
+
+    The final overrides dict wins per key, so to avoid silently overriding a
+    user's ``config_file``: an explicit ``cors_allowed_origins`` arg always wins
+    (empty -> [''], CORS off); with no arg and a custom config file, inject
+    nothing so the file's value is respected; with no arg and the default config,
+    apply the web UI origins so the bundled UI works out of the box.
+    """
+    if cors_arg.strip() != CORS_DEFAULT:
+        origins = [o.strip() for o in cors_arg.split(',') if o.strip()] or ['']
+        return {'cors.allowed_origins': origins}
+    if not config_file or config_file == default_config:
+        return {'cors.allowed_origins': CORS_DEFAULT.split(',')}
+    return {}
+
 
 def generate_certificates(cert_dir: str) -> dict:
     """
@@ -143,6 +165,7 @@ def launch_setup(context):
     refresh_interval = LaunchConfiguration('refresh_interval_ms').perform(context)
     min_tls_version = LaunchConfiguration('min_tls_version').perform(context)
     override_config = LaunchConfiguration('config_file').perform(context)
+    cors_arg = LaunchConfiguration('cors_allowed_origins').perform(context)
 
     # Use temp directory if not specified
     if not cert_dir:
@@ -191,6 +214,7 @@ def launch_setup(context):
                     'server.tls.key_file': cert_paths['key_file'],
                     'server.tls.min_version': min_tls_version,
                     'refresh_interval_ms': int(refresh_interval),
+                    **cors_override(cors_arg, override_config, default_config),
                 }
             ],
             arguments=['--ros-args', '--log-level', 'info']
@@ -244,6 +268,15 @@ def generate_launch_description():
                 'config', 'gateway_params.yaml'),
             description='Path to YAML config file to override gateway parameters. Default config '
                         'is the ros2_medkit_gateway/config/gateway_params.yaml.'
+        ),
+
+        DeclareLaunchArgument(
+            'cors_allowed_origins',
+            default_value=CORS_DEFAULT,
+            description='Comma-separated CORS origins allowed to call the gateway from a browser, '
+                        'so the web UI works over HTTPS out of the box. Pass an explicit value to '
+                        'override (empty disables CORS); when left at the default, a config_file '
+                        'that sets cors.allowed_origins is respected.'
         ),
 
         # Use OpaqueFunction to generate certs and set up node


### PR DESCRIPTION
The native `gateway.launch.py` / `bringup.launch.py` ran the gateway with CORS off (the gateway's `cors.allowed_origins` defaults to empty). So the documented path of running the web UI next to the gateway fails with "Failed to fetch" on a native bringup - the browser calls the gateway from a different origin and is blocked. The image CORS fix (#452) only covered `docker/gateway_docker_params.yaml`, not the native launch.

This adds a `cors_allowed_origins` launch arg (comma-separated) defaulting to the web UI origins (`http://localhost:3000,http://localhost:5173`), resolved into the gateway's `cors.allowed_origins` via an OpaqueFunction. Empty disables CORS. A wildcard is intentionally not the default (with auth off and write methods enabled it would let any site drive cross-origin writes), matching #452.

Verified live: launching `gateway.launch.py` logs `CORS enabled - origins: [http://localhost:3000, http://localhost:5173], credentials: false`; `curl -H "Origin: http://localhost:3000"` gets `Access-Control-Allow-Origin: http://localhost:3000`; `curl -H "Origin: http://evil.com"` gets no ACAO header (blocked). flake8 clean.
