### PR TITLE
fix(action_status_bridge): retry deferred fault reports instead of dropping them

### DIFF
--- a/src/ros2_medkit_action_status_bridge/README.md
+++ b/src/ros2_medkit_action_status_bridge/README.md
@@ -21,8 +21,9 @@ generically, by observing the goal-status topic.
 ## What it does
 
 - Discovers every action on the graph by scanning for `*/_action/status`
-  topics (re-scanned on a timer to catch actions that appear later, and to drop
-  actions that vanish, e.g. a Nav2 lifecycle deactivate or a one-shot node).
+  topics (re-scanned on a timer to catch actions that appear later, to drop
+  actions that vanish, e.g. a Nav2 lifecycle deactivate or a one-shot node, and
+  to retry any fault whose delivery to the FaultManager was deferred).
 - `ABORTED (6)` -> fault (`SEVERITY_ERROR` by default).
 - `CANCELED (5)` -> fault only if `canceled_is_fault` (off by default; cancel is
   usually intentional). When enabled it emits a `_CANCELED` code.
@@ -48,6 +49,16 @@ A fault is raised only on the `healthy -> failed` transition and healed only on
 another goal is still failed, and a dropped terminal message cannot leave a
 fault stuck. Per-goal dedup (keyed on `goal_id:status`) only suppresses
 duplicate log lines; it never gates the transition.
+
+The bridge tracks the latest observed state (the *desired* state) separately
+from what the FaultManager was actually told. The transition is committed only
+once the report is delivered: if the FaultManager service is not discovered yet
+- e.g. an action's status topic is `transient_local` (latched) and its terminal
+status reaches the bridge during the startup discovery window, before the report
+client connects - the transition stays pending and is retried on the next
+rescan, rather than the high-severity fault being silently dropped. (The latched
+status is delivered to a subscription only once, so without this retry the
+dropped report would never recover.)
 
 ## Scope: the terminal verdict, not the reason
 

--- a/src/ros2_medkit_action_status_bridge/README.md
+++ b/src/ros2_medkit_action_status_bridge/README.md
@@ -55,10 +55,10 @@ from what the FaultManager was actually told. The transition is committed only
 once the report is delivered: if the FaultManager service is not discovered yet
 - e.g. an action's status topic is `transient_local` (latched) and its terminal
 status reaches the bridge during the startup discovery window, before the report
-client connects - the transition stays pending and is retried on the next
-rescan, rather than the high-severity fault being silently dropped. (The latched
-status is delivered to a subscription only once, so without this retry the
-dropped report would never recover.)
+client connects - the transition stays pending and is retried, rather than the
+high-severity fault being silently dropped. (The latched status is delivered to
+a subscription only once, so without this retry the dropped report would never
+recover.) See [Delivery latency and freeze-frame](#delivery-latency-and-freeze-frame).
 
 ## Scope: the terminal verdict, not the reason
 
@@ -68,6 +68,49 @@ This bridge delivers the generic "it aborted" event. The action-specific
 enrichment concern (a future action-result reader using runtime message
 introspection / dynmsg). Per-project plugins are only needed for human-readable
 labels, not to surface the fault.
+
+## Delivery latency and freeze-frame
+
+The FaultManager captures the freeze-frame (topic snapshot, rosbag) **when it
+receives the report**, so the value of that context decays with delivery
+latency: a late fault is reported against state that has already moved on. The
+bridge therefore optimises for delivering a fault to the FaultManager as soon as
+physically possible.
+
+- **Happy path (service discovered):** the fault is reported synchronously in
+  the status callback, the instant the terminal status arrives. This is the
+  normal runtime case and is already ASAP - nothing is deferred.
+- **Degraded path (service not yet discovered):** a fault cannot physically be
+  delivered before the FaultManager `report_fault` service is discovered (startup
+  before the FaultManager is up, or a FaultManager restart). The transition is
+  kept pending and retried on a dedicated **fast retry timer** (`retry_period_sec`,
+  default 50 ms), decoupled from the slow discovery `rescan`. So the fault lands
+  within one short tick of the service appearing - keeping the freeze-frame as
+  contemporaneous as the discovery floor allows.
+
+We deliberately do **not** block the (single-threaded) executor waiting for the
+service: blocking would stall detection of *other* actions' faults during an
+outage to shave the last few milliseconds off one fault - a bad trade when the
+freeze-frame is already only ~tens of ms fresher. The retry timer is armed only
+while a delivery is pending, so an idle bridge does no periodic work.
+
+**Known boundaries** (narrow, and shrunk further by the fast retry; both are
+consequences of the level-triggered, net-state model, not silent loss in the
+common case):
+
+- *Flap entirely within an outage:* if an action both fails **and** recovers
+  while the report channel is undiscovered, the net observed state collapses to
+  healthy and no retroactive raise+heal pair is emitted (there is nothing to
+  freeze-frame after the fact anyway). A flap while the channel is up still
+  produces a raise+heal per cycle as normal.
+- *Vanish during an outage:* if a still-failed action disappears from the graph
+  (its state is dropped, so it cannot be retried) at the exact moment the service
+  is undiscovered, its heal cannot be delivered and the fault may remain active
+  in the FaultManager. This is logged as a warning rather than dropped silently.
+- *Latched historical fault at startup:* a goal that aborted before the bridge
+  existed delivers its latched status on first subscribe; its freeze-frame
+  reflects post-hoc startup state regardless of delivery speed, so prompt
+  delivery just records that it happened.
 
 ## Run it
 
@@ -83,6 +126,7 @@ ros2 launch ros2_medkit_action_status_bridge action_status_bridge.launch.py
 | `canceled_is_fault` | `false` | treat CANCELED as a fault |
 | `heal_on_succeeded` | `true` | send PASSED on a successful goal |
 | `rescan_period_sec` | `2.0` | how often to look for new actions |
+| `retry_period_sec` | `0.05` | fast retry cadence for reports deferred while the FaultManager service is undiscovered (armed only while pending) |
 | `code_prefix` | `ACTION` | prefix for generated codes |
 | `exclude_actions` | `[]` | action-name substrings to skip |
 | `include_only_actions` | `[]` | if set, only watch these |

--- a/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
+++ b/src/ros2_medkit_action_status_bridge/config/action_status_bridge.yaml
@@ -9,6 +9,11 @@ action_status_bridge:
     heal_on_succeeded: true
     # How often to rescan the graph for new (and vanished) action status topics.
     rescan_period_sec: 2.0
+    # Fast retry cadence (seconds) for delivering a fault that was deferred while
+    # the FaultManager service was not yet discovered. Kept short so the
+    # freeze-frame snapshot stays contemporaneous; the timer is armed only while a
+    # delivery is pending.
+    retry_period_sec: 0.05
     # Prefix for generated fault codes (<PREFIX>_<ACTION>_ABORTED/_CANCELED).
     # Normalized to UPPER_SNAKE at load.
     code_prefix: "ACTION"

--- a/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
+++ b/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
@@ -93,17 +93,34 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   /// the goals in the array does not affect the result (any failing goal wins).
   static ActionState derive_state(const action_msgs::msg::GoalStatusArray & msg, bool canceled_is_fault);
 
-  /// Update per-action state from a message and act on the transition only.
-  /// Returns the state that was reported on (kFailed on raise, kHealthy on
-  /// heal) or kUnknown when nothing was reported. Side-effect free w.r.t.
-  /// reporting when `reporter` is null (test seam): the transition decision and
-  /// stored per-action state still update, so tests assert on the return value.
+  /// Update the desired per-action state from a message and reconcile it,
+  /// acting on the transition only. Returns the state that was reported on
+  /// (kFailed on raise, kHealthy on heal) or kUnknown when nothing was reported
+  /// - including when the report could not be delivered yet (the FaultManager
+  /// service is not discovered), in which case the transition stays pending and
+  /// is retried on the next rescan. A null `reporter` is the unit-test seam:
+  /// delivery is a no-op treated as successful, so the transition decision and
+  /// stored per-action state still update and tests assert on the return value.
   ActionState apply_message(const std::string & action_name, const action_msgs::msg::GoalStatusArray & msg,
                             ros2_medkit_fault_reporter::FaultReporter * reporter);
 
  private:
   void rescan_actions();
   void status_callback(const std::string & action_name, const action_msgs::msg::GoalStatusArray::ConstSharedPtr & msg);
+
+  /// Deliver the pending raise/heal for one action when the desired state
+  /// differs from what the FaultManager was last told AND the report is
+  /// deliverable (a null reporter is the test seam, treated as deliverable; a
+  /// real reporter must have a discovered service). Commits `last_reported_state_`
+  /// only after delivery, so a report that cannot go out yet stays pending and
+  /// is retried later instead of being silently dropped. Returns the state
+  /// reported on this call (kFailed/kHealthy) or kUnknown when nothing was sent.
+  ActionState reconcile(const std::string & action_name, ros2_medkit_fault_reporter::FaultReporter * reporter);
+
+  /// Re-attempt every action whose desired state has not been delivered to the
+  /// FaultManager yet. Driven from the rescan timer so a report dropped during
+  /// the startup discovery window is retried once the service is discovered.
+  void reconcile_pending();
 
   /// Get (creating on first use) the FaultReporter for an action. The reporter's
   /// source_id is fixed when first created: the resolved server FQN if discovery
@@ -142,7 +159,20 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   std::map<std::string, std::unique_ptr<ros2_medkit_fault_reporter::FaultReporter>> reporters_;
   std::mutex reporters_mutex_;
 
-  // Last reported action-level state, keyed by action name. Drives transitions.
+  // Desired (latest observed) action-level state derived from status messages:
+  // the source of truth the bridge tries to make the FaultManager reflect.
+  // `canceled` records whether a failure was a CANCELED (vs ABORTED), to pick
+  // the right fault code when the report is delivered later.
+  struct DesiredState {
+    ActionState net{ActionState::kUnknown};
+    bool canceled{false};
+  };
+
+  // Desired vs last-reported state, both keyed by action name and guarded by
+  // state_mutex_. The transition raises/heals only when they differ; a report
+  // that cannot be delivered yet leaves last_reported_state_ behind desired_,
+  // so reconcile_pending() retries it on the next rescan instead of dropping it.
+  std::map<std::string, DesiredState> desired_state_;
   std::map<std::string, ActionState> last_reported_state_;
   std::mutex state_mutex_;
 
@@ -180,6 +210,19 @@ class ActionStatusBridgeTestAccess {
 
   bool is_watched(const std::string & action_name) const;
   bool has_state(const std::string & action_name) const;
+
+  /// True if the FaultManager was actually told this action is failed (the
+  /// last-reported state was committed, i.e. the report was delivered).
+  bool reported_failed(const std::string & action_name) const;
+
+  /// True if a failed state is observed but not yet delivered: the desired state
+  /// is failed while the last-reported state is not. This is the "pending retry"
+  /// condition - the fault is remembered, not dropped.
+  bool pending_failed(const std::string & action_name) const;
+
+  /// The FaultReporter for an action (created on first call). Lets a test drive
+  /// the deferred-delivery path with a real reporter whose service is not ready.
+  ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & action_name);
 
   /// Identity of the FaultReporter for an action (created on first call). Lets a
   /// test assert the reporter is created once and never swapped out.

--- a/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
+++ b/src/ros2_medkit_action_status_bridge/include/ros2_medkit_action_status_bridge/action_status_bridge_node.hpp
@@ -118,9 +118,16 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   ActionState reconcile(const std::string & action_name, ros2_medkit_fault_reporter::FaultReporter * reporter);
 
   /// Re-attempt every action whose desired state has not been delivered to the
-  /// FaultManager yet. Driven from the rescan timer so a report dropped during
-  /// the startup discovery window is retried once the service is discovered.
+  /// FaultManager yet, then arm/disarm the retry timer. Driven from the fast
+  /// retry timer (and the rescan as a backstop) so a report deferred during a
+  /// discovery window is delivered within one short tick of the service
+  /// appearing - keeping the FaultManager freeze-frame snapshot contemporaneous.
   void reconcile_pending();
+
+  /// Arm the fast retry timer when at least one transition is undelivered, and
+  /// disarm it once everything is delivered, so an idle bridge does no periodic
+  /// work. Caller must not hold state_mutex_.
+  void update_retry_timer();
 
   /// Get (creating on first use) the FaultReporter for an action. The reporter's
   /// source_id is fixed when first created: the resolved server FQN if discovery
@@ -151,6 +158,12 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   static std::string to_upper_snake(const std::string & in, size_t max_len);
 
   rclcpp::TimerBase::SharedPtr rescan_timer_;
+  // Fast, lightweight timer that retries undelivered reports. Decoupled from the
+  // (slow, expensive) rescan so a fault deferred because the FaultManager service
+  // was not yet discovered is delivered within one short tick of it appearing -
+  // keeping the FaultManager's freeze-frame snapshot as close to the event as the
+  // discovery floor allows. See the delivery-latency note in the README.
+  rclcpp::TimerBase::SharedPtr retry_timer_;
   std::map<std::string, rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr> subs_;
 
   // Per-action FaultReporter, created lazily on the first report. The source_id is
@@ -187,6 +200,7 @@ class ActionStatusBridgeNode : public rclcpp::Node {
   bool canceled_is_fault_;
   bool heal_on_succeeded_;
   double rescan_period_sec_;
+  double retry_period_sec_;
   std::string code_prefix_;
   std::vector<std::string> exclude_actions_;
   std::vector<std::string> include_only_actions_;
@@ -223,6 +237,15 @@ class ActionStatusBridgeTestAccess {
   /// The FaultReporter for an action (created on first call). Lets a test drive
   /// the deferred-delivery path with a real reporter whose service is not ready.
   ros2_medkit_fault_reporter::FaultReporter * reporter_for(const std::string & action_name);
+
+  /// Run the retry pass (what the retry timer fires) so a test can exercise the
+  /// deferred-then-delivered loop without a live timer.
+  void run_reconcile_pending();
+
+  /// Reconcile one action treating delivery as available (the null-reporter
+  /// seam), so a test can prove a previously deferred transition is delivered
+  /// once the service becomes ready.
+  ActionStatusBridgeNode::ActionState reconcile_deliverable(const std::string & action_name);
 
   /// Identity of the FaultReporter for an action (created on first call). Lets a
   /// test assert the reporter is created once and never swapped out.

--- a/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
@@ -76,13 +76,21 @@ ActionStatusBridgeNode::ActionStatusBridgeNode(const rclcpp::NodeOptions & optio
   : Node("action_status_bridge", options) {
   load_parameters();
 
+  // Fast retry timer, created up front but kept disarmed (cancelled) until a
+  // report is actually deferred, so an idle bridge does no periodic work.
+  retry_timer_ = create_wall_timer(std::chrono::duration<double>(retry_period_sec_), [this]() {
+    reconcile_pending();
+  });
+  retry_timer_->cancel();
+
   rescan_actions();
   rescan_timer_ = create_wall_timer(std::chrono::duration<double>(rescan_period_sec_), [this]() {
     rescan_actions();
   });
 
-  RCLCPP_INFO(get_logger(), "ActionStatusBridge started (prefix=%s, aborted_severity=%u, rescan=%.1fs)",
-              code_prefix_.c_str(), static_cast<unsigned>(aborted_severity_), rescan_period_sec_);
+  RCLCPP_INFO(get_logger(), "ActionStatusBridge started (prefix=%s, aborted_severity=%u, rescan=%.1fs, retry=%.0fms)",
+              code_prefix_.c_str(), static_cast<unsigned>(aborted_severity_), rescan_period_sec_,
+              retry_period_sec_ * 1000.0);
 }
 
 ActionStatusBridgeNode::~ActionStatusBridgeNode() {
@@ -92,6 +100,7 @@ ActionStatusBridgeNode::~ActionStatusBridgeNode() {
   // (subscription destructor pattern). subs_ is only mutated from the (now
   // stopped) rescan path, so no lock is needed here.
   rescan_timer_.reset();
+  retry_timer_.reset();
   subs_.clear();
 }
 
@@ -112,6 +121,16 @@ void ActionStatusBridgeNode::load_parameters() {
   if (rescan_period_sec_ <= 0.0) {
     RCLCPP_WARN(get_logger(), "rescan_period_sec %.3f not positive; using 2.0", rescan_period_sec_);
     rescan_period_sec_ = 2.0;
+  }
+
+  // Fast retry cadence for delivering reports deferred while the FaultManager
+  // service was undiscovered. Kept short (default 50 ms) so the FaultManager
+  // freeze-frame snapshot is taken as close to the event as the discovery floor
+  // allows; the timer is armed only while a delivery is pending.
+  retry_period_sec_ = declare_parameter<double>("retry_period_sec", 0.05);
+  if (retry_period_sec_ <= 0.0) {
+    RCLCPP_WARN(get_logger(), "retry_period_sec %.3f not positive; using 0.05", retry_period_sec_);
+    retry_period_sec_ = 0.05;
   }
 
   code_prefix_ = to_upper_snake(declare_parameter<std::string>("code_prefix", "ACTION"), kMaxActionPart);
@@ -190,10 +209,10 @@ void ActionStatusBridgeNode::rescan_actions() {
 
   prune_vanished(present);
 
-  // Re-attempt any fault delivery that was deferred because the FaultManager
-  // service was not discovered when the (latched) status arrived during startup.
-  // The latched message is delivered only once, so without this a dropped report
-  // would never be retried.
+  // Backstop the fast retry timer: re-attempt any deferred delivery and clean up
+  // healed-and-vanished actions on the (slow) rescan tick too, so a missed timer
+  // arming can never strand a pending report. The fast timer is what keeps the
+  // FaultManager freeze-frame contemporaneous; this is just belt-and-suspenders.
   reconcile_pending();
 }
 
@@ -216,14 +235,26 @@ void ActionStatusBridgeNode::prune_vanished(const std::map<std::string, std::str
       std::lock_guard<std::mutex> lock(reporters_mutex_);
       // If a still-failed action vanishes (e.g. Nav2 lifecycle deactivate), heal
       // its fault before forgetting it - otherwise the fault stays stuck active
-      // in the FaultManager and the bridge can no longer clear it.
+      // in the FaultManager and the bridge can no longer clear it. Gate the heal
+      // on service readiness: unlike a live heal, a vanished action cannot be
+      // retried (its state is dropped here), so if the FaultManager service is
+      // not discovered at this instant the heal cannot be delivered. Surface that
+      // narrow case with a warning instead of dropping it silently. See the
+      // delivery-latency note in the README.
       auto rit = reporters_.find(action_name);
       if (was_failed && heal_on_succeeded_ && rit != reporters_.end()) {
-        rit->second->report_passed(fault_code_for(action_name, false));
-        if (canceled_is_fault_) {
-          rit->second->report_passed(fault_code_for(action_name, true));
+        if (rit->second->is_service_ready()) {
+          rit->second->report_passed(fault_code_for(action_name, false));
+          if (canceled_is_fault_) {
+            rit->second->report_passed(fault_code_for(action_name, true));
+          }
+          RCLCPP_INFO(get_logger(), "Action '%s' vanished while failed; healed before dropping", action_name.c_str());
+        } else {
+          RCLCPP_WARN(get_logger(),
+                      "Action '%s' vanished while failed but FaultManager service is not ready; its heal could not be "
+                      "delivered and the fault may remain active",
+                      action_name.c_str());
         }
-        RCLCPP_INFO(get_logger(), "Action '%s' vanished while failed; healed before dropping", action_name.c_str());
       }
       reporters_.erase(action_name);
     }
@@ -279,36 +310,39 @@ ActionStatusBridgeNode::apply_message(const std::string & action_name, const act
     }
   }
 
-  return reconcile(action_name, reporter);
+  const ActionState delivered = reconcile(action_name, reporter);
+  update_retry_timer();  // arm the fast retry if this could not be delivered yet
+  return delivered;
 }
 
 ActionStatusBridgeNode::ActionState
 ActionStatusBridgeNode::reconcile(const std::string & action_name,
                                   ros2_medkit_fault_reporter::FaultReporter * reporter) {
-  DesiredState desired;
-  ActionState reported;
-  {
-    std::lock_guard<std::mutex> lock(state_mutex_);
-    auto dit = desired_state_.find(action_name);
-    if (dit == desired_state_.end() || dit->second.net == ActionState::kUnknown) {
-      return ActionState::kUnknown;  // nothing desired yet
-    }
-    desired = dit->second;
-    auto rit = last_reported_state_.find(action_name);
-    // Absent reported state is treated as healthy: a first SUCCEEDED must not
-    // heal a fault that was never raised.
-    reported = (rit == last_reported_state_.end()) ? ActionState::kHealthy : rit->second;
+  // state_mutex_ is held across the gate, the report() call and the commit so a
+  // second caller (the status callback and the retry timer both reconcile)
+  // cannot pass the gate concurrently and double-report under a multi-threaded
+  // executor. report()/report_passed() are async (fire-and-forget), so the
+  // critical section stays short. Callers must NOT hold state_mutex_.
+  std::lock_guard<std::mutex> lock(state_mutex_);
+
+  auto dit = desired_state_.find(action_name);
+  if (dit == desired_state_.end() || dit->second.net == ActionState::kUnknown) {
+    return ActionState::kUnknown;  // nothing desired yet
   }
+  const DesiredState desired = dit->second;
+  auto rit = last_reported_state_.find(action_name);
+  // Absent reported state is treated as healthy: a first SUCCEEDED must not heal
+  // a fault that was never raised.
+  const ActionState reported = (rit == last_reported_state_.end()) ? ActionState::kHealthy : rit->second;
 
   if (desired.net == reported) {
     return ActionState::kUnknown;  // already in sync, nothing to report
   }
 
   // A real reporter can only deliver once the FaultManager service is
-  // discovered; until then keep the transition pending (retried by
-  // reconcile_pending() on the next rescan) instead of dropping it. A null
-  // reporter is the unit-test decision-only seam: delivery is a no-op that
-  // still commits the transition.
+  // discovered; until then keep the transition pending (the fast retry timer
+  // re-attempts it) instead of dropping it. A null reporter is the unit-test
+  // decision-only seam: delivery is a no-op that still commits the transition.
   const bool deliverable = (reporter == nullptr) || reporter->is_service_ready();
   if (!deliverable) {
     RCLCPP_DEBUG(get_logger(), "FaultManager service not ready; deferring %s for action %s",
@@ -323,7 +357,6 @@ ActionStatusBridgeNode::reconcile(const std::string & action_name,
                        std::string("Action ") + action_name + (desired.canceled ? " canceled" : " aborted"));
       RCLCPP_INFO(get_logger(), "Action %s -> fault %s", action_name.c_str(), code.c_str());
     }
-    std::lock_guard<std::mutex> lock(state_mutex_);
     last_reported_state_[action_name] = ActionState::kFailed;
     return ActionState::kFailed;
   }
@@ -337,16 +370,15 @@ ActionStatusBridgeNode::reconcile(const std::string & action_name,
     }
     RCLCPP_INFO(get_logger(), "Action %s healed", action_name.c_str());
   }
-  std::lock_guard<std::mutex> lock(state_mutex_);
   last_reported_state_[action_name] = ActionState::kHealthy;
   return ActionState::kHealthy;
 }
 
 void ActionStatusBridgeNode::reconcile_pending() {
   // Collect actions whose desired state has not been delivered to the
-  // FaultManager, then reconcile each outside the lock (reconcile + report()
-  // must not hold state_mutex_). reporter_for() is only called for actions with
-  // a real pending transition, so this never creates reporters speculatively.
+  // FaultManager, then reconcile each outside the lock (reconcile() takes
+  // state_mutex_ itself). reporter_for() is only called for actions with a real
+  // pending transition, so this never creates reporters speculatively.
   std::vector<std::string> pending;
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
@@ -363,6 +395,38 @@ void ActionStatusBridgeNode::reconcile_pending() {
   }
   for (const auto & action_name : pending) {
     reconcile(action_name, reporter_for(action_name));
+  }
+
+  update_retry_timer();
+}
+
+void ActionStatusBridgeNode::update_retry_timer() {
+  if (!retry_timer_) {
+    return;
+  }
+  bool any_pending = false;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    for (const auto & [action_name, desired] : desired_state_) {
+      if (desired.net == ActionState::kUnknown) {
+        continue;
+      }
+      auto rit = last_reported_state_.find(action_name);
+      const ActionState reported = (rit == last_reported_state_.end()) ? ActionState::kHealthy : rit->second;
+      if (desired.net != reported) {
+        any_pending = true;
+        break;
+      }
+    }
+  }
+  // Arm only on the no-pending -> pending edge so an already-running timer is not
+  // restarted (which would push out its next fire); disarm once drained.
+  if (any_pending) {
+    if (retry_timer_->is_canceled()) {
+      retry_timer_->reset();
+    }
+  } else {
+    retry_timer_->cancel();
   }
 }
 
@@ -591,6 +655,15 @@ bool ActionStatusBridgeTestAccess::pending_failed(const std::string & action_nam
 ros2_medkit_fault_reporter::FaultReporter *
 ActionStatusBridgeTestAccess::reporter_for(const std::string & action_name) {
   return node_->reporter_for(action_name);
+}
+
+void ActionStatusBridgeTestAccess::run_reconcile_pending() {
+  node_->reconcile_pending();
+}
+
+ActionStatusBridgeNode::ActionState
+ActionStatusBridgeTestAccess::reconcile_deliverable(const std::string & action_name) {
+  return node_->reconcile(action_name, nullptr);
 }
 
 const void * ActionStatusBridgeTestAccess::reporter_identity(const std::string & action_name) {

--- a/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
@@ -20,6 +20,7 @@
 #include <chrono>
 #include <cstdio>
 #include <functional>
+#include <vector>
 
 #include "action_msgs/msg/goal_status.hpp"
 #include "ros2_medkit_msgs/msg/fault.hpp"
@@ -188,6 +189,12 @@ void ActionStatusBridgeNode::rescan_actions() {
   }
 
   prune_vanished(present);
+
+  // Re-attempt any fault delivery that was deferred because the FaultManager
+  // service was not discovered when the (latched) status arrived during startup.
+  // The latched message is delivered only once, so without this a dropped report
+  // would never be retried.
+  reconcile_pending();
 }
 
 void ActionStatusBridgeNode::prune_vanished(const std::map<std::string, std::string> & present_topics) {
@@ -223,6 +230,7 @@ void ActionStatusBridgeNode::prune_vanished(const std::map<std::string, std::str
     {
       std::lock_guard<std::mutex> lock(state_mutex_);
       last_reported_state_.erase(action_name);
+      desired_state_.erase(action_name);
     }
     RCLCPP_INFO(get_logger(), "Action '%s' vanished; dropped (topic %s)", action_name.c_str(), topic.c_str());
     it = subs_.erase(it);
@@ -256,49 +264,106 @@ ActionStatusBridgeNode::apply_message(const std::string & action_name, const act
     return ActionState::kUnknown;  // no terminal verdict in this message
   }
 
-  ActionState prev;
+  // Record the latest observed action-level state as the desired state, then
+  // reconcile it against what the FaultManager was last told. A SUCCEEDED while
+  // healing is disabled leaves the desired state untouched, so a prior failure
+  // stays failed (the no-heal contract).
   {
     std::lock_guard<std::mutex> lock(state_mutex_);
-    auto it = last_reported_state_.find(action_name);
-    // Absent state is treated as healthy: a first SUCCEEDED must not heal a
-    // fault that was never raised.
-    prev = (it == last_reported_state_.end()) ? ActionState::kHealthy : it->second;
+    auto & desired = desired_state_[action_name];
+    if (net == ActionState::kFailed) {
+      desired.net = ActionState::kFailed;
+      desired.canceled = describe_failure_is_cancel(msg, canceled_is_fault_);
+    } else if (heal_on_succeeded_) {  // net == kHealthy
+      desired.net = ActionState::kHealthy;
+    }
   }
 
-  // Only the two real transitions act: raise on (not failed)->failed, heal on
-  // failed->(healthy). Everything else is a no-op.
-  if (net == ActionState::kFailed && prev != ActionState::kFailed) {
-    const bool canceled = describe_failure_is_cancel(msg, canceled_is_fault_);
+  return reconcile(action_name, reporter);
+}
+
+ActionStatusBridgeNode::ActionState
+ActionStatusBridgeNode::reconcile(const std::string & action_name,
+                                  ros2_medkit_fault_reporter::FaultReporter * reporter) {
+  DesiredState desired;
+  ActionState reported;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    auto dit = desired_state_.find(action_name);
+    if (dit == desired_state_.end() || dit->second.net == ActionState::kUnknown) {
+      return ActionState::kUnknown;  // nothing desired yet
+    }
+    desired = dit->second;
+    auto rit = last_reported_state_.find(action_name);
+    // Absent reported state is treated as healthy: a first SUCCEEDED must not
+    // heal a fault that was never raised.
+    reported = (rit == last_reported_state_.end()) ? ActionState::kHealthy : rit->second;
+  }
+
+  if (desired.net == reported) {
+    return ActionState::kUnknown;  // already in sync, nothing to report
+  }
+
+  // A real reporter can only deliver once the FaultManager service is
+  // discovered; until then keep the transition pending (retried by
+  // reconcile_pending() on the next rescan) instead of dropping it. A null
+  // reporter is the unit-test decision-only seam: delivery is a no-op that
+  // still commits the transition.
+  const bool deliverable = (reporter == nullptr) || reporter->is_service_ready();
+  if (!deliverable) {
+    RCLCPP_DEBUG(get_logger(), "FaultManager service not ready; deferring %s for action %s",
+                 desired.net == ActionState::kFailed ? "fault" : "heal", action_name.c_str());
+    return ActionState::kUnknown;
+  }
+
+  if (desired.net == ActionState::kFailed) {
     if (reporter != nullptr) {
-      const std::string code = fault_code_for(action_name, canceled);
+      const std::string code = fault_code_for(action_name, desired.canceled);
       reporter->report(code, aborted_severity_,
-                       std::string("Action ") + action_name + (canceled ? " canceled" : " aborted"));
+                       std::string("Action ") + action_name + (desired.canceled ? " canceled" : " aborted"));
       RCLCPP_INFO(get_logger(), "Action %s -> fault %s", action_name.c_str(), code.c_str());
     }
-    {
-      std::lock_guard<std::mutex> lock(state_mutex_);
-      last_reported_state_[action_name] = ActionState::kFailed;
-    }
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    last_reported_state_[action_name] = ActionState::kFailed;
     return ActionState::kFailed;
   }
 
-  if (net == ActionState::kHealthy && prev == ActionState::kFailed && heal_on_succeeded_) {
-    if (reporter != nullptr) {
-      // Heal both possible codes; only the one previously raised exists.
-      reporter->report_passed(fault_code_for(action_name, false));
-      if (canceled_is_fault_) {
-        reporter->report_passed(fault_code_for(action_name, true));
-      }
-      RCLCPP_INFO(get_logger(), "Action %s healed", action_name.c_str());
+  // desired.net == kHealthy, and healing was enabled when it was set.
+  if (reporter != nullptr) {
+    // Heal both possible codes; only the one previously raised exists.
+    reporter->report_passed(fault_code_for(action_name, false));
+    if (canceled_is_fault_) {
+      reporter->report_passed(fault_code_for(action_name, true));
     }
-    {
-      std::lock_guard<std::mutex> lock(state_mutex_);
-      last_reported_state_[action_name] = ActionState::kHealthy;
-    }
-    return ActionState::kHealthy;
+    RCLCPP_INFO(get_logger(), "Action %s healed", action_name.c_str());
   }
+  std::lock_guard<std::mutex> lock(state_mutex_);
+  last_reported_state_[action_name] = ActionState::kHealthy;
+  return ActionState::kHealthy;
+}
 
-  return ActionState::kUnknown;
+void ActionStatusBridgeNode::reconcile_pending() {
+  // Collect actions whose desired state has not been delivered to the
+  // FaultManager, then reconcile each outside the lock (reconcile + report()
+  // must not hold state_mutex_). reporter_for() is only called for actions with
+  // a real pending transition, so this never creates reporters speculatively.
+  std::vector<std::string> pending;
+  {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    for (const auto & [action_name, desired] : desired_state_) {
+      if (desired.net == ActionState::kUnknown) {
+        continue;
+      }
+      auto rit = last_reported_state_.find(action_name);
+      const ActionState reported = (rit == last_reported_state_.end()) ? ActionState::kHealthy : rit->second;
+      if (desired.net != reported) {
+        pending.push_back(action_name);
+      }
+    }
+  }
+  for (const auto & action_name : pending) {
+    reconcile(action_name, reporter_for(action_name));
+  }
 }
 
 void ActionStatusBridgeNode::status_callback(const std::string & action_name,
@@ -503,6 +568,29 @@ bool ActionStatusBridgeTestAccess::is_watched(const std::string & action_name) c
 bool ActionStatusBridgeTestAccess::has_state(const std::string & action_name) const {
   std::lock_guard<std::mutex> lock(node_->state_mutex_);
   return node_->last_reported_state_.find(action_name) != node_->last_reported_state_.end();
+}
+
+bool ActionStatusBridgeTestAccess::reported_failed(const std::string & action_name) const {
+  std::lock_guard<std::mutex> lock(node_->state_mutex_);
+  auto it = node_->last_reported_state_.find(action_name);
+  return it != node_->last_reported_state_.end() && it->second == ActionStatusBridgeNode::ActionState::kFailed;
+}
+
+bool ActionStatusBridgeTestAccess::pending_failed(const std::string & action_name) const {
+  std::lock_guard<std::mutex> lock(node_->state_mutex_);
+  auto dit = node_->desired_state_.find(action_name);
+  if (dit == node_->desired_state_.end() || dit->second.net != ActionStatusBridgeNode::ActionState::kFailed) {
+    return false;
+  }
+  auto rit = node_->last_reported_state_.find(action_name);
+  const auto reported =
+      (rit == node_->last_reported_state_.end()) ? ActionStatusBridgeNode::ActionState::kHealthy : rit->second;
+  return reported != ActionStatusBridgeNode::ActionState::kFailed;
+}
+
+ros2_medkit_fault_reporter::FaultReporter *
+ActionStatusBridgeTestAccess::reporter_for(const std::string & action_name) {
+  return node_->reporter_for(action_name);
 }
 
 const void * ActionStatusBridgeTestAccess::reporter_identity(const std::string & action_name) {

--- a/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
+++ b/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
@@ -310,6 +310,60 @@ TEST_F(ActionStatusBridgeTest, Reconcile_FaultDeferredWhenServiceUnavailable) {
   EXPECT_TRUE(access.pending_failed("/nav"));    // remembered for retry, not dropped
 }
 
+TEST_F(ActionStatusBridgeTest, Reconcile_DeferredRaiseDeliveredOnceServiceReady) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  ActionStatusBridgeTestAccess access(node.get());
+  auto * reporter = access.reporter_for("/nav");
+  ASSERT_FALSE(reporter->is_service_ready());
+
+  // Defer: service not ready -> pending, not delivered.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), reporter), State::kUnknown);
+  EXPECT_TRUE(access.pending_failed("/nav"));
+
+  // Retry once the report is deliverable (null-reporter seam stands in for a
+  // discovered service): the deferred raise is now delivered, nothing left pending.
+  EXPECT_EQ(access.reconcile_deliverable("/nav"), State::kFailed);
+  EXPECT_TRUE(access.reported_failed("/nav"));
+  EXPECT_FALSE(access.pending_failed("/nav"));
+}
+
+TEST_F(ActionStatusBridgeTest, Reconcile_DeferredHealDeliveredOnceServiceReady) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  ActionStatusBridgeTestAccess access(node.get());
+
+  // Raise + deliver (null seam), so a real fault exists to heal.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), nullptr), State::kFailed);
+  ASSERT_TRUE(access.reported_failed("/nav"));
+
+  // A SUCCEEDED whose heal cannot be delivered yet: stays reported-failed (the
+  // heal is not lost, just deferred).
+  auto * reporter = access.reporter_for("/nav");
+  ASSERT_FALSE(reporter->is_service_ready());
+  EXPECT_EQ(node->apply_message("/nav", one_goal(2, GoalStatus::STATUS_SUCCEEDED), reporter), State::kUnknown);
+  EXPECT_TRUE(access.reported_failed("/nav"));  // heal deferred, fault still active
+
+  // Retry once deliverable: the heal lands.
+  EXPECT_EQ(access.reconcile_deliverable("/nav"), State::kHealthy);
+  EXPECT_FALSE(access.reported_failed("/nav"));
+}
+
+TEST_F(ActionStatusBridgeTest, ReconcilePending_RetriesWithoutDroppingWhileServiceDown) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  ActionStatusBridgeTestAccess access(node.get());
+  auto * reporter = access.reporter_for("/nav");
+  ASSERT_FALSE(reporter->is_service_ready());
+
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), reporter), State::kUnknown);
+  ASSERT_TRUE(access.pending_failed("/nav"));
+
+  // The retry pass (what the fast retry timer fires) must keep retrying without
+  // dropping the pending fault while the service stays down.
+  access.run_reconcile_pending();
+  access.run_reconcile_pending();
+  EXPECT_TRUE(access.pending_failed("/nav"));
+  EXPECT_FALSE(access.reported_failed("/nav"));
+}
+
 // --- rescan add + prune ---
 
 TEST_F(ActionStatusBridgeTest, RescanPrune_DropsVanishedAction) {

--- a/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
+++ b/src/ros2_medkit_action_status_bridge/test/test_action_status_bridge.cpp
@@ -289,6 +289,27 @@ TEST_F(ActionStatusBridgeTest, ReporterFor_StickyCreatedOnceNeverSwapped) {
   EXPECT_EQ(access.reporter_identity("/nav"), first);
 }
 
+// --- deferred delivery: a fault that cannot reach the FaultManager yet (its
+// service is not discovered) must be kept pending and retried, never silently
+// dropped. This is the startup discovery race a latched ABORTED status hits. ---
+
+TEST_F(ActionStatusBridgeTest, Reconcile_FaultDeferredWhenServiceUnavailable) {
+  auto node = std::make_shared<ActionStatusBridgeNode>();
+  ActionStatusBridgeTestAccess access(node.get());
+  auto * reporter = access.reporter_for("/nav");
+  ASSERT_NE(reporter, nullptr);
+  // No FaultManager runs in this unit test, so the report service is not ready.
+  ASSERT_FALSE(reporter->is_service_ready());
+
+  // An ABORTED whose report cannot be delivered must NOT commit the reported
+  // state (otherwise a later SUCCEEDED would "heal" a fault the manager never
+  // received) and must stay pending so a rescan can retry it once the service
+  // appears.
+  EXPECT_EQ(node->apply_message("/nav", one_goal(1, GoalStatus::STATUS_ABORTED), reporter), State::kUnknown);
+  EXPECT_FALSE(access.reported_failed("/nav"));  // not falsely recorded as delivered
+  EXPECT_TRUE(access.pending_failed("/nav"));    // remembered for retry, not dropped
+}
+
 // --- rescan add + prune ---
 
 TEST_F(ActionStatusBridgeTest, RescanPrune_DropsVanishedAction) {

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -120,6 +120,16 @@ class SSEFaultHandler {
   size_t connected_clients() const;
 
   /**
+   * @brief Total number of fault events received and processed so far.
+   *
+   * Monotonically increasing (it never resets, even when the replay buffer
+   * evicts old events). Lets tests wait deterministically until a published
+   * event has actually been consumed by `on_fault_event` - which is where the
+   * owning entity is snapshotted - instead of spinning for a fixed time.
+   */
+  uint64_t events_received() const;
+
+  /**
    * @brief Signal shutdown so in-flight chunked-content-provider loops exit.
    *
    * Call this BEFORE stopping the HTTP server. The server thread's join

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -306,6 +306,12 @@ size_t SSEFaultHandler::connected_clients() const {
   return client_tracker_->connected_clients();
 }
 
+uint64_t SSEFaultHandler::events_received() const {
+  // next_event_id_ starts at 1 and is incremented once per received event in
+  // on_fault_event, so (next_event_id_ - 1) is the count consumed so far.
+  return next_event_id_.load(std::memory_order_relaxed) - 1;
+}
+
 std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) {
   const auto sanitized_event_type = sanitize_sse_event_type(queued.event.event_type);
 

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -215,12 +215,21 @@ class SSEFaultHandlerTest : public ::testing::Test {
   }
 
   void enqueue_event(const FaultEvent & event) {
+    // Wait until the handler has actually consumed this event (its
+    // on_fault_event ran and snapshotted the owning entity) before returning,
+    // so a test that mutates the entity cache afterwards cannot race the
+    // snapshot. A fixed spin budget was too short under sanitizer slowdown.
+    const uint64_t before = handler_->events_received();
     publisher_->publish(event);
 
-    for (int i = 0; i < 20; ++i) {
+    for (int i = 0; i < 500; ++i) {  // up to ~5s, generous for sanitizer runs
       executor_->spin_some();
+      if (handler_->events_received() > before) {
+        return;
+      }
       std::this_thread::sleep_for(10ms);
     }
+    FAIL() << "Timed out waiting for the SSE handler to receive the published fault event";
   }
 
   void wait_for_subscribers() {


### PR DESCRIPTION
# Pull Request

## Summary

Two fixes (see commits):

### 1. action_status_bridge: don't lose / promptly deliver faults when the FaultManager service isn't discovered yet (closes #471)

The bridge silently lost the first fault of a failing action when the FaultManager's `report_fault` service was not yet discovered at the instant the bridge observed the terminal status (startup discovery window; exposed by DDS timing - failing on Humble, passing on Jazzy).

Root cause: on the `healthy -> failed` transition `apply_message()` called the fire-and-forget `reporter->report()` and then committed `last_reported_state_ = kFailed` **unconditionally**. If the service was not ready, `FaultReporter` dropped the request - but the bridge had already recorded the action as reported. The latched (`transient_local`) status is delivered to a subscription exactly once and a rescan skips already-subscribed topics, so the dropped report was never retried and the high-severity fault was lost permanently.

Fix:
- Track the latest observed action state (`desired_state_`) separately from what the FaultManager was told (`last_reported_state_`); deliver via `reconcile()` only when they differ **and** the report is deliverable (service ready; null reporter = unit-test seam), committing only after delivery.
- **Deliver as fast as the discovery floor allows:** the FaultManager captures its freeze-frame snapshot when it receives the report, so delivery latency makes that snapshot stale. The happy path reports synchronously in the status callback; a deferred report is retried on a dedicated **fast retry timer** (`retry_period_sec`, default 50 ms, armed only while pending), decoupled from the slow discovery rescan, so it lands within one short tick of the service appearing. The executor is deliberately not blocked. The README documents this delivery-latency model and its level-triggered boundaries.
- `reconcile()` holds `state_mutex_` across gate -> report -> commit so the status callback and retry timer can't double-report under a multi-threaded executor.
- The prune-vanished heal is gated on service readiness and warns (instead of silently dropping) when a vanished action's heal can't be delivered.
- The shared `FaultReporter` fire-and-forget contract is unchanged.

### 2. gateway: fix flaky SSE handler test under ASan

`SSEFaultHandlerTest.StreamSnapshotsEntityContextAtEnqueue` flaked under AddressSanitizer. `enqueue_event()` spun for a fixed budget after publishing; under sanitizer slowdown the handler's `on_fault_event` (which snapshots the owning entity) could run after that budget, so the test cleared the cache before the snapshot was taken and the replayed event omitted `x-medkit`. Added `SSEFaultHandler::events_received()` (a monotonic counter, like `connected_clients()`) and made `enqueue_event()` wait until the handler has actually consumed the event. Test-only timing fix; no product behavior change.

---

## Issue

- closes #471

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- action_status_bridge: 31 unit tests pass (incl. deferred raise/heal delivered once the service is ready, and the retry pass not dropping while the service is down); the `test_integration` launch test passes (raise + heal); linters + `clang-tidy` clean. CI `Pixi (humble)` (originally failing) and Humble/Jazzy/Lyrical/TSan green on the prior commits.
- gateway SSE: full `test_sse_fault_handler` (19 tests) passes; the snapshot test passes 30/30 in a repeat loop; `clang-format` + `clang-tidy` clean on the changed files.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
