### PR TITLE
Release v0.6.0: version bump and changelogs

### DIFF
--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -33,7 +33,7 @@ All packages in the repository share the same version number.
 
 ### Version Stability [1.ii]
 
-The current version is **0.5.0**.
+The current version is **0.6.0**.
 The package follows semver; the pre-1.0 version reflects that the public API may still evolve
 based on early adopter feedback, not a lack of quality infrastructure.
 The 1.0.0 release is planned after the API has been validated through pilot deployments.
@@ -225,7 +225,7 @@ Security issues can be reported via GitHub Security Advisories on the
 
 | Requirement | Status | Notes |
 |---|---|---|
-| Version policy | Met | Semver, all packages at 0.5.0 |
+| Version policy | Met | Semver, all packages at 0.6.0 |
 | Stable version (>=1.0.0) | Caveat | Pre-1.0; API versioned, 1.0.0 planned post-pilot |
 | Change requests | Met | All changes via PR |
 | CI | Met | Build + test + coverage on every PR |
@@ -237,6 +237,6 @@ Security issues can be reported via GitHub Security Advisories on the
 | Platform support | Met | Ubuntu Noble / ROS 2 Jazzy + Ubuntu Jammy / ROS 2 Humble + Ubuntu Resolute / ROS 2 Lyrical |
 | Security policy | Met | REP-2006 compliant |
 
-**Caveat:** Version is 0.5.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
+**Caveat:** Version is 0.6.0 (pre-1.0.0, requirement 1.ii). The REST API is versioned (`/api/v1/`)
 and the package meets all other Level 3 requirements. The 1.0.0 release is planned after
 API validation through pilot deployments.

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2,7 +2,7 @@
 # Used by Breathe extension to integrate with Sphinx
 
 PROJECT_NAME           = "ros2_medkit"
-PROJECT_NUMBER         = "0.5.0"
+PROJECT_NUMBER         = "0.6.0"
 PROJECT_BRIEF          = "SOVD Gateway for ROS 2"
 
 # Input settings

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -25,7 +25,7 @@ Server Capabilities
 
       {
         "name": "ROS 2 Medkit Gateway",
-        "version": "0.5.0",
+        "version": "0.6.0",
         "api_base": "/api/v1",
         "endpoints": [
           "GET /api/v1/health",
@@ -78,7 +78,7 @@ Server Capabilities
             "version": "1.0.0",
             "base_uri": "/api/v1",
             "vendor_info": {
-              "version": "0.5.0",
+              "version": "0.6.0",
               "name": "ros2_medkit"
             }
           }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,8 @@ project = "ros2_medkit"
 project_copyright = f"{datetime.now().year}, selfpatch"
 author = "selfpatch Team"
 
-version = "0.5.0"
-release = "0.5.0"
+version = "0.6.0"
+release = "0.6.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ros2-medkit-docs"
-version = "0.5.0"
+version = "0.6.0"
 description = "Documentation for ROS 2 Medkit"
 authors = [{ name = "bburda", email = "bartoszburda93@gmail.com" }]
 requires-python = ">=3.12"

--- a/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_action_status_bridge/CHANGELOG.rst
@@ -2,13 +2,13 @@
 Changelog for package ros2_medkit_action_status_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2026-06-22)
+------------------
 * Initial release: generic action-status bridge. Watches every
   ``/<action>/_action/status`` topic and turns ABORTED goals into FaultManager
   faults (``<PREFIX>_<ACTION>_ABORTED``), heals on a non-failing terminal state.
   Captures the terminal action verdict that the diagnostic and log bridges
-  cannot see.
+  cannot see (`#423 <https://github.com/selfpatch/ros2_medkit/pull/423>`_).
 * Fault state is per-ACTION, derived from the whole ``GoalStatusArray`` on each
   message: a fault is raised only on the ``healthy -> failed`` transition and
   healed only on ``failed -> healthy``, so it is order-independent and resilient
@@ -20,3 +20,6 @@ Forthcoming
 * Vanished actions (lifecycle deactivate, one-shot nodes) are pruned on rescan.
 * Parameters are range-checked/normalized at load; an incompatible action status
   QoS is now warned about instead of silently dropping faults.
+* Ships a default configuration so the bridge starts out of the box (`#459 <https://github.com/selfpatch/ros2_medkit/pull/459>`_)
+* Fault source is fixed at first report instead of being re-attributed later: faults raised before discovery settles register the server FQN, faults are never attributed to the discovery placeholder node name, and the subscriptions and timer are reset in the destructor (`#466 <https://github.com/selfpatch/ros2_medkit/pull/466>`_)
+* Contributors: @bburda, @mfaferek93

--- a/src/ros2_medkit_action_status_bridge/package.xml
+++ b/src/ros2_medkit_action_status_bridge/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_action_status_bridge</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Bridge node turning terminal ROS2 action goal states (aborted) into FaultManager faults</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_cmake/CHANGELOG.rst
+++ b/src/ros2_medkit_cmake/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_cmake
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* ``ROS2MedkitTestDomain``: carve dedicated ``ROS_DOMAIN_ID`` ranges for the new log bridge (210-214) and action-status bridge (215-219) test suites out of the integration-tests range (`#422 <https://github.com/selfpatch/ros2_medkit/pull/422>`_)
+* Contributors: @mfaferek93
+
 0.5.0 (2026-06-08)
 ------------------
 * ``ROS2MedkitWarnings.cmake`` module centralizes compiler warning flags across all packages, with selective ``-Werror`` (namespaced ``MEDKIT_ENABLE_WERROR``, defaults OFF) applied only to flags safe against external headers

--- a/src/ros2_medkit_cmake/package.xml
+++ b/src/ros2_medkit_cmake/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_cmake</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Shared CMake modules for ros2_medkit packages (multi-distro compat, ccache, linting)</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_diagnostic_bridge/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_diagnostic_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* Tests: label ``test_integration`` as an integration test so it runs in the integration suite instead of the unit set (`#443 <https://github.com/selfpatch/ros2_medkit/pull/443>`_)
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Build: adopt the centralized ``ROS2MedkitWarnings`` and ``ROS2MedkitSanitizers`` cmake modules

--- a/src/ros2_medkit_diagnostic_bridge/package.xml
+++ b/src/ros2_medkit_diagnostic_bridge/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_diagnostic_bridge</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Bridge node converting ROS2 /diagnostics to FaultManager faults</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_beacon_common
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Updated include paths for the gateway core / ROS 2 ``PluginContext`` layer split and removal of backwards-compat shim headers

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_beacon_common</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Shared library for ros2_medkit beacon discovery plugins</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_linux_introspection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Migrated the introspection plugins to the ``get_routes()`` plugin API

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_linux_introspection</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Linux introspection plugins for ros2_medkit gateway - procfs, systemd, and container</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_param_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Migrated ``ParameterBeaconPlugin`` to the ``get_routes()`` plugin API

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_param_beacon</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Parameter-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_topic_beacon
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Migrated ``TopicBeaconPlugin`` to the ``get_routes()`` plugin API

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_topic_beacon</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Topic-based beacon discovery plugin for ros2_medkit gateway</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_fault_manager/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_manager/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package ros2_medkit_fault_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* Bounded concurrent snapshot capture under fault storms with a ``CaptureThreadPool`` and configurable capture pool / queue / overflow-policy parameters. The rosbag leg is serialized and the cooldown map is bounded, so a burst of simultaneous faults can no longer exhaust capture threads or grow memory without limit (`#456 <https://github.com/selfpatch/ros2_medkit/pull/456>`_)
+* Entity-scoped rosbag capture by default (`#431 <https://github.com/selfpatch/ros2_medkit/pull/431>`_)
+* Made rosbag capture enablement crash-safe (`#430 <https://github.com/selfpatch/ros2_medkit/pull/430>`_)
+* Contributors: @bburda, @mfaferek93
+
 0.5.0 (2026-06-08)
 ------------------
 * ``ClearFault`` honors the new ``skip_correlation_auto_clear`` request flag so per-entity fault clears can opt out of cascade-clearing correlated symptom fault codes (`#395 <https://github.com/selfpatch/ros2_medkit/issues/395>`_)

--- a/src/ros2_medkit_fault_manager/package.xml
+++ b/src/ros2_medkit_fault_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_manager</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Central fault manager node for ros2_medkit fault management system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_fault_reporter/CHANGELOG.rst
+++ b/src/ros2_medkit_fault_reporter/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_fault_reporter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * ``LocalFilter`` now debounces ``PASSED`` events with the same threshold / window filtering as ``FAILED``, preventing rapid CONFIRMED/CLEARED status cycling from triggering unbounded snapshot recapture (`#308 <https://github.com/selfpatch/ros2_medkit/issues/308>`_)

--- a/src/ros2_medkit_fault_reporter/package.xml
+++ b/src/ros2_medkit_fault_reporter/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_fault_reporter</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Client library for easy fault reporting with local filtering</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_gateway/CHANGELOG.rst
+++ b/src/ros2_medkit_gateway/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Changelog for package ros2_medkit_gateway
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* SOVD entity status and lifecycle control endpoints: ``GET /apps/{id}/status`` and ``GET /components/{id}/status``, plus lifecycle control routes backed by a new ``LifecycleProvider`` plugin interface and plugin-manager routing. Control returns ``501 Not Implemented`` until a provider is registered; the routes are RBAC-gated, advertised via a ``status`` link on app and component detail, and declared under the OpenAPI ``Lifecycle`` tag (`#437 <https://github.com/selfpatch/ros2_medkit/pull/437>`_)
+* Accurate app and component status: app status is read from the managed-node lifecycle state through a ``GetState``-backed reader, and a component reports ``notReady`` when all hosted apps are offline while staying ``ready`` as long as it is reachable (`#455 <https://github.com/selfpatch/ros2_medkit/pull/455>`_)
+* Bounded the executor and HTTP server thread pools, sized to the cold-wait plus SSE budget, with misconfiguration guards and a bounded keep-alive timeout (`#457 <https://github.com/selfpatch/ros2_medkit/pull/457>`_)
+* Startup discovery summary logged at boot, with an empty-graph warning when no entities are discovered (`#438 <https://github.com/selfpatch/ros2_medkit/pull/438>`_)
+* Bounded the unsupported-message-type cache and exposed its size; unknown message types now warn once instead of on every sample (`#450 <https://github.com/selfpatch/ros2_medkit/pull/450>`_)
+* OpenAPI query parameters are derived from a typed query contract, tightening the query-parameter schema and its regression gate (`#417 <https://github.com/selfpatch/ros2_medkit/pull/417>`_)
+* ``PluginContext`` can aggregate peer faults across daisy-chained gateways through the SOVD service interface (`#419 <https://github.com/selfpatch/ros2_medkit/pull/419>`_)
+* Single-command bringup of the local medkit stack via ``bringup.launch.py`` and ``bringup_params.yaml`` (`#439 <https://github.com/selfpatch/ros2_medkit/pull/439>`_)
+* Docker image enables CORS for the documented web UI path and uses explicit web UI origins instead of wildcard CORS (`#452 <https://github.com/selfpatch/ros2_medkit/pull/452>`_)
+* Docker image bundles the CycloneDDS RMW as an opt-in alternative implementation (`#451 <https://github.com/selfpatch/ros2_medkit/pull/451>`_)
+* Native gateway launch enables web UI CORS by default and honors the CORS settings from a supplied ``config_file`` (`#461 <https://github.com/selfpatch/ros2_medkit/pull/461>`_)
+* Incremental, embedded-hardened entity cache: ``ThreadSafeEntityCache`` stores entities in a fixed-capacity ``SlotStore`` object pool indexed by open-addressed flat hash maps, and ``update_all`` reconciles the discovery output by id (add / remove / change only) so steady-state refresh does zero structural allocations. Capacity is reserved via ``entity_cache.capacity`` (default 256) and cache stats are exposed on ``/health`` as ``x-medkit-entity-cache``. Discovery refreshes are debounced via ``discovery.refresh_debounce_ms`` (default 1000) and operation ``type_info`` schemas resolve lazily, cutting gateway CPU under graph churn roughly 4x. Entity detail ``operations[]`` no longer embeds schemas eagerly; the schemas remain on the ``/operations`` resource (`#462 <https://github.com/selfpatch/ros2_medkit/pull/462>`_)
+* Contributors: @bburda, @mfaferek93
+
 0.5.0 (2026-06-08)
 ------------------
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/version.hpp
@@ -21,7 +21,7 @@ namespace ros2_medkit_gateway {
 #ifdef GATEWAY_VERSION_STRING
 constexpr const char * kGatewayVersion = GATEWAY_VERSION_STRING;
 #else
-constexpr const char * kGatewayVersion = "0.5.0";
+constexpr const char * kGatewayVersion = "0.6.0";
 #endif
 
 /// SOVD specification version

--- a/src/ros2_medkit_gateway/package.xml
+++ b/src/ros2_medkit_gateway/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_gateway</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>HTTP gateway for ros2_medkit diagnostics system</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_integration_tests/CHANGELOG.rst
+++ b/src/ros2_medkit_integration_tests/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_integration_tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* New suites covering the SOVD entity status endpoints (REQ_INTEROP_076), lifecycle-aware app and component status (`#455 <https://github.com/selfpatch/ros2_medkit/pull/455>`_), and fault-storm capture liveness under bounded concurrency (`#456 <https://github.com/selfpatch/ros2_medkit/pull/456>`_)
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * New peer-aggregation suites: peer aggregation, cross-ECU fan-out across all resource types, daisy-chain hierarchical aggregation, leaf-collision aggregation, and cross-ECU log aggregation

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_integration_tests</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Integration tests and demo nodes for ros2_medkit</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_log_bridge/CHANGELOG.rst
+++ b/src/ros2_medkit_log_bridge/CHANGELOG.rst
@@ -2,8 +2,11 @@
 Changelog for package ros2_medkit_log_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.6.0 (2026-06-22)
+------------------
 * Initial release: promote ``/rosout`` log entries (WARN/ERROR/FATAL) to
   FaultManager faults, attributed to the originating node via a per-source
-  FaultReporter, with auto-generated stable fault codes.
+  FaultReporter, with auto-generated stable fault codes (`#422 <https://github.com/selfpatch/ros2_medkit/pull/422>`_)
+* Ships a default configuration so the bridge starts out of the box (`#449 <https://github.com/selfpatch/ros2_medkit/pull/449>`_)
+* Skips the medkit stack's own nodes by default, matching on the raw logger name (`#460 <https://github.com/selfpatch/ros2_medkit/pull/460>`_)
+* Contributors: @mfaferek93

--- a/src/ros2_medkit_log_bridge/package.xml
+++ b/src/ros2_medkit_log_bridge/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_log_bridge</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Bridge node promoting ROS2 /rosout log entries to FaultManager faults</description>
 
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_msgs/CHANGELOG.rst
+++ b/src/ros2_medkit_msgs/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * New service definitions ``ListEntities.srv``, ``GetEntityData.srv``, ``GetCapabilities.srv`` and the ``EntityInfo.msg`` type for exposing the entity tree over ROS 2 services (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)

--- a/src/ros2_medkit_msgs/package.xml
+++ b/src/ros2_medkit_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_msgs</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>ROS 2 message and service definitions for ros2_medkit fault management</description>
 
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_graph_provider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Migrated ``GraphProviderPlugin`` to the ``get_routes()`` plugin API and fixed a route-separator bug

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_graph_provider</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Graph provider plugin for ros2_medkit gateway</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_opcua
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* No functional changes; version bump for the coordinated 0.6.0 release.
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Native OPC-UA Part 9 ``AlarmConditionType`` event subscription. The plugin now subscribes to vendor-defined alarms (Siemens S7-1500 ``Program_Alarm`` / ProDiag, Beckhoff TF6100, CodeSys 3.5+, Rockwell via FactoryTalk Linx) and bridges each event into the SOVD fault lifecycle. Configured via a new top-level ``event_alarms:`` block in the node map YAML; mutually exclusive per entry with the existing threshold-based ``alarm`` form. (issue #386)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_opcua</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>OPC-UA gateway plugin for ros2_medkit - bridges PLC systems into the SOVD entity tree</description>
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>
   <license>Apache-2.0</license>

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_sovd_service_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* ``list_entity_faults`` handles a fault ``status`` returned as an object (not just a string), supporting peer-fault aggregation across daisy-chained gateways (`#419 <https://github.com/selfpatch/ros2_medkit/pull/419>`_)
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * Initial release - gateway plugin that exposes the medkit entity tree and fault data over standard ROS 2 services, so other ROS 2 nodes can query entities and faults without going through the HTTP API (`#330 <https://github.com/selfpatch/ros2_medkit/issues/330>`_)

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_sovd_service_interface</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>SOVD Service Interface plugin - exposes medkit entity tree and fault data via ROS 2 services</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <maintainer email="michal.faferek@selfpatch.ai">mfaferek93</maintainer>

--- a/src/ros2_medkit_serialization/CHANGELOG.rst
+++ b/src/ros2_medkit_serialization/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ros2_medkit_serialization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2026-06-22)
+------------------
+* ``TypeIntrospection`` resolves service and action ``type_info`` schemas lazily and caches them as shared, immutable per-type objects, so discovery no longer rebuilds and deep-copies operation schemas on every refresh (`#462 <https://github.com/selfpatch/ros2_medkit/pull/462>`_)
+* Contributors: @bburda
+
 0.5.0 (2026-06-08)
 ------------------
 * ``TypeIntrospection`` relocated into this package as part of the gateway core / ROS 2 layer split

--- a/src/ros2_medkit_serialization/package.xml
+++ b/src/ros2_medkit_serialization/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ros2_medkit_serialization</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Runtime JSON to ROS 2 message serialization library</description>
   <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
   <license>Apache-2.0</license>


### PR DESCRIPTION
## Summary

Release preparation for **v0.6.0**. Rebased onto the latest `main`.

- **Version bump** to `0.6.0` across all 17 packages, the `core/version.hpp` fallback, `docs/conf.py`, `docs/pyproject.toml`, `docs/Doxyfile`, `QUALITY_DECLARATION.md`, and the version literals in the root and version-info API example responses (`docs/api/rest.rst`), via `scripts/release.sh bump 0.6.0`.
- **Changelogs**: `0.6.0 (2026-06-22)` sections on every package. The `ros2_medkit_log_bridge` and `ros2_medkit_action_status_bridge` `Forthcoming` sections are promoted to `0.6.0`. 9 packages with changes get real entries; the 8 unchanged packages get a version-bump note.

Main changes this cycle: SOVD entity status and lifecycle control endpoints (#437), accurate lifecycle-aware app/component status (#455), bounded executor/HTTP and snapshot-capture thread pools (#457, #456), incremental entity cache and bounded discovery allocation under churn (#462), two new fault bridges for `/rosout` logs (#422) and action status (#423), a typed OpenAPI query contract (#417), peer-fault aggregation over the SOVD service interface (#419), native-launch web UI CORS by default (#461), and action-status fault-attribution fixes (#466).

The #462 changelog entries (gateway incremental cache + serialization lazy `TypeIntrospection`) are added here ahead of that PR's own merge; #462 must land before the `0.6.0` tag is cut.

No code logic changed in this PR: only version literals and changelog text.

---

## Issue

- Closes #468

---

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [x] Documentation only (changelogs + version)

---

## Testing

- `scripts/release.sh verify 0.6.0` reports all 17 packages, `core/version.hpp`, `docs/conf.py`, `docs/pyproject.toml`, `docs/Doxyfile`, `QUALITY_DECLARATION.md`, and the `docs/api/rest.rst` examples consistent at `0.6.0`.
- Every `CHANGELOG.rst` parses clean through docutils; one `0.6.0` section per package, no leftover `Forthcoming`.
- pre-commit hooks pass on all changed files.

---

## Checklist

- [x] Breaking changes are clearly described (none this cycle; the status/lifecycle endpoints are additive)
- [x] Tests were added or updated if needed (no code-logic change; version and changelog only)
- [x] Docs were updated if behavior or public API changed (changelogs and API example version literals)
