### PR TITLE
Incremental embedded-hardened entity cache + bounded discovery allocation under churn (#442)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,10 @@ plantuml = "java -Djava.awt.headless=true -jar /usr/share/plantuml/plantuml.jar"
 plantuml_output_format = "svg"
 
 # -- Options for linkcheck ---------------------------------------------------
+# Retry transient external failures (e.g. docs.ros.org read timeouts) instead of
+# failing the whole build on a single network blip.
+linkcheck_retries = 3
+linkcheck_timeout = 30
 linkcheck_ignore = [
     r"http://localhost:\d+",  # Ignore localhost URLs
     r"http://127\.0\.0\.1:\d+",

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -259,6 +259,15 @@ Performance Tuning
      - Safety-backstop refresh interval (ms). Primary discovery is graph-event
        driven (polled every 100 ms); this timer forces a full refresh only if
        a graph event is missed. Range: 100-60000 (0.1s-60s).
+   * - ``entity_cache.capacity``
+     - int
+     - ``256``
+     - Fixed capacity of the thread-safe entity cache object pool, reserved once
+       at startup. Steady-state refresh cycles perform zero structural allocations
+       in the cache layer as long as the live entity count stays within this
+       value. Valid range: 16-1000000 (values outside this range are clamped with
+       a warning). Raise it for graphs larger than the default; exceeding the
+       reserved capacity is harmless but triggers a one-shot WARN log.
 
 Lower values shorten the worst-case recovery window if a graph event is missed
 but increase idle CPU. The default rarely fires on a stable graph because the

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -267,7 +267,8 @@ Performance Tuning
        full discovery pipeline. Coalesces graph events so a refresh runs at most
        once per this interval, bounding per-event allocation. A pending change is
        serviced within this interval plus one 100 ms poll. Range: 0-60000
-       (0 disables debouncing; clamped with a warning if out of range).
+       (0 disables debouncing). A value outside the range is rejected with a
+       warning and the default (1000) is used.
    * - ``entity_cache.capacity``
      - int
      - ``256``
@@ -276,7 +277,11 @@ Performance Tuning
        in the cache layer as long as the live entity count stays within this
        value. Valid range: 16-1000000 (values outside this range are clamped with
        a warning). Raise it for graphs larger than the default; exceeding the
-       reserved capacity is harmless but triggers a one-shot WARN log.
+       reserved capacity is harmless but triggers a one-shot WARN log. Note that a
+       refresh that fully turns the entity set over allocates the new slots before
+       freeing the absent old ones, so the pool transiently holds up to ~2x the
+       steady-state live count - size capacity to about twice the expected peak to
+       keep full-turnover ticks allocation-free.
 
 Lower values shorten the worst-case recovery window if a graph event is missed
 but increase idle CPU. The default rarely fires on a stable graph because the

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -259,6 +259,15 @@ Performance Tuning
      - Safety-backstop refresh interval (ms). Primary discovery is graph-event
        driven (polled every 100 ms); this timer forces a full refresh only if
        a graph event is missed. Range: 100-60000 (0.1s-60s).
+   * - ``discovery.refresh_debounce_ms``
+     - int
+     - ``1000``
+     - Debounce for graph-event-driven refreshes (ms). Under graph churn the
+       rclcpp graph event fires many times per second; each refresh runs the
+       full discovery pipeline. Coalesces graph events so a refresh runs at most
+       once per this interval, bounding per-event allocation. A pending change is
+       serviced within this interval plus one 100 ms poll. Range: 0-60000
+       (0 disables debouncing; clamped with a warning if out of range).
    * - ``entity_cache.capacity``
      - int
      - ``256``

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -679,6 +679,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_opaque_object test/test_opaque_object.cpp)
   target_link_libraries(test_opaque_object gateway_core)
 
+  # Entity value equality (operator==) - pure C++17, no ROS node
+  ament_add_gtest(test_entity_equality test/test_entity_equality.cpp)
+  target_link_libraries(test_entity_equality gateway_core)
+
   # Typed router foundational types (pure C++17, no ROS node)
   ament_add_gtest(test_typed_router test/test_typed_router.cpp)
   target_link_libraries(test_typed_router gateway_core)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1009,6 +1009,8 @@ if(BUILD_TESTING)
   # No medkit_set_test_domain - this is ROS-free (gateway_core only).
   ament_add_gtest(test_entity_cache_alloc test/test_entity_cache_alloc.cpp)
   target_link_libraries(test_entity_cache_alloc gateway_core)
+  # NOTE: test_entity_cache_alloc is intentionally excluded from _test_targets below.
+  # Its global operator new/delete override corrupts lcov allocation counters in other TUs.
 
   # Apply coverage flags to test targets
   if(ENABLE_COVERAGE)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -663,6 +663,13 @@ if(BUILD_TESTING)
     target_link_libraries(test_slot_store gateway_core)
   endif()
 
+  # ThreadSafeEntityCache incremental reconcile (pure C++17, no ROS node)
+  ament_add_gtest(test_thread_safe_entity_cache
+    test/test_thread_safe_entity_cache.cpp)
+  if(TARGET test_thread_safe_entity_cache)
+    target_link_libraries(test_thread_safe_entity_cache gateway_core)
+  endif()
+
   # DTO contract core (pure C++17, no ROS node)
   ament_add_gtest(test_dto_contract test/test_dto_contract.cpp)
   target_link_libraries(test_dto_contract gateway_core)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1001,6 +1001,15 @@ if(BUILD_TESTING)
   ament_add_gtest(test_network_utils test/test_network_utils.cpp)
   target_link_libraries(test_network_utils gateway_ros2)
 
+  # ─── Allocation-counter proxy gate (gateway_core only) ────────────────────
+  # Standalone TU with its own global operator new/delete override (gated by
+  # g_armed). Proves update_all performs ~zero net structural allocations in
+  # steady-state churn over a bounded id-set. Must be its OWN executable so
+  # the operator new override does not bleed into other test binaries.
+  # No medkit_set_test_domain - this is ROS-free (gateway_core only).
+  ament_add_gtest(test_entity_cache_alloc test/test_entity_cache_alloc.cpp)
+  target_link_libraries(test_entity_cache_alloc gateway_core)
+
   # Apply coverage flags to test targets
   if(ENABLE_COVERAGE)
     set(_test_targets

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -651,6 +651,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_handler_context gateway_ros2)
   medkit_set_test_domain(test_handler_context)
 
+  # FlatHashMap open-addressed container (pure C++17, no ROS node)
+  ament_add_gtest(test_flat_hash_map test/test_flat_hash_map.cpp)
+  if(TARGET test_flat_hash_map)
+    target_link_libraries(test_flat_hash_map gateway_core)
+  endif()
+
   # DTO contract core (pure C++17, no ROS node)
   ament_add_gtest(test_dto_contract test/test_dto_contract.cpp)
   target_link_libraries(test_dto_contract gateway_core)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -657,6 +657,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_flat_hash_map gateway_core)
   endif()
 
+  # SlotStore object pool (pure C++17, no ROS node)
+  ament_add_gtest(test_slot_store test/test_slot_store.cpp)
+  if(TARGET test_slot_store)
+    target_link_libraries(test_slot_store gateway_core)
+  endif()
+
   # DTO contract core (pure C++17, no ROS node)
   ament_add_gtest(test_dto_contract test/test_dto_contract.cpp)
   target_link_libraries(test_dto_contract gateway_core)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -657,6 +657,12 @@ if(BUILD_TESTING)
     target_link_libraries(test_flat_hash_map gateway_core)
   endif()
 
+  # Graph-event refresh debounce decision (pure C++17, no ROS node)
+  ament_add_gtest(test_refresh_debounce test/test_refresh_debounce.cpp)
+  if(TARGET test_refresh_debounce)
+    target_link_libraries(test_refresh_debounce gateway_core)
+  endif()
+
   # SlotStore object pool (pure C++17, no ROS node)
   ament_add_gtest(test_slot_store test/test_slot_store.cpp)
   if(TARGET test_slot_store)

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -10,6 +10,7 @@ The ROS 2 Medkit Gateway exposes ROS 2 system information and data through a RES
 - **Auto-discovery**: Automatically detects ROS 2 nodes and topics
 - **SOVD entity model**: Areas, Components (host-level), Apps (ROS 2 nodes), and Functions (namespace-based logical grouping)
 - **REST API**: Standard HTTP/JSON interface
+- **Incremental entity cache**: Discovery refresh diffs add/remove/change and performs zero structural allocations in the cache layer at steady state (object-pool backed, fixed capacity reserved at init via `entity_cache.capacity`)
 - **Real-time updates**: Configurable cache refresh for up-to-date system state
 - **Bulk Data Management**: Upload, download, list, and delete bulk data files (calibration, firmware, etc.)
 - **Resource Locking**: SOVD-compliant entity locking with scoped access control, lock breaking, and automatic expiry

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -213,6 +213,9 @@ ros2_medkit_gateway:
       # memory-constrained or real-time embedded deployments).
       # Growing beyond the reserved capacity is harmless but triggers a one-shot
       # WARN log; raise this value if you see that warning.
+      # A fully-turning-over refresh allocates the new slots before freeing the
+      # absent old ones, so the pool transiently needs ~2x the steady-state live
+      # count; size this to about twice the expected peak to stay allocation-free.
       # Valid range: 16-1000000 (values outside this range are clamped with a warning).
       # Default: 256 (covers most production graphs with headroom)
       capacity: 256

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -98,6 +98,18 @@ ros2_medkit_gateway:
     # Default: 30000 (30 seconds)
     refresh_interval_ms: 30000
 
+    # Graph-event refresh debounce (milliseconds).
+    # The rclcpp graph event fires many times per second under graph churn
+    # (nodes/topics repeatedly created and destroyed). Each refresh runs the
+    # full discovery pipeline, so coalescing graph events bounds the per-event
+    # allocation churn. A graph change triggers at most one refresh per this
+    # interval; a pending change is always serviced within this interval plus
+    # one 100 ms poll. The ROS graph rarely changes faster than ~1s in practice.
+    #
+    # Valid range: 0-60000 (0 disables debouncing: refresh on every graph event)
+    # Default: 1000 (1 second)
+    discovery.refresh_debounce_ms: 1000
+
     # CORS Configuration
     # Cross-Origin Resource Sharing settings for browser-based clients
     # If cors section is missing or empty, CORS handling is disabled

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -193,6 +193,18 @@ ros2_medkit_gateway:
       # Default: 3600 (1 hour)
       max_duration_sec: 3600
 
+    # Entity Cache Configuration
+    entity_cache:
+      # Pre-reserved capacity for the thread-safe entity cache.
+      # Setting this to a value at or above the expected peak entity count prevents
+      # structural reallocation during steady-state refreshes (desirable for
+      # memory-constrained or real-time embedded deployments).
+      # Growing beyond the reserved capacity is harmless but triggers a one-shot
+      # WARN log; raise this value if you see that warning.
+      # Valid range: 16-1000000 (values outside this range are clamped with a warning).
+      # Default: 256 (covers most production graphs with headroom)
+      capacity: 256
+
     # Logging Configuration
     logs:
       # Ring buffer capacity per node name.

--- a/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
+++ b/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
@@ -1,0 +1,167 @@
+Entity Cache Architecture
+=========================
+
+Background
+----------
+
+The gateway's ``ThreadSafeEntityCache`` holds the live SOVD entity tree
+(Areas, Components, Apps, Functions) and is read by every HTTP handler
+thread. Prior to issue #442 the cache stored entities in
+``std::unordered_map`` containers that reallocated on insert and shifted
+slot addresses on erase. Discovery refreshes - which run every 100 ms on
+graph-event detection - caused structural allocations even when nothing had
+changed, adding heap churn and making the cache unsuitable for
+memory-constrained or embedded deployments.
+
+This document describes the replacement architecture introduced in #442.
+
+Goals
+-----
+
+1. Eliminate per-refresh structural allocations in the cache layer for a
+   stable entity graph.
+2. Make heap use predictable: capacity is fixed at startup, not
+   open-ended.
+3. Gate the generation counter on actual changes so polling it on a quiet
+   graph is cheap.
+4. Preserve the existing public API and SOVD REST contract - the changes
+   are entirely below the handler layer.
+
+Object Pool and Flat Index Architecture
+---------------------------------------
+
+The cache uses two building blocks.
+
+**SlotStore<T>** - a stable-slot object pool. Each entity type (Area,
+Component, App, Function) gets its own ``SlotStore<T>``. The store holds
+entities in a flat ``std::vector`` that is pre-reserved to ``capacity``
+slots at construction. Slots are never moved or shifted after allocation;
+a freed slot is marked available and reused for the next insert. Slot IDs
+are stable for the lifetime of an entity. The store exposes typed
+references so callers do not hold raw pointers across mutations.
+
+**FlatHashMap<K, V>** - a linear-probe open-address hash map pre-reserved
+to the same capacity at construction. Used for all index maps:
+
+- ``area_index_``, ``component_index_``, ``app_index_``,
+  ``function_index_`` - map entity ID to slot ID (O(1) lookup)
+- ``component_to_apps_``, ``area_to_components_``, etc. - relationship
+  indexes (parent ID to child slot ID list)
+- ``operation_index_`` - operation full_path to owning entity reference
+- ``topic_type_cache_`` - topic name to message type
+
+All these maps are reserved once at ``ThreadSafeEntityCache`` construction
+and do not rehash as long as the live entity count stays within
+``capacity``. The ``capacity`` value comes from the
+``entity_cache.capacity`` ROS parameter (default: 256, valid range:
+16-1000000; values outside this range are clamped with a warning at
+startup).
+
+Incremental Reconcile
+---------------------
+
+``update_all`` (and the per-type variants ``update_areas``,
+``update_components``, ``update_apps``, ``update_functions``) implement an
+in-place diff instead of a clear-and-rebuild:
+
+1. **Remove** slots whose IDs are absent from the incoming list.
+2. **Add** incoming IDs that are not yet in the index (allocate a new
+   slot from the pool).
+3. **Change** slots where an existing entity's payload differs from the
+   incoming value (in-place overwrite, no slot movement).
+
+Only mutations that fall into categories 1, 2, or 3 advance the
+generation counter. A no-op call (incoming set is identical to the
+current cache) leaves the generation unchanged. This allows consumers such
+as the OpenAPI capability generator to skip expensive regeneration when
+the graph has not changed.
+
+Zero-Structural-Allocation Property
+------------------------------------
+
+Once ``capacity`` slots are reserved and the entity count stabilises
+below that threshold, steady-state ``update_all`` calls perform zero
+structural allocations in the cache layer: no ``std::vector`` resize, no
+hash map rehash, no ``new``/``delete`` for index entries. In-place slot
+overwrites update entity payloads without touching the pool structure.
+
+.. note::
+
+   **Honest boundary.** Entity payloads themselves - ``nlohmann::json``
+   objects (e.g., ``host_metadata``, ``type_info``) and
+   ``std::vector<std::string>`` fields (topic lists, service lists) -
+   still allocate on the heap inside the discovery layer before the cache
+   sees them. Making those payloads fixed-capacity (e.g., custom
+   allocators or pre-sized arenas) is a separate future effort and is
+   explicitly out of scope for this change. The zero-structural-allocation
+   guarantee applies to the cache data structures, not to the payloads
+   stored in them.
+
+Overflow Behaviour
+------------------
+
+If ``update_all`` receives more entities than the reserved ``capacity``,
+the pool and maps grow dynamically (the standard resize path). A one-shot
+WARN log fires when this happens:
+
+.. code-block:: text
+
+   [WARN] entity cache capacity (256) exceeded; grew to N entries.
+   Consider raising entity_cache.capacity.
+
+The gateway continues operating normally. The WARN fires once per process
+lifetime to avoid log spam.
+
+Generation Counter
+------------------
+
+``ThreadSafeEntityCache::generation()`` returns a ``uint64_t`` that
+increments on each mutation that actually changes the cache contents.
+Callers use it as a change token:
+
+.. code-block:: cpp
+
+   auto gen = cache.generation();
+   // ... later ...
+   if (cache.generation() != gen) {
+     rebuild_openapi_spec();
+   }
+
+Because the counter is gated on real changes, polling it on a stable
+graph costs nothing beyond an atomic load.
+
+Health Endpoint Stats
+---------------------
+
+``GET /api/v1/health`` exposes entity cache statistics under the
+``x-medkit-entity-cache`` vendor-extension key:
+
+.. code-block:: json
+
+   {
+     "status": "healthy",
+     "x-medkit-entity-cache": {
+       "capacity": 256,
+       "areas": 2,
+       "components": 1,
+       "apps": 14,
+       "functions": 3,
+       "generation": 7,
+       "grew": false
+     }
+   }
+
+Configuration
+-------------
+
+The cache capacity is set via ``entity_cache.capacity`` in
+``gateway_params.yaml`` (or any ROS parameter source). See
+:doc:`/config/server` (Performance Tuning section) for the full parameter
+reference.
+
+See Also
+--------
+
+- :doc:`ros2_subscription_architecture` - Analogous embedded-hardened
+  design for the topic subscription pool
+- :doc:`/config/server` - ``entity_cache.capacity`` parameter reference

--- a/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
+++ b/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
@@ -97,6 +97,29 @@ overwrites update entity payloads without touching the pool structure.
    guarantee applies to the cache data structures, not to the payloads
    stored in them.
 
+Discovery-Side Allocation Under Graph Churn
+-------------------------------------------
+
+The cache is only the last step of ``refresh_cache()``. Per-graph-event
+allocation profiling showed the dominant churn under a churning graph was in
+the discovery pipeline, not the cache rebuild, driven by two things:
+
+1. **Eager schema building.** ``discover_apps`` rebuilt the JSON request/
+   response (and goal/result/feedback) schemas for every service and action in
+   the graph on every refresh, then deep-copied them through several
+   intermediate containers. These schemas are immutable per type and are not
+   read from the discovered entities at all - the ``/operations`` handler
+   already resolves them on demand. Discovery now leaves ``type_info`` empty;
+   the handler resolves it lazily and ``TypeIntrospection`` caches the
+   assembled per-type ``type_info`` as a shared, immutable object
+   (``get_service_type_info`` / ``get_action_type_info``), so repeated requests
+   reuse it.
+
+2. **Refresh frequency.** The rclcpp graph event fires many times per second
+   under churn, running the full discovery pipeline each time. Graph events are
+   now debounced (``discovery.refresh_debounce_ms``, default 1 s) so a burst of
+   graph changes coalesces into a single refresh.
+
 Overflow Behaviour
 ------------------
 

--- a/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
+++ b/src/ros2_medkit_gateway/design/entity_cache_architecture.rst
@@ -106,8 +106,8 @@ WARN log fires when this happens:
 
 .. code-block:: text
 
-   [WARN] entity cache capacity (256) exceeded; grew to N entries.
-   Consider raising entity_cache.capacity.
+   [WARN] entity_cache capacity 256 exceeded (grew); raise
+   entity_cache.capacity for embedded determinism
 
 The gateway continues operating normally. The WARN fires once per process
 lifetime to avoid log spam.

--- a/src/ros2_medkit_gateway/design/index.rst
+++ b/src/ros2_medkit_gateway/design/index.rst
@@ -673,6 +673,7 @@ Additional Design Documents
 
    aggregation
    dto_contract
+   entity_cache_architecture
    lifecycle
    plugin_entity_notifications
    ros2_subscription_architecture

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/app.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/app.hpp
@@ -80,6 +80,14 @@ struct App {
   };
   std::optional<RosBinding> ros_binding;
 
+  friend bool operator==(const RosBinding & a, const RosBinding & b) {
+    return a.node_name == b.node_name && a.namespace_pattern == b.namespace_pattern &&
+           a.topic_namespace == b.topic_namespace;
+  }
+  friend bool operator!=(const RosBinding & a, const RosBinding & b) {
+    return !(a == b);
+  }
+
   // === Runtime state (populated after linking) ===
   std::optional<std::string> bound_fqn;  ///< Bound ROS node FQN
   bool is_online{false};                 ///< Whether the bound node is running
@@ -141,5 +149,16 @@ struct App {
    */
   json to_capabilities(const std::string & base_url) const;
 };
+
+inline bool operator==(const App & a, const App & b) {
+  return a.id == b.id && a.name == b.name && a.translation_id == b.translation_id && a.description == b.description &&
+         a.tags == b.tags && a.component_id == b.component_id && a.depends_on == b.depends_on &&
+         a.ros_binding == b.ros_binding && a.bound_fqn == b.bound_fqn && a.is_online == b.is_online &&
+         a.external == b.external && a.topics == b.topics && a.services == b.services && a.actions == b.actions &&
+         a.source == b.source && a.original_id == b.original_id && a.contributors == b.contributors;
+}
+inline bool operator!=(const App & a, const App & b) {
+  return !(a == b);
+}
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/area.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/area.hpp
@@ -129,4 +129,13 @@ struct Area {
   }
 };
 
+inline bool operator==(const Area & a, const Area & b) {
+  return a.id == b.id && a.name == b.name && a.namespace_path == b.namespace_path && a.type == b.type &&
+         a.translation_id == b.translation_id && a.description == b.description && a.tags == b.tags &&
+         a.parent_area_id == b.parent_area_id && a.source == b.source && a.contributors == b.contributors;
+}
+inline bool operator!=(const Area & a, const Area & b) {
+  return !(a == b);
+}
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/common.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/common.hpp
@@ -116,6 +116,13 @@ struct ComponentTopics {
   }
 };
 
+inline bool operator==(const ComponentTopics & a, const ComponentTopics & b) {
+  return a.publishes == b.publishes && a.subscribes == b.subscribes;
+}
+inline bool operator!=(const ComponentTopics & a, const ComponentTopics & b) {
+  return !(a == b);
+}
+
 /**
  * @brief Information about a ROS2 service discovered in the system
  */
@@ -134,6 +141,13 @@ struct ServiceInfo {
   }
 };
 
+inline bool operator==(const ServiceInfo & a, const ServiceInfo & b) {
+  return a.name == b.name && a.full_path == b.full_path && a.type == b.type && a.type_info == b.type_info;
+}
+inline bool operator!=(const ServiceInfo & a, const ServiceInfo & b) {
+  return !(a == b);
+}
+
 /**
  * @brief Information about a ROS2 action discovered in the system
  */
@@ -151,5 +165,12 @@ struct ActionInfo {
     return j;
   }
 };
+
+inline bool operator==(const ActionInfo & a, const ActionInfo & b) {
+  return a.name == b.name && a.full_path == b.full_path && a.type == b.type && a.type_info == b.type_info;
+}
+inline bool operator!=(const ActionInfo & a, const ActionInfo & b) {
+  return !(a == b);
+}
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/component.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/component.hpp
@@ -172,4 +172,16 @@ struct Component {
   }
 };
 
+inline bool operator==(const Component & a, const Component & b) {
+  return a.id == b.id && a.name == b.name && a.namespace_path == b.namespace_path && a.fqn == b.fqn &&
+         a.type == b.type && a.area == b.area && a.source == b.source && a.translation_id == b.translation_id &&
+         a.description == b.description && a.variant == b.variant && a.tags == b.tags &&
+         a.parent_component_id == b.parent_component_id && a.depends_on == b.depends_on &&
+         a.contributors == b.contributors && a.services == b.services && a.actions == b.actions &&
+         a.topics == b.topics && a.host_metadata == b.host_metadata;
+}
+inline bool operator!=(const Component & a, const Component & b) {
+  return !(a == b);
+}
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/function.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/function.hpp
@@ -71,4 +71,13 @@ struct Function {
   json to_capabilities(const std::string & base_url) const;
 };
 
+inline bool operator==(const Function & a, const Function & b) {
+  return a.id == b.id && a.name == b.name && a.translation_id == b.translation_id && a.description == b.description &&
+         a.tags == b.tags && a.hosts == b.hosts && a.depends_on == b.depends_on && a.source == b.source &&
+         a.contributors == b.contributors;
+}
+inline bool operator!=(const Function & a, const Function & b) {
+  return !(a == b);
+}
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/refresh_debounce.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/refresh_debounce.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+
+namespace ros2_medkit_gateway {
+
+/// Outcome of one graph-check tick's debounce decision.
+struct GraphRefreshDecision {
+  bool refresh;  ///< run the (expensive) refresh_cache() pipeline now
+  bool dirty;    ///< next value of the pending-change latch
+};
+
+/// Pure debounce decision for graph-event-driven cache refresh (issue #442).
+///
+/// The graph event fires many times per second under graph churn; each refresh
+/// runs the full discovery pipeline, so graph changes are coalesced into at most
+/// one refresh per `debounce_ms`. Kept free of ROS/clock state so the coalescing,
+/// 0 ms (disabled), and cold-start cases are unit-testable.
+///
+/// @param event_fired    a graph event was observed on this tick
+/// @param currently_dirty a graph change is pending (latched, not yet serviced)
+/// @param elapsed_ms      milliseconds since the last graph-driven refresh
+/// @param debounce_ms     minimum interval between refreshes; 0 disables debouncing
+///
+/// Cold start: callers seed the last-refresh time to the clock epoch, so the
+/// first pending change sees a large `elapsed_ms` and refreshes immediately.
+inline GraphRefreshDecision decide_graph_refresh(bool event_fired, bool currently_dirty, std::int64_t elapsed_ms,
+                                                 int debounce_ms) {
+  const bool dirty = currently_dirty || event_fired;
+  if (!dirty) {
+    return {false, false};  // nothing pending
+  }
+  if (elapsed_ms < static_cast<std::int64_t>(debounce_ms)) {
+    return {false, true};  // pending, but still inside the debounce window
+  }
+  return {true, false};  // service the pending change and clear the latch
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
@@ -129,9 +129,9 @@ struct EntityCacheStats {
   size_t function_count{0};   ///< Live functions
   size_t total_operations{0};
   size_t capacity{0};        ///< Configured reserve capacity (0 = lazy growth)
-  bool grew{false};          ///< true if any backing store/index reallocated since the last refresh
+  bool grew{false};          ///< true if any backing store/index reallocated since reserve()
   uint64_t generation{0};    ///< Current cache generation counter
-  size_t overflow_count{0};  ///< Reserved for incremental reconcile overflow accounting (Task 5)
+  size_t overflow_count{0};  ///< Number of reconcile cycles that triggered a structural grow
   std::chrono::system_clock::time_point last_update;
 };
 
@@ -530,28 +530,49 @@ class ThreadSafeEntityCache {
   // Node FQN -> app entity ID mapping from linking result (for trigger entity resolution)
   FlatHashMap<std::string, std::string> node_to_app_;
 
-  // Reconcile scratch buffers (reserved alongside the stores). seen_ is used on
-  // the overflow/grow path only; dead_ids_/patch_dead_ back the incremental
-  // reconcile introduced in a later task. Kept here so reserve() can size them.
+  // Reconcile scratch buffers (reserved alongside the stores). seen_ marks which
+  // live slots were re-seen during a reconcile pass; dead_ids_ collects ids of
+  // slots to free (collected before mutating to avoid invalidating iteration);
+  // patch_dead_ collects map keys to erase. Pre-reserved so steady-state
+  // reconcile does not allocate; seen_ only ever resize()s on the grow path.
   std::vector<uint8_t> seen_;
   std::vector<std::string> dead_ids_;
   std::vector<std::string> patch_dead_;
 
   // Configured reserve capacity (0 = lazy growth from empty).
   size_t capacity_{0};
-  // Whether any store/index reallocated since the last stats refresh.
+  // Sticky "any backing store/index reallocated since reserve()" flag, folded
+  // from the container grew() flags by refresh_grew() (which clears them).
   bool grew_{false};
-  // Reserved for incremental reconcile overflow accounting (Task 5).
+  // Count of reconcile cycles that triggered a fresh structural grow.
   size_t overflow_count_{0};
 
-  // Internal helpers (called under lock)
-  void rebuild_all_indexes();
-  void rebuild_area_index();
-  void rebuild_component_index();
-  void rebuild_app_index();
-  void rebuild_function_index();
+  // Internal helpers (called under lock). Primary id->slot indexes are kept up
+  // to date incrementally by reconcile(); only the derived relationship and
+  // operation indexes are rebuilt wholesale (cheap, slot-based) after a change.
   void rebuild_relationship_indexes();
   void rebuild_operation_index();
+
+  /// In-place incremental reconcile of one store against `incoming` (move-from).
+  /// Reuses `store`/`index`: only allocates/frees slots that actually change.
+  /// Returns true if any slot was assigned, allocated, or freed (i.e. the live
+  /// set or any payload changed). Duplicate ids within `incoming` collapse to
+  /// last-wins in a single slot. Uses the member scratch buffers `seen_` /
+  /// `dead_ids_` so there is no per-call heap allocation in steady state.
+  template <typename T>
+  bool reconcile(SlotStore<T> & store, FlatHashMap<std::string, uint32_t> & index, std::vector<T> && incoming);
+
+  /// In-place incremental patch of a string-valued map against `incoming`
+  /// (move-from). Erases keys absent from `incoming`, updates changed values,
+  /// inserts new keys, leaves unchanged keys untouched. Returns true iff the
+  /// map content changed. Uses the member scratch buffer `patch_dead_`.
+  bool patch_map(FlatHashMap<std::string, std::string> & map, std::unordered_map<std::string, std::string> && incoming);
+
+  /// Fold each backing container's transient `grew()` flag into the cached
+  /// `grew_` member and clear the container flags. Increments `overflow_count_`
+  /// once whenever a new grow happened since the last refresh. Because this
+  /// clears the container flags, `get_stats()` must report the cached members.
+  void refresh_grew();
 
   // Aggregation helpers (called under shared lock); slot ids guarded with is_live.
   void collect_operations_from_apps(const std::vector<uint32_t> & app_slots,

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
@@ -487,17 +487,22 @@ class ThreadSafeEntityCache {
   /**
    * @brief Get the current generation counter
    *
-   * The generation counter advances on every cache mutation (update_all,
-   * update_areas, update_components, update_apps, update_functions,
-   * update_topic_types). Consumers can use this to detect when cached derived
-   * data (e.g., OpenAPI specs) is stale and needs regeneration.
+   * The generation counter advances ONLY when a mutation actually changes the
+   * cache contents. This gate applies to every mutator (update_all, the
+   * per-type update_* methods, and update_topic_types): a no-op call (e.g.,
+   * update_all with the same entity set, or update_topic_types with an
+   * unchanged topic map) does NOT bump the generation.
+   *
+   * Consumers use the generation to detect when cached derived data
+   * (e.g., OpenAPI specs) is stale and needs regeneration. Because the counter
+   * is gated on actual changes, polling it is cheap on a stable graph.
    */
   uint64_t generation() const;
 
  private:
   mutable std::shared_mutex mutex_;
 
-  // Generation counter - advances on every entity mutation
+  // Generation counter - advances only when a mutation changes the cache.
   std::atomic<uint64_t> generation_{0};
 
   // Primary storage: stable-slot object pools (slots never shift on free).

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp
@@ -19,9 +19,12 @@
 #include "ros2_medkit_gateway/core/discovery/models/component.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/function.hpp"
 #include "ros2_medkit_gateway/core/models/entity_types.hpp"
+#include "ros2_medkit_gateway/core/util/flat_hash_map.hpp"
+#include "ros2_medkit_gateway/core/util/slot_store.hpp"
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <optional>
 #include <shared_mutex>
 #include <string>
@@ -33,6 +36,8 @@ namespace ros2_medkit_gateway {
 
 /**
  * @brief Reference to an entity in the cache
+ *
+ * `index` is a stable SlotStore slot id (not a compacted vector position).
  */
 struct EntityRef {
   SovdEntityType type{SovdEntityType::UNKNOWN};
@@ -118,11 +123,15 @@ struct AggregatedConfigurations {
  * @brief Cache statistics
  */
 struct EntityCacheStats {
-  size_t area_count{0};
-  size_t component_count{0};
-  size_t app_count{0};
-  size_t function_count{0};
+  size_t area_count{0};       ///< Live areas
+  size_t component_count{0};  ///< Live components
+  size_t app_count{0};        ///< Live apps
+  size_t function_count{0};   ///< Live functions
   size_t total_operations{0};
+  size_t capacity{0};        ///< Configured reserve capacity (0 = lazy growth)
+  bool grew{false};          ///< true if any backing store/index reallocated since the last refresh
+  uint64_t generation{0};    ///< Current cache generation counter
+  size_t overflow_count{0};  ///< Reserved for incremental reconcile overflow accounting (Task 5)
   std::chrono::system_clock::time_point last_update;
 };
 
@@ -149,6 +158,17 @@ struct EntityCacheStats {
 class ThreadSafeEntityCache {
  public:
   ThreadSafeEntityCache() = default;
+
+  /// Construct with all stores, indexes and scratch buffers pre-reserved for
+  /// `capacity` entities. Steady-state updates below this size cause no
+  /// structural reallocation. `capacity == 0` is equivalent to the default
+  /// constructor (lazy growth from empty).
+  explicit ThreadSafeEntityCache(size_t capacity);
+
+  /// Reserve every backing store, every index/relationship map, and the
+  /// reconcile scratch buffers for `capacity` entities. Idempotent; safe to
+  /// call on a populated cache (only grows the backing arrays).
+  void reserve(size_t capacity);
 
   // =========================================================================
   // Writer methods (exclusive lock) - called by discovery thread
@@ -467,48 +487,62 @@ class ThreadSafeEntityCache {
   /**
    * @brief Get the current generation counter
    *
-   * The generation counter is incremented on every cache mutation (update_all,
-   * update_areas, update_components, update_apps, update_functions). Consumers
-   * can use this to detect when cached derived data (e.g., OpenAPI specs) is
-   * stale and needs regeneration.
+   * The generation counter advances on every cache mutation (update_all,
+   * update_areas, update_components, update_apps, update_functions,
+   * update_topic_types). Consumers can use this to detect when cached derived
+   * data (e.g., OpenAPI specs) is stale and needs regeneration.
    */
   uint64_t generation() const;
 
  private:
   mutable std::shared_mutex mutex_;
 
-  // Generation counter - incremented on every entity mutation
+  // Generation counter - advances on every entity mutation
   std::atomic<uint64_t> generation_{0};
 
-  // Primary storage
-  std::vector<Area> areas_;
-  std::vector<Component> components_;
-  std::vector<App> apps_;
-  std::vector<Function> functions_;
+  // Primary storage: stable-slot object pools (slots never shift on free).
+  SlotStore<Area> areas_;
+  SlotStore<Component> components_;
+  SlotStore<App> apps_;
+  SlotStore<Function> functions_;
 
   // Timestamp
   std::chrono::system_clock::time_point last_update_;
 
-  // Primary indexes (ID → vector index)
-  std::unordered_map<std::string, size_t> area_index_;
-  std::unordered_map<std::string, size_t> component_index_;
-  std::unordered_map<std::string, size_t> app_index_;
-  std::unordered_map<std::string, size_t> function_index_;
+  // Primary indexes (ID -> stable slot id)
+  FlatHashMap<std::string, uint32_t> area_index_;
+  FlatHashMap<std::string, uint32_t> component_index_;
+  FlatHashMap<std::string, uint32_t> app_index_;
+  FlatHashMap<std::string, uint32_t> function_index_;
 
-  // Relationship indexes (parent ID → child vector indexes)
-  std::unordered_map<std::string, std::vector<size_t>> component_to_apps_;
-  std::unordered_map<std::string, std::vector<size_t>> area_to_components_;
-  std::unordered_map<std::string, std::vector<size_t>> area_to_subareas_;
-  std::unordered_map<std::string, std::vector<size_t>> function_to_apps_;
+  // Relationship indexes (parent ID -> child slot ids)
+  FlatHashMap<std::string, std::vector<uint32_t>> component_to_apps_;
+  FlatHashMap<std::string, std::vector<uint32_t>> area_to_components_;
+  FlatHashMap<std::string, std::vector<uint32_t>> area_to_subareas_;
+  FlatHashMap<std::string, std::vector<uint32_t>> function_to_apps_;
 
-  // Operation index (operation full_path → owning entity)
-  std::unordered_map<std::string, EntityRef> operation_index_;
+  // Operation index (operation full_path -> owning entity)
+  FlatHashMap<std::string, EntityRef> operation_index_;
 
   // Topic type cache (topic name -> message type) - refreshed periodically
-  std::unordered_map<std::string, std::string> topic_type_cache_;
+  FlatHashMap<std::string, std::string> topic_type_cache_;
 
   // Node FQN -> app entity ID mapping from linking result (for trigger entity resolution)
-  std::unordered_map<std::string, std::string> node_to_app_;
+  FlatHashMap<std::string, std::string> node_to_app_;
+
+  // Reconcile scratch buffers (reserved alongside the stores). seen_ is used on
+  // the overflow/grow path only; dead_ids_/patch_dead_ back the incremental
+  // reconcile introduced in a later task. Kept here so reserve() can size them.
+  std::vector<uint8_t> seen_;
+  std::vector<std::string> dead_ids_;
+  std::vector<std::string> patch_dead_;
+
+  // Configured reserve capacity (0 = lazy growth from empty).
+  size_t capacity_{0};
+  // Whether any store/index reallocated since the last stats refresh.
+  bool grew_{false};
+  // Reserved for incremental reconcile overflow accounting (Task 5).
+  size_t overflow_count_{0};
 
   // Internal helpers (called under lock)
   void rebuild_all_indexes();
@@ -519,18 +553,18 @@ class ThreadSafeEntityCache {
   void rebuild_relationship_indexes();
   void rebuild_operation_index();
 
-  // Aggregation helpers (called under shared lock)
-  void collect_operations_from_apps(const std::vector<size_t> & app_indexes,
+  // Aggregation helpers (called under shared lock); slot ids guarded with is_live.
+  void collect_operations_from_apps(const std::vector<uint32_t> & app_slots,
                                     std::unordered_set<std::string> & seen_paths, AggregatedOperations & result) const;
-  void collect_operations_from_component(size_t comp_index, std::unordered_set<std::string> & seen_paths,
+  void collect_operations_from_component(uint32_t comp_slot, std::unordered_set<std::string> & seen_paths,
                                          AggregatedOperations & result) const;
 
-  // Data aggregation helpers (called under shared lock)
-  void collect_topics_from_app(size_t app_index, std::unordered_set<std::string> & seen_topics,
+  // Data aggregation helpers (called under shared lock); slot ids guarded with is_live.
+  void collect_topics_from_app(uint32_t app_slot, std::unordered_set<std::string> & seen_topics,
                                AggregatedData & result) const;
-  void collect_topics_from_apps(const std::vector<size_t> & app_indexes, std::unordered_set<std::string> & seen_topics,
+  void collect_topics_from_apps(const std::vector<uint32_t> & app_slots, std::unordered_set<std::string> & seen_topics,
                                 AggregatedData & result) const;
-  void collect_topics_from_component(size_t comp_index, std::unordered_set<std::string> & seen_topics,
+  void collect_topics_from_component(uint32_t comp_slot, std::unordered_set<std::string> & seen_topics,
                                      AggregatedData & result) const;
 };
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
@@ -78,10 +78,16 @@ class FlatHashMap {
   // -------------------------------------------------------------------------
 
   /// Ensure the table can hold at least `capacity` entries at max_load.
+  ///
+  /// reserve() establishes the baseline capacity and is NOT a structural growth:
+  /// the post-reserve grew_ flag is cleared so grew() reports only reallocations
+  /// that occur because the live set later outgrew the reserved capacity. This
+  /// matches SlotStore, whose reserve() likewise never sets grew().
   void reserve(size_t capacity) {
     size_t needed = next_pow2(static_cast<size_t>(static_cast<double>(capacity) / kMaxLoad + 1.0));
     if (needed > table_.size()) {
       rehash(needed);
+      grew_ = false;  // baseline allocation, not a growth
     }
   }
 
@@ -348,22 +354,37 @@ class FlatHashMap {
     return p;
   }
 
-  /// Grow to at least double current capacity if (occupied+deleted) load is too high.
-  /// O(1): uses the tracked `used_` counter rather than scanning the table.
+  /// Keep the table below max load. When (occupied+deleted) load is too high we
+  /// distinguish two causes, which matters for steady-state add/remove churn:
+  ///   - If the LIVE entries (size_) still fit at the current capacity, the load
+  ///     is driven by accumulated tombstones - rehash to the SAME capacity to
+  ///     vacuum them. This does not grow the table, so grew() stays false and
+  ///     churn over a bounded set never reallocates.
+  ///   - Otherwise the live set genuinely outgrew the table - double capacity.
+  /// O(1): uses the tracked size_/used_ counters rather than scanning the table.
   void ensure_capacity() {
     if (table_.empty()) {
       rehash(4);
       return;
     }
-    if (static_cast<double>(used_ + 1) > kMaxLoad * static_cast<double>(table_.size())) {
-      rehash(table_.size() * 2);
+    const double cap = static_cast<double>(table_.size());
+    if (static_cast<double>(used_ + 1) <= kMaxLoad * cap) {
+      return;  // within load - nothing to do
+    }
+    if (static_cast<double>(size_ + 1) <= kMaxLoad * cap) {
+      rehash(table_.size());  // tombstone-driven: vacuum in place, no growth
+    } else {
+      rehash(table_.size() * 2);  // live set outgrew capacity: grow
     }
   }
 
   /// Rehash into a new table of the given size (must be power-of-two).
-  /// Vacuums tombstones (used_ resets to size_ after rehash). Sets grew_ = true.
+  /// Vacuums tombstones (used_ resets to size_ after rehash). Sets grew_ only
+  /// when the new capacity exceeds the old one - a same-size vacuum preserves
+  /// capacity and must not be reported as a structural growth.
   void rehash(size_t new_cap) {
     new_cap = next_pow2(new_cap);
+    const bool grew_capacity = new_cap > table_.size();
     std::vector<Entry> new_table(new_cap);
     for (Entry & old_e : table_) {
       if (old_e.state != kOccupied) {
@@ -380,7 +401,9 @@ class FlatHashMap {
     }
     table_ = std::move(new_table);
     used_ = size_;  // tombstones vacuumed
-    grew_ = true;
+    if (grew_capacity) {
+      grew_ = true;
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
@@ -1,0 +1,395 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+
+// ---------------------------------------------------------------------------
+// flat_reset_value: clears container-valued entries in place (retains capacity)
+// Generic overload is a no-op (scalars, integral types, etc.)
+// ---------------------------------------------------------------------------
+
+template <typename V>
+inline void flat_reset_value(V & /*value*/) noexcept {
+}
+
+template <typename T, typename A>
+inline void flat_reset_value(std::vector<T, A> & value) noexcept {
+  value.clear();
+}
+
+inline void flat_reset_value(std::string & value) noexcept {
+  value.clear();
+}
+
+// ---------------------------------------------------------------------------
+// FlatHashMap<K,V,Hash>
+//
+// Open-addressed hash table with linear probing, tombstone deletion, and
+// ZERO structural allocation in steady state after reserve().
+//
+// Invariants:
+//   - Table size is always a power of two.
+//   - max_load = 0.70: (occupied + deleted) / capacity triggers a grow.
+//   - On grow, a brand-new table is allocated, all OCCUPIED entries rehashed,
+//     tombstones are vacuumed, and grew_ is set to true.
+//   - reset() retains the backing array (no deallocation) and calls
+//     flat_reset_value() on each entry's value so container-valued maps
+//     retain their heap buffers across refills.
+//   - used_ tracks (occupied + deleted) in O(1) so ensure_capacity() never
+//     scans the table.
+// ---------------------------------------------------------------------------
+
+template <typename K, typename V, typename Hash = std::hash<K>>
+class FlatHashMap {
+ public:
+  FlatHashMap() = default;
+
+  explicit FlatHashMap(size_t capacity) {
+    reserve(capacity);
+  }
+
+  ~FlatHashMap() = default;
+  FlatHashMap(const FlatHashMap &) = default;
+  FlatHashMap & operator=(const FlatHashMap &) = default;
+  FlatHashMap(FlatHashMap &&) noexcept = default;
+  FlatHashMap & operator=(FlatHashMap &&) noexcept = default;
+
+  // -------------------------------------------------------------------------
+  // Capacity management
+  // -------------------------------------------------------------------------
+
+  /// Ensure the table can hold at least `capacity` entries at max_load.
+  void reserve(size_t capacity) {
+    size_t needed = next_pow2(static_cast<size_t>(static_cast<double>(capacity) / kMaxLoad + 1.0));
+    if (needed > table_.size()) {
+      rehash(needed);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Lookup
+  // -------------------------------------------------------------------------
+
+  V * find(const K & key) {
+    return const_cast<V *>(const_cast<const FlatHashMap *>(this)->find(key));
+  }
+
+  const V * find(const K & key) const {
+    if (table_.empty()) {
+      return nullptr;
+    }
+    const uint64_t h = hash_of(key);
+    size_t idx = slot(h);
+    const size_t cap = table_.size();
+    for (size_t probe = 0; probe < cap; ++probe) {
+      const Entry & e = table_[idx];
+      if (e.state == kEmpty) {
+        return nullptr;
+      }
+      if (e.state == kOccupied && e.hash == h && e.key == key) {
+        return &e.value;
+      }
+      idx = (idx + 1) & (cap - 1);
+    }
+    return nullptr;
+  }
+
+  bool contains(const K & key) const {
+    return find(key) != nullptr;
+  }
+
+  // -------------------------------------------------------------------------
+  // Insertion / assignment
+  // -------------------------------------------------------------------------
+
+  /// Insert key with default V if absent; return reference to value.
+  /// If key already exists (OCCUPIED), return its existing value.
+  /// On insertion reuses any available DELETED slot (or an EMPTY slot).
+  V & get_or_create(const K & key) {
+    ensure_capacity();
+    const uint64_t h = hash_of(key);
+    size_t idx = slot(h);
+    const size_t cap = table_.size();
+    size_t first_tombstone = cap;  // sentinel: no tombstone seen yet
+
+    for (size_t probe = 0; probe < cap; ++probe) {
+      Entry & e = table_[idx];
+      if (e.state == kOccupied) {
+        if (e.hash == h && e.key == key) {
+          return e.value;
+        }
+      } else if (e.state == kDeleted) {
+        if (first_tombstone == cap) {
+          first_tombstone = idx;
+        }
+      } else {
+        // kEmpty - key is absent; use tombstone if we saw one, else this slot
+        size_t insert_at = (first_tombstone != cap) ? first_tombstone : idx;
+        Entry & slot_ref = table_[insert_at];
+        // Tombstone reuse: used_ already counted this slot; only bump if EMPTY
+        if (slot_ref.state == kEmpty) {
+          ++used_;
+        }
+        slot_ref.state = kOccupied;
+        slot_ref.hash = h;
+        slot_ref.key = key;
+        flat_reset_value(slot_ref.value);
+        ++size_;
+        return slot_ref.value;
+      }
+      idx = (idx + 1) & (cap - 1);
+    }
+
+    // All slots DELETED, no EMPTY found - reuse tombstone (used_ already counted)
+    if (first_tombstone != cap) {
+      Entry & slot_ref = table_[first_tombstone];
+      slot_ref.state = kOccupied;
+      slot_ref.hash = h;
+      slot_ref.key = key;
+      flat_reset_value(slot_ref.value);
+      ++size_;
+      return slot_ref.value;
+    }
+
+    // Should be unreachable due to load factor guard.
+    rehash(table_.size() * 2);
+    return get_or_create(key);
+  }
+
+  /// Assign value to key. Returns true if a NEW key was inserted (false if
+  /// key already existed and was updated).
+  bool insert_or_assign(const K & key, V value) {
+    ensure_capacity();
+    const uint64_t h = hash_of(key);
+    size_t idx = slot(h);
+    const size_t cap = table_.size();
+    size_t first_tombstone = cap;
+
+    for (size_t probe = 0; probe < cap; ++probe) {
+      Entry & e = table_[idx];
+      if (e.state == kOccupied) {
+        if (e.hash == h && e.key == key) {
+          e.value = std::move(value);
+          return false;  // updated, not new
+        }
+      } else if (e.state == kDeleted) {
+        if (first_tombstone == cap) {
+          first_tombstone = idx;
+        }
+      } else {
+        // kEmpty
+        size_t insert_at = (first_tombstone != cap) ? first_tombstone : idx;
+        Entry & slot_ref = table_[insert_at];
+        // Tombstone reuse: used_ already counted this slot; only bump if EMPTY
+        if (slot_ref.state == kEmpty) {
+          ++used_;
+        }
+        slot_ref.state = kOccupied;
+        slot_ref.hash = h;
+        slot_ref.key = key;
+        slot_ref.value = std::move(value);
+        ++size_;
+        return true;
+      }
+      idx = (idx + 1) & (cap - 1);
+    }
+
+    // All slots DELETED, no EMPTY found - reuse tombstone (used_ already counted)
+    if (first_tombstone != cap) {
+      Entry & slot_ref = table_[first_tombstone];
+      slot_ref.state = kOccupied;
+      slot_ref.hash = h;
+      slot_ref.key = key;
+      slot_ref.value = std::move(value);
+      ++size_;
+      return true;
+    }
+
+    rehash(table_.size() * 2);
+    return insert_or_assign(key, std::move(value));
+  }
+
+  // -------------------------------------------------------------------------
+  // Deletion
+  // -------------------------------------------------------------------------
+
+  /// Erase key. Returns true if the key was present and removed.
+  bool erase(const K & key) {
+    if (table_.empty()) {
+      return false;
+    }
+    const uint64_t h = hash_of(key);
+    size_t idx = slot(h);
+    const size_t cap = table_.size();
+    for (size_t probe = 0; probe < cap; ++probe) {
+      Entry & e = table_[idx];
+      if (e.state == kEmpty) {
+        return false;
+      }
+      if (e.state == kOccupied && e.hash == h && e.key == key) {
+        e.state = kDeleted;
+        --size_;
+        // used_ stays unchanged: DELETED still counts toward load
+        return true;
+      }
+      idx = (idx + 1) & (cap - 1);
+    }
+    return false;
+  }
+
+  // -------------------------------------------------------------------------
+  // Reset (logical clear, retain allocation)
+  // -------------------------------------------------------------------------
+
+  /// Clear all entries in place. Backing array is NOT shrunk.
+  /// For container-valued entries, calls flat_reset_value() to retain capacity.
+  void reset() {
+    for (Entry & e : table_) {
+      if (e.state == kOccupied) {
+        flat_reset_value(e.value);
+      }
+      e.state = kEmpty;
+    }
+    size_ = 0;
+    used_ = 0;
+    // Note: grew_ is NOT cleared by reset - only clear_grew() does that.
+    // Note: grew_ is NOT set by reset - only actual reallocation sets it.
+  }
+
+  // -------------------------------------------------------------------------
+  // Observers
+  // -------------------------------------------------------------------------
+
+  size_t size() const noexcept {
+    return size_;
+  }
+
+  bool grew() const noexcept {
+    return grew_;
+  }
+
+  void clear_grew() noexcept {
+    grew_ = false;
+  }
+
+  // -------------------------------------------------------------------------
+  // Iteration
+  // -------------------------------------------------------------------------
+
+  template <typename Fn>
+  void for_each(Fn && fn) const {
+    for (const Entry & e : table_) {
+      if (e.state == kOccupied) {
+        fn(e.key, e.value);
+      }
+    }
+  }
+
+ private:
+  // -------------------------------------------------------------------------
+  // Entry state constants
+  // -------------------------------------------------------------------------
+  static constexpr uint8_t kEmpty = 0;
+  static constexpr uint8_t kOccupied = 1;
+  static constexpr uint8_t kDeleted = 2;
+
+  // Maximum load factor: (occupied + deleted) / capacity
+  static constexpr double kMaxLoad = 0.7;
+
+  // -------------------------------------------------------------------------
+  // Entry structure
+  // -------------------------------------------------------------------------
+  struct Entry {
+    uint64_t hash{0};
+    K key{};
+    V value{};
+    uint8_t state{kEmpty};
+  };
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  uint64_t hash_of(const K & key) const {
+    return static_cast<uint64_t>(Hash{}(key));
+  }
+
+  size_t slot(uint64_t h) const {
+    return static_cast<size_t>(h) & (table_.size() - 1);
+  }
+
+  static size_t next_pow2(size_t n) {
+    if (n == 0) {
+      return 1;
+    }
+    size_t p = 1;
+    while (p < n) {
+      p <<= 1;
+    }
+    return p;
+  }
+
+  /// Grow to at least double current capacity if (occupied+deleted) load is too high.
+  /// O(1): uses the tracked `used_` counter rather than scanning the table.
+  void ensure_capacity() {
+    if (table_.empty()) {
+      rehash(4);
+      return;
+    }
+    if (static_cast<double>(used_ + 1) > kMaxLoad * static_cast<double>(table_.size())) {
+      rehash(table_.size() * 2);
+    }
+  }
+
+  /// Rehash into a new table of the given size (must be power-of-two).
+  /// Vacuums tombstones (used_ resets to size_ after rehash). Sets grew_ = true.
+  void rehash(size_t new_cap) {
+    new_cap = next_pow2(new_cap);
+    std::vector<Entry> new_table(new_cap);
+    for (Entry & old_e : table_) {
+      if (old_e.state != kOccupied) {
+        continue;
+      }
+      size_t idx = static_cast<size_t>(old_e.hash) & (new_cap - 1);
+      while (new_table[idx].state == kOccupied) {
+        idx = (idx + 1) & (new_cap - 1);
+      }
+      new_table[idx].hash = old_e.hash;
+      new_table[idx].key = std::move(old_e.key);
+      new_table[idx].value = std::move(old_e.value);
+      new_table[idx].state = kOccupied;
+    }
+    table_ = std::move(new_table);
+    used_ = size_;  // tombstones vacuumed
+    grew_ = true;
+  }
+
+  // -------------------------------------------------------------------------
+  // Data members
+  // -------------------------------------------------------------------------
+  std::vector<Entry> table_;
+  size_t size_{0};  // number of OCCUPIED entries
+  size_t used_{0};  // number of OCCUPIED + DELETED entries (load denominator)
+  bool grew_{false};
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/flat_hash_map.hpp
@@ -347,6 +347,12 @@ class FlatHashMap {
     if (n == 0) {
       return 1;
     }
+    // Highest representable power of two. Beyond it `p <<= 1` wraps to 0 and the
+    // loop would spin forever, so saturate instead of overflowing.
+    constexpr size_t kMaxPow2 = size_t{1} << (sizeof(size_t) * 8 - 1);
+    if (n >= kMaxPow2) {
+      return kMaxPow2;
+    }
     size_t p = 1;
     while (p < n) {
       p <<= 1;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
@@ -65,18 +65,27 @@ class SlotStore {
     return static_cast<uint32_t>(items_.size() - 1u);
   }
 
-  /// Copy value into the slot and mark it live.
+  /// Copy value into the slot and mark it live. Assigning over an already-live
+  /// slot updates the payload in place and does NOT change live_count_; only a
+  /// dead -> live transition bumps the count. This makes assign() safe for the
+  /// incremental-reconcile update path that overwrites existing live slots.
   void assign(uint32_t slot, const T & value) {
     items_[static_cast<size_t>(slot)] = value;
-    live_[static_cast<size_t>(slot)] = 1u;
-    ++live_count_;
+    if (live_[static_cast<size_t>(slot)] == 0u) {
+      live_[static_cast<size_t>(slot)] = 1u;
+      ++live_count_;
+    }
   }
 
-  /// Move value into the slot and mark it live.
+  /// Move value into the slot and mark it live. Assigning over an already-live
+  /// slot updates the payload in place and does NOT change live_count_; only a
+  /// dead -> live transition bumps the count.
   void assign(uint32_t slot, T && value) {
     items_[static_cast<size_t>(slot)] = std::move(value);
-    live_[static_cast<size_t>(slot)] = 1u;
-    ++live_count_;
+    if (live_[static_cast<size_t>(slot)] == 0u) {
+      live_[static_cast<size_t>(slot)] = 1u;
+      ++live_count_;
+    }
   }
 
   /// Release the slot: reset payload to T{}, mark dead, push to free-list.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -48,48 +49,52 @@ class SlotStore {
     free_list_.reserve(cap);
   }
 
-  /// Allocate a slot index: pop from free-list if available, else append.
-  /// Appending past items_.capacity() causes a vector grow and sets grew_.
+  /// Allocate a slot index and mark it live: pop from free-list if available,
+  /// else append. Returning the slot both removes it from the free-list and
+  /// flips it live (bumping live_count_), so the slot can never be simultaneously
+  /// live and free-listed; assign() then only fills its payload. Appending past
+  /// items_.capacity() causes a vector grow and sets grew_.
   uint32_t alloc_slot() {
     if (!free_list_.empty()) {
       uint32_t slot = free_list_.back();
       free_list_.pop_back();
+      live_[static_cast<size_t>(slot)] = 1u;
+      ++live_count_;
       return slot;
     }
     size_t before = items_.capacity();
     items_.emplace_back();
-    live_.push_back(0u);
+    live_.push_back(1u);
+    ++live_count_;
     if (items_.capacity() != before) {
       grew_ = true;
     }
     return static_cast<uint32_t>(items_.size() - 1u);
   }
 
-  /// Copy value into the slot and mark it live. Assigning over an already-live
-  /// slot updates the payload in place and does NOT change live_count_; only a
-  /// dead -> live transition bumps the count. This makes assign() safe for the
-  /// incremental-reconcile update path that overwrites existing live slots.
+  /// Copy value into a live slot's payload. The slot MUST be live (obtained from
+  /// alloc_slot() for a new entity, or an existing live slot for an update);
+  /// live_count_ is owned entirely by alloc_slot()/free(). Assigning to a dead
+  /// slot is a caller error - it could revive a free-listed slot and alias it.
   void assign(uint32_t slot, const T & value) {
+    assert(live_[static_cast<size_t>(slot)] != 0u);
     items_[static_cast<size_t>(slot)] = value;
-    if (live_[static_cast<size_t>(slot)] == 0u) {
-      live_[static_cast<size_t>(slot)] = 1u;
-      ++live_count_;
-    }
   }
 
-  /// Move value into the slot and mark it live. Assigning over an already-live
-  /// slot updates the payload in place and does NOT change live_count_; only a
-  /// dead -> live transition bumps the count.
+  /// Move value into a live slot's payload. See the copy overload for the
+  /// liveness contract.
   void assign(uint32_t slot, T && value) {
+    assert(live_[static_cast<size_t>(slot)] != 0u);
     items_[static_cast<size_t>(slot)] = std::move(value);
-    if (live_[static_cast<size_t>(slot)] == 0u) {
-      live_[static_cast<size_t>(slot)] = 1u;
-      ++live_count_;
-    }
   }
 
   /// Release the slot: reset payload to T{}, mark dead, push to free-list.
+  /// Idempotent - freeing an already-dead slot is a no-op, so a double free
+  /// cannot underflow live_count_ or push the slot onto the free-list twice.
   void free(uint32_t slot) {
+    if (live_[static_cast<size_t>(slot)] == 0u) {
+      return;
+    }
     items_[static_cast<size_t>(slot)] = T{};
     live_[static_cast<size_t>(slot)] = 0u;
     --live_count_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/slot_store.hpp
@@ -1,0 +1,152 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+
+/// Fixed-capacity object pool with stable slot indices.
+///
+/// Slots are never shifted; removal tombstones a slot onto a free-list so the
+/// next alloc_slot() reuses it without growing the underlying vectors.
+/// This keeps capacity() bounded under add/remove churn - the embedded crux:
+/// structural arrays are reserved at init, no realloc in steady state.
+template <typename T>
+class SlotStore {
+ public:
+  SlotStore() = default;
+
+  explicit SlotStore(size_t cap) {
+    reserve(cap);
+  }
+
+  ~SlotStore() = default;
+  SlotStore(const SlotStore &) = default;
+  SlotStore & operator=(const SlotStore &) = default;
+  SlotStore(SlotStore &&) = default;
+  SlotStore & operator=(SlotStore &&) = default;
+
+  /// Reserve storage for `cap` slots without marking any live.
+  void reserve(size_t cap) {
+    items_.reserve(cap);
+    live_.reserve(cap);
+    free_list_.reserve(cap);
+  }
+
+  /// Allocate a slot index: pop from free-list if available, else append.
+  /// Appending past items_.capacity() causes a vector grow and sets grew_.
+  uint32_t alloc_slot() {
+    if (!free_list_.empty()) {
+      uint32_t slot = free_list_.back();
+      free_list_.pop_back();
+      return slot;
+    }
+    size_t before = items_.capacity();
+    items_.emplace_back();
+    live_.push_back(0u);
+    if (items_.capacity() != before) {
+      grew_ = true;
+    }
+    return static_cast<uint32_t>(items_.size() - 1u);
+  }
+
+  /// Copy value into the slot and mark it live.
+  void assign(uint32_t slot, const T & value) {
+    items_[static_cast<size_t>(slot)] = value;
+    live_[static_cast<size_t>(slot)] = 1u;
+    ++live_count_;
+  }
+
+  /// Move value into the slot and mark it live.
+  void assign(uint32_t slot, T && value) {
+    items_[static_cast<size_t>(slot)] = std::move(value);
+    live_[static_cast<size_t>(slot)] = 1u;
+    ++live_count_;
+  }
+
+  /// Release the slot: reset payload to T{}, mark dead, push to free-list.
+  void free(uint32_t slot) {
+    items_[static_cast<size_t>(slot)] = T{};
+    live_[static_cast<size_t>(slot)] = 0u;
+    --live_count_;
+    free_list_.push_back(slot);
+  }
+
+  bool is_live(uint32_t slot) const noexcept {
+    return live_[static_cast<size_t>(slot)] != 0u;
+  }
+
+  T & operator[](size_t slot) noexcept {
+    return items_[slot];
+  }
+  const T & operator[](size_t slot) const noexcept {
+    return items_[slot];
+  }
+
+  /// Number of slots allocated (including dead). Use for index bounds checks.
+  size_t slot_count() const noexcept {
+    return items_.size();
+  }
+
+  size_t live_count() const noexcept {
+    return live_count_;
+  }
+
+  /// Current storage capacity (= items_.capacity()).
+  size_t capacity() const noexcept {
+    return items_.capacity();
+  }
+
+  bool grew() const noexcept {
+    return grew_;
+  }
+  void clear_grew() noexcept {
+    grew_ = false;
+  }
+
+  /// Call fn(uint32_t slot, const T&) for every live slot.
+  template <typename Fn>
+  void for_each_live(Fn && fn) const {
+    for (size_t i = 0; i < items_.size(); ++i) {
+      if (live_[i] != 0u) {
+        fn(static_cast<uint32_t>(i), items_[i]);
+      }
+    }
+  }
+
+  /// Compact copy of all live values (order: increasing slot index).
+  std::vector<T> collect_live() const {
+    std::vector<T> result;
+    result.reserve(live_count_);
+    for (size_t i = 0; i < items_.size(); ++i) {
+      if (live_[i] != 0u) {
+        result.push_back(items_[i]);
+      }
+    }
+    return result;
+  }
+
+ private:
+  std::vector<T> items_;
+  std::vector<uint8_t> live_;  // NOT vector<bool>
+  std::vector<uint32_t> free_list_;
+  size_t live_count_{0};
+  bool grew_{false};
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
@@ -132,6 +132,7 @@ struct Health {
   std::optional<HealthDiscovery> discovery;
   std::optional<nlohmann::json> x_medkit_data_provider;          // wire key: "x-medkit-data-provider"
   std::optional<nlohmann::json> x_medkit_subscription_executor;  // wire key: "x-medkit-subscription-executor"
+  std::optional<nlohmann::json> x_medkit_entity_cache;           // wire key: "x-medkit-entity-cache"
   std::optional<nlohmann::json> peers;                           // free-form array of peer status objects
   std::optional<int64_t> warning_schema_version;
   std::optional<std::vector<HealthAggregationWarning>> warnings;
@@ -141,7 +142,8 @@ template <>
 inline constexpr auto dto_fields<Health> = std::make_tuple(
     field("status", &Health::status), field("timestamp", &Health::timestamp), field("discovery", &Health::discovery),
     field("x-medkit-data-provider", &Health::x_medkit_data_provider),
-    field("x-medkit-subscription-executor", &Health::x_medkit_subscription_executor), field("peers", &Health::peers),
+    field("x-medkit-subscription-executor", &Health::x_medkit_subscription_executor),
+    field("x-medkit-entity-cache", &Health::x_medkit_entity_cache), field("peers", &Health::peers),
     field("warning_schema_version", &Health::warning_schema_version), field("warnings", &Health::warnings));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
@@ -378,9 +380,12 @@ class GatewayNode : public rclcpp::Node {
   // at most once per `refresh_debounce_ms_`. `graph_dirty_` marks a pending
   // (consumed-but-not-yet-serviced) graph change; `last_graph_refresh_` is the
   // last graph-driven refresh time. Set via `discovery.refresh_debounce_ms`.
+  // `graph_dirty_`/`last_graph_refresh_` are atomic: under a MultiThreadedExecutor
+  // successive ticks of the graph-check timer can run on different worker threads,
+  // so this cross-tick state is accessed from more than one thread.
   int refresh_debounce_ms_{1000};
-  bool graph_dirty_{false};
-  std::chrono::steady_clock::time_point last_graph_refresh_{};
+  std::atomic<bool> graph_dirty_{false};
+  std::atomic<std::chrono::steady_clock::time_point> last_graph_refresh_{};
 
   // Serializes `refresh_cache()` across the refresh timer, plugin
   // `notify_entities_changed` calls and any other caller. Required because

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -373,6 +373,15 @@ class GatewayNode : public rclcpp::Node {
   rclcpp::TimerBase::SharedPtr graph_check_timer_;
   rclcpp::TimerBase::SharedPtr backstop_timer_;
 
+  // Debounce graph-event-driven refreshes (issue #442). The graph event fires
+  // many times per second under graph churn; coalesce so refresh_cache() runs
+  // at most once per `refresh_debounce_ms_`. `graph_dirty_` marks a pending
+  // (consumed-but-not-yet-serviced) graph change; `last_graph_refresh_` is the
+  // last graph-driven refresh time. Set via `discovery.refresh_debounce_ms`.
+  int refresh_debounce_ms_{1000};
+  bool graph_dirty_{false};
+  std::chrono::steady_clock::time_point last_graph_refresh_{};
+
   // Serializes `refresh_cache()` across the refresh timer, plugin
   // `notify_entities_changed` calls and any other caller. Required because
   // the refresh pipeline touches discovery state that is not itself

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -351,6 +351,9 @@ class GatewayNode : public rclcpp::Node {
 
   // Cache with thread safety
   ThreadSafeEntityCache thread_safe_cache_;
+  // One-shot WARN when entity_cache capacity is exceeded (grew on first refresh after reserve).
+  // Cleared only at construction time; never reset so the WARN fires at most once per run.
+  bool warned_cache_grow_{false};
 
   // Graph-change-driven discovery refresh.
   //

--- a/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
+++ b/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
@@ -21,26 +21,127 @@
 
 namespace ros2_medkit_gateway {
 
-namespace {
+// ============================================================================
+// Incremental reconcile primitives (in-place; reuse the existing stores)
+// ============================================================================
 
-/// Replace the entire contents of a store with `incoming`, assigning slots in
-/// input order (slot i holds incoming[i]). This is a FULL rebuild: a fresh
-/// store is built so no stale free-list entries reorder the slots, preserving
-/// the insertion-order semantics the previous std::vector storage guaranteed
-/// across repeated update_*/update_all calls. The new store keeps at least the
-/// old reserved capacity so steady-state churn still avoids reallocation.
 template <typename T>
-void replace_store(SlotStore<T> & store, std::vector<T> incoming) {
-  size_t reserve_to = std::max(store.capacity(), incoming.size());
-  SlotStore<T> fresh(reserve_to);
-  for (auto & item : incoming) {
-    uint32_t slot = fresh.alloc_slot();
-    fresh.assign(slot, std::move(item));
+bool ThreadSafeEntityCache::reconcile(SlotStore<T> & store, FlatHashMap<std::string, uint32_t> & index,
+                                      std::vector<T> && incoming) {
+  bool changed = false;
+
+  // Mark every currently-allocated slot as not-yet-seen. seen_ is sized to the
+  // slot count; it only resize()s on the grow path below (steady state reuses
+  // the reserved buffer). slot_count() includes dead slots, which is fine: dead
+  // slots stay unseen and are skipped by the live-collect below.
+  const size_t slot_count = store.slot_count();
+  if (seen_.size() < slot_count) {
+    seen_.assign(slot_count, 0u);
+  } else {
+    std::fill(seen_.begin(), seen_.begin() + static_cast<std::ptrdiff_t>(slot_count), 0u);
   }
-  store = std::move(fresh);
+
+  for (auto & e : incoming) {
+    if (uint32_t * slot = index.find(e.id)) {
+      const uint32_t s = *slot;
+      seen_[s] = 1u;
+      // Compare against current payload; only assign (and flag) on a real diff.
+      if (!(store[s] == e)) {
+        store.assign(s, std::move(e));
+        changed = true;
+      }
+    } else {
+      const uint32_t s = store.alloc_slot();
+      // alloc_slot() may have appended a brand-new slot past seen_'s size.
+      if (s >= seen_.size()) {
+        seen_.resize(store.slot_count(), 0u);
+      }
+      seen_[s] = 1u;
+      store.assign(s, std::move(e));
+      // Read the id from the freshly-assigned slot, never from the moved-out e.
+      index.insert_or_assign(store[s].id, s);
+      changed = true;
+    }
+  }
+
+  // Collect ids of live slots that were not re-seen; free them after iterating
+  // so we never mutate the store while for_each_live walks it.
+  dead_ids_.clear();
+  store.for_each_live([&](uint32_t slot, const T & cur) {
+    if (!seen_[slot]) {
+      dead_ids_.push_back(cur.id);
+    }
+  });
+  for (const auto & id : dead_ids_) {
+    if (uint32_t * slot = index.find(id)) {
+      const uint32_t s = *slot;
+      index.erase(id);
+      store.free(s);
+      changed = true;
+    }
+  }
+  dead_ids_.clear();
+
+  return changed;
 }
 
-}  // namespace
+bool ThreadSafeEntityCache::patch_map(FlatHashMap<std::string, std::string> & map,
+                                      std::unordered_map<std::string, std::string> && incoming) {
+  bool changed = false;
+
+  patch_dead_.clear();
+  map.for_each([&](const std::string & k, const std::string &) {
+    if (incoming.count(k) == 0) {
+      patch_dead_.push_back(k);
+    }
+  });
+  for (const auto & k : patch_dead_) {
+    map.erase(k);
+    changed = true;
+  }
+  patch_dead_.clear();
+
+  for (auto & kv : incoming) {
+    std::string * cur = map.find(kv.first);
+    if (!cur) {
+      map.insert_or_assign(kv.first, std::move(kv.second));
+      changed = true;
+    } else if (*cur != kv.second) {
+      *cur = std::move(kv.second);
+      changed = true;
+    }
+  }
+
+  return changed;
+}
+
+void ThreadSafeEntityCache::refresh_grew() {
+  const bool any_grew = areas_.grew() || components_.grew() || apps_.grew() || functions_.grew() ||
+                        area_index_.grew() || component_index_.grew() || app_index_.grew() || function_index_.grew() ||
+                        component_to_apps_.grew() || area_to_components_.grew() || area_to_subareas_.grew() ||
+                        function_to_apps_.grew() || operation_index_.grew() || topic_type_cache_.grew() ||
+                        node_to_app_.grew();
+  if (any_grew) {
+    grew_ = true;
+    ++overflow_count_;
+  }
+
+  areas_.clear_grew();
+  components_.clear_grew();
+  apps_.clear_grew();
+  functions_.clear_grew();
+  area_index_.clear_grew();
+  component_index_.clear_grew();
+  app_index_.clear_grew();
+  function_index_.clear_grew();
+  component_to_apps_.clear_grew();
+  area_to_components_.clear_grew();
+  area_to_subareas_.clear_grew();
+  function_to_apps_.clear_grew();
+  operation_index_.clear_grew();
+  topic_type_cache_.clear_grew();
+  node_to_app_.clear_grew();
+}
 
 // ============================================================================
 // Construction / capacity
@@ -88,67 +189,83 @@ void ThreadSafeEntityCache::update_all(std::vector<Area> areas, std::vector<Comp
                                        std::unordered_map<std::string, std::string> node_to_app) {
   std::unique_lock lock(mutex_);
 
-  replace_store(areas_, std::move(areas));
-  replace_store(components_, std::move(components));
-  replace_store(apps_, std::move(apps));
-  replace_store(functions_, std::move(functions));
+  bool changed = false;
+  changed |= reconcile(areas_, area_index_, std::move(areas));
+  changed |= reconcile(components_, component_index_, std::move(components));
+  changed |= reconcile(apps_, app_index_, std::move(apps));
+  changed |= reconcile(functions_, function_index_, std::move(functions));
+  changed |= patch_map(node_to_app_, std::move(node_to_app));
 
-  node_to_app_.reset();
-  for (auto & [fqn, app_id] : node_to_app) {
-    node_to_app_.insert_or_assign(fqn, std::move(app_id));
+  if (!changed) {
+    refresh_grew();
+    return;
   }
 
+  rebuild_relationship_indexes();
+  rebuild_operation_index();
   last_update_ = std::chrono::system_clock::now();
-
-  rebuild_all_indexes();
+  refresh_grew();
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 void ThreadSafeEntityCache::update_areas(std::vector<Area> areas) {
   std::unique_lock lock(mutex_);
-  replace_store(areas_, std::move(areas));
-  last_update_ = std::chrono::system_clock::now();
-  rebuild_area_index();
+  if (!reconcile(areas_, area_index_, std::move(areas))) {
+    refresh_grew();
+    return;
+  }
   rebuild_relationship_indexes();
+  last_update_ = std::chrono::system_clock::now();
+  refresh_grew();
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 void ThreadSafeEntityCache::update_components(std::vector<Component> components) {
   std::unique_lock lock(mutex_);
-  replace_store(components_, std::move(components));
-  last_update_ = std::chrono::system_clock::now();
-  rebuild_component_index();
+  if (!reconcile(components_, component_index_, std::move(components))) {
+    refresh_grew();
+    return;
+  }
   rebuild_relationship_indexes();
   rebuild_operation_index();
+  last_update_ = std::chrono::system_clock::now();
+  refresh_grew();
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 void ThreadSafeEntityCache::update_apps(std::vector<App> apps) {
   std::unique_lock lock(mutex_);
-  replace_store(apps_, std::move(apps));
-  last_update_ = std::chrono::system_clock::now();
-  rebuild_app_index();
+  if (!reconcile(apps_, app_index_, std::move(apps))) {
+    refresh_grew();
+    return;
+  }
   rebuild_relationship_indexes();
   rebuild_operation_index();
+  last_update_ = std::chrono::system_clock::now();
+  refresh_grew();
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 void ThreadSafeEntityCache::update_functions(std::vector<Function> functions) {
   std::unique_lock lock(mutex_);
-  replace_store(functions_, std::move(functions));
-  last_update_ = std::chrono::system_clock::now();
-  rebuild_function_index();
+  if (!reconcile(functions_, function_index_, std::move(functions))) {
+    refresh_grew();
+    return;
+  }
   rebuild_relationship_indexes();
+  last_update_ = std::chrono::system_clock::now();
+  refresh_grew();
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 void ThreadSafeEntityCache::update_topic_types(std::unordered_map<std::string, std::string> topic_types) {
   std::unique_lock lock(mutex_);
-  topic_type_cache_.reset();
-  for (auto & [name, type] : topic_types) {
-    topic_type_cache_.insert_or_assign(name, std::move(type));
+  if (patch_map(topic_type_cache_, std::move(topic_types))) {
+    refresh_grew();
+    generation_.fetch_add(1, std::memory_order_release);
+  } else {
+    refresh_grew();
   }
-  generation_.fetch_add(1, std::memory_order_release);
 }
 
 std::unordered_map<std::string, std::string> ThreadSafeEntityCache::get_node_to_app() const {
@@ -736,13 +853,10 @@ EntityCacheStats ThreadSafeEntityCache::get_stats() const {
   stats.function_count = functions_.live_count();
   stats.total_operations = operation_index_.size();
   stats.capacity = capacity_;
-  // No read-and-clear refresh exists yet (introduced in Task 5), so derive
-  // `grew` from the live container flags. `grew_` is reserved for that future
-  // cached path and currently stays false.
-  stats.grew = grew_ || areas_.grew() || components_.grew() || apps_.grew() || functions_.grew() ||
-               area_index_.grew() || component_index_.grew() || app_index_.grew() || function_index_.grew() ||
-               component_to_apps_.grew() || area_to_components_.grew() || area_to_subareas_.grew() ||
-               function_to_apps_.grew() || operation_index_.grew() || topic_type_cache_.grew() || node_to_app_.grew();
+  // refresh_grew() folds each container's transient grew() flag into grew_ and
+  // clears the containers, so the cached member is the source of truth here.
+  // Re-querying the containers would always read false post-refresh.
+  stats.grew = grew_;
   stats.generation = generation_.load(std::memory_order_acquire);
   stats.overflow_count = overflow_count_;
   stats.last_update = last_update_;
@@ -830,43 +944,10 @@ uint64_t ThreadSafeEntityCache::generation() const {
 // ============================================================================
 // Index rebuild helpers
 // ============================================================================
-
-void ThreadSafeEntityCache::rebuild_all_indexes() {
-  rebuild_area_index();
-  rebuild_component_index();
-  rebuild_app_index();
-  rebuild_function_index();
-  rebuild_relationship_indexes();
-  rebuild_operation_index();
-}
-
-void ThreadSafeEntityCache::rebuild_area_index() {
-  area_index_.reset();
-  areas_.for_each_live([&](uint32_t slot, const Area & area) {
-    area_index_.insert_or_assign(area.id, slot);
-  });
-}
-
-void ThreadSafeEntityCache::rebuild_component_index() {
-  component_index_.reset();
-  components_.for_each_live([&](uint32_t slot, const Component & comp) {
-    component_index_.insert_or_assign(comp.id, slot);
-  });
-}
-
-void ThreadSafeEntityCache::rebuild_app_index() {
-  app_index_.reset();
-  apps_.for_each_live([&](uint32_t slot, const App & app) {
-    app_index_.insert_or_assign(app.id, slot);
-  });
-}
-
-void ThreadSafeEntityCache::rebuild_function_index() {
-  function_index_.reset();
-  functions_.for_each_live([&](uint32_t slot, const Function & func) {
-    function_index_.insert_or_assign(func.id, slot);
-  });
-}
+//
+// Primary id->slot indexes are maintained incrementally inside reconcile().
+// Only the derived relationship and operation indexes are rebuilt from scratch
+// after a change, since they are pure functions of the (now-updated) stores.
 
 void ThreadSafeEntityCache::rebuild_relationship_indexes() {
   component_to_apps_.reset();

--- a/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
+++ b/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
@@ -154,6 +154,13 @@ ThreadSafeEntityCache::ThreadSafeEntityCache(size_t capacity) {
 void ThreadSafeEntityCache::reserve(size_t capacity) {
   std::unique_lock lock(mutex_);
 
+  // Capacity only ever grows. A smaller request would shrink seen_ (assign) and
+  // capacity_ while the index containers (reserve never shrinks) would not,
+  // breaking the documented "only grows" invariant; treat it as a no-op.
+  if (capacity <= capacity_) {
+    return;
+  }
+
   areas_.reserve(capacity);
   components_.reserve(capacity);
   apps_.reserve(capacity);

--- a/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
+++ b/src/ros2_medkit_gateway/src/core/models/thread_safe_entity_cache.cpp
@@ -17,8 +17,67 @@
 #include <algorithm>
 #include <mutex>
 #include <sstream>
+#include <utility>
 
 namespace ros2_medkit_gateway {
+
+namespace {
+
+/// Replace the entire contents of a store with `incoming`, assigning slots in
+/// input order (slot i holds incoming[i]). This is a FULL rebuild: a fresh
+/// store is built so no stale free-list entries reorder the slots, preserving
+/// the insertion-order semantics the previous std::vector storage guaranteed
+/// across repeated update_*/update_all calls. The new store keeps at least the
+/// old reserved capacity so steady-state churn still avoids reallocation.
+template <typename T>
+void replace_store(SlotStore<T> & store, std::vector<T> incoming) {
+  size_t reserve_to = std::max(store.capacity(), incoming.size());
+  SlotStore<T> fresh(reserve_to);
+  for (auto & item : incoming) {
+    uint32_t slot = fresh.alloc_slot();
+    fresh.assign(slot, std::move(item));
+  }
+  store = std::move(fresh);
+}
+
+}  // namespace
+
+// ============================================================================
+// Construction / capacity
+// ============================================================================
+
+ThreadSafeEntityCache::ThreadSafeEntityCache(size_t capacity) {
+  reserve(capacity);
+}
+
+void ThreadSafeEntityCache::reserve(size_t capacity) {
+  std::unique_lock lock(mutex_);
+
+  areas_.reserve(capacity);
+  components_.reserve(capacity);
+  apps_.reserve(capacity);
+  functions_.reserve(capacity);
+
+  area_index_.reserve(capacity);
+  component_index_.reserve(capacity);
+  app_index_.reserve(capacity);
+  function_index_.reserve(capacity);
+
+  component_to_apps_.reserve(capacity);
+  area_to_components_.reserve(capacity);
+  area_to_subareas_.reserve(capacity);
+  function_to_apps_.reserve(capacity);
+
+  operation_index_.reserve(capacity);
+  topic_type_cache_.reserve(capacity);
+  node_to_app_.reserve(capacity);
+
+  seen_.assign(capacity, 0u);
+  dead_ids_.reserve(capacity);
+  patch_dead_.reserve(capacity);
+
+  capacity_ = capacity;
+}
 
 // ============================================================================
 // Writer methods (exclusive lock)
@@ -29,11 +88,16 @@ void ThreadSafeEntityCache::update_all(std::vector<Area> areas, std::vector<Comp
                                        std::unordered_map<std::string, std::string> node_to_app) {
   std::unique_lock lock(mutex_);
 
-  areas_ = std::move(areas);
-  components_ = std::move(components);
-  apps_ = std::move(apps);
-  functions_ = std::move(functions);
-  node_to_app_ = std::move(node_to_app);
+  replace_store(areas_, std::move(areas));
+  replace_store(components_, std::move(components));
+  replace_store(apps_, std::move(apps));
+  replace_store(functions_, std::move(functions));
+
+  node_to_app_.reset();
+  for (auto & [fqn, app_id] : node_to_app) {
+    node_to_app_.insert_or_assign(fqn, std::move(app_id));
+  }
+
   last_update_ = std::chrono::system_clock::now();
 
   rebuild_all_indexes();
@@ -42,7 +106,7 @@ void ThreadSafeEntityCache::update_all(std::vector<Area> areas, std::vector<Comp
 
 void ThreadSafeEntityCache::update_areas(std::vector<Area> areas) {
   std::unique_lock lock(mutex_);
-  areas_ = std::move(areas);
+  replace_store(areas_, std::move(areas));
   last_update_ = std::chrono::system_clock::now();
   rebuild_area_index();
   rebuild_relationship_indexes();
@@ -51,7 +115,7 @@ void ThreadSafeEntityCache::update_areas(std::vector<Area> areas) {
 
 void ThreadSafeEntityCache::update_components(std::vector<Component> components) {
   std::unique_lock lock(mutex_);
-  components_ = std::move(components);
+  replace_store(components_, std::move(components));
   last_update_ = std::chrono::system_clock::now();
   rebuild_component_index();
   rebuild_relationship_indexes();
@@ -61,7 +125,7 @@ void ThreadSafeEntityCache::update_components(std::vector<Component> components)
 
 void ThreadSafeEntityCache::update_apps(std::vector<App> apps) {
   std::unique_lock lock(mutex_);
-  apps_ = std::move(apps);
+  replace_store(apps_, std::move(apps));
   last_update_ = std::chrono::system_clock::now();
   rebuild_app_index();
   rebuild_relationship_indexes();
@@ -71,7 +135,7 @@ void ThreadSafeEntityCache::update_apps(std::vector<App> apps) {
 
 void ThreadSafeEntityCache::update_functions(std::vector<Function> functions) {
   std::unique_lock lock(mutex_);
-  functions_ = std::move(functions);
+  replace_store(functions_, std::move(functions));
   last_update_ = std::chrono::system_clock::now();
   rebuild_function_index();
   rebuild_relationship_indexes();
@@ -80,19 +144,27 @@ void ThreadSafeEntityCache::update_functions(std::vector<Function> functions) {
 
 void ThreadSafeEntityCache::update_topic_types(std::unordered_map<std::string, std::string> topic_types) {
   std::unique_lock lock(mutex_);
-  topic_type_cache_ = std::move(topic_types);
+  topic_type_cache_.reset();
+  for (auto & [name, type] : topic_types) {
+    topic_type_cache_.insert_or_assign(name, std::move(type));
+  }
   generation_.fetch_add(1, std::memory_order_release);
 }
 
 std::unordered_map<std::string, std::string> ThreadSafeEntityCache::get_node_to_app() const {
   std::shared_lock lock(mutex_);
-  return node_to_app_;
+  std::unordered_map<std::string, std::string> result;
+  result.reserve(node_to_app_.size());
+  node_to_app_.for_each([&](const std::string & fqn, const std::string & app_id) {
+    result.emplace(fqn, app_id);
+  });
+  return result;
 }
 
 std::string ThreadSafeEntityCache::resolve_node_to_app(const std::string & node_fqn) const {
   std::shared_lock lock(mutex_);
-  auto it = node_to_app_.find(node_fqn);
-  return (it != node_to_app_.end()) ? it->second : "";
+  const std::string * app_id = node_to_app_.find(node_fqn);
+  return app_id ? *app_id : "";
 }
 
 // ============================================================================
@@ -101,31 +173,28 @@ std::string ThreadSafeEntityCache::resolve_node_to_app(const std::string & node_
 
 std::vector<Area> ThreadSafeEntityCache::get_areas() const {
   std::shared_lock lock(mutex_);
-  return areas_;
+  return areas_.collect_live();
 }
 
 std::vector<Component> ThreadSafeEntityCache::get_components() const {
   std::shared_lock lock(mutex_);
-  return components_;
+  return components_.collect_live();
 }
 
 std::vector<App> ThreadSafeEntityCache::get_apps() const {
   std::shared_lock lock(mutex_);
-  return apps_;
+  return apps_.collect_live();
 }
 
 std::vector<Function> ThreadSafeEntityCache::get_functions() const {
   std::shared_lock lock(mutex_);
-  return functions_;
+  return functions_.collect_live();
 }
 
 std::string ThreadSafeEntityCache::get_topic_type(const std::string & topic_name) const {
   std::shared_lock lock(mutex_);
-  auto it = topic_type_cache_.find(topic_name);
-  if (it != topic_type_cache_.end()) {
-    return it->second;
-  }
-  return "";
+  const std::string * type = topic_type_cache_.find(topic_name);
+  return type ? *type : "";
 }
 
 // ============================================================================
@@ -134,27 +203,27 @@ std::string ThreadSafeEntityCache::get_topic_type(const std::string & topic_name
 
 std::optional<Area> ThreadSafeEntityCache::get_area(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  auto it = area_index_.find(id);
-  if (it != area_index_.end() && it->second < areas_.size()) {
-    return areas_[it->second];
+  const uint32_t * slot = area_index_.find(id);
+  if (slot && areas_.is_live(*slot)) {
+    return areas_[*slot];
   }
   return std::nullopt;
 }
 
 std::optional<Component> ThreadSafeEntityCache::get_component(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  auto it = component_index_.find(id);
-  if (it != component_index_.end() && it->second < components_.size()) {
-    return components_[it->second];
+  const uint32_t * slot = component_index_.find(id);
+  if (slot && components_.is_live(*slot)) {
+    return components_[*slot];
   }
   return std::nullopt;
 }
 
 std::optional<App> ThreadSafeEntityCache::get_app(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  auto it = app_index_.find(id);
-  if (it != app_index_.end() && it->second < apps_.size()) {
-    return apps_[it->second];
+  const uint32_t * slot = app_index_.find(id);
+  if (slot && apps_.is_live(*slot)) {
+    return apps_[*slot];
   }
   return std::nullopt;
 }
@@ -163,33 +232,33 @@ ThreadSafeEntityCache::AppLinksSnapshot ThreadSafeEntityCache::get_app_with_link
   AppLinksSnapshot snapshot;
   std::shared_lock lock(mutex_);
 
-  auto app_it = app_index_.find(id);
-  if (app_it == app_index_.end() || app_it->second >= apps_.size()) {
+  const uint32_t * app_slot = app_index_.find(id);
+  if (!app_slot || !apps_.is_live(*app_slot)) {
     return snapshot;
   }
-  snapshot.app = apps_[app_it->second];
+  snapshot.app = apps_[*app_slot];
 
   const auto & component_id = snapshot.app->component_id;
   if (component_id.empty()) {
     return snapshot;
   }
 
-  auto comp_it = component_index_.find(component_id);
-  if (comp_it == component_index_.end() || comp_it->second >= components_.size()) {
+  const uint32_t * comp_slot = component_index_.find(component_id);
+  if (!comp_slot || !components_.is_live(*comp_slot)) {
     return snapshot;  // component referenced but missing - leave .component empty
   }
-  snapshot.component = components_[comp_it->second];
+  snapshot.component = components_[*comp_slot];
 
   const auto & area_id = snapshot.component->area;
   if (area_id.empty()) {
     return snapshot;
   }
 
-  auto area_it = area_index_.find(area_id);
-  if (area_it == area_index_.end() || area_it->second >= areas_.size()) {
+  const uint32_t * area_slot = area_index_.find(area_id);
+  if (!area_slot || !areas_.is_live(*area_slot)) {
     return snapshot;  // area referenced but missing
   }
-  snapshot.area = areas_[area_it->second];
+  snapshot.area = areas_[*area_slot];
   return snapshot;
 }
 
@@ -198,17 +267,17 @@ ThreadSafeEntityCache::get_app_with_dependencies(const std::string & id) const {
   AppDependenciesSnapshot snapshot;
   std::shared_lock lock(mutex_);
 
-  auto app_it = app_index_.find(id);
-  if (app_it == app_index_.end() || app_it->second >= apps_.size()) {
+  const uint32_t * app_slot = app_index_.find(id);
+  if (!app_slot || !apps_.is_live(*app_slot)) {
     return snapshot;
   }
-  snapshot.app = apps_[app_it->second];
+  snapshot.app = apps_[*app_slot];
 
   snapshot.dependencies.reserve(snapshot.app->depends_on.size());
   for (const auto & dep_id : snapshot.app->depends_on) {
-    auto dep_it = app_index_.find(dep_id);
-    if (dep_it != app_index_.end() && dep_it->second < apps_.size()) {
-      snapshot.dependencies.emplace_back(dep_id, apps_[dep_it->second]);
+    const uint32_t * dep_slot = app_index_.find(dep_id);
+    if (dep_slot && apps_.is_live(*dep_slot)) {
+      snapshot.dependencies.emplace_back(dep_id, apps_[*dep_slot]);
     } else {
       snapshot.dependencies.emplace_back(dep_id, std::nullopt);
     }
@@ -218,9 +287,9 @@ ThreadSafeEntityCache::get_app_with_dependencies(const std::string & id) const {
 
 std::optional<Function> ThreadSafeEntityCache::get_function(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  auto it = function_index_.find(id);
-  if (it != function_index_.end() && it->second < functions_.size()) {
-    return functions_[it->second];
+  const uint32_t * slot = function_index_.find(id);
+  if (slot && functions_.is_live(*slot)) {
+    return functions_[*slot];
   }
   return std::nullopt;
 }
@@ -231,22 +300,26 @@ std::optional<Function> ThreadSafeEntityCache::get_function(const std::string & 
 
 bool ThreadSafeEntityCache::has_area(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  return area_index_.count(id) > 0;
+  const uint32_t * slot = area_index_.find(id);
+  return slot && areas_.is_live(*slot);
 }
 
 bool ThreadSafeEntityCache::has_component(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  return component_index_.count(id) > 0;
+  const uint32_t * slot = component_index_.find(id);
+  return slot && components_.is_live(*slot);
 }
 
 bool ThreadSafeEntityCache::has_app(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  return app_index_.count(id) > 0;
+  const uint32_t * slot = app_index_.find(id);
+  return slot && apps_.is_live(*slot);
 }
 
 bool ThreadSafeEntityCache::has_function(const std::string & id) const {
   std::shared_lock lock(mutex_);
-  return function_index_.count(id) > 0;
+  const uint32_t * slot = function_index_.find(id);
+  return slot && functions_.is_live(*slot);
 }
 
 // ============================================================================
@@ -257,17 +330,17 @@ std::optional<EntityRef> ThreadSafeEntityCache::find_entity(const std::string & 
   std::shared_lock lock(mutex_);
 
   // Search order: Component, App, Area, Function
-  if (auto it = component_index_.find(id); it != component_index_.end()) {
-    return EntityRef{SovdEntityType::COMPONENT, it->second};
+  if (const uint32_t * slot = component_index_.find(id); slot && components_.is_live(*slot)) {
+    return EntityRef{SovdEntityType::COMPONENT, *slot};
   }
-  if (auto it = app_index_.find(id); it != app_index_.end()) {
-    return EntityRef{SovdEntityType::APP, it->second};
+  if (const uint32_t * slot = app_index_.find(id); slot && apps_.is_live(*slot)) {
+    return EntityRef{SovdEntityType::APP, *slot};
   }
-  if (auto it = area_index_.find(id); it != area_index_.end()) {
-    return EntityRef{SovdEntityType::AREA, it->second};
+  if (const uint32_t * slot = area_index_.find(id); slot && areas_.is_live(*slot)) {
+    return EntityRef{SovdEntityType::AREA, *slot};
   }
-  if (auto it = function_index_.find(id); it != function_index_.end()) {
-    return EntityRef{SovdEntityType::FUNCTION, it->second};
+  if (const uint32_t * slot = function_index_.find(id); slot && functions_.is_live(*slot)) {
+    return EntityRef{SovdEntityType::FUNCTION, *slot};
   }
 
   return std::nullopt;
@@ -286,12 +359,12 @@ std::vector<std::string> ThreadSafeEntityCache::get_apps_for_component(const std
   std::shared_lock lock(mutex_);
   std::vector<std::string> result;
 
-  auto it = component_to_apps_.find(component_id);
-  if (it != component_to_apps_.end()) {
-    result.reserve(it->second.size());
-    for (size_t idx : it->second) {
-      if (idx < apps_.size()) {
-        result.push_back(apps_[idx].id);
+  const std::vector<uint32_t> * slots = component_to_apps_.find(component_id);
+  if (slots) {
+    result.reserve(slots->size());
+    for (uint32_t slot : *slots) {
+      if (apps_.is_live(slot)) {
+        result.push_back(apps_[slot].id);
       }
     }
   }
@@ -302,12 +375,12 @@ std::vector<std::string> ThreadSafeEntityCache::get_components_for_area(const st
   std::shared_lock lock(mutex_);
   std::vector<std::string> result;
 
-  auto it = area_to_components_.find(area_id);
-  if (it != area_to_components_.end()) {
-    result.reserve(it->second.size());
-    for (size_t idx : it->second) {
-      if (idx < components_.size()) {
-        result.push_back(components_[idx].id);
+  const std::vector<uint32_t> * slots = area_to_components_.find(area_id);
+  if (slots) {
+    result.reserve(slots->size());
+    for (uint32_t slot : *slots) {
+      if (components_.is_live(slot)) {
+        result.push_back(components_[slot].id);
       }
     }
   }
@@ -318,12 +391,12 @@ std::vector<std::string> ThreadSafeEntityCache::get_apps_for_function(const std:
   std::shared_lock lock(mutex_);
   std::vector<std::string> result;
 
-  auto it = function_to_apps_.find(function_id);
-  if (it != function_to_apps_.end()) {
-    result.reserve(it->second.size());
-    for (size_t idx : it->second) {
-      if (idx < apps_.size()) {
-        result.push_back(apps_[idx].id);
+  const std::vector<uint32_t> * slots = function_to_apps_.find(function_id);
+  if (slots) {
+    result.reserve(slots->size());
+    for (uint32_t slot : *slots) {
+      if (apps_.is_live(slot)) {
+        result.push_back(apps_[slot].id);
       }
     }
   }
@@ -334,12 +407,12 @@ std::vector<std::string> ThreadSafeEntityCache::get_subareas(const std::string &
   std::shared_lock lock(mutex_);
   std::vector<std::string> result;
 
-  auto it = area_to_subareas_.find(area_id);
-  if (it != area_to_subareas_.end()) {
-    result.reserve(it->second.size());
-    for (size_t idx : it->second) {
-      if (idx < areas_.size()) {
-        result.push_back(areas_[idx].id);
+  const std::vector<uint32_t> * slots = area_to_subareas_.find(area_id);
+  if (slots) {
+    result.reserve(slots->size());
+    for (uint32_t slot : *slots) {
+      if (areas_.is_live(slot)) {
+        result.push_back(areas_[slot].id);
       }
     }
   }
@@ -356,12 +429,12 @@ AggregatedOperations ThreadSafeEntityCache::get_app_operations(const std::string
   result.aggregation_level = "app";
   result.is_aggregated = false;
 
-  auto it = app_index_.find(app_id);
-  if (it == app_index_.end() || it->second >= apps_.size()) {
+  const uint32_t * slot = app_index_.find(app_id);
+  if (!slot || !apps_.is_live(*slot)) {
     return result;
   }
 
-  const auto & app = apps_[it->second];
+  const auto & app = apps_[*slot];
   result.services = app.services;
   result.actions = app.actions;
   result.source_ids.push_back(app_id);
@@ -374,22 +447,22 @@ AggregatedOperations ThreadSafeEntityCache::get_component_operations(const std::
   AggregatedOperations result;
   result.aggregation_level = "component";
 
-  auto comp_it = component_index_.find(component_id);
-  if (comp_it == component_index_.end() || comp_it->second >= components_.size()) {
+  const uint32_t * comp_slot = component_index_.find(component_id);
+  if (!comp_slot || !components_.is_live(*comp_slot)) {
     return result;
   }
 
   std::unordered_set<std::string> seen_paths;
 
   // Add component's own operations first
-  collect_operations_from_component(comp_it->second, seen_paths, result);
+  collect_operations_from_component(*comp_slot, seen_paths, result);
 
   // Add operations from hosted apps
-  auto apps_it = component_to_apps_.find(component_id);
-  if (apps_it != component_to_apps_.end()) {
-    collect_operations_from_apps(apps_it->second, seen_paths, result);
+  const std::vector<uint32_t> * app_slots = component_to_apps_.find(component_id);
+  if (app_slots) {
+    collect_operations_from_apps(*app_slots, seen_paths, result);
     // Mark as aggregated if we collected from apps
-    if (!apps_it->second.empty()) {
+    if (!app_slots->empty()) {
       result.is_aggregated = true;
     }
   }
@@ -403,30 +476,30 @@ AggregatedOperations ThreadSafeEntityCache::get_area_operations(const std::strin
   result.aggregation_level = "area";
   result.is_aggregated = true;  // Area operations are always aggregated
 
-  auto area_it = area_index_.find(area_id);
-  if (area_it == area_index_.end()) {
+  const uint32_t * area_slot = area_index_.find(area_id);
+  if (!area_slot || !areas_.is_live(*area_slot)) {
     return result;
   }
 
   std::unordered_set<std::string> seen_paths;
 
   // Get all components in this area
-  auto comps_it = area_to_components_.find(area_id);
-  if (comps_it != area_to_components_.end()) {
-    for (size_t comp_idx : comps_it->second) {
-      if (comp_idx >= components_.size()) {
+  const std::vector<uint32_t> * comp_slots = area_to_components_.find(area_id);
+  if (comp_slots) {
+    for (uint32_t comp_slot : *comp_slots) {
+      if (!components_.is_live(comp_slot)) {
         continue;
       }
 
-      const auto & comp = components_[comp_idx];
+      const auto & comp = components_[comp_slot];
 
       // Add component's own operations
-      collect_operations_from_component(comp_idx, seen_paths, result);
+      collect_operations_from_component(comp_slot, seen_paths, result);
 
       // Add operations from component's apps
-      auto apps_it = component_to_apps_.find(comp.id);
-      if (apps_it != component_to_apps_.end()) {
-        collect_operations_from_apps(apps_it->second, seen_paths, result);
+      const std::vector<uint32_t> * app_slots = component_to_apps_.find(comp.id);
+      if (app_slots) {
+        collect_operations_from_apps(*app_slots, seen_paths, result);
       }
     }
   }
@@ -440,17 +513,17 @@ AggregatedOperations ThreadSafeEntityCache::get_function_operations(const std::s
   result.aggregation_level = "function";
   result.is_aggregated = true;  // Function operations are always aggregated
 
-  auto func_it = function_index_.find(function_id);
-  if (func_it == function_index_.end()) {
+  const uint32_t * func_slot = function_index_.find(function_id);
+  if (!func_slot || !functions_.is_live(*func_slot)) {
     return result;
   }
 
   std::unordered_set<std::string> seen_paths;
 
   // Get all apps implementing this function
-  auto apps_it = function_to_apps_.find(function_id);
-  if (apps_it != function_to_apps_.end()) {
-    collect_operations_from_apps(apps_it->second, seen_paths, result);
+  const std::vector<uint32_t> * app_slots = function_to_apps_.find(function_id);
+  if (app_slots) {
+    collect_operations_from_apps(*app_slots, seen_paths, result);
   }
 
   return result;
@@ -489,12 +562,12 @@ AggregatedConfigurations ThreadSafeEntityCache::get_app_configurations(const std
   result.aggregation_level = "app";
   result.is_aggregated = false;
 
-  auto it = app_index_.find(app_id);
-  if (it == app_index_.end() || it->second >= apps_.size()) {
+  const uint32_t * slot = app_index_.find(app_id);
+  if (!slot || !apps_.is_live(*slot)) {
     return result;
   }
 
-  const auto & app = apps_[it->second];
+  const auto & app = apps_[*slot];
 
   // App must have a resolvable FQN to have parameters
   auto eff_fqn = app.effective_fqn();
@@ -515,21 +588,21 @@ AggregatedConfigurations ThreadSafeEntityCache::get_component_configurations(con
   AggregatedConfigurations result;
   result.aggregation_level = "component";
 
-  auto comp_it = component_index_.find(component_id);
-  if (comp_it == component_index_.end() || comp_it->second >= components_.size()) {
+  const uint32_t * comp_slot = component_index_.find(component_id);
+  if (!comp_slot || !components_.is_live(*comp_slot)) {
     return result;
   }
 
   result.source_ids.push_back(component_id);
 
   // Collect node FQNs from hosted apps
-  auto apps_it = component_to_apps_.find(component_id);
-  if (apps_it != component_to_apps_.end()) {
-    for (size_t app_idx : apps_it->second) {
-      if (app_idx >= apps_.size()) {
+  const std::vector<uint32_t> * app_slots = component_to_apps_.find(component_id);
+  if (app_slots) {
+    for (uint32_t app_slot : *app_slots) {
+      if (!apps_.is_live(app_slot)) {
         continue;
       }
-      const auto & app = apps_[app_idx];
+      const auto & app = apps_[app_slot];
       auto eff_fqn = app.effective_fqn();
       if (!eff_fqn.empty()) {
         NodeConfigInfo info;
@@ -553,32 +626,32 @@ AggregatedConfigurations ThreadSafeEntityCache::get_area_configurations(const st
   AggregatedConfigurations result;
   result.aggregation_level = "area";
 
-  auto area_it = area_index_.find(area_id);
-  if (area_it == area_index_.end()) {
+  const uint32_t * area_slot = area_index_.find(area_id);
+  if (!area_slot || !areas_.is_live(*area_slot)) {
     return result;
   }
 
   result.source_ids.push_back(area_id);
 
   // Get all components in this area
-  auto comps_it = area_to_components_.find(area_id);
-  if (comps_it != area_to_components_.end()) {
-    for (size_t comp_idx : comps_it->second) {
-      if (comp_idx >= components_.size()) {
+  const std::vector<uint32_t> * comp_slots = area_to_components_.find(area_id);
+  if (comp_slots) {
+    for (uint32_t comp_slot : *comp_slots) {
+      if (!components_.is_live(comp_slot)) {
         continue;
       }
 
-      const auto & comp = components_[comp_idx];
+      const auto & comp = components_[comp_slot];
       result.source_ids.push_back(comp.id);
 
       // Add node FQNs from component's apps
-      auto apps_it = component_to_apps_.find(comp.id);
-      if (apps_it != component_to_apps_.end()) {
-        for (size_t app_idx : apps_it->second) {
-          if (app_idx >= apps_.size()) {
+      const std::vector<uint32_t> * app_slots = component_to_apps_.find(comp.id);
+      if (app_slots) {
+        for (uint32_t app_slot : *app_slots) {
+          if (!apps_.is_live(app_slot)) {
             continue;
           }
-          const auto & app = apps_[app_idx];
+          const auto & app = apps_[app_slot];
           auto eff_fqn = app.effective_fqn();
           if (!eff_fqn.empty()) {
             NodeConfigInfo info;
@@ -604,21 +677,21 @@ AggregatedConfigurations ThreadSafeEntityCache::get_function_configurations(cons
   AggregatedConfigurations result;
   result.aggregation_level = "function";
 
-  auto func_it = function_index_.find(function_id);
-  if (func_it == function_index_.end()) {
+  const uint32_t * func_slot = function_index_.find(function_id);
+  if (!func_slot || !functions_.is_live(*func_slot)) {
     return result;
   }
 
   result.source_ids.push_back(function_id);
 
   // Get all apps implementing this function
-  auto apps_it = function_to_apps_.find(function_id);
-  if (apps_it != function_to_apps_.end()) {
-    for (size_t app_idx : apps_it->second) {
-      if (app_idx >= apps_.size()) {
+  const std::vector<uint32_t> * app_slots = function_to_apps_.find(function_id);
+  if (app_slots) {
+    for (uint32_t app_slot : *app_slots) {
+      if (!apps_.is_live(app_slot)) {
         continue;
       }
-      const auto & app = apps_[app_idx];
+      const auto & app = apps_[app_slot];
       auto eff_fqn = app.effective_fqn();
       if (!eff_fqn.empty()) {
         NodeConfigInfo info;
@@ -643,9 +716,9 @@ AggregatedConfigurations ThreadSafeEntityCache::get_function_configurations(cons
 
 std::optional<EntityRef> ThreadSafeEntityCache::find_operation_owner(const std::string & operation_path) const {
   std::shared_lock lock(mutex_);
-  auto it = operation_index_.find(operation_path);
-  if (it != operation_index_.end()) {
-    return it->second;
+  const EntityRef * ref = operation_index_.find(operation_path);
+  if (ref) {
+    return *ref;
   }
   return std::nullopt;
 }
@@ -657,11 +730,21 @@ std::optional<EntityRef> ThreadSafeEntityCache::find_operation_owner(const std::
 EntityCacheStats ThreadSafeEntityCache::get_stats() const {
   std::shared_lock lock(mutex_);
   EntityCacheStats stats;
-  stats.area_count = areas_.size();
-  stats.component_count = components_.size();
-  stats.app_count = apps_.size();
-  stats.function_count = functions_.size();
+  stats.area_count = areas_.live_count();
+  stats.component_count = components_.live_count();
+  stats.app_count = apps_.live_count();
+  stats.function_count = functions_.live_count();
   stats.total_operations = operation_index_.size();
+  stats.capacity = capacity_;
+  // No read-and-clear refresh exists yet (introduced in Task 5), so derive
+  // `grew` from the live container flags. `grew_` is reserved for that future
+  // cached path and currently stays false.
+  stats.grew = grew_ || areas_.grew() || components_.grew() || apps_.grew() || functions_.grew() ||
+               area_index_.grew() || component_index_.grew() || app_index_.grew() || function_index_.grew() ||
+               component_to_apps_.grew() || area_to_components_.grew() || area_to_subareas_.grew() ||
+               function_to_apps_.grew() || operation_index_.grew() || topic_type_cache_.grew() || node_to_app_.grew();
+  stats.generation = generation_.load(std::memory_order_acquire);
+  stats.overflow_count = overflow_count_;
   stats.last_update = last_update_;
   return stats;
 }
@@ -670,64 +753,67 @@ std::string ThreadSafeEntityCache::validate() const {
   std::shared_lock lock(mutex_);
   std::ostringstream errors;
 
-  // Check area index
-  for (const auto & [id, idx] : area_index_) {
-    if (idx >= areas_.size()) {
-      errors << "Area index out of bounds: " << id << " -> " << idx << "\n";
-    } else if (areas_[idx].id != id) {
-      errors << "Area index mismatch: " << id << " -> " << areas_[idx].id << "\n";
-    }
-  }
+  auto check_index = [&errors](const char * what, const auto & index, const auto & store) {
+    index.for_each([&](const std::string & id, uint32_t slot) {
+      if (slot >= store.slot_count()) {
+        errors << what << " index out of bounds: " << id << " -> " << slot << "\n";
+      } else if (!store.is_live(slot)) {
+        errors << what << " index points to dead slot: " << id << " -> " << slot << "\n";
+      } else if (store[static_cast<size_t>(slot)].id != id) {
+        errors << what << " index mismatch: " << id << " -> " << store[static_cast<size_t>(slot)].id << "\n";
+      }
+    });
+  };
 
-  // Check component index
-  for (const auto & [id, idx] : component_index_) {
-    if (idx >= components_.size()) {
-      errors << "Component index out of bounds: " << id << " -> " << idx << "\n";
-    } else if (components_[idx].id != id) {
-      errors << "Component index mismatch: " << id << " -> " << components_[idx].id << "\n";
-    }
-  }
+  check_index("Area", area_index_, areas_);
+  check_index("Component", component_index_, components_);
+  check_index("App", app_index_, apps_);
+  check_index("Function", function_index_, functions_);
 
-  // Check app index
-  for (const auto & [id, idx] : app_index_) {
-    if (idx >= apps_.size()) {
-      errors << "App index out of bounds: " << id << " -> " << idx << "\n";
-    } else if (apps_[idx].id != id) {
-      errors << "App index mismatch: " << id << " -> " << apps_[idx].id << "\n";
+  // Live-count consistency: each live slot must be reachable via its index.
+  auto check_live_consistency = [&errors](const char * what, const auto & store, const auto & index) {
+    size_t reachable = 0;
+    store.for_each_live([&](uint32_t slot, const auto & entity) {
+      const uint32_t * mapped = index.find(entity.id);
+      if (mapped && *mapped == slot) {
+        ++reachable;
+      } else {
+        errors << what << " live slot not reachable via index: " << entity.id << " (slot " << slot << ")\n";
+      }
+    });
+    if (reachable != store.live_count()) {
+      errors << what << " live-count inconsistency: reachable=" << reachable << " live_count=" << store.live_count()
+             << "\n";
     }
-  }
+  };
 
-  // Check function index
-  for (const auto & [id, idx] : function_index_) {
-    if (idx >= functions_.size()) {
-      errors << "Function index out of bounds: " << id << " -> " << idx << "\n";
-    } else if (functions_[idx].id != id) {
-      errors << "Function index mismatch: " << id << " -> " << functions_[idx].id << "\n";
-    }
-  }
+  check_live_consistency("Area", areas_, area_index_);
+  check_live_consistency("Component", components_, component_index_);
+  check_live_consistency("App", apps_, app_index_);
+  check_live_consistency("Function", functions_, function_index_);
 
-  // Check for duplicate IDs
+  // Check for duplicate IDs across all live entities
   std::unordered_set<std::string> seen_ids;
-  for (const auto & area : areas_) {
+  areas_.for_each_live([&](uint32_t, const Area & area) {
     if (!seen_ids.insert(area.id).second) {
       errors << "Duplicate area ID: " << area.id << "\n";
     }
-  }
-  for (const auto & comp : components_) {
+  });
+  components_.for_each_live([&](uint32_t, const Component & comp) {
     if (!seen_ids.insert(comp.id).second) {
       errors << "Duplicate component ID (or conflicts with area): " << comp.id << "\n";
     }
-  }
-  for (const auto & app : apps_) {
+  });
+  apps_.for_each_live([&](uint32_t, const App & app) {
     if (!seen_ids.insert(app.id).second) {
       errors << "Duplicate app ID (or conflicts with other entity): " << app.id << "\n";
     }
-  }
-  for (const auto & func : functions_) {
+  });
+  functions_.for_each_live([&](uint32_t, const Function & func) {
     if (!seen_ids.insert(func.id).second) {
       errors << "Duplicate function ID (or conflicts with other entity): " << func.id << "\n";
     }
-  }
+  });
 
   return errors.str();
 }
@@ -755,117 +841,109 @@ void ThreadSafeEntityCache::rebuild_all_indexes() {
 }
 
 void ThreadSafeEntityCache::rebuild_area_index() {
-  area_index_.clear();
-  area_index_.reserve(areas_.size());
-  for (size_t i = 0; i < areas_.size(); ++i) {
-    area_index_[areas_[i].id] = i;
-  }
+  area_index_.reset();
+  areas_.for_each_live([&](uint32_t slot, const Area & area) {
+    area_index_.insert_or_assign(area.id, slot);
+  });
 }
 
 void ThreadSafeEntityCache::rebuild_component_index() {
-  component_index_.clear();
-  component_index_.reserve(components_.size());
-  for (size_t i = 0; i < components_.size(); ++i) {
-    component_index_[components_[i].id] = i;
-  }
+  component_index_.reset();
+  components_.for_each_live([&](uint32_t slot, const Component & comp) {
+    component_index_.insert_or_assign(comp.id, slot);
+  });
 }
 
 void ThreadSafeEntityCache::rebuild_app_index() {
-  app_index_.clear();
-  app_index_.reserve(apps_.size());
-  for (size_t i = 0; i < apps_.size(); ++i) {
-    app_index_[apps_[i].id] = i;
-  }
+  app_index_.reset();
+  apps_.for_each_live([&](uint32_t slot, const App & app) {
+    app_index_.insert_or_assign(app.id, slot);
+  });
 }
 
 void ThreadSafeEntityCache::rebuild_function_index() {
-  function_index_.clear();
-  function_index_.reserve(functions_.size());
-  for (size_t i = 0; i < functions_.size(); ++i) {
-    function_index_[functions_[i].id] = i;
-  }
+  function_index_.reset();
+  functions_.for_each_live([&](uint32_t slot, const Function & func) {
+    function_index_.insert_or_assign(func.id, slot);
+  });
 }
 
 void ThreadSafeEntityCache::rebuild_relationship_indexes() {
-  component_to_apps_.clear();
-  area_to_components_.clear();
-  area_to_subareas_.clear();
-  function_to_apps_.clear();
+  component_to_apps_.reset();
+  area_to_components_.reset();
+  area_to_subareas_.reset();
+  function_to_apps_.reset();
 
   // Build component_to_apps from apps' component_id
-  for (size_t i = 0; i < apps_.size(); ++i) {
-    const auto & app = apps_[i];
+  apps_.for_each_live([&](uint32_t slot, const App & app) {
     if (!app.component_id.empty()) {
-      component_to_apps_[app.component_id].push_back(i);
+      component_to_apps_.get_or_create(app.component_id).push_back(slot);
     }
-  }
+  });
 
   // Build area_to_components from components' area
-  for (size_t i = 0; i < components_.size(); ++i) {
-    const auto & comp = components_[i];
+  components_.for_each_live([&](uint32_t slot, const Component & comp) {
     if (!comp.area.empty()) {
-      area_to_components_[comp.area].push_back(i);
+      area_to_components_.get_or_create(comp.area).push_back(slot);
     }
-  }
+  });
 
   // Build area_to_subareas from areas' parent_area_id
-  for (size_t i = 0; i < areas_.size(); ++i) {
-    const auto & area = areas_[i];
+  areas_.for_each_live([&](uint32_t slot, const Area & area) {
     if (!area.parent_area_id.empty()) {
-      area_to_subareas_[area.parent_area_id].push_back(i);
+      area_to_subareas_.get_or_create(area.parent_area_id).push_back(slot);
     }
-  }
+  });
 
-  // Build function_to_apps (functions have a hosts field which is vector of app IDs)
-  // Note: Function.hosts contains app IDs that implement this function
-  for (const auto & func : functions_) {
+  // Build function_to_apps (functions have a hosts field which is a vector of app IDs).
+  // Function.hosts may also name Components - host ids that do not resolve to an
+  // app are silently dropped (preserving the original behaviour).
+  functions_.for_each_live([&](uint32_t, const Function & func) {
     for (const auto & app_id : func.hosts) {
-      auto app_it = app_index_.find(app_id);
-      if (app_it != app_index_.end()) {
-        function_to_apps_[func.id].push_back(app_it->second);
+      const uint32_t * app_slot = app_index_.find(app_id);
+      if (app_slot && apps_.is_live(*app_slot)) {
+        function_to_apps_.get_or_create(func.id).push_back(*app_slot);
       }
     }
-  }
+  });
 }
 
 void ThreadSafeEntityCache::rebuild_operation_index() {
-  operation_index_.clear();
+  operation_index_.reset();
 
   // Index operations from components
-  for (size_t i = 0; i < components_.size(); ++i) {
-    const auto & comp = components_[i];
+  components_.for_each_live([&](uint32_t slot, const Component & comp) {
     for (const auto & svc : comp.services) {
-      operation_index_[svc.full_path] = {SovdEntityType::COMPONENT, i};
+      operation_index_.insert_or_assign(svc.full_path, EntityRef{SovdEntityType::COMPONENT, slot});
     }
     for (const auto & act : comp.actions) {
-      operation_index_[act.full_path] = {SovdEntityType::COMPONENT, i};
+      operation_index_.insert_or_assign(act.full_path, EntityRef{SovdEntityType::COMPONENT, slot});
     }
-  }
+  });
 
   // Index operations from apps (apps take priority over components for same path)
-  for (size_t i = 0; i < apps_.size(); ++i) {
-    const auto & app = apps_[i];
+  apps_.for_each_live([&](uint32_t slot, const App & app) {
     for (const auto & svc : app.services) {
-      operation_index_[svc.full_path] = {SovdEntityType::APP, i};
+      operation_index_.insert_or_assign(svc.full_path, EntityRef{SovdEntityType::APP, slot});
     }
     for (const auto & act : app.actions) {
-      operation_index_[act.full_path] = {SovdEntityType::APP, i};
+      operation_index_.insert_or_assign(act.full_path, EntityRef{SovdEntityType::APP, slot});
     }
-  }
+  });
 }
 
 // ============================================================================
 // Aggregation helpers
 // ============================================================================
 
-void ThreadSafeEntityCache::collect_operations_from_apps(const std::vector<size_t> & app_indexes,
+void ThreadSafeEntityCache::collect_operations_from_apps(const std::vector<uint32_t> & app_slots,
                                                          std::unordered_set<std::string> & seen_paths,
                                                          AggregatedOperations & result) const {
-  for (size_t idx : app_indexes) {
-    if (idx >= apps_.size()) {
+  for (uint32_t slot : app_slots) {
+    if (!apps_.is_live(slot)) {
       continue;
     }
-    const auto & app = apps_[idx];
+    const auto & app = apps_[slot];
     result.source_ids.push_back(app.id);
 
     for (const auto & svc : app.services) {
@@ -881,14 +959,14 @@ void ThreadSafeEntityCache::collect_operations_from_apps(const std::vector<size_
   }
 }
 
-void ThreadSafeEntityCache::collect_operations_from_component(size_t comp_index,
+void ThreadSafeEntityCache::collect_operations_from_component(uint32_t comp_slot,
                                                               std::unordered_set<std::string> & seen_paths,
                                                               AggregatedOperations & result) const {
-  if (comp_index >= components_.size()) {
+  if (!components_.is_live(comp_slot)) {
     return;
   }
 
-  const auto & comp = components_[comp_index];
+  const auto & comp = components_[comp_slot];
   result.source_ids.push_back(comp.id);
 
   for (const auto & svc : comp.services) {
@@ -934,8 +1012,8 @@ AggregatedData ThreadSafeEntityCache::get_entity_data(const std::string & entity
 AggregatedData ThreadSafeEntityCache::get_app_data(const std::string & app_id) const {
   std::shared_lock lock(mutex_);
 
-  auto it = app_index_.find(app_id);
-  if (it == app_index_.end()) {
+  const uint32_t * slot = app_index_.find(app_id);
+  if (!slot || !apps_.is_live(*slot)) {
     return {};
   }
 
@@ -944,7 +1022,7 @@ AggregatedData ThreadSafeEntityCache::get_app_data(const std::string & app_id) c
   result.is_aggregated = false;
 
   std::unordered_set<std::string> seen_topics;
-  collect_topics_from_app(it->second, seen_topics, result);
+  collect_topics_from_app(*slot, seen_topics, result);
 
   return result;
 }
@@ -952,8 +1030,8 @@ AggregatedData ThreadSafeEntityCache::get_app_data(const std::string & app_id) c
 AggregatedData ThreadSafeEntityCache::get_component_data(const std::string & component_id) const {
   std::shared_lock lock(mutex_);
 
-  auto comp_it = component_index_.find(component_id);
-  if (comp_it == component_index_.end()) {
+  const uint32_t * comp_slot = component_index_.find(component_id);
+  if (!comp_slot || !components_.is_live(*comp_slot)) {
     return {};
   }
 
@@ -963,13 +1041,13 @@ AggregatedData ThreadSafeEntityCache::get_component_data(const std::string & com
   std::unordered_set<std::string> seen_topics;
 
   // Collect from component itself
-  collect_topics_from_component(comp_it->second, seen_topics, result);
+  collect_topics_from_component(*comp_slot, seen_topics, result);
 
   // Collect from hosted apps
-  auto apps_it = component_to_apps_.find(component_id);
-  if (apps_it != component_to_apps_.end()) {
-    collect_topics_from_apps(apps_it->second, seen_topics, result);
-    result.is_aggregated = !apps_it->second.empty();
+  const std::vector<uint32_t> * app_slots = component_to_apps_.find(component_id);
+  if (app_slots) {
+    collect_topics_from_apps(*app_slots, seen_topics, result);
+    result.is_aggregated = !app_slots->empty();
   }
 
   return result;
@@ -978,8 +1056,8 @@ AggregatedData ThreadSafeEntityCache::get_component_data(const std::string & com
 AggregatedData ThreadSafeEntityCache::get_area_data(const std::string & area_id) const {
   std::shared_lock lock(mutex_);
 
-  auto area_it = area_index_.find(area_id);
-  if (area_it == area_index_.end()) {
+  const uint32_t * area_slot = area_index_.find(area_id);
+  if (!area_slot || !areas_.is_live(*area_slot)) {
     return {};
   }
 
@@ -991,7 +1069,7 @@ AggregatedData ThreadSafeEntityCache::get_area_data(const std::string & area_id)
   std::unordered_set<std::string> seen_topics;
 
   // Collect from all components in this area **and its subareas** (recursive)
-  std::vector<size_t> component_indices;
+  std::vector<uint32_t> component_slots;
   std::unordered_set<std::string> visited_areas;
   std::vector<std::string> pending_areas;
   pending_areas.push_back(area_id);
@@ -1006,30 +1084,30 @@ AggregatedData ThreadSafeEntityCache::get_area_data(const std::string & area_id)
     }
 
     // Collect components directly associated with this area
-    auto comps_it = area_to_components_.find(current_area);
-    if (comps_it != area_to_components_.end()) {
-      component_indices.insert(component_indices.end(), comps_it->second.begin(), comps_it->second.end());
+    const std::vector<uint32_t> * comp_slots = area_to_components_.find(current_area);
+    if (comp_slots) {
+      component_slots.insert(component_slots.end(), comp_slots->begin(), comp_slots->end());
     }
 
     // Traverse into subareas
-    auto subareas_it = area_to_subareas_.find(current_area);
-    if (subareas_it != area_to_subareas_.end()) {
-      for (size_t subarea_idx : subareas_it->second) {
-        if (subarea_idx < areas_.size()) {
-          pending_areas.push_back(areas_[subarea_idx].id);
+    const std::vector<uint32_t> * subarea_slots = area_to_subareas_.find(current_area);
+    if (subarea_slots) {
+      for (uint32_t subarea_slot : *subarea_slots) {
+        if (areas_.is_live(subarea_slot)) {
+          pending_areas.push_back(areas_[subarea_slot].id);
         }
       }
     }
   }
 
-  for (size_t comp_idx : component_indices) {
-    collect_topics_from_component(comp_idx, seen_topics, result);
+  for (uint32_t comp_slot : component_slots) {
+    collect_topics_from_component(comp_slot, seen_topics, result);
 
     // Also collect from apps hosted on each component
-    if (comp_idx < components_.size()) {
-      auto apps_it = component_to_apps_.find(components_[comp_idx].id);
-      if (apps_it != component_to_apps_.end()) {
-        collect_topics_from_apps(apps_it->second, seen_topics, result);
+    if (components_.is_live(comp_slot)) {
+      const std::vector<uint32_t> * app_slots = component_to_apps_.find(components_[comp_slot].id);
+      if (app_slots) {
+        collect_topics_from_apps(*app_slots, seen_topics, result);
       }
     }
   }
@@ -1040,8 +1118,8 @@ AggregatedData ThreadSafeEntityCache::get_area_data(const std::string & area_id)
 AggregatedData ThreadSafeEntityCache::get_function_data(const std::string & function_id) const {
   std::shared_lock lock(mutex_);
 
-  auto func_it = function_index_.find(function_id);
-  if (func_it == function_index_.end()) {
+  const uint32_t * func_slot = function_index_.find(function_id);
+  if (!func_slot || !functions_.is_live(*func_slot)) {
     return {};
   }
 
@@ -1053,9 +1131,9 @@ AggregatedData ThreadSafeEntityCache::get_function_data(const std::string & func
   std::unordered_set<std::string> seen_topics;
 
   // Collect from all apps implementing this function
-  auto apps_it = function_to_apps_.find(function_id);
-  if (apps_it != function_to_apps_.end()) {
-    collect_topics_from_apps(apps_it->second, seen_topics, result);
+  const std::vector<uint32_t> * app_slots = function_to_apps_.find(function_id);
+  if (app_slots) {
+    collect_topics_from_apps(*app_slots, seen_topics, result);
   }
 
   return result;
@@ -1065,13 +1143,13 @@ AggregatedData ThreadSafeEntityCache::get_function_data(const std::string & func
 // Data aggregation helpers
 // ============================================================================
 
-void ThreadSafeEntityCache::collect_topics_from_app(size_t app_index, std::unordered_set<std::string> & seen_topics,
+void ThreadSafeEntityCache::collect_topics_from_app(uint32_t app_slot, std::unordered_set<std::string> & seen_topics,
                                                     AggregatedData & result) const {
-  if (app_index >= apps_.size()) {
+  if (!apps_.is_live(app_slot)) {
     return;
   }
 
-  const auto & app = apps_[app_index];
+  const auto & app = apps_[app_slot];
   result.source_ids.push_back(app.id);
 
   // Publishers
@@ -1107,22 +1185,22 @@ void ThreadSafeEntityCache::collect_topics_from_app(size_t app_index, std::unord
   }
 }
 
-void ThreadSafeEntityCache::collect_topics_from_apps(const std::vector<size_t> & app_indexes,
+void ThreadSafeEntityCache::collect_topics_from_apps(const std::vector<uint32_t> & app_slots,
                                                      std::unordered_set<std::string> & seen_topics,
                                                      AggregatedData & result) const {
-  for (size_t idx : app_indexes) {
-    collect_topics_from_app(idx, seen_topics, result);
+  for (uint32_t slot : app_slots) {
+    collect_topics_from_app(slot, seen_topics, result);
   }
 }
 
-void ThreadSafeEntityCache::collect_topics_from_component(size_t comp_index,
+void ThreadSafeEntityCache::collect_topics_from_component(uint32_t comp_slot,
                                                           std::unordered_set<std::string> & seen_topics,
                                                           AggregatedData & result) const {
-  if (comp_index >= components_.size()) {
+  if (!components_.is_live(comp_slot)) {
     return;
   }
 
-  const auto & comp = components_[comp_index];
+  const auto & comp = components_[comp_slot];
   result.source_ids.push_back(comp.id);
 
   // Publishers

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1508,18 +1508,20 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     // bounds the per-event allocation churn (issue #442). A pending event is
     // always serviced within refresh_debounce_ms + one 100 ms tick.
     if (graph_event_->check_and_clear()) {
-      graph_dirty_ = true;
+      graph_dirty_.store(true, std::memory_order_relaxed);
     }
-    if (!graph_dirty_) {
+    if (!graph_dirty_.load(std::memory_order_relaxed)) {
       return;
     }
     const auto now = std::chrono::steady_clock::now();
-    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_graph_refresh_).count();
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - last_graph_refresh_.load(std::memory_order_relaxed))
+            .count();
     if (elapsed_ms < refresh_debounce_ms_) {
       return;  // within debounce window; refresh on a later tick
     }
-    graph_dirty_ = false;
-    last_graph_refresh_ = now;
+    graph_dirty_.store(false, std::memory_order_relaxed);
+    last_graph_refresh_.store(now, std::memory_order_relaxed);
     refresh_cache();
     // Note: orphan-trigger sweep is deliberately NOT run from the graph-event
     // path. Graph events fire on every node up/down at high frequency,

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -204,6 +204,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   declare_parameter("logs.buffer_size",
                     200);  // Ring buffer capacity per node; entries exceeding this are dropped (oldest first)
 
+  // Entity cache capacity. Pre-reserves the cache backing stores so steady-state
+  // refreshes below this entity count cause no structural reallocation.
+  // Valid range: 16-1000000 (values outside this range are clamped with a warning).
+  // Default: 256 (covers most production graphs with headroom).
+  declare_parameter("entity_cache.capacity", 256);
+
   // Topic-sample default timeout used by the data-access path.
   declare_parameter("topic_sample_timeout_sec", 1.0);
 
@@ -764,6 +770,22 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     RCLCPP_WARN(get_logger(), "logs.buffer_size %" PRId64 " clamped to %" PRId64, raw_buffer_size, clamped);
   }
   auto log_buffer_size = static_cast<size_t>(clamped);
+
+  // Apply entity_cache.capacity: clamp to [16, 1000000] and pre-reserve the cache.
+  // Reserve is called here (in the ctor) so the backing stores are sized before
+  // the first refresh_cache() call. thread_safe_cache_ is a value member so it
+  // is already default-constructed at this point; reserve() only grows it.
+  static constexpr int kMinCacheCapacity = 16;
+  static constexpr int kMaxCacheCapacity = 1000000;
+  auto raw_cache_capacity = get_parameter("entity_cache.capacity").as_int();
+  auto clamped_cache_capacity =
+      std::clamp(raw_cache_capacity, static_cast<int64_t>(kMinCacheCapacity), static_cast<int64_t>(kMaxCacheCapacity));
+  if (clamped_cache_capacity != raw_cache_capacity) {
+    RCLCPP_WARN(get_logger(), "entity_cache.capacity %" PRId64 " clamped to %" PRId64, raw_cache_capacity,
+                clamped_cache_capacity);
+  }
+  thread_safe_cache_.reserve(static_cast<size_t>(clamped_cache_capacity));
+
   log_source_ = std::make_shared<ros2::Ros2LogSource>(this);
   // Inject a sink that forwards LogManager's neutral diagnostics back to the
   // gateway's rclcpp logger so plugin-provider exceptions remain visible to
@@ -2120,6 +2142,20 @@ void GatewayNode::refresh_cache() {
     // Update ThreadSafeEntityCache atomically (entities + node_to_app under single lock)
     thread_safe_cache_.update_all(std::move(areas), std::move(all_components), std::move(apps), std::move(functions),
                                   std::move(node_to_app));
+
+    // Emit a one-shot WARN when the entity cache grew beyond its reserved capacity.
+    // Growing is harmless but causes structural reallocation; embedded / memory-
+    // constrained deployments should raise entity_cache.capacity to prevent it.
+    if (!warned_cache_grow_) {
+      const auto stats = thread_safe_cache_.get_stats();
+      if (stats.grew) {
+        RCLCPP_WARN(get_logger(),
+                    "entity_cache capacity %zu exceeded (grew); raise entity_cache.capacity "
+                    "for embedded determinism",
+                    stats.capacity);
+        warned_cache_grow_ = true;
+      }
+    }
 
     // Update topic type cache (avoids expensive ROS graph queries on /data requests)
     if (data_access_mgr_) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -181,6 +181,7 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   // by rclcpp graph events; this only controls the periodic forced
   // refresh used when a graph event would otherwise be missed.
   declare_parameter("refresh_interval_ms", 30000);
+  declare_parameter("discovery.refresh_debounce_ms", 1000);
   declare_parameter("fault_manager.namespace", "");
   declare_parameter("fault_manager.service_timeout_sec", 5.0);
   declare_parameter("cors.allowed_origins", std::vector<std::string>{});
@@ -398,6 +399,7 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   server_host_ = get_parameter("server.host").as_string();
   server_port_ = static_cast<int>(get_parameter("server.port").as_int());
   refresh_interval_ms_ = static_cast<int>(get_parameter("refresh_interval_ms").as_int());
+  refresh_debounce_ms_ = static_cast<int>(get_parameter("discovery.refresh_debounce_ms").as_int());
 
   // Build CORS configuration using builder pattern
   // Throws std::invalid_argument if configuration is invalid
@@ -435,6 +437,16 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
                 "Invalid backstop refresh interval %dms. Must be between 100-60000ms. Using default 30000ms.",
                 refresh_interval_ms_);
     refresh_interval_ms_ = 30000;
+  }
+
+  // Validate graph-event refresh debounce. 0 disables debouncing (refresh on
+  // every graph event, the pre-#442 behaviour); otherwise coalesce graph events
+  // into at most one refresh per this interval. Clamp to [0, 60000] ms.
+  if (refresh_debounce_ms_ < 0 || refresh_debounce_ms_ > 60000) {
+    RCLCPP_WARN(get_logger(),
+                "Invalid discovery.refresh_debounce_ms %dms. Must be between 0-60000ms. Using default 1000ms.",
+                refresh_debounce_ms_);
+    refresh_debounce_ms_ = 1000;
   }
 
   // Log configuration
@@ -1488,9 +1500,26 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     if (!graph_event_) {
       return;
     }
-    if (!graph_event_->check_and_clear()) {
+    // Coalesce graph events: under graph churn (nodes/topics created and
+    // destroyed repeatedly) the event fires many times per second, and each
+    // refresh_cache() runs the full discovery pipeline. Debounce so we run at
+    // most one refresh per `refresh_debounce_ms` (default 1000 ms) - the ROS
+    // graph rarely changes faster than that in practice, and coalescing
+    // bounds the per-event allocation churn (issue #442). A pending event is
+    // always serviced within refresh_debounce_ms + one 100 ms tick.
+    if (graph_event_->check_and_clear()) {
+      graph_dirty_ = true;
+    }
+    if (!graph_dirty_) {
       return;
     }
+    const auto now = std::chrono::steady_clock::now();
+    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_graph_refresh_).count();
+    if (elapsed_ms < refresh_debounce_ms_) {
+      return;  // within debounce window; refresh on a later tick
+    }
+    graph_dirty_ = false;
+    last_graph_refresh_ = now;
     refresh_cache();
     // Note: orphan-trigger sweep is deliberately NOT run from the graph-event
     // path. Graph events fire on every node up/down at high frequency,

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1567,7 +1567,11 @@ size_t GatewayNode::count_peer_nodes(const std::vector<std::pair<std::string, st
     if (!name.empty() && name.front() == '_') {
       continue;  // hidden node (name part starts with '_')
     }
-    const std::string fqn = (ns == "/") ? ("/" + name) : (ns + "/" + name);
+    std::string fqn = ns;
+    if (ns != "/") {
+      fqn += "/";
+    }
+    fqn += name;
     // Exclude the gateway's own nodes by exact FQN: the main node and its known
     // internal helpers. A plain prefix match would also drop a genuine peer whose
     // name starts with the gateway name (e.g. "<fqn>_monitor" or "<fqn>2").

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -29,6 +29,7 @@
 
 #include "ros2_medkit_gateway/core/aggregation/network_utils.hpp"
 #include "ros2_medkit_gateway/core/data/topic_data_provider.hpp"
+#include "ros2_medkit_gateway/core/discovery/refresh_debounce.hpp"
 #include "ros2_medkit_gateway/core/entity_validation.hpp"
 #include "ros2_medkit_gateway/core/thread_pool_config.hpp"
 #include "ros2_medkit_gateway/param_utils.hpp"
@@ -399,7 +400,21 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   server_host_ = get_parameter("server.host").as_string();
   server_port_ = static_cast<int>(get_parameter("server.port").as_int());
   refresh_interval_ms_ = static_cast<int>(get_parameter("refresh_interval_ms").as_int());
-  refresh_debounce_ms_ = static_cast<int>(get_parameter("discovery.refresh_debounce_ms").as_int());
+  // Read as int64 and validate BEFORE narrowing to int: a value above INT_MAX
+  // would otherwise wrap into the valid range and silently bypass the range
+  // check (e.g. 4294967296 -> 0, disabling debounce). 0 disables debouncing
+  // (refresh on every graph event, the pre-#442 behaviour); otherwise coalesce
+  // graph events into at most one refresh per this interval. An out-of-range
+  // value is rejected with a warning and the default (1000 ms) is used.
+  const int64_t refresh_debounce_raw = get_parameter("discovery.refresh_debounce_ms").as_int();
+  if (refresh_debounce_raw < 0 || refresh_debounce_raw > 60000) {
+    RCLCPP_WARN(get_logger(),
+                "Invalid discovery.refresh_debounce_ms %" PRId64 "ms. Must be between 0-60000ms. Using default 1000ms.",
+                refresh_debounce_raw);
+    refresh_debounce_ms_ = 1000;
+  } else {
+    refresh_debounce_ms_ = static_cast<int>(refresh_debounce_raw);
+  }
 
   // Build CORS configuration using builder pattern
   // Throws std::invalid_argument if configuration is invalid
@@ -437,16 +452,6 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
                 "Invalid backstop refresh interval %dms. Must be between 100-60000ms. Using default 30000ms.",
                 refresh_interval_ms_);
     refresh_interval_ms_ = 30000;
-  }
-
-  // Validate graph-event refresh debounce. 0 disables debouncing (refresh on
-  // every graph event, the pre-#442 behaviour); otherwise coalesce graph events
-  // into at most one refresh per this interval. Clamp to [0, 60000] ms.
-  if (refresh_debounce_ms_ < 0 || refresh_debounce_ms_ > 60000) {
-    RCLCPP_WARN(get_logger(),
-                "Invalid discovery.refresh_debounce_ms %dms. Must be between 0-60000ms. Using default 1000ms.",
-                refresh_debounce_ms_);
-    refresh_debounce_ms_ = 1000;
   }
 
   // Log configuration
@@ -1507,20 +1512,17 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     // graph rarely changes faster than that in practice, and coalescing
     // bounds the per-event allocation churn (issue #442). A pending event is
     // always serviced within refresh_debounce_ms + one 100 ms tick.
-    if (graph_event_->check_and_clear()) {
-      graph_dirty_.store(true, std::memory_order_relaxed);
-    }
-    if (!graph_dirty_.load(std::memory_order_relaxed)) {
-      return;
-    }
+    const bool event_fired = graph_event_->check_and_clear();
     const auto now = std::chrono::steady_clock::now();
     const auto elapsed_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - last_graph_refresh_.load(std::memory_order_relaxed))
             .count();
-    if (elapsed_ms < refresh_debounce_ms_) {
-      return;  // within debounce window; refresh on a later tick
+    const auto decision = decide_graph_refresh(event_fired, graph_dirty_.load(std::memory_order_relaxed), elapsed_ms,
+                                               refresh_debounce_ms_);
+    graph_dirty_.store(decision.dirty, std::memory_order_relaxed);
+    if (!decision.refresh) {
+      return;  // nothing pending, or still within the debounce window
     }
-    graph_dirty_.store(false, std::memory_order_relaxed);
     last_graph_refresh_.store(now, std::memory_order_relaxed);
     refresh_cache();
     // Note: orphan-trigger sweep is deliberately NOT run from the graph-event

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -97,6 +97,15 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
           response.x_medkit_subscription_executor = x["x-medkit-subscription-executor"];
         }
       }
+
+      // Surface entity cache live counts and capacity via x-medkit-entity-cache.
+      // Enables external monitors and operators to verify the cache is sized
+      // correctly (grew == true signals that entity_cache.capacity should be raised).
+      const auto stats = ctx_.node()->get_thread_safe_cache().get_stats();
+      response.x_medkit_entity_cache =
+          json{{"capacity", stats.capacity}, {"areas", stats.area_count},         {"components", stats.component_count},
+               {"apps", stats.app_count},    {"functions", stats.function_count}, {"generation", stats.generation},
+               {"grew", stats.grew}};
     }
 
     // Add peer status when aggregation is active

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -156,15 +156,16 @@ dto::XMedkitOperationItem build_service_xmedkit(const ServiceInfo & svc, const s
   x_medkit.entity_id = entity_id;
   x_medkit.source = "ros2_medkit_gateway";
 
-  try {
-    json type_info_json;
-    auto request_info = type_introspection->get_type_info(svc.type + "_Request");
-    auto response_info = type_introspection->get_type_info(svc.type + "_Response");
-    type_info_json["request"] = request_info.schema;
-    type_info_json["response"] = response_info.schema;
-    x_medkit.type_info = type_info_json;
-  } catch (const std::exception & e) {
-    RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for service '%s': %s", svc.type.c_str(), e.what());
+  if (type_introspection != nullptr && !svc.type.empty()) {
+    try {
+      // Schemas are assembled once per type and cached (shared) in
+      // TypeIntrospection, so repeated /operations requests reuse them instead
+      // of rebuilding + deep-copying (issue #442).
+      x_medkit.type_info = *type_introspection->get_service_type_info(svc.type);
+    } catch (const std::exception & e) {
+      RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for service '%s': %s", svc.type.c_str(),
+                   e.what());
+    }
   }
   return x_medkit;
 }
@@ -181,17 +182,12 @@ dto::XMedkitOperationItem build_action_xmedkit(const ActionInfo & act, const std
   x_medkit.entity_id = entity_id;
   x_medkit.source = "ros2_medkit_gateway";
 
-  try {
-    json type_info_json;
-    auto goal_info_entry = type_introspection->get_type_info(act.type + "_Goal");
-    auto result_info = type_introspection->get_type_info(act.type + "_Result");
-    auto feedback_info = type_introspection->get_type_info(act.type + "_Feedback");
-    type_info_json["goal"] = goal_info_entry.schema;
-    type_info_json["result"] = result_info.schema;
-    type_info_json["feedback"] = feedback_info.schema;
-    x_medkit.type_info = type_info_json;
-  } catch (const std::exception & e) {
-    RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for action '%s': %s", act.type.c_str(), e.what());
+  if (type_introspection != nullptr && !act.type.empty()) {
+    try {
+      x_medkit.type_info = *type_introspection->get_action_type_info(act.type);
+    } catch (const std::exception & e) {
+      RCLCPP_DEBUG(HandlerContext::logger(), "Could not get type info for action '%s': %s", act.type.c_str(), e.what());
+    }
   }
   return x_medkit;
 }

--- a/src/ros2_medkit_gateway/src/ros2/providers/ros2_runtime_introspection.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/providers/ros2_runtime_introspection.cpp
@@ -264,19 +264,11 @@ std::vector<ServiceInfo> Ros2RuntimeIntrospection::discover_services() {
     info.name = extract_name_from_path(service_path);
     info.type = types.empty() ? "" : types[0];
 
-    // Service types: pkg/srv/Type -> Request/Response companions.
-    if (type_introspection_ && !info.type.empty()) {
-      try {
-        json type_info_json;
-        auto request_info = type_introspection_->get_type_info(info.type + "_Request");
-        auto response_info = type_introspection_->get_type_info(info.type + "_Response");
-        type_info_json["request"] = request_info.schema;
-        type_info_json["response"] = response_info.schema;
-        info.type_info = type_info_json;
-      } catch (const std::exception & e) {
-        RCLCPP_DEBUG(node_->get_logger(), "Could not get schema for service '%s': %s", info.type.c_str(), e.what());
-      }
-    }
+    // Schemas (type_info) are resolved lazily by the operations handler
+    // (build_service_xmedkit) on request, keyed by `info.type` and cached in
+    // TypeIntrospection. Building + deep-copying request/response schemas here
+    // on every discovery refresh was the dominant allocation under graph churn
+    // (issue #442); the discovered ServiceInfo only needs path/name/type.
 
     services.push_back(info);
   }
@@ -329,21 +321,9 @@ std::vector<ActionInfo> Ros2RuntimeIntrospection::discover_actions() {
           }
         }
 
-        // Action types: pkg/action/Type -> Goal/Result/Feedback companions.
-        if (type_introspection_ && !info.type.empty()) {
-          try {
-            json type_info_json;
-            auto goal_info = type_introspection_->get_type_info(info.type + "_Goal");
-            auto result_info = type_introspection_->get_type_info(info.type + "_Result");
-            auto feedback_info = type_introspection_->get_type_info(info.type + "_Feedback");
-            type_info_json["goal"] = goal_info.schema;
-            type_info_json["result"] = result_info.schema;
-            type_info_json["feedback"] = feedback_info.schema;
-            info.type_info = type_info_json;
-          } catch (const std::exception & e) {
-            RCLCPP_DEBUG(node_->get_logger(), "Could not get schema for action '%s': %s", info.type.c_str(), e.what());
-          }
-        }
+        // Schemas (type_info) are resolved lazily by the operations handler
+        // (build_action_xmedkit) on request; see the matching note in
+        // discover_services. Avoids per-refresh schema build+copy (issue #442).
 
         actions.push_back(info);
       }

--- a/src/ros2_medkit_gateway/test/test_capability_generator.cpp
+++ b/src/ros2_medkit_gateway/test/test_capability_generator.cpp
@@ -466,27 +466,55 @@ TEST(ThreadSafeEntityCacheGenerationTest, GenerationStartsAtZero) {
 }
 
 TEST(ThreadSafeEntityCacheGenerationTest, GenerationIncrementsOnUpdateAll) {
+  // Empty-into-empty is a no-op; a real change (inserting an entity) must bump.
   ThreadSafeEntityCache cache;
-  cache.update_all({}, {}, {}, {});
+  Area ar;
+  ar.id = "ar1";
+  ar.name = "Area 1";
+  cache.update_all({ar}, {}, {}, {});
+  EXPECT_EQ(cache.generation(), 1u);
+
+  // Identical second call - no-op, generation must NOT advance.
+  cache.update_all({ar}, {}, {}, {});
   EXPECT_EQ(cache.generation(), 1u);
 }
 
 TEST(ThreadSafeEntityCacheGenerationTest, GenerationIncrementsOnEachUpdate) {
+  // Each per-type updater bumps generation ONLY when it changes the cache.
+  // We seed distinct entities per call so every call is a real change.
   ThreadSafeEntityCache cache;
 
-  cache.update_areas({});
+  Area ar;
+  ar.id = "ar1";
+  ar.name = "Area 1";
+  cache.update_areas({ar});
   EXPECT_EQ(cache.generation(), 1u);
 
-  cache.update_components({});
+  Component comp;
+  comp.id = "comp1";
+  comp.name = "Comp 1";
+  cache.update_components({comp});
   EXPECT_EQ(cache.generation(), 2u);
 
-  cache.update_apps({});
+  App app;
+  app.id = "app1";
+  app.name = "App 1";
+  app.component_id = "comp1";
+  cache.update_apps({app});
   EXPECT_EQ(cache.generation(), 3u);
 
-  cache.update_functions({});
+  Function func;
+  func.id = "func1";
+  func.name = "Func 1";
+  cache.update_functions({func});
   EXPECT_EQ(cache.generation(), 4u);
 
-  cache.update_all({}, {}, {}, {});
+  // update_all with different data (remove the area, keep rest) - real change.
+  cache.update_all({}, {comp}, {app}, {func});
+  EXPECT_EQ(cache.generation(), 5u);
+
+  // Repeat the same update_all - identical, must NOT bump.
+  cache.update_all({}, {comp}, {app}, {func});
   EXPECT_EQ(cache.generation(), 5u);
 }
 
@@ -540,16 +568,35 @@ TEST_F(CapabilityGeneratorTest, DifferentGenerationsProduceDifferentCacheKeys) {
 
 TEST(CacheGenerationTest, GenerationCounterTracksEntityUpdates) {
   // Standalone test verifying the generation counter mechanism
-  // that CapabilityGenerator depends on for cache invalidation
+  // that CapabilityGenerator depends on for cache invalidation.
+  // Only REAL changes (insert / modify / remove) advance the counter;
+  // identical repeated calls must not, so the spec cache stays valid
+  // across no-op discovery ticks.
   ThreadSafeEntityCache cache;
   EXPECT_EQ(cache.generation(), 0u);
 
-  cache.update_areas({});
+  Area ar;
+  ar.id = "ar1";
+  ar.name = "Area 1";
+  cache.update_areas({ar});
   EXPECT_EQ(cache.generation(), 1u);
 
-  cache.update_components({});
+  Component comp;
+  comp.id = "comp1";
+  comp.name = "Comp 1";
+  cache.update_components({comp});
   EXPECT_EQ(cache.generation(), 2u);
 
-  // Each update increments, which would cause CapabilityGenerator
-  // to clear its spec_cache_ in get_cache_key()
+  // Identical repeated calls are no-ops - generation must not advance.
+  cache.update_areas({ar});
+  EXPECT_EQ(cache.generation(), 2u);
+
+  cache.update_components({comp});
+  EXPECT_EQ(cache.generation(), 2u);
+
+  // A real modification (rename) DOES bump - CapabilityGenerator would
+  // see a new cache key and regenerate the spec.
+  ar.name = "Area 1 Renamed";
+  cache.update_areas({ar});
+  EXPECT_EQ(cache.generation(), 3u);
 }

--- a/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
@@ -41,7 +41,7 @@ void operator delete(void * p) noexcept {
   }
   std::free(p);
 }
-void operator delete(void * p, std::size_t) noexcept {
+void operator delete(void * p, std::size_t /*n*/) noexcept {
   ::operator delete(p);
 }
 using namespace ros2_medkit_gateway;

--- a/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
@@ -24,8 +24,13 @@
 namespace {
 std::atomic<long> g_net{0};
 std::atomic<bool> g_armed{false};
-}  // namespace
-void * operator new(std::size_t n) {
+
+// All allocation routes through malloc, all deallocation through free. The
+// FULL overload set (scalar + array + nothrow) must be replaced consistently:
+// under AddressSanitizer the default array/nothrow operators are ASan's own
+// (not delegating to our scalar new), so a partial replacement would pair an
+// ASan operator-new with our free() and trip alloc-dealloc-mismatch.
+void * counted_new(std::size_t n) {
   if (g_armed.load(std::memory_order_relaxed)) {
     g_net.fetch_add(1, std::memory_order_relaxed);
   }
@@ -35,14 +40,48 @@ void * operator new(std::size_t n) {
   }
   return p;
 }
-void operator delete(void * p) noexcept {
+void * counted_new_nothrow(std::size_t n) noexcept {
+  if (g_armed.load(std::memory_order_relaxed)) {
+    g_net.fetch_add(1, std::memory_order_relaxed);
+  }
+  return std::malloc(n ? n : 1);
+}
+void counted_delete(void * p) noexcept {
   if (p && g_armed.load(std::memory_order_relaxed)) {
     g_net.fetch_sub(1, std::memory_order_relaxed);
   }
   std::free(p);
 }
+}  // namespace
+void * operator new(std::size_t n) {
+  return counted_new(n);
+}
+void * operator new[](std::size_t n) {
+  return counted_new(n);
+}
+void * operator new(std::size_t n, const std::nothrow_t & /*tag*/) noexcept {
+  return counted_new_nothrow(n);
+}
+void * operator new[](std::size_t n, const std::nothrow_t & /*tag*/) noexcept {
+  return counted_new_nothrow(n);
+}
+void operator delete(void * p) noexcept {
+  counted_delete(p);
+}
+void operator delete[](void * p) noexcept {
+  counted_delete(p);
+}
 void operator delete(void * p, std::size_t /*n*/) noexcept {
-  ::operator delete(p);
+  counted_delete(p);
+}
+void operator delete[](void * p, std::size_t /*n*/) noexcept {
+  counted_delete(p);
+}
+void operator delete(void * p, const std::nothrow_t & /*tag*/) noexcept {
+  counted_delete(p);
+}
+void operator delete[](void * p, const std::nothrow_t & /*tag*/) noexcept {
+  counted_delete(p);
 }
 using namespace ros2_medkit_gateway;
 static App mkapp(const std::string & id) {

--- a/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
@@ -115,5 +115,12 @@ TEST(EntityCacheAlloc, SteadyStateChurnNoNetStructuralGrowth) {
   g_armed.store(false);
   // Only update_all ran while armed; no copies, no container mutation, no getter calls.
   const long kSlack = 4;  // tiny; tolerates allocator bookkeeping noise only. Do NOT inflate.
+  // Only the UPPER bound is meaningful here. The regression this guards against
+  // is the old full rebuild, which allocates under churn -> a positive net. The
+  // steady-state net is legitimately negative (about -1 per tick): every tick's
+  // payloads are pre-built before arming, so payload/structural frees during the
+  // armed window are counted while their allocations are not. A symmetric lower
+  // bound would therefore false-fail without catching any growth, so we do not
+  // assert one (a net that only ever frees cannot grow memory under churn).
   EXPECT_LE(g_net.load(), kSlack) << "cache layer allocated under steady-state churn (regression to rebuild?)";
 }

--- a/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
@@ -84,24 +84,49 @@ void operator delete[](void * p, const std::nothrow_t & /*tag*/) noexcept {
   counted_delete(p);
 }
 using namespace ros2_medkit_gateway;
+
+// Populate an App with a NON-SSO id and a service carrying a non-SSO full_path,
+// so the reconcile + operation-index path copies real heap keys every tick. With
+// short SSO ids and empty payloads nothing on that path would allocate, making
+// the steady-state assertion below pass vacuously.
 static App mkapp(const std::string & id) {
   App a;
   a.id = id;
   a.name = id;
   a.component_id = "host";
+  ServiceInfo svc;
+  svc.name = "calibrate_with_a_deliberately_long_name";
+  svc.full_path = id + "/calibrate_with_a_deliberately_long_name";  // non-SSO operation key
+  svc.type = "std_srvs/srv/Trigger";
+  a.services.push_back(std::move(svc));
   return a;
+}
+
+TEST(EntityCacheAlloc, AllocationInterposerIsActive) {
+  // Positive control: prove the global new/delete interposer actually counts, so
+  // a green steady-state assertion cannot be a vacuous "nothing was measured".
+  g_net.store(0);
+  g_armed.store(true);
+  auto * probe = new std::string(64, 'z');  // heap: the object and its 64-char buffer
+  const long during = g_net.load();
+  g_armed.store(false);
+  delete probe;
+  EXPECT_GT(during, 0) << "global operator new interposer is not active";
 }
 
 TEST(EntityCacheAlloc, SteadyStateChurnNoNetStructuralGrowth) {
   ThreadSafeEntityCache c(256);
-  // Pre-build ALL inputs BEFORE arming. Two alternating SSO id-sets (<=15 chars), recycled every other tick:
-  // structural reconcile work (slot reuse, index reset/refill) must not allocate; key strings are SSO.
+  // Pre-build ALL inputs BEFORE arming. Two alternating id-sets with NON-SSO ids
+  // (and a service each), recycled every other tick: the structural reconcile
+  // work (slot reuse, index reset/refill, operation-index rebuild) must reuse its
+  // backing storage rather than reallocating it under churn.
   const std::size_t kTicks = 200;
   std::vector<std::vector<App>> ticks(kTicks);
   for (std::size_t i = 0; i < kTicks; ++i) {
     for (int k = 0; k < 50; ++k) {
-      ticks[i].push_back(
-          mkapp("a" + std::to_string((i % 2) * 100 + static_cast<std::size_t>(k))));  // ids "a0".."a149", <=5 chars
+      // ids like "application_entity_with_long_id_000" - well past the SSO limit.
+      const std::size_t n = (i % 2) * 100 + static_cast<std::size_t>(k);
+      ticks[i].push_back(mkapp("application_entity_with_long_id_" + std::to_string(n)));
     }
   }
   const std::vector<Component> host{};   // empty (Component churn not under test here)
@@ -117,10 +142,10 @@ TEST(EntityCacheAlloc, SteadyStateChurnNoNetStructuralGrowth) {
   const long kSlack = 4;  // tiny; tolerates allocator bookkeeping noise only. Do NOT inflate.
   // Only the UPPER bound is meaningful here. The regression this guards against
   // is the old full rebuild, which allocates under churn -> a positive net. The
-  // steady-state net is legitimately negative (about -1 per tick): every tick's
-  // payloads are pre-built before arming, so payload/structural frees during the
-  // armed window are counted while their allocations are not. A symmetric lower
-  // bound would therefore false-fail without catching any growth, so we do not
-  // assert one (a net that only ever frees cannot grow memory under churn).
+  // steady-state net is legitimately negative: every tick's payloads (incl. the
+  // non-SSO id/full_path heap strings) are pre-built before arming, so their
+  // frees during the armed window are counted while their allocations are not. A
+  // symmetric lower bound would therefore false-fail without catching any growth
+  // (a net that only ever frees cannot grow memory under churn).
   EXPECT_LE(g_net.load(), kSlack) << "cache layer allocated under steady-state churn (regression to rebuild?)";
 }

--- a/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_cache_alloc.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Standalone TU: overrides global operator new/delete, gated by an armed flag, to assert the cache layer
+// performs ~zero net structural allocations during steady-state reconcile churn.
+#include <atomic>
+#include <cstdlib>
+#include <gtest/gtest.h>
+#include <new>
+#include <string>
+#include <vector>
+#include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+namespace {
+std::atomic<long> g_net{0};
+std::atomic<bool> g_armed{false};
+}  // namespace
+void * operator new(std::size_t n) {
+  if (g_armed.load(std::memory_order_relaxed)) {
+    g_net.fetch_add(1, std::memory_order_relaxed);
+  }
+  void * p = std::malloc(n ? n : 1);
+  if (!p) {
+    throw std::bad_alloc();
+  }
+  return p;
+}
+void operator delete(void * p) noexcept {
+  if (p && g_armed.load(std::memory_order_relaxed)) {
+    g_net.fetch_sub(1, std::memory_order_relaxed);
+  }
+  std::free(p);
+}
+void operator delete(void * p, std::size_t) noexcept {
+  ::operator delete(p);
+}
+using namespace ros2_medkit_gateway;
+static App mkapp(const std::string & id) {
+  App a;
+  a.id = id;
+  a.name = id;
+  a.component_id = "host";
+  return a;
+}
+
+TEST(EntityCacheAlloc, SteadyStateChurnNoNetStructuralGrowth) {
+  ThreadSafeEntityCache c(256);
+  // Pre-build ALL inputs BEFORE arming. Two alternating SSO id-sets (<=15 chars), recycled every other tick:
+  // structural reconcile work (slot reuse, index reset/refill) must not allocate; key strings are SSO.
+  const std::size_t kTicks = 200;
+  std::vector<std::vector<App>> ticks(kTicks);
+  for (std::size_t i = 0; i < kTicks; ++i) {
+    for (int k = 0; k < 50; ++k) {
+      ticks[i].push_back(
+          mkapp("a" + std::to_string((i % 2) * 100 + static_cast<std::size_t>(k))));  // ids "a0".."a149", <=5 chars
+    }
+  }
+  const std::vector<Component> host{};   // empty (Component churn not under test here)
+  c.update_all({}, host, ticks[0], {});  // warm storage to high-water (built outside arming)
+  c.update_all({}, host, ticks[1], {});
+  g_net.store(0);
+  g_armed.store(true);
+  for (std::size_t i = 2; i < kTicks; ++i) {
+    c.update_all({}, std::vector<Component>{}, std::move(ticks[i]), {});
+  }
+  g_armed.store(false);
+  // Only update_all ran while armed; no copies, no container mutation, no getter calls.
+  const long kSlack = 4;  // tiny; tolerates allocator bookkeeping noise only. Do NOT inflate.
+  EXPECT_LE(g_net.load(), kSlack) << "cache layer allocated under steady-state churn (regression to rebuild?)";
+}

--- a/src/ros2_medkit_gateway/test/test_entity_equality.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_equality.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include "ros2_medkit_gateway/core/discovery/models/app.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/area.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/component.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/function.hpp"
+using namespace ros2_medkit_gateway;
+
+TEST(EntityEquality, AppFieldSensitivity) {
+  App a;
+  a.id = "n1";
+  a.name = "N";
+  a.component_id = "c";
+  a.services = {{"s", "/s", "t", std::nullopt}};
+  App b = a;
+  EXPECT_TRUE(a == b);
+  EXPECT_FALSE(a != b);
+  b.name = "M";
+  EXPECT_NE(a, b);
+  b = a;
+  b.services[0].type_info = nlohmann::json{{"k", 1}};
+  EXPECT_NE(a, b);
+  b = a;
+  b.is_online = !a.is_online;
+  EXPECT_NE(a, b);
+  b = a;
+  b.ros_binding = App::RosBinding{"node", "/ns", ""};
+  EXPECT_NE(a, b);
+}
+TEST(EntityEquality, ComponentHostMetadata) {
+  Component a;
+  a.id = "c";
+  a.area = "ar";
+  Component b = a;
+  EXPECT_EQ(a, b);
+  b.host_metadata = nlohmann::json{{"os", "linux"}};
+  EXPECT_NE(a, b);
+}
+TEST(EntityEquality, AreaAndFunction) {
+  Area a;
+  a.id = "ar";
+  a.parent_area_id = "root";
+  Area b = a;
+  EXPECT_EQ(a, b);
+  b.source = "x";
+  EXPECT_NE(a, b);
+  Function f;
+  f.id = "fn";
+  f.hosts = {"a1"};
+  Function g = f;
+  EXPECT_EQ(f, g);
+  g.hosts = {"a2"};
+  EXPECT_NE(f, g);
+}

--- a/src/ros2_medkit_gateway/test/test_flat_hash_map.cpp
+++ b/src/ros2_medkit_gateway/test/test_flat_hash_map.cpp
@@ -44,14 +44,30 @@ TEST(FlatHashMap, GetOrCreateAndReset) {
   EXPECT_EQ(m.find("p")->size(), 1u);
 }
 
-TEST(FlatHashMap, GrowsAndVacuumsTombstones) {
+TEST(FlatHashMap, BoundedChurnVacuumsWithoutGrowing) {
+  // Add/remove churn over a bounded live set (size stays <= 2) must reclaim
+  // tombstones via an in-place same-capacity rehash, never growing the table.
+  // This keeps grew() false so a steady-state index does not report growth.
   FlatHashMap<int, int> m(4);
   for (int i = 0; i < 1000; ++i) {
     m.insert_or_assign(i, i);
     m.erase(i - 1);
   }
-  EXPECT_TRUE(m.grew());
+  EXPECT_FALSE(m.grew());
   EXPECT_LE(m.size(), 2u);
+  ASSERT_NE(m.find(999), nullptr);
+  EXPECT_EQ(*m.find(999), 999);
+}
+
+TEST(FlatHashMap, LiveSetOutgrowingCapacityGrows) {
+  // When the live (occupied) set genuinely exceeds the reserved capacity the
+  // table must grow and report grew() == true.
+  FlatHashMap<int, int> m(4);
+  for (int i = 0; i < 1000; ++i) {
+    m.insert_or_assign(i, i);  // never erased: live set grows past capacity
+  }
+  EXPECT_TRUE(m.grew());
+  EXPECT_EQ(m.size(), 1000u);
   ASSERT_NE(m.find(999), nullptr);
   EXPECT_EQ(*m.find(999), 999);
 }

--- a/src/ros2_medkit_gateway/test/test_flat_hash_map.cpp
+++ b/src/ros2_medkit_gateway/test/test_flat_hash_map.cpp
@@ -1,0 +1,71 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include "ros2_medkit_gateway/core/util/flat_hash_map.hpp"
+using ros2_medkit_gateway::FlatHashMap;
+
+TEST(FlatHashMap, InsertFindErase) {
+  FlatHashMap<std::string, int> m(8);
+  EXPECT_TRUE(m.insert_or_assign("a", 1));
+  EXPECT_FALSE(m.insert_or_assign("a", 2));  // existing key -> not new
+  ASSERT_NE(m.find("a"), nullptr);
+  EXPECT_EQ(*m.find("a"), 2);
+  EXPECT_EQ(m.find("b"), nullptr);
+  EXPECT_TRUE(m.erase("a"));
+  EXPECT_FALSE(m.erase("a"));
+  EXPECT_EQ(m.find("a"), nullptr);
+  EXPECT_EQ(m.size(), 0u);
+}
+
+TEST(FlatHashMap, GetOrCreateAndReset) {
+  FlatHashMap<std::string, std::vector<uint32_t>> m(8);
+  m.get_or_create("p").push_back(5);
+  m.get_or_create("p").push_back(6);
+  ASSERT_NE(m.find("p"), nullptr);
+  EXPECT_EQ(m.find("p")->size(), 2u);
+  m.reset();
+  EXPECT_EQ(m.size(), 0u);
+  EXPECT_EQ(m.find("p"), nullptr);
+  m.get_or_create("p").push_back(9);  // reuse after reset
+  EXPECT_EQ(m.find("p")->size(), 1u);
+}
+
+TEST(FlatHashMap, GrowsAndVacuumsTombstones) {
+  FlatHashMap<int, int> m(4);
+  for (int i = 0; i < 1000; ++i) {
+    m.insert_or_assign(i, i);
+    m.erase(i - 1);
+  }
+  EXPECT_TRUE(m.grew());
+  EXPECT_LE(m.size(), 2u);
+  ASSERT_NE(m.find(999), nullptr);
+  EXPECT_EQ(*m.find(999), 999);
+}
+
+TEST(FlatHashMap, ForEachVisitsOccupiedOnly) {
+  FlatHashMap<std::string, int> m(8);
+  m.insert_or_assign("x", 1);
+  m.insert_or_assign("y", 2);
+  m.erase("x");
+  int sum = 0, count = 0;
+  m.for_each([&](const std::string &, int v) {
+    sum += v;
+    ++count;
+  });
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(sum, 2);
+}

--- a/src/ros2_medkit_gateway/test/test_health_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_health_handlers.cpp
@@ -398,3 +398,43 @@ TEST_F(HealthHandlersLiveTest, HealthDiscoveryBlockContainsExpectedFields) {
   EXPECT_FALSE(disc.contains("pipeline"));
   EXPECT_FALSE(disc.contains("linking"));
 }
+
+TEST_F(HealthHandlersLiveTest, HealthEntityCacheStatsPresent) {
+  // x-medkit-entity-cache block is present with the required fields
+  httplib::Client client("127.0.0.1", server_port_);
+  auto res = client.Get(std::string(API_BASE_PATH) + "/health");
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(res->status, 200);
+
+  auto body = json::parse(res->body);
+
+  ASSERT_TRUE(body.contains("x-medkit-entity-cache"))
+      << "/health must include x-medkit-entity-cache when entity_cache.capacity is configured";
+  const auto & ec = body["x-medkit-entity-cache"];
+
+  EXPECT_TRUE(ec.contains("capacity")) << "x-medkit-entity-cache must include capacity";
+  EXPECT_TRUE(ec["capacity"].is_number_unsigned());
+  // Default capacity is 256 (from declare_parameter("entity_cache.capacity", 256))
+  EXPECT_EQ(ec["capacity"].get<std::size_t>(), 256u);
+
+  EXPECT_TRUE(ec.contains("areas")) << "x-medkit-entity-cache must include areas";
+  EXPECT_TRUE(ec["areas"].is_number_unsigned());
+
+  EXPECT_TRUE(ec.contains("components")) << "x-medkit-entity-cache must include components";
+  EXPECT_TRUE(ec["components"].is_number_unsigned());
+
+  EXPECT_TRUE(ec.contains("apps")) << "x-medkit-entity-cache must include apps";
+  EXPECT_TRUE(ec["apps"].is_number_unsigned());
+
+  EXPECT_TRUE(ec.contains("functions")) << "x-medkit-entity-cache must include functions";
+  EXPECT_TRUE(ec["functions"].is_number_unsigned());
+
+  EXPECT_TRUE(ec.contains("generation")) << "x-medkit-entity-cache must include generation";
+  EXPECT_TRUE(ec["generation"].is_number_unsigned());
+
+  EXPECT_TRUE(ec.contains("grew")) << "x-medkit-entity-cache must include grew";
+  EXPECT_TRUE(ec["grew"].is_boolean());
+  // A fresh cache with default capacity=256 must not have grown
+  EXPECT_FALSE(ec["grew"].get<bool>());
+}

--- a/src/ros2_medkit_gateway/test/test_refresh_debounce.cpp
+++ b/src/ros2_medkit_gateway/test/test_refresh_debounce.cpp
@@ -1,0 +1,69 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_gateway/core/discovery/refresh_debounce.hpp"
+
+using ros2_medkit_gateway::decide_graph_refresh;
+
+// No graph event and nothing pending -> idle, no refresh, latch stays clear.
+TEST(RefreshDebounce, IdleDoesNotRefresh) {
+  auto d = decide_graph_refresh(/*event_fired=*/false, /*currently_dirty=*/false, /*elapsed_ms=*/100000, 1000);
+  EXPECT_FALSE(d.refresh);
+  EXPECT_FALSE(d.dirty);
+}
+
+// An event inside the debounce window latches dirty but does not refresh yet.
+TEST(RefreshDebounce, EventWithinWindowLatchesButDefers) {
+  auto d = decide_graph_refresh(/*event_fired=*/true, /*currently_dirty=*/false, /*elapsed_ms=*/10, 1000);
+  EXPECT_FALSE(d.refresh);
+  EXPECT_TRUE(d.dirty);
+}
+
+// A burst of events inside the window coalesces: still pending, still no refresh.
+TEST(RefreshDebounce, CoalescesPendingWithinWindow) {
+  auto d = decide_graph_refresh(/*event_fired=*/true, /*currently_dirty=*/true, /*elapsed_ms=*/500, 1000);
+  EXPECT_FALSE(d.refresh);
+  EXPECT_TRUE(d.dirty);
+}
+
+// Once the window elapses, a pending change is serviced and the latch clears.
+TEST(RefreshDebounce, PendingPastWindowRefreshesAndClears) {
+  auto d = decide_graph_refresh(/*event_fired=*/false, /*currently_dirty=*/true, /*elapsed_ms=*/1500, 1000);
+  EXPECT_TRUE(d.refresh);
+  EXPECT_FALSE(d.dirty);
+}
+
+// debounce_ms == 0 disables debouncing: any pending change refreshes immediately.
+TEST(RefreshDebounce, ZeroDebounceRefreshesImmediately) {
+  auto d = decide_graph_refresh(/*event_fired=*/true, /*currently_dirty=*/false, /*elapsed_ms=*/0, 0);
+  EXPECT_TRUE(d.refresh);
+  EXPECT_FALSE(d.dirty);
+}
+
+// Cold start (last refresh seeded to the epoch) yields a huge elapsed, so the
+// first event refreshes immediately rather than waiting out a window.
+TEST(RefreshDebounce, ColdStartRefreshesOnFirstEvent) {
+  auto d = decide_graph_refresh(/*event_fired=*/true, /*currently_dirty=*/false, /*elapsed_ms=*/9'000'000'000LL, 1000);
+  EXPECT_TRUE(d.refresh);
+  EXPECT_FALSE(d.dirty);
+}
+
+// A spurious tick (no event) past the window with nothing pending does nothing.
+TEST(RefreshDebounce, NoEventPastWindowStaysIdle) {
+  auto d = decide_graph_refresh(/*event_fired=*/false, /*currently_dirty=*/false, /*elapsed_ms=*/5000, 1000);
+  EXPECT_FALSE(d.refresh);
+  EXPECT_FALSE(d.dirty);
+}

--- a/src/ros2_medkit_gateway/test/test_slot_store.cpp
+++ b/src/ros2_medkit_gateway/test/test_slot_store.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <string>
+#include "ros2_medkit_gateway/core/util/slot_store.hpp"
+using ros2_medkit_gateway::SlotStore;
+
+TEST(SlotStore, AllocAssignFreeReuse) {
+  SlotStore<std::string> s(4);
+  uint32_t a = s.alloc_slot();
+  s.assign(a, std::string("alpha"));
+  uint32_t b = s.alloc_slot();
+  s.assign(b, std::string("beta"));
+  EXPECT_EQ(s.live_count(), 2u);
+  EXPECT_TRUE(s.is_live(a));
+  EXPECT_EQ(s[a], "alpha");
+  s.free(a);
+  EXPECT_FALSE(s.is_live(a));
+  EXPECT_EQ(s.live_count(), 1u);
+  EXPECT_TRUE(s[a].empty());    // payload released
+  uint32_t c = s.alloc_slot();  // reuses freed slot
+  EXPECT_EQ(c, a);
+  s.assign(c, std::string("gamma"));
+  EXPECT_EQ(s.live_count(), 2u);
+}
+
+TEST(SlotStore, CollectLiveAndForEachSkipDead) {
+  SlotStore<int> s(4);
+  uint32_t a = s.alloc_slot();
+  s.assign(a, 1);
+  uint32_t b = s.alloc_slot();
+  s.assign(b, 2);
+  uint32_t c = s.alloc_slot();
+  s.assign(c, 3);
+  s.free(b);
+  auto v = s.collect_live();
+  EXPECT_EQ(v.size(), 2u);
+  int sum = 0;
+  s.for_each_live([&](uint32_t, const int & x) {
+    sum += x;
+  });
+  EXPECT_EQ(sum, 4);
+}
+
+TEST(SlotStore, CapacityStableUnderChurnUntilOverflow) {
+  SlotStore<int> s(8);
+  size_t cap0 = s.capacity();
+  for (int i = 0; i < 1000; ++i) {
+    uint32_t k = s.alloc_slot();
+    s.assign(k, i);
+    s.free(k);
+  }
+  EXPECT_EQ(s.capacity(), cap0);  // bounded churn: no growth
+  EXPECT_FALSE(s.grew());
+}

--- a/src/ros2_medkit_gateway/test/test_thread_safe_entity_cache.cpp
+++ b/src/ros2_medkit_gateway/test/test_thread_safe_entity_cache.cpp
@@ -21,14 +21,14 @@
 
 using namespace ros2_medkit_gateway;
 
-static App mkapp(std::string id) {
+static App mkapp(const std::string & id) {
   App a;
   a.id = id;
   a.name = id;
   a.component_id = "host";
   return a;
 }
-static Component mkcomp(std::string id) {
+static Component mkcomp(const std::string & id) {
   Component c;
   c.id = id;
   c.name = id;
@@ -86,6 +86,7 @@ TEST(EntityCacheIncremental, ChurnKeepsCapacityBounded) {
   ThreadSafeEntityCache c(64);
   for (int i = 0; i < 500; ++i) {
     std::vector<App> apps;
+    apps.reserve(5);
     for (int k = 0; k < 5; ++k) {
       apps.push_back(mkapp("n" + std::to_string(i * 5 + k)));
     }
@@ -99,6 +100,7 @@ TEST(EntityCacheIncremental, ChurnKeepsCapacityBounded) {
 TEST(EntityCacheIncremental, OverflowGrowsAndFlags) {
   ThreadSafeEntityCache c(8);
   std::vector<App> apps;
+  apps.reserve(64);
   for (int i = 0; i < 64; ++i) {
     apps.push_back(mkapp("n" + std::to_string(i)));
   }

--- a/src/ros2_medkit_gateway/test/test_thread_safe_entity_cache.cpp
+++ b/src/ros2_medkit_gateway/test/test_thread_safe_entity_cache.cpp
@@ -1,0 +1,121 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+using namespace ros2_medkit_gateway;
+
+static App mkapp(std::string id) {
+  App a;
+  a.id = id;
+  a.name = id;
+  a.component_id = "host";
+  return a;
+}
+static Component mkcomp(std::string id) {
+  Component c;
+  c.id = id;
+  c.name = id;
+  return c;
+}
+
+TEST(EntityCacheIncremental, NoChangeDoesNotBumpGeneration) {
+  ThreadSafeEntityCache c(64);
+  std::vector<App> apps{mkapp("a"), mkapp("b")};
+  c.update_all({}, {mkcomp("host")}, apps, {});
+  uint64_t g = c.generation();
+  c.update_all({}, {mkcomp("host")}, apps, {});  // identical
+  EXPECT_EQ(c.generation(), g);                  // no bump
+}
+
+TEST(EntityCacheIncremental, AddRemoveUpdateReflected) {
+  ThreadSafeEntityCache c(64);
+  c.update_all({}, {mkcomp("host")}, {mkapp("a")}, {});
+  uint64_t g = c.generation();
+  auto a2 = mkapp("a");
+  a2.name = "renamed";
+  c.update_all({}, {mkcomp("host")}, {a2, mkapp("b")}, {});  // update a, add b
+  EXPECT_GT(c.generation(), g);
+  EXPECT_EQ(c.get_apps().size(), 2u);
+  ASSERT_TRUE(c.get_app("a"));
+  EXPECT_EQ(c.get_app("a")->name, "renamed");
+  c.update_all({}, {mkcomp("host")}, {mkapp("b")}, {});  // remove a
+  EXPECT_FALSE(c.get_app("a"));
+  EXPECT_TRUE(c.get_app("b"));
+  EXPECT_TRUE(c.validate().empty());
+}
+
+TEST(EntityCacheIncremental, AllRemovedBumpsGeneration) {
+  ThreadSafeEntityCache c(64);
+  c.update_all({}, {}, {mkapp("a")}, {});
+  uint64_t g = c.generation();
+  c.update_all({}, {}, {}, {});
+  EXPECT_GT(c.generation(), g);
+  EXPECT_EQ(c.get_apps().size(), 0u);
+}
+
+TEST(EntityCacheIncremental, DuplicateIdCollapsesLastWins) {
+  ThreadSafeEntityCache c(64);
+  auto a1 = mkapp("dup");
+  a1.name = "first";
+  auto a2 = mkapp("dup");
+  a2.name = "second";
+  c.update_all({}, {}, {a1, a2}, {});
+  EXPECT_EQ(c.get_apps().size(), 1u);
+  ASSERT_TRUE(c.get_app("dup"));
+  EXPECT_EQ(c.get_app("dup")->name, "second");
+}
+
+TEST(EntityCacheIncremental, ChurnKeepsCapacityBounded) {
+  ThreadSafeEntityCache c(64);
+  for (int i = 0; i < 500; ++i) {
+    std::vector<App> apps;
+    for (int k = 0; k < 5; ++k) {
+      apps.push_back(mkapp("n" + std::to_string(i * 5 + k)));
+    }
+    c.update_all({}, {mkcomp("host")}, apps, {});  // 5 fresh each tick (prev all removed)
+  }
+  auto s = c.get_stats();
+  EXPECT_FALSE(s.grew);  // bounded set <= capacity -> no grow
+  EXPECT_TRUE(c.validate().empty());
+}
+
+TEST(EntityCacheIncremental, OverflowGrowsAndFlags) {
+  ThreadSafeEntityCache c(8);
+  std::vector<App> apps;
+  for (int i = 0; i < 64; ++i) {
+    apps.push_back(mkapp("n" + std::to_string(i)));
+  }
+  c.update_all({}, {}, apps, {});
+  EXPECT_EQ(c.get_apps().size(), 64u);
+  EXPECT_TRUE(c.get_stats().grew);
+  EXPECT_TRUE(c.validate().empty());
+}
+
+TEST(EntityCacheIncremental, TopicTypesAndNodeMapConditional) {
+  ThreadSafeEntityCache c(64);
+  c.update_all({}, {}, {mkapp("a")}, {});
+  uint64_t g = c.generation();
+  c.update_topic_types({{"/t", "std_msgs/msg/String"}});
+  EXPECT_GT(c.generation(), g);
+  g = c.generation();
+  c.update_topic_types({{"/t", "std_msgs/msg/String"}});
+  EXPECT_EQ(c.generation(), g);  // identical -> no bump
+  EXPECT_EQ(c.get_topic_type("/t"), "std_msgs/msg/String");
+}

--- a/src/ros2_medkit_log_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_log_bridge/test/test_integration.test.py
@@ -163,4 +163,8 @@ class TestLogBridgeShutdown(unittest.TestCase):
     """Test clean shutdown."""
 
     def test_exit_code(self, proc_info):
-        launch_testing.asserts.assertExitCodes(proc_info)
+        # OK, SIGINT, SIGTERM: the launch harness stops the long-running node by
+        # signal, so SIGTERM is a clean shutdown (matches ALLOWED_EXIT_CODES used
+        # across the other integration tests). The bare default ([0]) made this
+        # flaky whenever the harness escalated SIGINT to SIGTERM.
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=[0, -2, -15])

--- a/src/ros2_medkit_serialization/CMakeLists.txt
+++ b/src/ros2_medkit_serialization/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_type_introspection test/test_type_introspection.cpp)
   target_link_libraries(test_type_introspection ${PROJECT_NAME})
-  medkit_target_dependencies(test_type_introspection std_msgs)
+  medkit_target_dependencies(test_type_introspection std_msgs std_srvs test_msgs)
 
   # Apply coverage flags to test targets
   if(ENABLE_COVERAGE)

--- a/src/ros2_medkit_serialization/include/ros2_medkit_serialization/type_introspection.hpp
+++ b/src/ros2_medkit_serialization/include/ros2_medkit_serialization/type_introspection.hpp
@@ -71,6 +71,28 @@ class TypeIntrospection {
   TopicTypeInfo get_type_info(const std::string & type_name);
 
   /**
+   * @brief Get the assembled service type_info ({request, response} schemas)
+   *
+   * Builds the wrapper once per service type and caches it as a shared,
+   * immutable object so repeated /operations requests reuse it instead of
+   * re-assembling and deep-copying the schemas (issue #442).
+   *
+   * @param service_type Service type (e.g., "std_srvs/srv/Trigger")
+   * @return shared, immutable JSON {"request": ..., "response": ...}
+   */
+  std::shared_ptr<const nlohmann::json> get_service_type_info(const std::string & service_type);
+
+  /**
+   * @brief Get the assembled action type_info ({goal, result, feedback} schemas)
+   *
+   * Cached + shared, same rationale as get_service_type_info.
+   *
+   * @param action_type Action type (e.g., "nav2_msgs/action/NavigateToPose")
+   * @return shared, immutable JSON {"goal": ..., "result": ..., "feedback": ...}
+   */
+  std::shared_ptr<const nlohmann::json> get_action_type_info(const std::string & action_type);
+
+  /**
    * @brief Get the default value template for a message type
    *
    * Uses native JsonSerializer to generate a template with default values.
@@ -97,7 +119,12 @@ class TypeIntrospection {
   std::shared_ptr<JsonSerializer> serializer_;
 
   std::unordered_map<std::string, TopicTypeInfo> type_cache_;  ///< Cache for type info
-  mutable std::mutex cache_mutex_;                             ///< Mutex for thread-safe cache access
+  /// Cache for assembled service/action type_info (shared, immutable). Keyed by
+  /// service/action type. Avoids re-assembling + deep-copying schemas on every
+  /// /operations request (issue #442).
+  std::unordered_map<std::string, std::shared_ptr<const nlohmann::json>> service_type_info_cache_;
+  std::unordered_map<std::string, std::shared_ptr<const nlohmann::json>> action_type_info_cache_;
+  mutable std::mutex cache_mutex_;  ///< Mutex for thread-safe cache access
 };
 
 }  // namespace ros2_medkit_serialization

--- a/src/ros2_medkit_serialization/src/type_introspection.cpp
+++ b/src/ros2_medkit_serialization/src/type_introspection.cpp
@@ -70,18 +70,25 @@ TopicTypeInfo TypeIntrospection::get_type_info(const std::string & type_name) {
   }
 
   // Get schema (type structure)
+  bool schema_resolved = true;
   try {
     info.schema = get_type_schema(type_name);
   } catch (const std::exception & e) {
-    // If schema fails, use empty object
+    // If schema fails, use empty object and do NOT memoize: resolution may be
+    // transient (e.g. the type support library is not yet loadable), and caching
+    // the empty result would pin it empty for the process lifetime.
     info.schema = nlohmann::json::object();
+    schema_resolved = false;
+  }
+
+  if (!schema_resolved) {
+    return info;  // return empty result without poisoning the cache; retry later
   }
 
   // Cache it (use try_emplace to avoid overwriting if another thread added it first)
   {
     std::lock_guard<std::mutex> lock(cache_mutex_);
-    auto [it, inserted] = type_cache_.try_emplace(type_name, info);
-    return it->second;  // Return cached version (may be from another thread)
+    return type_cache_.try_emplace(type_name, info).first->second;  // may be another thread's
   }
 }
 
@@ -98,7 +105,15 @@ std::shared_ptr<const nlohmann::json> TypeIntrospection::get_service_type_info(c
   auto assembled = std::make_shared<nlohmann::json>();
   (*assembled)["request"] = get_type_info(service_type + "_Request").schema;
   (*assembled)["response"] = get_type_info(service_type + "_Response").schema;
+  // Memoize only a resolved wrapper. If neither side resolved, the type support
+  // was not available; return without caching so a later request can retry
+  // instead of pinning an empty wrapper for the process lifetime. (A genuinely
+  // empty service still has a non-empty schema object on at least one side.)
+  const bool resolved = !(*assembled)["request"].empty() || !(*assembled)["response"].empty();
   std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
+  if (!resolved) {
+    return shared;
+  }
   {
     std::lock_guard<std::mutex> lock(cache_mutex_);
     // try_emplace keeps the first cached instance if another thread raced us.
@@ -118,7 +133,14 @@ std::shared_ptr<const nlohmann::json> TypeIntrospection::get_action_type_info(co
   (*assembled)["goal"] = get_type_info(action_type + "_Goal").schema;
   (*assembled)["result"] = get_type_info(action_type + "_Result").schema;
   (*assembled)["feedback"] = get_type_info(action_type + "_Feedback").schema;
+  // Memoize only a resolved wrapper (see get_service_type_info); if none of the
+  // three sides resolved, return without caching so a later request can retry.
+  const bool resolved =
+      !(*assembled)["goal"].empty() || !(*assembled)["result"].empty() || !(*assembled)["feedback"].empty();
   std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
+  if (!resolved) {
+    return shared;
+  }
   {
     std::lock_guard<std::mutex> lock(cache_mutex_);
     // try_emplace keeps the first cached instance if another thread raced us.

--- a/src/ros2_medkit_serialization/src/type_introspection.cpp
+++ b/src/ros2_medkit_serialization/src/type_introspection.cpp
@@ -93,15 +93,16 @@ std::shared_ptr<const nlohmann::json> TypeIntrospection::get_service_type_info(c
       return it->second;
     }
   }
-  // get_type_info is itself cached + throws on failure; build the wrapper once.
+  // get_type_info is itself cached and returns empty schemas for unknown types
+  // (it does not throw); build the wrapper once.
   auto assembled = std::make_shared<nlohmann::json>();
   (*assembled)["request"] = get_type_info(service_type + "_Request").schema;
   (*assembled)["response"] = get_type_info(service_type + "_Response").schema;
   std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
   {
     std::lock_guard<std::mutex> lock(cache_mutex_);
-    auto [it, inserted] = service_type_info_cache_.try_emplace(service_type, shared);
-    return it->second;
+    // try_emplace keeps the first cached instance if another thread raced us.
+    return service_type_info_cache_.try_emplace(service_type, shared).first->second;
   }
 }
 
@@ -120,8 +121,8 @@ std::shared_ptr<const nlohmann::json> TypeIntrospection::get_action_type_info(co
   std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
   {
     std::lock_guard<std::mutex> lock(cache_mutex_);
-    auto [it, inserted] = action_type_info_cache_.try_emplace(action_type, shared);
-    return it->second;
+    // try_emplace keeps the first cached instance if another thread raced us.
+    return action_type_info_cache_.try_emplace(action_type, shared).first->second;
   }
 }
 

--- a/src/ros2_medkit_serialization/src/type_introspection.cpp
+++ b/src/ros2_medkit_serialization/src/type_introspection.cpp
@@ -85,4 +85,44 @@ TopicTypeInfo TypeIntrospection::get_type_info(const std::string & type_name) {
   }
 }
 
+std::shared_ptr<const nlohmann::json> TypeIntrospection::get_service_type_info(const std::string & service_type) {
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto it = service_type_info_cache_.find(service_type);
+    if (it != service_type_info_cache_.end()) {
+      return it->second;
+    }
+  }
+  // get_type_info is itself cached + throws on failure; build the wrapper once.
+  auto assembled = std::make_shared<nlohmann::json>();
+  (*assembled)["request"] = get_type_info(service_type + "_Request").schema;
+  (*assembled)["response"] = get_type_info(service_type + "_Response").schema;
+  std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto [it, inserted] = service_type_info_cache_.try_emplace(service_type, shared);
+    return it->second;
+  }
+}
+
+std::shared_ptr<const nlohmann::json> TypeIntrospection::get_action_type_info(const std::string & action_type) {
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto it = action_type_info_cache_.find(action_type);
+    if (it != action_type_info_cache_.end()) {
+      return it->second;
+    }
+  }
+  auto assembled = std::make_shared<nlohmann::json>();
+  (*assembled)["goal"] = get_type_info(action_type + "_Goal").schema;
+  (*assembled)["result"] = get_type_info(action_type + "_Result").schema;
+  (*assembled)["feedback"] = get_type_info(action_type + "_Feedback").schema;
+  std::shared_ptr<const nlohmann::json> shared = std::move(assembled);
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex_);
+    auto [it, inserted] = action_type_info_cache_.try_emplace(action_type, shared);
+    return it->second;
+  }
+}
+
 }  // namespace ros2_medkit_serialization

--- a/src/ros2_medkit_serialization/test/test_type_introspection.cpp
+++ b/src/ros2_medkit_serialization/test/test_type_introspection.cpp
@@ -85,4 +85,34 @@ TEST_F(TypeIntrospectionTest, get_type_info_for_unknown_type_returns_empty) {
   EXPECT_TRUE(info.schema.is_object());
 }
 
+// issue #442: assembled service/action type_info is built once per type and
+// shared (cached), so repeated /operations requests reuse it instead of
+// rebuilding + deep-copying the schemas.
+TEST_F(TypeIntrospectionTest, get_service_type_info_assembles_request_response) {
+  auto info = introspection_->get_service_type_info("std_srvs/srv/Trigger");
+  ASSERT_NE(info, nullptr);
+  EXPECT_TRUE(info->contains("request"));
+  EXPECT_TRUE(info->contains("response"));
+}
+
+TEST_F(TypeIntrospectionTest, get_service_type_info_returns_same_shared_instance) {
+  auto a = introspection_->get_service_type_info("std_srvs/srv/Trigger");
+  auto b = introspection_->get_service_type_info("std_srvs/srv/Trigger");
+  EXPECT_EQ(a.get(), b.get());  // cached: same object, not rebuilt
+}
+
+TEST_F(TypeIntrospectionTest, get_action_type_info_assembles_goal_result_feedback) {
+  auto info = introspection_->get_action_type_info("test_msgs/action/Fibonacci");
+  ASSERT_NE(info, nullptr);
+  EXPECT_TRUE(info->contains("goal"));
+  EXPECT_TRUE(info->contains("result"));
+  EXPECT_TRUE(info->contains("feedback"));
+}
+
+TEST_F(TypeIntrospectionTest, get_action_type_info_returns_same_shared_instance) {
+  auto a = introspection_->get_action_type_info("test_msgs/action/Fibonacci");
+  auto b = introspection_->get_action_type_info("test_msgs/action/Fibonacci");
+  EXPECT_EQ(a.get(), b.get());  // cached: same object, not rebuilt
+}
+
 }  // namespace ros2_medkit_serialization


### PR DESCRIPTION
# Pull Request

## Summary

Rework the gateway entity cache for incremental, embedded-friendly refresh and
bound the discovery pipeline's per-graph-event allocation under graph churn.

**Entity cache (object pool + flat indexes):**
- `ThreadSafeEntityCache` now stores entities in a fixed-capacity `SlotStore`
  object pool with stable slots and a free-list, indexed by pre-reserved
  open-addressed `FlatHashMap`s instead of `std::vector` + `std::unordered_map`.
- `update_all` reconciles the incoming discovery output against the current
  state by id (add / remove / change only) and skips work entirely when nothing
  changed; `generation` advances only on a real change.
- Capacity is reserved at startup via `entity_cache.capacity` (default 256,
  clamped); steady-state refresh performs zero structural allocations in the
  cache layer. Cache stats are exposed on `/health` as `x-medkit-entity-cache`,
  with a one-shot WARN if capacity is exceeded.

**Discovery (bound per-graph-event allocation):**
- Operation `type_info` schemas are resolved lazily by the `/operations` handler
  and cached as shared, immutable per-type objects in `TypeIntrospection`, so
  they are no longer rebuilt and deep-copied on every discovery refresh.
- Graph-event refreshes are debounced via `discovery.refresh_debounce_ms`
  (default 1000 ms) so bursts of graph changes coalesce into one refresh.

Net effect under graph churn: gateway CPU drops ~4x (0.45 -> 0.11 cores) and the
gateway-side per-refresh allocation is largely eliminated.

## Issue

- Closes #442

(Not "closes" - see "Memory growth under churn: what this does and does not fix"
below. The gateway-side contribution is addressed here; the dominant residual is
a DDS-middleware property, outside this repo's scope.)

## Memory growth under churn: what this does and does not fix

The `benchmark churn` gate measures total-process USS slope under node churn.
Per-allocation profiling (operator-new counters per refresh phase) and isolation
experiments attribute the growth as follows:

- The entity-cache rebuild was **not** the leak. An in-repo allocation-counter
  test proves `update_all` does zero structural allocations under steady-state
  churn, yet removing all cache/refresh allocation left the USS slope unchanged.
- ~50% of the growth is **glibc multi-arena retention** (freed memory retained
  per-arena, and the arena count scales with thread count). This is addressed by
  bounding the executor / HTTP thread pools (separate work), which lowers the
  arena count; no allocator tuning is added here.
- Resource handles are **not** leaked: under churn the gateway's open file
  descriptors stay flat (18) and thread count stays flat (50), and the
  subscription count does not grow. The growth is allocation churn, not a
  pub/sub / handle leak.
- ~50% is **DDS participant-churn growth in the middleware**, not the gateway: a
  bare rclpy node (no gateway code) leaks ~24 KB/s under FastDDS and ~31 KB/s
  under CycloneDDS, and ~24 KB/s even when node names are reused. It is the
  participant create/destroy churn itself, independent of the gateway and of the
  RMW implementation.

So the gate's threshold is not reachable by any ROS 2 process under this churn
because the DDS layer alone exceeds it. The gateway-side improvements here (CPU,
cache structure, lazy schemas, debounce) are real and worthwhile; the residual
memory behaviour is a middleware concern (the RMW is swappable).

Long-run trajectory (bare node, FastDDS, ~40 min): net-growing but decelerating (first third ~64 KB/s, last third ~12 KB/s) with a periodic DDS lease-purge sawtooth (~8 MB reclaimed around the 26-minute mark); 0.4 MB -> 61.5 MB over 42 min, not fully plateaued. The gate's 10-minute window captures only the steep initial ramp, so it overstates the steady-state slope. This is a bare rclpy node (no gateway code), i.e. purely the DDS layer.

## Type

- [x] New feature or tests
- [x] Bug fix (performance / allocation under churn)
- [ ] Breaking change
- [ ] Documentation only

## Testing

- Full gateway unit suite green (2327 tests, 0 failures).
- New unit tests: `FlatHashMap`, `SlotStore`, entity `operator==`,
  `ThreadSafeEntityCache` incremental reconcile, an isolated allocation-counter
  gate (proves zero structural allocations under steady-state churn), and
  `TypeIntrospection` shared service/action `type_info` caching.
- Generation-counter tests updated to the change-gated contract.
- clang-tidy clean on changed files; gateway_core ROS-free purity preserved;
  Sphinx docs build clean.
- Docker `benchmark churn` gate exercised; findings summarised above.

## Checklist

- [x] Breaking changes are clearly described (no breaking API changes; entity
      detail `operations[]` no longer eagerly embeds schemas - schemas remain on
      the `/operations` resource)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
