### PR TITLE
docs: lead the root README with a diagnostics-first front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/6CXPMApAyq)
 
 <p align="center">
-  <img src="docs/_static/images/18_faults_injected_dashboard.png" alt="ros2_medkit faults dashboard" width="760">
+  <img src="docs/_static/images/medkit_hero.gif" alt="A Nav2 NavigateToPose goal aborts: stock ROS 2 diagnostics leave you a log line lost in the noise, while ros2_medkit turns it into one structured fault over REST" width="820">
 </p>
 
 <p align="center">
-  <b>A diagnostic REST API for ROS 2 robots.</b><br>
-  Drop it next to the stack you already run - no code changes - and your failures become
-  structured faults you can query remotely, with the state captured at the moment they happened.
+  <b>A structured diagnostic model for ROS 2 robots, over REST.</b><br>
+  Drop it next to the stack you already run - no code changes - and a failure that ROS 2
+  diagnostics leaves as a log line becomes one structured fault: a fault code on a SOVD entity
+  tree, with lifecycle, history, and the state captured at the moment it happened.
 </p>
 
 <p align="center">
-  Fault lifecycle · Freeze-frame + black-box capture · Live introspection · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
+  Structured fault codes · SOVD entity tree · Fault lifecycle · Freeze-frame + black-box capture · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
 </p>
 
 ## Drop it into the stack you already run

--- a/README.md
+++ b/README.md
@@ -52,9 +52,22 @@ curl http://localhost:8080/api/v1/apps/move_group/faults
 # → the aborted MoveGroup goal, as a structured fault with its snapshot
 ```
 
-**The point:** ros2_medkit reads the signals your stack already emits - aborted actions,
-`/rosout` errors, `/diagnostics` - through drop-in bridges. You add nothing to Nav2, MoveIt,
-or your own nodes; you get a remote, queryable, time-traveled fault instead of a log line.
+**Two ways to feed it:**
+
+- **Native, for code you own** - report faults directly with the
+  [`FaultReporter`](https://github.com/selfpatch/ros2_medkit/tree/main/src/ros2_medkit_fault_reporter)
+  client. This is the richest path (your own codes, severities and context) and the canonical way
+  for new code; see the
+  [integration tutorial](https://selfpatch.github.io/ros2_medkit/tutorials/integration.html).
+- **Drop-in bridges, for the stack you will not rewrite** - most real robots run huge existing
+  projects nobody is going to retrofit with diagnostics. Point the bridges at what they already
+  emit and you get structured faults (and states) in minutes, zero code changes:
+  [`/diagnostics`](https://github.com/selfpatch/ros2_medkit/tree/main/src/ros2_medkit_diagnostic_bridge),
+  [`/rosout` logs](https://github.com/selfpatch/ros2_medkit/tree/main/src/ros2_medkit_log_bridge),
+  [aborted actions](https://github.com/selfpatch/ros2_medkit/tree/main/src/ros2_medkit_action_status_bridge).
+
+So you get a remote, queryable, time-traveled fault instead of a log line - whether or not you
+touch the node's code.
 
 ## vs. standard ROS 2 diagnostics
 
@@ -63,7 +76,7 @@ current node health to a desktop GUI. ros2_medkit turns that into a queryable, r
 time-traveled, actionable fault - and it **consumes `/diagnostics` too**, so it is additive,
 not a rip-and-replace.
 
-| | ROS 2 diagnostics | ros2_medkit |
+| | 🔴 ROS 2 diagnostics | 🟢 ros2_medkit |
 |---|---|---|
 | Access | `/diagnostics` topic + rqt GUI (local desktop) | SOVD REST API (remote; any tool / dashboard / agent) |
 | Instrumentation | required (`diagnostic_updater` in node code) | works without it - drop-in bridges (`/rosout`, action status, `/diagnostics` passthrough) |

--- a/README.md
+++ b/README.md
@@ -74,47 +74,6 @@ curl http://localhost:8080/api/v1/apps/move_group/faults
 So you get a remote, queryable, time-traveled fault instead of a log line - whether or not you
 touch the node's code.
 
-## vs. standard ROS 2 diagnostics
-
-`diagnostic_updater` + `/diagnostics` + `diagnostic_aggregator` + `rqt_robot_monitor` report
-current node health to a desktop GUI. ros2_medkit turns that into a queryable, remote,
-time-traveled, actionable fault.
-
-> [!NOTE]
-> It **consumes `/diagnostics` too**, so it is additive, not a rip-and-replace. Keep your
-> existing `diagnostic_updater` publishers; medkit reads them and gives you the rest.
-
-| | 🔴 ROS 2 diagnostics | 🟢 ros2_medkit |
-|---|---|---|
-| Access | `/diagnostics` topic + rqt GUI (local desktop) | SOVD REST API (remote; any tool / dashboard / agent) |
-| Instrumentation | required (`diagnostic_updater` in node code) | works without it - drop-in bridges (`/rosout`, action status, `/diagnostics` passthrough) |
-| State | live OK / WARN / ERROR / STALE | fault lifecycle (debounce, confirm, heal) |
-| Moment of failure | none | freeze-frame snapshot + black-box rosbag |
-| History | none (live only) | persisted, queryable |
-| Model | key/value pairs | structured fault codes + SOVD entity model |
-| Scope | ROS only | ROS today; PLC / ECU on one API |
-| Agent access | none | MCP adapter |
-
-## "I already have Foxglove. Why do I need this?"
-
-Foxglove, Rerun and PlotJuggler are how you *look* at robot data - plots, 3D, logs, live or
-from a bag - and they're great at it. ros2_medkit does the job they leave undone: it turns a
-failure into a **structured fault**.
-
-> Every mature machine industry already draws this line: in a car, an oscilloscope is not a
-> scan tool. UDS / DTC diagnostics sit *above* the signal layer, as structured, queryable
-> state. Robotics just hasn't drawn it yet.
-
-| Common pushback | Why a structured fault still wins |
-|---|---|
-| *"I'll just set an alert."* | A threshold alert fires on a raw signal and is gone - no entity, no lifecycle, no history, and it means something different on every robot. A fault is confirmed, persisted, entity-attributed state - and, being SOVD, it means the same thing across robots and vendors. **Alerting pages a human; diagnostics gives a machine an answer.** |
-| *"I'll just watch the fleet dashboard."* | Visualization is O(humans) - one operator, one timeline, and nobody scrubs 400 of them. A structured fault is O(1): the same code and lifecycle aggregate across the fleet, so *"which 12 of 400 robots have a confirmed navigation fault right now?"* is a query, not a person. |
-| *"I can already see it fail."* | Observability is read-only by design. A structured fault is the precondition for doing something about it - gating an OTA on robot health, triggering remediation. **You can't safely patch what you haven't first diagnosed as a fault.** |
-
-So it is not a replacement for your observability stack - it is the **diagnosis layer
-underneath it**. medkit flags and persists the fault (readable by dashboards, fleet managers
-and agents, not just people) and captures the black-box rosbag you then open in Foxglove.
-
 ## Run it in 5 minutes
 
 **Two commands. No code changes, no config.** Install from the ROS 2 distribution, then launch
@@ -189,6 +148,47 @@ CORS (the prebuilt gateway Docker image enables it; for a native bringup set
 
 For a guided walkthrough, see the
 [Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).
+
+## vs. standard ROS 2 diagnostics
+
+`diagnostic_updater` + `/diagnostics` + `diagnostic_aggregator` + `rqt_robot_monitor` report
+current node health to a desktop GUI. ros2_medkit turns that into a queryable, remote,
+time-traveled, actionable fault.
+
+> [!NOTE]
+> It **consumes `/diagnostics` too**, so it is additive, not a rip-and-replace. Keep your
+> existing `diagnostic_updater` publishers; medkit reads them and gives you the rest.
+
+| | 🔴 ROS 2 diagnostics | 🟢 ros2_medkit |
+|---|---|---|
+| Access | `/diagnostics` topic + rqt GUI (local desktop) | SOVD REST API (remote; any tool / dashboard / agent) |
+| Instrumentation | required (`diagnostic_updater` in node code) | works without it - drop-in bridges (`/rosout`, action status, `/diagnostics` passthrough) |
+| State | live OK / WARN / ERROR / STALE | fault lifecycle (debounce, confirm, heal) |
+| Moment of failure | none | freeze-frame snapshot + black-box rosbag |
+| History | none (live only) | persisted, queryable |
+| Model | key/value pairs | structured fault codes + SOVD entity model |
+| Scope | ROS only | ROS today; PLC / ECU on one API |
+| Agent access | none | MCP adapter |
+
+## "I already have Foxglove. Why do I need this?"
+
+Foxglove, Rerun and PlotJuggler are how you *look* at robot data - plots, 3D, logs, live or
+from a bag - and they're great at it. ros2_medkit does the job they leave undone: it turns a
+failure into a **structured fault**.
+
+> Every mature machine industry already draws this line: in a car, an oscilloscope is not a
+> scan tool. UDS / DTC diagnostics sit *above* the signal layer, as structured, queryable
+> state. Robotics just hasn't drawn it yet.
+
+| Common pushback | Why a structured fault still wins |
+|---|---|
+| *"I'll just set an alert."* | A threshold alert fires on a raw signal and is gone - no entity, no lifecycle, no history, and it means something different on every robot. A fault is confirmed, persisted, entity-attributed state - and, being SOVD, it means the same thing across robots and vendors. **Alerting pages a human; diagnostics gives a machine an answer.** |
+| *"I'll just watch the fleet dashboard."* | Visualization is O(humans) - one operator, one timeline, and nobody scrubs 400 of them. A structured fault is O(1): the same code and lifecycle aggregate across the fleet, so *"which 12 of 400 robots have a confirmed navigation fault right now?"* is a query, not a person. |
+| *"I can already see it fail."* | Observability is read-only by design. A structured fault is the precondition for doing something about it - gating an OTA on robot health, triggering remediation. **You can't safely patch what you haven't first diagnosed as a fault.** |
+
+So it is not a replacement for your observability stack - it is the **diagnosis layer
+underneath it**. medkit flags and persists the fault (readable by dashboards, fleet managers
+and agents, not just people) and captures the black-box rosbag you then open in Foxglove.
 
 ## Beyond faults
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@
   tree, with lifecycle, history, and the state captured at the moment it happened.
 </p>
 
-<p align="center">
-  Structured fault codes · SOVD entity tree · Fault lifecycle · Freeze-frame + black-box capture · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
-</p>
-
 ## Drop it into the stack you already run
 
 ### Nav2: a navigation goal that quietly aborts
@@ -86,6 +82,33 @@ not a rip-and-replace.
 | Model | key/value pairs | structured fault codes + SOVD entity model |
 | Scope | ROS only | ROS today; PLC / ECU on one API |
 | Agent access | none | MCP adapter |
+
+## "I already have Foxglove. Why do I need this?"
+
+Foxglove, Rerun and PlotJuggler are how you *look* at robot data - plots, 3D, logs, live or
+from a bag - and they're great at it. ros2_medkit does the job they leave undone: it turns a
+failure into a **structured fault**.
+
+> Every mature machine industry already draws this line: in a car, an oscilloscope is not a
+> scan tool. UDS / DTC diagnostics sit *above* the signal layer, as structured, queryable
+> state. Robotics just hasn't drawn it yet.
+
+- **"I'll just set an alert."**  A threshold alert fires on a raw signal and is gone - no
+  entity, no lifecycle, no history, and it means something different on every robot. A fault is
+  confirmed, persisted, entity-attributed state you can query later - and, being SOVD, it means
+  the same thing across robots and vendors. Alerting pages a human; diagnostics gives a machine
+  an answer.
+- **It has to survive a fleet.**  Visualization is O(humans) - one operator, one timeline, and
+  nobody scrubs 400 of them. A structured fault is O(1): the same code and lifecycle aggregate
+  across the fleet, so *"which 12 of 400 robots have a confirmed navigation fault right now?"*
+  is a query, not a person.
+- **You can't act on a plot.**  Observability is read-only by design. A structured fault is the
+  precondition for doing something about it - gating an OTA on robot health, triggering
+  remediation. You can't safely patch what you haven't first diagnosed as a fault.
+
+So it is not a replacement for your observability stack - it is the **diagnosis layer
+underneath it**. medkit flags and persists the fault (readable by dashboards, fleet managers
+and agents, not just people) and captures the black-box rosbag you then open in Foxglove.
 
 ## Run it in 5 minutes
 
@@ -160,13 +183,10 @@ For a guided walkthrough, see the
 
 ## Beyond faults
 
-Faults are the front door; the same REST surface exposes the whole ROS 2 graph - discovery,
-live topic data, service/action calls, parameters, bulk data, SSE subscriptions, triggers,
-locking, scripts, software updates and JWT/RBAC auth (OpenAPI 3.1.0 + Swagger UI at
-`/api/v1/docs`). It models your robot as a SOVD **entity tree** (areas -> components -> apps,
-with cross-cutting functions) so the same concepts carry across robots, vehicles and embedded
-systems. See the [full documentation](https://selfpatch.github.io/ros2_medkit/) and the
-[roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html).
+Faults are the wedge. Once medkit is in, the same REST surface is a full SOVD diagnostic
+gateway - your whole robot as an entity tree, live data, service and action calls, bulk data,
+software updates and JWT/RBAC auth. The fault gets you in the door;
+[the docs](https://selfpatch.github.io/ros2_medkit/) have the rest.
 
 ## Documentation & community
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ It works because an aborted action goal is often the *only* failure signal Nav2 
 ros2_medkit's action bridge turns that into a structured fault on the `bt_navigator` entity -
 no instrumentation, no callbacks added to Nav2.
 
-### MoveIt: a motion that fails to execute
+> [!TIP]
+> Nothing was added to Nav2. The bridge reads the action status your stack already publishes,
+> so the same trick works for **any** action server - MoveIt, Nav2, or your own nodes.
+
+<details>
+<summary><b>↳ Another example: MoveIt - a motion that fails to execute</b></summary>
+
+<br>
 
 You run MoveIt. A `MoveGroup` goal aborts - no valid plan, or the controller rejects the
 trajectory. Same story: the same action bridge surfaces the aborted move as a fault on the
@@ -47,6 +54,8 @@ trajectory. Same story: the same action bridge surfaces the aborted move as a fa
 curl http://localhost:8080/api/v1/apps/move_group/faults
 # → the aborted MoveGroup goal, as a structured fault with its snapshot
 ```
+
+</details>
 
 **Two ways to feed it:**
 
@@ -69,8 +78,11 @@ touch the node's code.
 
 `diagnostic_updater` + `/diagnostics` + `diagnostic_aggregator` + `rqt_robot_monitor` report
 current node health to a desktop GUI. ros2_medkit turns that into a queryable, remote,
-time-traveled, actionable fault - and it **consumes `/diagnostics` too**, so it is additive,
-not a rip-and-replace.
+time-traveled, actionable fault.
+
+> [!NOTE]
+> It **consumes `/diagnostics` too**, so it is additive, not a rip-and-replace. Keep your
+> existing `diagnostic_updater` publishers; medkit reads them and gives you the rest.
 
 | | 🔴 ROS 2 diagnostics | 🟢 ros2_medkit |
 |---|---|---|
@@ -167,7 +179,10 @@ Nav2 `NavigateToPose` goal aborts):
 }
 ```
 
-**Prefer a dashboard?** Run the web UI alongside it (optional):
+<details>
+<summary><b>Prefer a dashboard? Run the web UI alongside it (optional)</b></summary>
+
+<br>
 
 ```bash
 docker run -p 3000:80 ghcr.io/selfpatch/ros2_medkit_web_ui:latest
@@ -177,6 +192,8 @@ docker run -p 3000:80 ghcr.io/selfpatch/ros2_medkit_web_ui:latest
 The browser calls the gateway from a different origin, so the gateway must allow that origin via
 CORS (the prebuilt gateway Docker image enables it; for a native bringup set
 `cors.allowed_origins`). See the [web UI tutorial](https://selfpatch.github.io/ros2_medkit/tutorials/web-ui.html).
+
+</details>
 
 For a guided walkthrough, see the
 [Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).

--- a/README.md
+++ b/README.md
@@ -117,25 +117,24 @@ and agents, not just people) and captures the black-box rosbag you then open in 
 
 ## Run it in 5 minutes
 
-**Install** from the ROS 2 distribution (source build and Pixi in the
-[installation docs](https://selfpatch.github.io/ros2_medkit/installation.html)):
+**Two commands. No code changes, no config.** Install from the ROS 2 distribution, then launch
+it next to your already-running robot:
 
 ```bash
-sudo apt install ros-jazzy-ros2-medkit-gateway   # or ros-humble-ros2-medkit-gateway
-```
+# 1. Install (the gateway package pulls in the fault manager + the drop-in bridges)
+sudo apt install ros-jazzy-ros2-medkit-gateway      # or ros-humble-ros2-medkit-gateway
 
-The gateway package pulls in the fault manager and the drop-in bridges.
-
-**Run it next to your robot** - one command attaches to your already-running ROS 2 graph
-(same `ROS_DOMAIN_ID` / RMW, no config) and starts the gateway, the fault manager and the
-generic fault bridges (`/rosout`, action status, `/diagnostics`):
-
-```bash
+# 2. Attach to your running ROS 2 graph - same ROS_DOMAIN_ID / RMW, nothing to configure
 ros2 launch ros2_medkit_gateway bringup.launch.py
-# REST API on http://localhost:8080/api/v1/
+# → REST API live at http://localhost:8080/api/v1/
 ```
 
-**Use it - just curl the REST API** (no UI, no CORS):
+> [!TIP]
+> That is the whole setup. It auto-discovers every node, topic, service and action and starts
+> emitting structured faults over REST - no instrumentation, no changes to your stack. Prefer
+> source or Pixi? See the [installation docs](https://selfpatch.github.io/ros2_medkit/installation.html).
+
+**Then just curl the REST API** (no UI, no CORS):
 
 ```bash
 # Your whole graph as a SOVD entity tree, instantly:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/6CXPMApAyq)
 
 <p align="center">
-  <img src="docs/_static/images/medkit_hero.gif" alt="A Nav2 NavigateToPose goal aborts: stock ROS 2 diagnostics leave you a log line lost in the noise, while ros2_medkit turns it into one structured fault over REST" width="820">
+  <img src="docs/_static/images/medkit_hero.gif" alt="A Nav2 NavigateToPose goal aborts: stock ROS 2 diagnostics leave you a log line lost in the noise, while ros2_medkit turns it into one structured fault over REST" width="100%">
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -105,18 +105,11 @@ failure into a **structured fault**.
 > scan tool. UDS / DTC diagnostics sit *above* the signal layer, as structured, queryable
 > state. Robotics just hasn't drawn it yet.
 
-- **"I'll just set an alert."**  A threshold alert fires on a raw signal and is gone - no
-  entity, no lifecycle, no history, and it means something different on every robot. A fault is
-  confirmed, persisted, entity-attributed state you can query later - and, being SOVD, it means
-  the same thing across robots and vendors. Alerting pages a human; diagnostics gives a machine
-  an answer.
-- **It has to survive a fleet.**  Visualization is O(humans) - one operator, one timeline, and
-  nobody scrubs 400 of them. A structured fault is O(1): the same code and lifecycle aggregate
-  across the fleet, so *"which 12 of 400 robots have a confirmed navigation fault right now?"*
-  is a query, not a person.
-- **You can't act on a plot.**  Observability is read-only by design. A structured fault is the
-  precondition for doing something about it - gating an OTA on robot health, triggering
-  remediation. You can't safely patch what you haven't first diagnosed as a fault.
+| Common pushback | Why a structured fault still wins |
+|---|---|
+| *"I'll just set an alert."* | A threshold alert fires on a raw signal and is gone - no entity, no lifecycle, no history, and it means something different on every robot. A fault is confirmed, persisted, entity-attributed state - and, being SOVD, it means the same thing across robots and vendors. **Alerting pages a human; diagnostics gives a machine an answer.** |
+| *"I'll just watch the fleet dashboard."* | Visualization is O(humans) - one operator, one timeline, and nobody scrubs 400 of them. A structured fault is O(1): the same code and lifecycle aggregate across the fleet, so *"which 12 of 400 robots have a confirmed navigation fault right now?"* is a query, not a person. |
+| *"I can already see it fail."* | Observability is read-only by design. A structured fault is the precondition for doing something about it - gating an OTA on robot health, triggering remediation. **You can't safely patch what you haven't first diagnosed as a fault.** |
 
 So it is not a replacement for your observability stack - it is the **diagnosis layer
 underneath it**. medkit flags and persists the fault (readable by dashboards, fleet managers

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ curl localhost:8080/api/v1/apps
 # The headline - structured faults (code, severity, source node, lifecycle, history):
 curl localhost:8080/api/v1/faults
 
+# Watch faults arrive live (Server-Sent Events):
+curl -N localhost:8080/api/v1/faults/stream
+
 # One fault's full context (freeze-frame snapshots + black-box rosbag reference):
 curl localhost:8080/api/v1/apps/bt_navigator/faults/ACTION_NAVIGATE_TO_POSE_ABORTED
 

--- a/README.md
+++ b/README.md
@@ -4,196 +4,111 @@
 [![codecov](https://codecov.io/gh/selfpatch/ros2_medkit/branch/main/graph/badge.svg)](https://codecov.io/gh/selfpatch/ros2_medkit)
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://selfpatch.github.io/ros2_medkit/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![ROS 2 Jazzy](https://img.shields.io/badge/ROS%202-Jazzy-blue)](https://docs.ros.org/en/jazzy/)
-[![ROS 2 Humble](https://img.shields.io/badge/ROS%202-Humble-blue)](https://docs.ros.org/en/humble/)
-[![ROS 2 Lyrical](https://img.shields.io/badge/ROS%202-Lyrical-blue)](https://docs.ros.org/en/lyrical/)
+[![ROS 2 Jazzy | Humble | Lyrical](https://img.shields.io/badge/ROS%202-Jazzy%20%7C%20Humble%20%7C%20Lyrical-blue)](https://docs.ros.org/en/jazzy/)
 [![Discord](https://img.shields.io/badge/Discord-Join%20Us-7289DA?logo=discord&logoColor=white)](https://discord.gg/6CXPMApAyq)
-[![Quality Level 3](https://img.shields.io/badge/Quality-Level%203-yellow)](QUALITY_DECLARATION.md)
 
 <p align="center">
-  <img src="hero-full-720-12fps.gif" alt="Robots break. Now you'll know why." width="720">
+  <img src="docs/_static/images/18_faults_injected_dashboard.png" alt="ros2_medkit faults dashboard" width="760">
 </p>
 
 <p align="center">
-  <b>Structured diagnostics for ROS 2 robots.</b><br>
-  When your robot fails, find out why - in minutes, not hours.
+  <b>A diagnostic REST API for ROS 2 robots.</b><br>
+  When your robot fails, query <i>what</i> failed and <i>why</i> - remotely, in minutes, without SSH.
 </p>
 
 <p align="center">
-  Fault management · Live introspection · REST API · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
+  Fault lifecycle · Freeze-frame + black-box capture · Live introspection · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
 </p>
 
-## The problem
+When a robot breaks in the field you SSH in, run `ros2 node list`, grep logs and try to
+reconstruct what happened. That works for one robot on your desk - not for 20 robots at a
+customer site, at 2 AM, when you cannot reproduce the issue. ros2_medkit turns your ROS 2
+system into a queryable diagnostic surface: structured faults with the state at the moment
+of failure, served over a [SOVD](https://www.asam.net/standards/detail/sovd/) REST API that
+any tool, dashboard, or agent can reach.
 
-When a robot breaks in the field, you SSH in, run `ros2 node list`, grep through logs, and try to reconstruct what happened. It works for one robot on your desk. It does not work for 20 robots at a customer site, at 2 AM, when you cannot reproduce the issue.
+## 5-minute quick start
 
-ros2_medkit gives your ROS 2 system a **diagnostic REST API** so you can inspect what is running, what failed, and why, without SSH and without custom tooling.
-
-## 🚀 Quick Start
-
-**Try the full demo** (requires [Docker](https://docs.docker.com/get-docker/) with Compose, no ROS 2 needed):
+**Install** (ROS 2 Jazzy, Humble, or Lyrical; Pixi and other options in the
+[installation docs](https://selfpatch.github.io/ros2_medkit/installation.html)):
 
 ```bash
-git clone https://github.com/selfpatch/selfpatch_demos.git
-cd selfpatch_demos/demos/turtlebot3_integration
-./run-demo.sh
-# → API: http://localhost:8080/api/v1/  Web UI: http://localhost:3000
-```
-
-Open `http://localhost:3000` in your browser. You will see a TurtleBot3 with Nav2, organized into a browsable entity tree with live faults, topic data, and parameter access.
-
-**Build from source** (ROS 2 Jazzy, Humble, or Lyrical):
-
-```bash
-source /opt/ros/jazzy/setup.bash   # or humble - adjust for your distro
+source /opt/ros/jazzy/setup.bash   # or humble / lyrical
 git clone --recurse-submodules https://github.com/selfpatch/ros2_medkit.git
 cd ros2_medkit
 rosdep install --from-paths src --ignore-src -r -y
 colcon build --symlink-install && source install/setup.bash
-ros2 launch ros2_medkit_gateway gateway.launch.py
-# → http://localhost:8080/api/v1/health
 ```
 
-Verify it works: `curl http://localhost:8080/api/v1/health` should return `{"status": "healthy", ...}`.
-
-For a guided walkthrough with demo nodes and the full API, see the [Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html). For API examples, see our [Postman collection](postman/).
-
-### Experimental: Pixi
-
-[Pixi](https://pixi.sh) provides a reproducible, lockfile-based environment
-without requiring a system-wide ROS 2 installation (Linux x86_64 only).
-This is experimental; the standard ROS 2 toolchain (rosdep + colcon) remains the primary method.
+**Run it next to your robot** - one command starts the gateway, the fault manager and the
+drop-in fault bridges, with no instrumentation in your nodes:
 
 ```bash
-curl -fsSL https://pixi.sh/install.sh | bash
-pixi install -e jazzy     # or: pixi install -e humble
-pixi run -e jazzy build
-pixi run -e jazzy test
-pixi run -e jazzy smoke   # verify gateway starts
+ros2 launch ros2_medkit_gateway bringup.launch.py
+# REST API on http://localhost:8080/api/v1/
 ```
 
-See [installation docs](https://selfpatch.github.io/ros2_medkit/installation.html#experimental-pixi)
-for details. Feedback welcome on [#265](https://github.com/selfpatch/ros2_medkit/issues/265).
-
-## What you get
-
-**Start here: Faults.** Your robot has 47 nodes. Something throws an error.
-Instead of grepping logs, you query `GET /api/v1/faults` and get a structured list
-with fault codes, timestamps, affected entities, environment snapshots, and history.
-Clear faults, subscribe to new ones via SSE, correlate them across components.
-
-Beyond faults, medkit exposes the full ROS 2 graph through REST:
-
-| | What it does |
-|---|---|
-| **Discovery** | Automatically finds running nodes, topics, services, and actions |
-| **Data** | Read and write topic data via REST |
-| **Operations** | Call services and actions with execution tracking |
-| **Configurations** | Read, write, and reset node parameters |
-| **Bulk Data** | Upload/download files (calibration, firmware, rosbags) |
-| **Subscriptions** | Stream live data and fault events via SSE |
-| **Triggers** | Condition-based push notifications for resource changes |
-| **Locking** | Resource locking for safe concurrent access |
-| **Scripts** | Upload and execute diagnostic scripts on entities |
-| **Software Updates** | Async prepare/execute lifecycle with pluggable backends |
-| **Authentication** | JWT-based RBAC (viewer, operator, configurator, admin) |
-| **Logs** | Log entries and configuration |
-| **Docs** | OpenAPI 3.1.0 spec and Swagger UI at `/api/v1/docs` - schemas are generated from typed C++ structs so the spec always matches the wire format |
-
-On the [roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html): entity lifecycle control, mode management, communication logs.
-
-## How it organizes your robot
-
-medkit models your system as an **entity tree** with four levels:
-
-```
-Areas          Components         Apps (nodes)
-─────          ──────────         ────────────
-base       ┬─ motor_controller ┬─ left_wheel_driver
-           │                   └─ right_wheel_driver
-           └─ battery_monitor  └─ bms_node
-
-navigation ┬─ lidar_driver     └─ rplidar_node
-           └─ nav_stack        ┬─ nav2_controller
-                               ├─ nav2_planner
-                               └─ nav2_bt_navigator
-```
-
-A small robot might have a single area. A large robot can use areas to separate physical domains:
-
-```
-areas/
-├── base/
-│   └── components/
-│       ├── motor_controller/   → apps: left_wheel, right_wheel
-│       └── battery_monitor/    → apps: bms_node
-├── arm/
-│   └── components/
-│       ├── joint_controller/   → apps: joint_1..joint_6
-│       └── gripper/            → apps: gripper_driver
-├── navigation/
-│   └── components/
-│       ├── lidar_driver/       → apps: rplidar_node
-│       ├── camera_driver/      → apps: realsense_node
-│       └── nav_stack/          → apps: controller, planner, bt_navigator
-└── safety/
-    └── components/
-        ├── emergency_stop/     → apps: estop_monitor
-        └── collision_detect/   → apps: collision_checker
-```
-
-**Functions** cut across the tree. A function like `localization` might depend on apps from both `navigation` and `base`, giving you a capability-oriented view alongside the physical hierarchy.
-
-This entity model follows the **SOVD (Service-Oriented Vehicle Diagnostics)** standard, so the same concepts work across robots, vehicles, and embedded systems.
-
-## 📋 Requirements
-
-- **OS:** Ubuntu 26.04 LTS (Resolute, for Lyrical), Ubuntu 24.04 LTS (Noble, for Jazzy), or Ubuntu 22.04 LTS (Jammy, for Humble)
-- **ROS 2:** Jazzy Jalisco, Humble Hawksbill, or Lyrical Luth (LTS, released May 2026)
-- **Compiler:** GCC 11+ (C++17 support)
-- **Build System:** colcon + ament_cmake
-
-## 📚 Documentation
-
-- 📖 [Full Documentation](https://selfpatch.github.io/ros2_medkit/)
-- 🗺️ [Roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html)
-- 📋 [GitHub Milestones](https://github.com/selfpatch/ros2_medkit/milestones)
-
-## 💬 Community
-
-- **💬 Discord** - [Join our server](https://discord.gg/6CXPMApAyq) for discussions, help, and announcements
-- **🐛 Issues** - [Report bugs or request features](https://github.com/selfpatch/ros2_medkit/issues)
-- **💡 Discussions** - [GitHub Discussions](https://github.com/selfpatch/ros2_medkit/discussions) for Q&A and ideas
-
-## 🤝 Contributing
-
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions, testing, pre-commit hooks, CI/CD details, and code coverage.
-
-Quick version:
+**See a fault.** A node logging an `ERROR`, or an action goal aborting, already becomes a
+fault via the bridges. To force one now:
 
 ```bash
-source /opt/ros/jazzy/setup.bash  # or humble
-pipx install pre-commit && pre-commit install && pre-commit install --hook-type pre-push
-colcon build --symlink-install
-source install/setup.bash
-./scripts/test.sh          # unit tests
-./scripts/test.sh all      # everything
+ros2 service call /fault_manager/report_fault ros2_medkit_msgs/srv/ReportFault \
+  "{fault_code: 'DEMO_FAULT', event_type: 0, severity: 2, description: 'hello medkit', source_id: '/your_node'}"
+
+curl http://localhost:8080/api/v1/faults
 ```
 
-Check out [good first issues](https://github.com/selfpatch/ros2_medkit/labels/good%20first%20issue) for places to start.
+**Verify:** the fault appears - a structured entry with its code, severity, source entity,
+status (`CONFIRMED`), and a black-box rosbag captured at the moment of failure. That is the
+whole point: a remote, structured, time-traveled fault instead of a log you have to be
+SSH'd in to read. For a guided walkthrough with demo nodes, see the
+[Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).
 
-## 🔒 Security
+## vs. standard ROS 2 diagnostics
 
-If you discover a security vulnerability, please follow the responsible disclosure process in [SECURITY.md](SECURITY.md).
+`diagnostic_updater` + `/diagnostics` + `diagnostic_aggregator` + `rqt_robot_monitor` report
+current node health to a desktop GUI. ros2_medkit turns that into a queryable, remote,
+time-traveled, actionable fault - and it **consumes `/diagnostics` too**, so it is additive,
+not a rip-and-replace.
 
-## 📄 License
+| | ROS 2 diagnostics | ros2_medkit |
+|---|---|---|
+| Access | `/diagnostics` topic + rqt GUI (local desktop) | SOVD REST API (remote; any tool / dashboard / agent) |
+| Instrumentation | required (`diagnostic_updater` in node code) | works without it - drop-in bridges (`/rosout`, action status, `/diagnostics` passthrough) |
+| State | live OK / WARN / ERROR / STALE | fault lifecycle (debounce, confirm, heal) |
+| Moment of failure | none | freeze-frame snapshot + black-box rosbag |
+| History | none (live only) | persisted, queryable |
+| Model | key/value pairs | structured fault codes + SOVD entity model |
+| Scope | ROS only | ROS today; PLC / ECU on one API |
+| Agent access | none | MCP adapter |
 
-Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+## Beyond faults
+
+Faults are the front door; the same REST surface exposes the whole ROS 2 graph - discovery
+(nodes, topics, services, actions), live topic data, service/action calls with execution
+tracking, parameters, bulk data (calibration, firmware, rosbags), SSE subscriptions,
+triggers, locking, scripts, software updates and JWT/RBAC auth. The OpenAPI 3.1.0 spec and
+Swagger UI live at `/api/v1/docs`. It models your robot as a SOVD **entity tree** (areas ->
+components -> apps, with cross-cutting functions) so the same concepts work across robots,
+vehicles and embedded systems.
+
+See the [full documentation](https://selfpatch.github.io/ros2_medkit/) for the API reference,
+the entity model, per-package guides, and the [roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html).
+
+## Documentation & community
+
+- 📖 [Documentation](https://selfpatch.github.io/ros2_medkit/) · 🗺️ [Roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html) · 🧩 [Postman collection](postman/)
+- 💬 [Discord](https://discord.gg/6CXPMApAyq) · 🐛 [Issues](https://github.com/selfpatch/ros2_medkit/issues) · 💡 [Discussions](https://github.com/selfpatch/ros2_medkit/discussions)
+- 🤝 Contributing: see [CONTRIBUTING.md](CONTRIBUTING.md) and [good first issues](https://github.com/selfpatch/ros2_medkit/labels/good%20first%20issue)
+- 🔒 Security: responsible disclosure in [SECURITY.md](SECURITY.md)
+
+## License
+
+Apache License 2.0 - see [LICENSE](LICENSE).
 
 ---
 
 <p align="center">
-  Made with ❤️ by the <a href="https://github.com/selfpatch">selfpatch</a> community
-  <br>
-  <a href="https://discord.gg/6CXPMApAyq">💬 Join us on Discord</a>
+  Made with ❤️ by the <a href="https://github.com/selfpatch">selfpatch</a> community ·
+  <a href="https://discord.gg/6CXPMApAyq">Join us on Discord</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -76,33 +76,68 @@ not a rip-and-replace.
 
 ## Run it in 5 minutes
 
-**Install** (ROS 2 Jazzy, Humble, or Lyrical; Pixi and other options in the
+**Install** from the ROS 2 distribution (source build and Pixi in the
 [installation docs](https://selfpatch.github.io/ros2_medkit/installation.html)):
 
 ```bash
-source /opt/ros/jazzy/setup.bash   # or humble / lyrical
-git clone --recurse-submodules https://github.com/selfpatch/ros2_medkit.git
-cd ros2_medkit
-rosdep install --from-paths src --ignore-src -r -y
-colcon build --symlink-install && source install/setup.bash
+sudo apt install ros-jazzy-ros2-medkit-gateway   # or ros-humble-ros2-medkit-gateway
 ```
 
-**Run it next to your robot** - one command starts the gateway, the fault manager and the
-drop-in bridges:
+The gateway package pulls in the fault manager and the drop-in bridges.
+
+**Run it next to your robot** - one command attaches to your already-running ROS 2 graph
+(same `ROS_DOMAIN_ID` / RMW, no config) and starts the gateway, the fault manager and the
+generic fault bridges (`/rosout`, action status, `/diagnostics`):
 
 ```bash
 ros2 launch ros2_medkit_gateway bringup.launch.py
 # REST API on http://localhost:8080/api/v1/
 ```
 
-**See a fault** (or just let a node log an `ERROR` / an action abort, as above):
+**Use it - just curl the REST API** (no UI, no CORS):
 
 ```bash
-ros2 service call /fault_manager/report_fault ros2_medkit_msgs/srv/ReportFault \
-  "{fault_code: 'DEMO_FAULT', event_type: 0, severity: 2, description: 'hello medkit', source_id: '/your_node'}"
+# Your whole graph as a SOVD entity tree, instantly:
+curl localhost:8080/api/v1/apps
 
-curl http://localhost:8080/api/v1/faults   # the fault appears, with its black-box
+# The headline - structured faults (code, severity, source node, lifecycle, history):
+curl localhost:8080/api/v1/faults
+
+# One fault's full context (freeze-frame snapshots + black-box rosbag reference):
+curl localhost:8080/api/v1/apps/bt_navigator/faults/ACTION_NAVIGATE_TO_POSE_ABORTED
+
+# Download the black-box rosbag captured around that fault:
+curl -O -J localhost:8080/api/v1/apps/bt_navigator/bulk-data/rosbags/ACTION_NAVIGATE_TO_POSE_ABORTED
 ```
+
+Full API: **Swagger UI at http://localhost:8080/api/v1/docs** · [Postman collection](postman/) ·
+[API reference](https://selfpatch.github.io/ros2_medkit/).
+
+**What you get the moment you attach** - no instrumentation, no code changes (right after a
+Nav2 `NavigateToPose` goal aborts):
+
+```jsonc
+// GET /api/v1/faults
+{
+  "items": [
+    { "fault_code": "ACTION_NAVIGATE_TO_POSE_ABORTED",
+      "severity_label": "ERROR", "status": "CONFIRMED",
+      "reporting_sources": ["/bt_navigator"] }
+  ],
+  "x-medkit": { "count": 1 }
+}
+```
+
+**Prefer a dashboard?** Run the web UI alongside it (optional):
+
+```bash
+docker run -p 3000:80 ghcr.io/selfpatch/ros2_medkit_web_ui:latest
+# open http://localhost:3000 -> Connect -> http://localhost:8080
+```
+
+The browser calls the gateway from a different origin, so the gateway must allow that origin via
+CORS (the prebuilt gateway Docker image enables it; for a native bringup set
+`cors.allowed_origins`). See the [web UI tutorial](https://selfpatch.github.io/ros2_medkit/tutorials/web-ui.html).
 
 For a guided walkthrough, see the
 [Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).

--- a/README.md
+++ b/README.md
@@ -13,56 +13,47 @@
 
 <p align="center">
   <b>A diagnostic REST API for ROS 2 robots.</b><br>
-  When your robot fails, query <i>what</i> failed and <i>why</i> - remotely, in minutes, without SSH.
+  Drop it next to the stack you already run - no code changes - and your failures become
+  structured faults you can query remotely, with the state captured at the moment they happened.
 </p>
 
 <p align="center">
   Fault lifecycle · Freeze-frame + black-box capture · Live introspection · <a href="https://github.com/selfpatch/ros2_medkit_mcp">AI via MCP</a>
 </p>
 
-When a robot breaks in the field you SSH in, run `ros2 node list`, grep logs and try to
-reconstruct what happened. That works for one robot on your desk - not for 20 robots at a
-customer site, at 2 AM, when you cannot reproduce the issue. ros2_medkit turns your ROS 2
-system into a queryable diagnostic surface: structured faults with the state at the moment
-of failure, served over a [SOVD](https://www.asam.net/standards/detail/sovd/) REST API that
-any tool, dashboard, or agent can reach.
+## Drop it into the stack you already run
 
-## 5-minute quick start
+### Nav2: a navigation goal that quietly aborts
 
-**Install** (ROS 2 Jazzy, Humble, or Lyrical; Pixi and other options in the
-[installation docs](https://selfpatch.github.io/ros2_medkit/installation.html)):
+You run Nav2. A `NavigateToPose` goal aborts - the planner gives up, the robot is wedged in a
+corner - and the only trace is a line buried in a log you would have to SSH in to read.
+
+Start ros2_medkit next to it (no changes to Nav2). The aborted goal becomes a fault:
 
 ```bash
-source /opt/ros/jazzy/setup.bash   # or humble / lyrical
-git clone --recurse-submodules https://github.com/selfpatch/ros2_medkit.git
-cd ros2_medkit
-rosdep install --from-paths src --ignore-src -r -y
-colcon build --symlink-install && source install/setup.bash
+curl http://localhost:8080/api/v1/apps/bt_navigator/faults
+# → ACTION_NAVIGATE_TO_POSE_ABORTED  severity=ERROR  source=/bt_navigator  status=CONFIRMED
+#   + a black-box rosbag of the seconds around the failure
 ```
 
-**Run it next to your robot** - one command starts the gateway, the fault manager and the
-drop-in fault bridges, with no instrumentation in your nodes:
+It works because an aborted action goal is often the *only* failure signal Nav2 emits, and
+ros2_medkit's action bridge turns that into a structured fault on the `bt_navigator` entity -
+no instrumentation, no callbacks added to Nav2.
+
+### MoveIt: a motion that fails to execute
+
+You run MoveIt. A `MoveGroup` goal aborts - no valid plan, or the controller rejects the
+trajectory. Same story: the same action bridge surfaces the aborted move as a fault on the
+`move_group` entity, with the freeze-frame of what the arm was doing, without touching MoveIt.
 
 ```bash
-ros2 launch ros2_medkit_gateway bringup.launch.py
-# REST API on http://localhost:8080/api/v1/
+curl http://localhost:8080/api/v1/apps/move_group/faults
+# → the aborted MoveGroup goal, as a structured fault with its snapshot
 ```
 
-**See a fault.** A node logging an `ERROR`, or an action goal aborting, already becomes a
-fault via the bridges. To force one now:
-
-```bash
-ros2 service call /fault_manager/report_fault ros2_medkit_msgs/srv/ReportFault \
-  "{fault_code: 'DEMO_FAULT', event_type: 0, severity: 2, description: 'hello medkit', source_id: '/your_node'}"
-
-curl http://localhost:8080/api/v1/faults
-```
-
-**Verify:** the fault appears - a structured entry with its code, severity, source entity,
-status (`CONFIRMED`), and a black-box rosbag captured at the moment of failure. That is the
-whole point: a remote, structured, time-traveled fault instead of a log you have to be
-SSH'd in to read. For a guided walkthrough with demo nodes, see the
-[Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).
+**The point:** ros2_medkit reads the signals your stack already emits - aborted actions,
+`/rosout` errors, `/diagnostics` - through drop-in bridges. You add nothing to Nav2, MoveIt,
+or your own nodes; you get a remote, queryable, time-traveled fault instead of a log line.
 
 ## vs. standard ROS 2 diagnostics
 
@@ -82,18 +73,48 @@ not a rip-and-replace.
 | Scope | ROS only | ROS today; PLC / ECU on one API |
 | Agent access | none | MCP adapter |
 
+## Run it in 5 minutes
+
+**Install** (ROS 2 Jazzy, Humble, or Lyrical; Pixi and other options in the
+[installation docs](https://selfpatch.github.io/ros2_medkit/installation.html)):
+
+```bash
+source /opt/ros/jazzy/setup.bash   # or humble / lyrical
+git clone --recurse-submodules https://github.com/selfpatch/ros2_medkit.git
+cd ros2_medkit
+rosdep install --from-paths src --ignore-src -r -y
+colcon build --symlink-install && source install/setup.bash
+```
+
+**Run it next to your robot** - one command starts the gateway, the fault manager and the
+drop-in bridges:
+
+```bash
+ros2 launch ros2_medkit_gateway bringup.launch.py
+# REST API on http://localhost:8080/api/v1/
+```
+
+**See a fault** (or just let a node log an `ERROR` / an action abort, as above):
+
+```bash
+ros2 service call /fault_manager/report_fault ros2_medkit_msgs/srv/ReportFault \
+  "{fault_code: 'DEMO_FAULT', event_type: 0, severity: 2, description: 'hello medkit', source_id: '/your_node'}"
+
+curl http://localhost:8080/api/v1/faults   # the fault appears, with its black-box
+```
+
+For a guided walkthrough, see the
+[Getting Started tutorial](https://selfpatch.github.io/ros2_medkit/getting_started.html).
+
 ## Beyond faults
 
-Faults are the front door; the same REST surface exposes the whole ROS 2 graph - discovery
-(nodes, topics, services, actions), live topic data, service/action calls with execution
-tracking, parameters, bulk data (calibration, firmware, rosbags), SSE subscriptions,
-triggers, locking, scripts, software updates and JWT/RBAC auth. The OpenAPI 3.1.0 spec and
-Swagger UI live at `/api/v1/docs`. It models your robot as a SOVD **entity tree** (areas ->
-components -> apps, with cross-cutting functions) so the same concepts work across robots,
-vehicles and embedded systems.
-
-See the [full documentation](https://selfpatch.github.io/ros2_medkit/) for the API reference,
-the entity model, per-package guides, and the [roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html).
+Faults are the front door; the same REST surface exposes the whole ROS 2 graph - discovery,
+live topic data, service/action calls, parameters, bulk data, SSE subscriptions, triggers,
+locking, scripts, software updates and JWT/RBAC auth (OpenAPI 3.1.0 + Swagger UI at
+`/api/v1/docs`). It models your robot as a SOVD **entity tree** (areas -> components -> apps,
+with cross-cutting functions) so the same concepts carry across robots, vehicles and embedded
+systems. See the [full documentation](https://selfpatch.github.io/ros2_medkit/) and the
+[roadmap](https://selfpatch.github.io/ros2_medkit/roadmap.html).
 
 ## Documentation & community
 


### PR DESCRIPTION
Closes #429.

Reworks the root README into a diagnostics-first front door that shows the value in the first screen, then how to run it.

What changed:
- **Ontology-first hero** at the top: a Nav2 `NavigateToPose` goal aborts, and the animation contrasts stock ROS 2 diagnostics (a log line lost in `/rosout`) with ros2_medkit turning it into one structured fault over REST - fault code on a SOVD entity, freeze-frame, black-box rosbag, full-system entity tree, and a side-by-side comparison table.
- **Drop it into the stack you already run**: concrete Nav2 and MoveIt stories - an aborted action becomes a structured fault on the `bt_navigator` / MoveGroup entity, with no changes to those stacks.
- **Two ways to feed it**: the native `FaultReporter` path for code you own (canonical for new code, links to the integration tutorial), and the drop-in bridges (`/diagnostics`, `/rosout` logs, aborted actions) for large existing stacks nobody is going to retrofit.
- **vs. standard ROS 2 diagnostics**: a comparison table across access, instrumentation, state, moment of failure, history, model, scope and agent access, framed as additive (it consumes `/diagnostics` too), not a rip-and-replace.
- **Run it in 5 minutes**: install from the ROS 2 distribution (`apt install ros-<distro>-ros2-medkit-gateway`, which pulls the fault manager and bridges), one-command `bringup.launch.py`, then a curl-first tour of the REST API (entity tree, structured faults, live SSE stream, a fault's full context, black-box rosbag download), with the web UI as an optional second path. Endpoints and the fault shape are the real responses.

All in-README links were verified to resolve (tutorial page in the docs toctree, the four package READMEs on `main`).
