### PR TITLE
Bundle the fault bridges in the image; docker-first quick start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -125,10 +125,12 @@ COPY docker/gateway_docker_params.yaml /etc/ros2_medkit/params.yaml
 # their full paths in your custom params file.
 RUN mkdir -p /opt/ros2_medkit/plugins
 
-# Non-root user for production safety
+# Non-root user for production safety. /var/lib/ros2_medkit is the default
+# fault_manager database_path parent; create and chown it so the fault manager
+# can persist faults.db without running as root.
 RUN groupadd -r medkit && useradd -r -g medkit -d /home/medkit -s /bin/bash medkit && \
-    mkdir -p /home/medkit && chown medkit:medkit /home/medkit && \
-    chown -R medkit:medkit ${COLCON_WS}/install /etc/ros2_medkit /opt/ros2_medkit
+    mkdir -p /home/medkit /var/lib/ros2_medkit && chown medkit:medkit /home/medkit && \
+    chown -R medkit:medkit ${COLCON_WS}/install /etc/ros2_medkit /opt/ros2_medkit /var/lib/ros2_medkit
 
 # Entrypoint that sources ROS and starts the gateway
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,8 @@ COPY src/ros2_medkit_gateway/ ${COLCON_WS}/src/ros2_medkit_gateway/
 COPY src/ros2_medkit_fault_manager/ ${COLCON_WS}/src/ros2_medkit_fault_manager/
 COPY src/ros2_medkit_fault_reporter/ ${COLCON_WS}/src/ros2_medkit_fault_reporter/
 COPY src/ros2_medkit_diagnostic_bridge/ ${COLCON_WS}/src/ros2_medkit_diagnostic_bridge/
+COPY src/ros2_medkit_log_bridge/ ${COLCON_WS}/src/ros2_medkit_log_bridge/
+COPY src/ros2_medkit_action_status_bridge/ ${COLCON_WS}/src/ros2_medkit_action_status_bridge/
 
 # Copy open-core plugins
 COPY src/ros2_medkit_discovery_plugins/ ${COLCON_WS}/src/ros2_medkit_discovery_plugins/

--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ speaks (Fast DDS and CycloneDDS are both baked in):
 
 ```bash
 docker run --rm --network host --ipc host \
-  -e ROS_DOMAIN_ID -e RMW_IMPLEMENTATION \
+  -e ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-0}" \
+  -e RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}" \
   ghcr.io/selfpatch/ros2_medkit-jazzy:latest \
   ros2 launch ros2_medkit_gateway bringup.launch.py
 # → REST API live at http://localhost:8080/api/v1/
 ```
 
-Swap `jazzy` for `humble`/`lyrical`; the two `-e` flags forward your shell's values so the
-container joins the same DDS graph as your robot. Rolling out to the ROS index now, so soon it is
-a plain apt install too:
+Swap `jazzy` for `humble`/`lyrical`; the two `-e` flags forward your shell's `ROS_DOMAIN_ID` and
+`RMW_IMPLEMENTATION` (falling back to domain `0` / Fast DDS if unset) so the container joins the
+same DDS graph as your robot. The packages are heading into the ROS index, so once your distro
+picks them up it is a plain apt install too:
 
 ```bash
 sudo apt install ros-jazzy-ros2-medkit-gateway   # or ros-humble- / ros-lyrical-

--- a/README.md
+++ b/README.md
@@ -76,16 +76,25 @@ touch the node's code.
 
 ## Run it in 5 minutes
 
-**Two commands. No code changes, no config.** Install from the ROS 2 distribution, then launch
-it next to your already-running robot:
+**One command. No code changes, no config.** Point a container at your already-running robot - it
+ships the gateway, the fault manager and the drop-in bridges, and speaks whatever DDS your stack
+speaks (Fast DDS and CycloneDDS are both baked in):
 
 ```bash
-# 1. Install (the gateway package pulls in the fault manager + the drop-in bridges)
-sudo apt install ros-jazzy-ros2-medkit-gateway      # or ros-humble-ros2-medkit-gateway
-
-# 2. Attach to your running ROS 2 graph - same ROS_DOMAIN_ID / RMW, nothing to configure
-ros2 launch ros2_medkit_gateway bringup.launch.py
+docker run --rm --network host --ipc host \
+  -e ROS_DOMAIN_ID -e RMW_IMPLEMENTATION \
+  ghcr.io/selfpatch/ros2_medkit-jazzy:latest \
+  ros2 launch ros2_medkit_gateway bringup.launch.py
 # → REST API live at http://localhost:8080/api/v1/
+```
+
+Swap `jazzy` for `humble`/`lyrical`; the two `-e` flags forward your shell's values so the
+container joins the same DDS graph as your robot. Rolling out to the ROS index now, so soon it is
+a plain apt install too:
+
+```bash
+sudo apt install ros-jazzy-ros2-medkit-gateway   # or ros-humble- / ros-lyrical-
+ros2 launch ros2_medkit_gateway bringup.launch.py
 ```
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ ros2 launch ros2_medkit_gateway bringup.launch.py
 > emitting structured faults over REST - no instrumentation, no changes to your stack. Prefer
 > source or Pixi? See the [installation docs](https://selfpatch.github.io/ros2_medkit/installation.html).
 
+> [!NOTE]
+> The log and action-status bridges are on by default; the `/diagnostics` bridge is opt-in. If your
+> stack publishes `/diagnostics` via `diagnostic_updater`, turn it on with
+> `ros2 launch ros2_medkit_gateway bringup.launch.py enable_diagnostic_bridge:=true`.
+
 **Then just curl the REST API** (no UI, no CORS):
 
 ```bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,13 @@ source "${COLCON_WS}/install/setup.bash"
 # Default to FastDDS (can be overridden via RMW_IMPLEMENTATION env var)
 export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}"
 
-# Pass all arguments directly to the gateway node.
-# Default CMD: --ros-args --params-file /etc/ros2_medkit/params.yaml
-# Override:    docker run ros2_medkit --ros-args --params-file /my/config.yaml -p server.port:=9090
-exec ros2 run ros2_medkit_gateway gateway_node "$@"
+# Dispatch on the first argument:
+#   - empty, or starts with "-" (the default CMD "--ros-args --params-file ..."
+#     or an override like --ros-args -p server.port:=9090): run the gateway node
+#     directly, so `docker run <img>` and arg-only overrides keep working.
+#   - a full command (e.g. `ros2 launch ros2_medkit_gateway bringup.launch.py`
+#     or `bash`): exec it as-is, so the image can launch the whole bringup stack.
+if [ -z "$1" ] || [ "${1#-}" != "$1" ]; then
+  exec ros2 run ros2_medkit_gateway gateway_node "$@"
+fi
+exec "$@"


### PR DESCRIPTION
## What

The documented install paths did not deliver the headline value:

- `log_bridge` and `action_status_bridge` were never `COPY`ed into the Docker image (only `diagnostic_bridge` was), so `ros2 launch ros2_medkit_gateway bringup.launch.py` errored on the missing bridge packages.
- The README quick start launched `gateway.launch.py` (gateway only, no fault_manager, no bridges), so a first-time user saw the entity tree but zero faults.

## Change

- **Dockerfile:** `COPY` `ros2_medkit_log_bridge` and `ros2_medkit_action_status_bridge` into the builder so the runtime image ships all the generic bridges. Verified end to end: with the bridges present, `bringup.launch.py` starts gateway + fault_manager + log_bridge + action_status_bridge cleanly, and a `/rosout` ERROR becomes a structured fault (`GET /faults`).
- **README:** lead the quick start with a one-command `docker run` that attaches to a running graph (forwarding `ROS_DOMAIN_ID`/`RMW_IMPLEMENTATION` so it matches the user's DDS; the image already ships both Fast DDS and CycloneDDS). Frame `apt install` as rolling out to the ROS index, and fix the source-build snippet to use `bringup.launch.py`.

Pushing to main rebuilds the jazzy/humble/lyrical images via the docker-publish workflow.