### PR TITLE
fix(fault_manager): clamp debounce counter and latch confirmed/healed status

### DIFF
--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -150,8 +150,8 @@ The fault manager uses an AUTOSAR DEM-style debounce model:
 
 The counter is always clamped to `[confirmation_threshold, healing_threshold]`, so a long run of
 one-sided events cannot push it out to the integer limits and delay the opposite transition.
-`confirmation_threshold < 0 < healing_threshold` is required; invalid thresholds fall back to safe
-defaults with a warning.
+`confirmation_threshold < 0 <= healing_threshold` is required (`healing_threshold = 0` heals on a
+single PASSED event); invalid thresholds fall back to safe defaults with a warning.
 
 `CONFIRMED` and `HEALED` are **latched** (hysteresis): once reached, the status holds until the
 counter reaches the opposite threshold, so a single opposite-direction event cannot flip it. As a

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -148,6 +148,17 @@ The fault manager uses an AUTOSAR DEM-style debounce model:
 - Fault becomes **CONFIRMED** when counter reaches `confirmation_threshold`
 - Fault becomes **HEALED** when counter reaches `healing_threshold` (if enabled)
 
+The counter is always clamped to `[confirmation_threshold, healing_threshold]`, so a long run of
+one-sided events cannot push it out to the integer limits and delay the opposite transition.
+`confirmation_threshold < 0 < healing_threshold` is required; invalid thresholds fall back to safe
+defaults with a warning.
+
+`CONFIRMED` and `HEALED` are **latched** (hysteresis): once reached, the status holds until the
+counter reaches the opposite threshold, so a single opposite-direction event cannot flip it. As a
+result a fault that becomes active again can take up to `healing_threshold - confirmation_threshold`
+events to return to the default (CONFIRMED-only) list; `occurrence_count` and `last_occurred` still
+update meanwhile.
+
 ### Fault Lifecycle with Debounce
 
 ```

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -239,7 +239,8 @@ becomes active again is not back in the default (CONFIRMED-only) list until the 
 up to ``healing_threshold - confirmation_threshold`` events. During that window ``occurrence_count``
 and ``last_occurred`` still reflect the activity.
 
-Thresholds must satisfy ``confirmation_threshold < 0 < healing_threshold``; the node validates the
+Thresholds must satisfy ``confirmation_threshold < 0 <= healing_threshold`` (``healing_threshold == 0``
+means heal on a single PASSED event); the node validates the
 merged per-entity config at startup, logs a warning, and falls back to safe defaults if not. When
 healing is disabled, any HEALED row left by a previous (healing-enabled) run is reclassified to
 CLEARED once at startup so it does not behave inconsistently under the latch.

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -227,3 +227,19 @@ Faults follow an AUTOSAR DEM-style debounce lifecycle:
 FAILED events decrement the debounce counter (towards confirmation).
 PASSED events increment the debounce counter (towards healing).
 CRITICAL severity bypasses debounce and confirms immediately.
+
+The counter is always clamped to ``[confirmation_threshold, healing_threshold]`` so a long run of
+one-sided events cannot push it out to the integer limits and delay the opposite transition.
+
+CONFIRMED and HEALED are *latched* (hysteresis): once reached, the status holds until the counter
+walks all the way to the opposite threshold. So PREFAILED/PREPASSED depend on the counter sign, but
+a CONFIRMED or HEALED fault keeps its status while the counter is between the thresholds - a single
+opposite-direction event cannot flip it. One consequence is a re-confirmation delay: a fault that
+becomes active again is not back in the default (CONFIRMED-only) list until the counter has fallen by
+up to ``healing_threshold - confirmation_threshold`` events. During that window ``occurrence_count``
+and ``last_occurred`` still reflect the activity.
+
+Thresholds must satisfy ``confirmation_threshold < 0 < healing_threshold``; the node validates the
+merged per-entity config at startup, logs a warning, and falls back to safe defaults if not. When
+healing is disabled, any HEALED row left by a previous (healing-enabled) run is reclassified to
+CLEARED once at startup so it does not behave inconsistently under the latch.

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -28,7 +28,16 @@
 
 namespace ros2_medkit_fault_manager {
 
-/// Debounce configuration for fault filtering
+/// Debounce configuration for fault filtering.
+///
+/// Status lifecycle uses a bounded counter (AUTOSAR-DEM-style) plus a hysteresis latch:
+/// FAILED events decrement the counter, PASSED events increment it, and the counter is always
+/// clamped to [confirmation_threshold, healing_threshold]. CONFIRMED and HEALED latch - they
+/// persist until the counter reaches the opposite threshold, so a single opposite-direction report
+/// cannot flip them. One consequence is a latch delay: a fault that becomes active again is not
+/// immediately back in the default (CONFIRMED-only) list - it can take up to
+/// (healing_threshold - confirmation_threshold) reports to re-confirm. During that window
+/// occurrence_count and last_occurred still reflect the activity.
 struct DebounceConfig {
   /// Confirmation threshold (typically negative). Fault is CONFIRMED when counter <= this value,
   /// and the debounce counter is clamped to this lower bound so a long burst of FAILED events
@@ -54,6 +63,18 @@ struct DebounceConfig {
   /// 0.0 = disabled.
   double auto_confirm_after_sec{0.0};
 };
+
+/// Clamp the debounce counter into [confirmation_threshold, healing_threshold].
+int32_t clamp_debounce_counter(int32_t counter, const DebounceConfig & config);
+
+/// Compute the debounce status from the counter and the current status (the current status drives
+/// the CONFIRMED/HEALED hysteresis latch). Does NOT apply the CRITICAL immediate-confirm bypass -
+/// callers handle that. This is the single source of truth shared by both storage backends.
+std::string compute_debounce_status(int32_t counter, const std::string & current_status, const DebounceConfig & config);
+
+/// Validate a (merged) debounce config in place, enforcing confirmation_threshold < 0 < healing_threshold.
+/// Offending fields are reset to safe defaults (-1 / 3). Returns true if the config was already valid.
+bool sanitize_debounce_config(DebounceConfig & config);
 
 /// Internal fault state stored in memory
 struct FaultState {
@@ -197,6 +218,14 @@ class FaultStorage {
   /// @return Vector of all faults in storage
   virtual std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const = 0;
 
+  /// One-time startup cleanup: reclassify HEALED faults as CLEARED. Called when healing is disabled,
+  /// so a HEALED row left by a previous (healing-enabled) run does not behave inconsistently under
+  /// the latch. Default is a no-op (in-memory storage starts empty).
+  /// @return number of faults reclassified
+  virtual size_t reclassify_healed_as_cleared() {
+    return 0;
+  }
+
  protected:
   FaultStorage() = default;
   FaultStorage(const FaultStorage &) = default;
@@ -243,6 +272,7 @@ class InMemoryFaultStorage : public FaultStorage {
   std::vector<RosbagFileInfo> get_all_rosbag_files() const override;
   std::vector<RosbagFileInfo> list_rosbags_for_entity(const std::string & entity_fqn) const override;
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
+  size_t reclassify_healed_as_cleared() override;
 
  private:
   /// Update fault status based on debounce counter and given config

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -49,8 +49,9 @@ struct DebounceConfig {
   /// Whether healing is enabled. When true, faults can transition to HEALED status.
   bool healing_enabled{false};
 
-  /// Healing threshold (positive). When healing is enabled, the fault is HEALED once the counter
-  /// reaches this value. The counter is always clamped to this upper bound, even when healing is
+  /// Healing threshold (non-negative; 0 means heal on a single PASSED event). When healing is enabled,
+  /// the fault is HEALED once the counter reaches this value. The counter is always clamped to this
+  /// upper bound, even when healing is
   /// disabled, so a heal heartbeat cannot drive it off to INT32_MAX; healing_enabled only controls
   /// whether reaching the bound produces a HEALED status.
   /// Default: 3 (3 more PASSED than FAILED events to heal).
@@ -72,8 +73,9 @@ int32_t clamp_debounce_counter(int32_t counter, const DebounceConfig & config);
 /// callers handle that. This is the single source of truth shared by both storage backends.
 std::string compute_debounce_status(int32_t counter, const std::string & current_status, const DebounceConfig & config);
 
-/// Validate a (merged) debounce config in place, enforcing confirmation_threshold < 0 < healing_threshold.
-/// Offending fields are reset to safe defaults (-1 / 3). Returns true if the config was already valid.
+/// Validate a (merged) debounce config in place, enforcing confirmation_threshold < 0 <= healing_threshold
+/// (healing_threshold == 0 means heal on a single PASSED event). Offending fields are reset to safe
+/// defaults (-1 / 3). Returns true if the config was already valid.
 bool sanitize_debounce_config(DebounceConfig & config);
 
 /// Internal fault state stored in memory

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -30,7 +30,9 @@ namespace ros2_medkit_fault_manager {
 
 /// Debounce configuration for fault filtering
 struct DebounceConfig {
-  /// Confirmation threshold (typically negative). Fault is CONFIRMED when counter <= this value.
+  /// Confirmation threshold (typically negative). Fault is CONFIRMED when counter <= this value,
+  /// and the debounce counter is clamped to this lower bound so a long burst of FAILED events
+  /// cannot drive it past confirmation.
   /// Default: -1 (immediate confirmation - first FAILED event confirms the fault).
   /// Set to lower values (e.g., -3) for debounce filtering.
   int32_t confirmation_threshold{-1};
@@ -38,8 +40,11 @@ struct DebounceConfig {
   /// Whether healing is enabled. When true, faults can transition to HEALED status.
   bool healing_enabled{false};
 
-  /// Healing threshold (positive). Fault is HEALED when counter >= this value.
-  /// Default: 3 (3 more PASSED than FAILED events to heal). Only used if healing_enabled.
+  /// Healing threshold (positive). When healing is enabled, the fault is HEALED once the counter
+  /// reaches this value. The counter is always clamped to this upper bound, even when healing is
+  /// disabled, so a heal heartbeat cannot drive it off to INT32_MAX; healing_enabled only controls
+  /// whether reaching the bound produces a HEALED status.
+  /// Default: 3 (3 more PASSED than FAILED events to heal).
   int32_t healing_threshold{3};
 
   /// Whether CRITICAL severity bypasses debounce and confirms immediately.

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
@@ -74,6 +74,7 @@ class SqliteFaultStorage : public FaultStorage {
   std::vector<RosbagFileInfo> get_all_rosbag_files() const override;
   std::vector<RosbagFileInfo> list_rosbags_for_entity(const std::string & entity_fqn) const override;
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
+  size_t reclassify_healed_as_cleared() override;
 
   /// Get the database path
   const std::string & db_path() const {

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -164,12 +164,50 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
   global_config_.healing_enabled = healing_enabled_;
   global_config_.healing_threshold = healing_threshold_;
   global_config_.auto_confirm_after_sec = auto_confirm_after_sec_;
+  if (!sanitize_debounce_config(global_config_)) {
+    RCLCPP_WARN(get_logger(),
+                "Invalid debounce thresholds (need confirmation_threshold < 0 < healing_threshold); using safe "
+                "defaults: confirmation=%d healing=%d",
+                global_config_.confirmation_threshold, global_config_.healing_threshold);
+  }
   storage_->set_debounce_config(global_config_);
+
+  // One-time cleanup: when healing is disabled, a HEALED row left by a previous (healing-enabled) run
+  // would behave inconsistently under the latch, so reclassify it as CLEARED at startup.
+  if (!global_config_.healing_enabled) {
+    size_t reclassified = storage_->reclassify_healed_as_cleared();
+    if (reclassified > 0) {
+      RCLCPP_INFO(get_logger(), "Healing disabled: reclassified %zu stale HEALED fault(s) as CLEARED", reclassified);
+    }
+  }
 
   // Load per-entity threshold overrides (optional)
   auto entity_thresholds_file = declare_parameter<std::string>("entity_thresholds.config_file", "");
   if (!entity_thresholds_file.empty()) {
     auto entries = EntityThresholdResolver::load_from_yaml(entity_thresholds_file);
+    // Validate each override against the global config: the merge is field by field, so an override
+    // can break confirmation_threshold < 0 < healing_threshold even when the global config is valid.
+    for (auto & entry : entries) {
+      DebounceConfig merged = global_config_;
+      if (entry.confirmation_threshold) {
+        merged.confirmation_threshold = *entry.confirmation_threshold;
+      }
+      if (entry.healing_threshold) {
+        merged.healing_threshold = *entry.healing_threshold;
+      }
+      if (!sanitize_debounce_config(merged)) {
+        RCLCPP_WARN(get_logger(),
+                    "Entity '%s' debounce thresholds invalid (need confirmation_threshold < 0 < healing_threshold); "
+                    "using safe defaults",
+                    entry.prefix.c_str());
+        if (entry.confirmation_threshold) {
+          entry.confirmation_threshold = merged.confirmation_threshold;
+        }
+        if (entry.healing_threshold) {
+          entry.healing_threshold = merged.healing_threshold;
+        }
+      }
+    }
     if (!entries.empty()) {
       threshold_resolver_ = std::make_unique<EntityThresholdResolver>(std::move(entries));
       RCLCPP_INFO(get_logger(), "Loaded %zu per-entity threshold overrides from %s", threshold_resolver_->size(),
@@ -1183,10 +1221,14 @@ bool FaultManagerNode::matches_entity(const std::vector<std::string> & reporting
 }
 
 DebounceConfig FaultManagerNode::resolve_config(const std::string & source_id) const {
+  DebounceConfig config = global_config_;
   if (threshold_resolver_) {
-    return threshold_resolver_->resolve(source_id, global_config_);
+    config = threshold_resolver_->resolve(source_id, global_config_);
   }
-  return global_config_;
+  // Defensive: the merged config is validated at load time, but never hand the storage backend a
+  // config that violates confirmation_threshold < 0 < healing_threshold (the counter would stick).
+  sanitize_debounce_config(config);
+  return config;
 }
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -166,7 +166,7 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
   global_config_.auto_confirm_after_sec = auto_confirm_after_sec_;
   if (!sanitize_debounce_config(global_config_)) {
     RCLCPP_WARN(get_logger(),
-                "Invalid debounce thresholds (need confirmation_threshold < 0 < healing_threshold); using safe "
+                "Invalid debounce thresholds (need confirmation_threshold < 0 <= healing_threshold); using safe "
                 "defaults: confirmation=%d healing=%d",
                 global_config_.confirmation_threshold, global_config_.healing_threshold);
   }
@@ -186,7 +186,7 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
   if (!entity_thresholds_file.empty()) {
     auto entries = EntityThresholdResolver::load_from_yaml(entity_thresholds_file);
     // Validate each override against the global config: the merge is field by field, so an override
-    // can break confirmation_threshold < 0 < healing_threshold even when the global config is valid.
+    // can break confirmation_threshold < 0 <= healing_threshold even when the global config is valid.
     for (auto & entry : entries) {
       DebounceConfig merged = global_config_;
       if (entry.confirmation_threshold) {
@@ -197,7 +197,7 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
       }
       if (!sanitize_debounce_config(merged)) {
         RCLCPP_WARN(get_logger(),
-                    "Entity '%s' debounce thresholds invalid (need confirmation_threshold < 0 < healing_threshold); "
+                    "Entity '%s' debounce thresholds invalid (need confirmation_threshold < 0 <= healing_threshold); "
                     "using safe defaults",
                     entry.prefix.c_str());
         if (entry.confirmation_threshold) {
@@ -1226,7 +1226,7 @@ DebounceConfig FaultManagerNode::resolve_config(const std::string & source_id) c
     config = threshold_resolver_->resolve(source_id, global_config_);
   }
   // Defensive: the merged config is validated at load time, but never hand the storage backend a
-  // config that violates confirmation_threshold < 0 < healing_threshold (the counter would stick).
+  // config that violates confirmation_threshold < 0 <= healing_threshold (the counter would stick).
   sanitize_debounce_config(config);
   return config;
 }

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -148,8 +148,9 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
       ++state.occurrence_count;
     }
 
-    // Decrement debounce counter (towards confirmation), clamped at the
-    // confirmation threshold so a heal heartbeat can't drive it off to INT32_MIN.
+    // Decrement debounce counter (towards confirmation), clamped at the confirmation
+    // threshold so a long burst of FAILED events can't drive it to INT32_MIN (which
+    // would then delay later healing).
     if (state.debounce_counter > config.confirmation_threshold) {
       --state.debounce_counter;
     }

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -60,7 +60,9 @@ bool sanitize_debounce_config(DebounceConfig & config) {
     config.confirmation_threshold = -1;
     valid = false;
   }
-  if (config.healing_threshold <= 0) {
+  // healing_threshold == 0 is valid: it means "heal on a single PASSED event" (the counter reaches
+  // the threshold at 0). Only a negative threshold is rejected.
+  if (config.healing_threshold < 0) {
     config.healing_threshold = 3;
     valid = false;
   }

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -19,6 +19,54 @@
 
 namespace ros2_medkit_fault_manager {
 
+int32_t clamp_debounce_counter(int32_t counter, const DebounceConfig & config) {
+  // Manual min/max rather than std::clamp: well-defined even if a bad config has lo > hi
+  // (sanitize_debounce_config normally prevents that, but the storage layer must never UB).
+  if (counter < config.confirmation_threshold) {
+    return config.confirmation_threshold;
+  }
+  if (counter > config.healing_threshold) {
+    return config.healing_threshold;
+  }
+  return counter;
+}
+
+std::string compute_debounce_status(int32_t counter, const std::string & current_status,
+                                    const DebounceConfig & config) {
+  namespace msg = ros2_medkit_msgs::msg;
+  if (counter <= config.confirmation_threshold) {
+    return msg::Fault::STATUS_CONFIRMED;
+  }
+  if (config.healing_enabled && counter >= config.healing_threshold) {
+    return msg::Fault::STATUS_HEALED;
+  }
+  // Hysteresis latch: a confirmed or healed fault stays put until the counter reaches the opposite
+  // threshold (handled above). A single opposite-direction report must not flip it to a pending state.
+  if (current_status == msg::Fault::STATUS_CONFIRMED || current_status == msg::Fault::STATUS_HEALED) {
+    return current_status;
+  }
+  if (counter < 0) {
+    return msg::Fault::STATUS_PREFAILED;
+  }
+  if (counter > 0) {
+    return msg::Fault::STATUS_PREPASSED;
+  }
+  return current_status;  // counter == 0 keeps the current status (avoids flapping at the boundary)
+}
+
+bool sanitize_debounce_config(DebounceConfig & config) {
+  bool valid = true;
+  if (config.confirmation_threshold >= 0) {
+    config.confirmation_threshold = -1;
+    valid = false;
+  }
+  if (config.healing_threshold <= 0) {
+    config.healing_threshold = 3;
+    valid = false;
+  }
+  return valid;
+}
+
 ros2_medkit_msgs::msg::Fault FaultState::to_msg() const {
   ros2_medkit_msgs::msg::Fault msg;
   msg.fault_code = fault_code;
@@ -49,24 +97,9 @@ DebounceConfig InMemoryFaultStorage::get_debounce_config() const {
 }
 
 void InMemoryFaultStorage::update_status(FaultState & state, const DebounceConfig & config) {
-  // Note: CLEARED faults are handled in report_fault_event() before this is called
-
-  if (state.debounce_counter <= config.confirmation_threshold) {
-    state.status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
-  } else if (config.healing_enabled && state.debounce_counter >= config.healing_threshold) {
-    state.status = ros2_medkit_msgs::msg::Fault::STATUS_HEALED;
-  } else if (state.status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED ||
-             state.status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED) {
-    // Hysteresis latch: a confirmed or healed fault stays put until the counter
-    // walks all the way to the opposite threshold (handled above). A single report
-    // must not flip it back to a pending state.
-  } else if (state.debounce_counter < 0) {
-    state.status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
-  } else if (state.debounce_counter > 0) {
-    state.status = ros2_medkit_msgs::msg::Fault::STATUS_PREPASSED;
-  }
-  // Note: debounce_counter == 0 keeps current status (hysteresis behavior).
-  // This avoids rapid status flapping at the zero crossing boundary.
+  // CLEARED faults are handled in report_fault_event() before this is called.
+  // Delegate to the shared state machine so both backends behave identically.
+  state.status = compute_debounce_status(state.debounce_counter, state.status, config);
 }
 
 bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, uint8_t event_type, uint8_t severity,
@@ -148,12 +181,9 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
       ++state.occurrence_count;
     }
 
-    // Decrement debounce counter (towards confirmation), clamped at the confirmation
-    // threshold so a long burst of FAILED events can't drive it to INT32_MIN (which
-    // would then delay later healing).
-    if (state.debounce_counter > config.confirmation_threshold) {
-      --state.debounce_counter;
-    }
+    // Decrement towards confirmation, clamped to the thresholds (a long FAILED burst can't
+    // run the counter off to INT32_MIN and delay later healing).
+    state.debounce_counter = clamp_debounce_counter(state.debounce_counter - 1, config);
 
     // Add source if not already present
     state.reporting_sources.insert(source_id);
@@ -177,11 +207,9 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
     // PASSED event
     state.last_passed_time = timestamp;
 
-    // Increment debounce counter (towards healing), clamped at the healing
-    // threshold so a heal heartbeat can't drive it off to INT32_MAX.
-    if (state.debounce_counter < config.healing_threshold) {
-      ++state.debounce_counter;
-    }
+    // Increment towards healing, clamped to the thresholds (a heal heartbeat can't run the
+    // counter off to INT32_MAX and then delay a real fault from confirming).
+    state.debounce_counter = clamp_debounce_counter(state.debounce_counter + 1, config);
   }
 
   // Update status based on debounce counter
@@ -435,6 +463,18 @@ std::vector<ros2_medkit_msgs::msg::Fault> InMemoryFaultStorage::get_all_faults()
   }
 
   return result;
+}
+
+size_t InMemoryFaultStorage::reclassify_healed_as_cleared() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  size_t changed = 0;
+  for (auto & [code, state] : faults_) {
+    if (state.status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED) {
+      state.status = ros2_medkit_msgs::msg::Fault::STATUS_CLEARED;
+      ++changed;
+    }
+  }
+  return changed;
 }
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -55,6 +55,11 @@ void InMemoryFaultStorage::update_status(FaultState & state, const DebounceConfi
     state.status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
   } else if (config.healing_enabled && state.debounce_counter >= config.healing_threshold) {
     state.status = ros2_medkit_msgs::msg::Fault::STATUS_HEALED;
+  } else if (state.status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED ||
+             state.status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED) {
+    // Hysteresis latch: a confirmed or healed fault stays put until the counter
+    // walks all the way to the opposite threshold (handled above). A single report
+    // must not flip it back to a pending state.
   } else if (state.debounce_counter < 0) {
     state.status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
   } else if (state.debounce_counter > 0) {
@@ -143,8 +148,9 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
       ++state.occurrence_count;
     }
 
-    // Decrement debounce counter (towards confirmation) with saturation
-    if (state.debounce_counter > std::numeric_limits<int32_t>::min()) {
+    // Decrement debounce counter (towards confirmation), clamped at the
+    // confirmation threshold so a heal heartbeat can't drive it off to INT32_MIN.
+    if (state.debounce_counter > config.confirmation_threshold) {
       --state.debounce_counter;
     }
 
@@ -170,8 +176,9 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
     // PASSED event
     state.last_passed_time = timestamp;
 
-    // Increment debounce counter (towards healing) with saturation
-    if (state.debounce_counter < std::numeric_limits<int32_t>::max()) {
+    // Increment debounce counter (towards healing), clamped at the healing
+    // threshold so a heal heartbeat can't drive it off to INT32_MAX.
+    if (state.debounce_counter < config.healing_threshold) {
       ++state.debounce_counter;
     }
   }

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -396,8 +396,9 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
       }
 
       // Decrement debounce counter, clamped at the confirmation threshold (lower
-      // bound). Without this floor it only stops at INT32_MIN, so after a long heal
-      // heartbeat the counter has to climb all the way back before a fault confirms.
+      // bound). Without this floor a long burst of FAILED events drives it to
+      // INT32_MIN, and a later heal then has to climb all the way back before the
+      // fault can clear.
       if (debounce_counter > config.confirmation_threshold) {
         --debounce_counter;
       }

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -395,8 +395,10 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         ++new_count;
       }
 
-      // Decrement debounce counter with saturation
-      if (debounce_counter > std::numeric_limits<int32_t>::min()) {
+      // Decrement debounce counter, clamped at the confirmation threshold (lower
+      // bound). Without this floor it only stops at INT32_MIN, so after a long heal
+      // heartbeat the counter has to climb all the way back before a fault confirms.
+      if (debounce_counter > config.confirmation_threshold) {
         --debounce_counter;
       }
 
@@ -406,6 +408,11 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
       } else if (debounce_counter <= config.confirmation_threshold) {
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
+      } else if (current_status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED) {
+        // Hysteresis latch: a healed fault stays healed until the counter walks all
+        // the way back down to the confirmation threshold (handled above). A single
+        // FAILED must not flip it straight to a pending state.
+        new_status = current_status;
       } else if (debounce_counter < 0) {
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
       } else if (debounce_counter > 0) {
@@ -448,14 +455,22 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         throw std::runtime_error(std::string("Failed to update fault: ") + sqlite3_errmsg(db_));
       }
     } else {
-      // PASSED event - increment debounce counter with saturation
-      if (debounce_counter < std::numeric_limits<int32_t>::max()) {
+      // PASSED event - increment debounce counter, clamped at the healing threshold
+      // (upper bound). Without this ceiling a periodic heal heartbeat on a healthy
+      // system drives the counter to INT32_MAX, so a real fault then takes a huge
+      // number of reports to confirm.
+      if (debounce_counter < config.healing_threshold) {
         ++debounce_counter;
       }
 
       std::string new_status = current_status;
       if (config.healing_enabled && debounce_counter >= config.healing_threshold) {
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_HEALED;
+      } else if (current_status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED) {
+        // Hysteresis latch: a confirmed fault stays confirmed until the counter
+        // climbs all the way up to the healing threshold (handled above). A single
+        // heal must not flip a confirmed fault back to a pending state.
+        new_status = current_status;
       } else if (debounce_counter > 0) {
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREPASSED;
       } else if (debounce_counter < 0) {

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -365,6 +365,10 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
     std::string current_status = check_stmt.column_text(3);
     int32_t debounce_counter = check_stmt.column_int(4);
 
+    // Bring a runaway counter persisted by an older build (the bug this fixes) back into range on
+    // first touch; this also keeps the +1/-1 below overflow-safe. The counter is local to this call.
+    debounce_counter = clamp_debounce_counter(debounce_counter, config);
+
     // CLEARED faults can be reactivated by FAILED events
     bool is_reactivation = false;
     if (current_status == ros2_medkit_msgs::msg::Fault::STATUS_CLEARED) {
@@ -395,31 +399,16 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         ++new_count;
       }
 
-      // Decrement debounce counter, clamped at the confirmation threshold (lower
-      // bound). Without this floor a long burst of FAILED events drives it to
-      // INT32_MIN, and a later heal then has to climb all the way back before the
-      // fault can clear.
-      if (debounce_counter > config.confirmation_threshold) {
-        --debounce_counter;
-      }
+      // Decrement towards confirmation, clamped to the thresholds.
+      debounce_counter = clamp_debounce_counter(debounce_counter - 1, config);
 
-      // Check for immediate confirmation of CRITICAL
-      std::string new_status = current_status;
+      // CRITICAL bypasses debounce; otherwise the shared state machine decides (with hysteresis).
+      std::string new_status;
       if (config.critical_immediate_confirm && severity == ros2_medkit_msgs::msg::Fault::SEVERITY_CRITICAL) {
         new_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
-      } else if (debounce_counter <= config.confirmation_threshold) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
-      } else if (current_status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED) {
-        // Hysteresis latch: a healed fault stays healed until the counter walks all
-        // the way back down to the confirmation threshold (handled above). A single
-        // FAILED must not flip it straight to a pending state.
-        new_status = current_status;
-      } else if (debounce_counter < 0) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
-      } else if (debounce_counter > 0) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREPASSED;
+      } else {
+        new_status = compute_debounce_status(debounce_counter, current_status, config);
       }
-      // Note: debounce_counter == 0 keeps current status
 
       // Update with new values
       SqliteStatement update_stmt(
@@ -456,27 +445,10 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         throw std::runtime_error(std::string("Failed to update fault: ") + sqlite3_errmsg(db_));
       }
     } else {
-      // PASSED event - increment debounce counter, clamped at the healing threshold
-      // (upper bound). Without this ceiling a periodic heal heartbeat on a healthy
-      // system drives the counter to INT32_MAX, so a real fault then takes a huge
-      // number of reports to confirm.
-      if (debounce_counter < config.healing_threshold) {
-        ++debounce_counter;
-      }
+      // PASSED event - increment towards healing, clamped to the thresholds.
+      debounce_counter = clamp_debounce_counter(debounce_counter + 1, config);
 
-      std::string new_status = current_status;
-      if (config.healing_enabled && debounce_counter >= config.healing_threshold) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_HEALED;
-      } else if (current_status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED) {
-        // Hysteresis latch: a confirmed fault stays confirmed until the counter
-        // climbs all the way up to the healing threshold (handled above). A single
-        // heal must not flip a confirmed fault back to a pending state.
-        new_status = current_status;
-      } else if (debounce_counter > 0) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREPASSED;
-      } else if (debounce_counter < 0) {
-        new_status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
-      }
+      std::string new_status = compute_debounce_status(debounce_counter, current_status, config);
 
       SqliteStatement update_stmt(
           db_,
@@ -502,17 +474,13 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
     return false;  // PASSED event for non-existent fault is ignored
   }
 
-  // Determine initial status based on debounce logic
+  // Determine initial status based on debounce logic (shared with the in-memory backend).
   std::string initial_status;
   constexpr int32_t initial_counter = -1;  // First FAILED event sets counter to -1
-  // CRITICAL severity bypasses debounce and confirms immediately
   if (config.critical_immediate_confirm && severity == ros2_medkit_msgs::msg::Fault::SEVERITY_CRITICAL) {
     initial_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
-  } else if (initial_counter <= config.confirmation_threshold) {
-    // Counter already meets threshold (e.g., threshold >= -1)
-    initial_status = ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
   } else {
-    initial_status = ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED;
+    initial_status = compute_debounce_status(initial_counter, "", config);
   }
 
   // New fault - insert with debounce_counter = -1
@@ -659,6 +627,26 @@ bool SqliteFaultStorage::clear_fault(const std::string & fault_code) {
   }
 
   return sqlite3_changes(db_) > 0;
+}
+
+size_t SqliteFaultStorage::reclassify_healed_as_cleared() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Drop snapshots for the affected faults so a reclassified row matches CLEARED semantics.
+  SqliteStatement del(db_,
+                      "DELETE FROM snapshots WHERE fault_code IN (SELECT fault_code FROM faults WHERE status = ?)");
+  del.bind_text(1, ros2_medkit_msgs::msg::Fault::STATUS_HEALED);
+  if (del.step() != SQLITE_DONE) {
+    throw std::runtime_error(std::string("Failed to delete snapshots: ") + sqlite3_errmsg(db_));
+  }
+
+  SqliteStatement stmt(db_, "UPDATE faults SET status = ? WHERE status = ?");
+  stmt.bind_text(1, ros2_medkit_msgs::msg::Fault::STATUS_CLEARED);
+  stmt.bind_text(2, ros2_medkit_msgs::msg::Fault::STATUS_HEALED);
+  if (stmt.step() != SQLITE_DONE) {
+    throw std::runtime_error(std::string("Failed to reclassify HEALED faults: ") + sqlite3_errmsg(db_));
+  }
+  return static_cast<size_t>(sqlite3_changes(db_));
 }
 
 size_t SqliteFaultStorage::size() const {

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -455,6 +455,7 @@ TEST_F(FaultStorageTest, PassedEventIncrementsCounter) {
   // latched and would not move to PREPASSED on a heal).
   DebounceConfig config;
   config.confirmation_threshold = -3;
+  config.healing_threshold = 3;  // explicit upper clamp (don't depend on the default)
 
   // Report 2 FAILED events (counter = -2, PREFAILED)
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -729,12 +729,34 @@ TEST(DebounceHelpers, SanitizeDebounceConfigFixesBadThresholds) {
   DebounceConfig good;
   EXPECT_TRUE(sanitize_debounce_config(good));  // defaults are valid
 
+  // healing_threshold == 0 is valid (heal on a single PASSED event); leave it untouched.
+  DebounceConfig single_event_heal;
+  single_event_heal.confirmation_threshold = -1;
+  single_event_heal.healing_threshold = 0;
+  EXPECT_TRUE(sanitize_debounce_config(single_event_heal));
+  EXPECT_EQ(single_event_heal.healing_threshold, 0);
+
   DebounceConfig bad;
-  bad.confirmation_threshold = 0;
-  bad.healing_threshold = 0;
+  bad.confirmation_threshold = 0;  // must be < 0
+  bad.healing_threshold = -1;      // must be >= 0
   EXPECT_FALSE(sanitize_debounce_config(bad));
   EXPECT_LT(bad.confirmation_threshold, 0);
-  EXPECT_GT(bad.healing_threshold, 0);
+  EXPECT_GE(bad.healing_threshold, 0);
+}
+
+// healing_threshold == 0 heals on a single PASSED event (used by action_status_bridge).
+TEST_F(FaultStorageTest, HealingThresholdZeroHealsOnSinglePassed) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -1;
+  config.healing_enabled = true;
+  config.healing_threshold = 0;
+
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                              config);
+  ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  EXPECT_EQ(storage_.get_fault("F")->status, Fault::STATUS_HEALED);
 }
 
 TEST(DebounceHelpers, ComputeDebounceStatusLatches) {

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -31,9 +31,12 @@
 #include "ros2_medkit_msgs/srv/list_faults_for_entity.hpp"
 #include "ros2_medkit_msgs/srv/report_fault.hpp"
 
+using ros2_medkit_fault_manager::clamp_debounce_counter;
+using ros2_medkit_fault_manager::compute_debounce_status;
 using ros2_medkit_fault_manager::DebounceConfig;
 using ros2_medkit_fault_manager::FaultManagerNode;
 using ros2_medkit_fault_manager::InMemoryFaultStorage;
+using ros2_medkit_fault_manager::sanitize_debounce_config;
 using ros2_medkit_msgs::msg::Fault;
 using ros2_medkit_msgs::msg::FaultEvent;
 using ros2_medkit_msgs::srv::ClearFault;
@@ -651,6 +654,100 @@ TEST_F(FaultStorageTest, HeartbeatHealClampedAndStatusLatched) {
   EXPECT_EQ(storage_.get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
 }
 
+// Latch holds in both directions, same as the SQLite backend: CONFIRMED with a positive counter
+// stays CONFIRMED on FAILED.
+TEST_F(FaultStorageTest, ConfirmedLatchSurvivesFailedAtPositiveCounter) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  config.healing_threshold = 3;
+  config.critical_immediate_confirm = true;
+
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_CRITICAL, "crit", "/n",
+                              clock.now(), config);
+  ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  for (int i = 0; i < 3; ++i) {
+    storage_.report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                              config);
+  EXPECT_EQ(storage_.get_fault("F")->status, Fault::STATUS_CONFIRMED);
+}
+
+// HEALED with a negative counter stays HEALED on PASSED.
+TEST_F(FaultStorageTest, HealedLatchSurvivesPassedAtNegativeCounter) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                              config);
+  for (int i = 0; i < 4; ++i) {
+    storage_.report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_HEALED);
+  for (int i = 0; i < 5; ++i) {  // +3 -> -2, latched HEALED
+    storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                                config);
+    ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_HEALED) << "latch broke after " << (i + 1);
+  }
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  EXPECT_EQ(storage_.get_fault("F")->status, Fault::STATUS_HEALED);
+}
+
+TEST_F(FaultStorageTest, ReclassifyHealedAsCleared) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_.report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                              config);
+  for (int i = 0; i < 4; ++i) {
+    storage_.report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_.get_fault("F")->status, Fault::STATUS_HEALED);
+
+  EXPECT_EQ(storage_.reclassify_healed_as_cleared(), 1u);
+  EXPECT_EQ(storage_.get_fault("F")->status, Fault::STATUS_CLEARED);
+}
+
+// Unit tests for the shared debounce helpers.
+TEST(DebounceHelpers, ClampDebounceCounterBounds) {
+  DebounceConfig config;
+  config.confirmation_threshold = -2;
+  config.healing_threshold = 2;
+  EXPECT_EQ(clamp_debounce_counter(100, config), 2);
+  EXPECT_EQ(clamp_debounce_counter(-100, config), -2);
+  EXPECT_EQ(clamp_debounce_counter(1, config), 1);
+}
+
+TEST(DebounceHelpers, SanitizeDebounceConfigFixesBadThresholds) {
+  DebounceConfig good;
+  EXPECT_TRUE(sanitize_debounce_config(good));  // defaults are valid
+
+  DebounceConfig bad;
+  bad.confirmation_threshold = 0;
+  bad.healing_threshold = 0;
+  EXPECT_FALSE(sanitize_debounce_config(bad));
+  EXPECT_LT(bad.confirmation_threshold, 0);
+  EXPECT_GT(bad.healing_threshold, 0);
+}
+
+TEST(DebounceHelpers, ComputeDebounceStatusLatches) {
+  DebounceConfig config;               // healing 3, healing disabled
+  config.confirmation_threshold = -3;  // so counters -1..+2 sit between the thresholds (latch range)
+  // A confirmed fault with a positive counter stays confirmed (latch), not PREPASSED.
+  EXPECT_EQ(compute_debounce_status(2, Fault::STATUS_CONFIRMED, config), Fault::STATUS_CONFIRMED);
+  // A healed fault with a negative counter stays healed (latch), not PREFAILED.
+  EXPECT_EQ(compute_debounce_status(-1, Fault::STATUS_HEALED, config), Fault::STATUS_HEALED);
+  // A pending fault is not latched.
+  EXPECT_EQ(compute_debounce_status(1, Fault::STATUS_PREFAILED, config), Fault::STATUS_PREPASSED);
+}
+
 TEST_F(FaultStorageTest, GetAllFaultsReturnsAllFaults) {
   rclcpp::Clock clock;
   auto timestamp = clock.now();
@@ -714,7 +811,7 @@ TEST(FaultManagerNodeParameterTest, CustomConfirmationThreshold) {
   EXPECT_EQ(config.confirmation_threshold, -5);
 }
 
-TEST(FaultManagerNodeParameterTest, ConfirmationThresholdDisabled) {
+TEST(FaultManagerNodeParameterTest, ConfirmationThresholdZeroSanitizedToDefault) {
   rclcpp::NodeOptions options;
   options.parameter_overrides({
       {"storage_type", "memory"},
@@ -722,9 +819,10 @@ TEST(FaultManagerNodeParameterTest, ConfirmationThresholdDisabled) {
   });
   auto node = std::make_shared<FaultManagerNode>(options);
 
-  // 0 means immediate confirmation
+  // 0 is invalid (must be < 0, otherwise the clamp would pin the counter and statuses get stuck).
+  // It is sanitized to the safe default -1, which still confirms immediately on the first FAILED.
   auto config = node->get_storage().get_debounce_config();
-  EXPECT_EQ(config.confirmation_threshold, 0);
+  EXPECT_EQ(config.confirmation_threshold, -1);
 }
 
 TEST(FaultManagerNodeParameterTest, HealingEnabled) {

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -451,20 +451,21 @@ TEST_F(FaultStorageTest, ClearedFaultReactivationRestartsDebounce) {
 
 TEST_F(FaultStorageTest, PassedEventIncrementsCounter) {
   rclcpp::Clock clock;
+  // confirmation_threshold = -3 so 2 FAILED stays PREFAILED (a confirmed fault is
+  // latched and would not move to PREPASSED on a heal).
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
 
-  // Report 2 FAILED events (counter = -2)
+  // Report 2 FAILED events (counter = -2, PREFAILED)
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
-                              clock.now(), default_config());
+                              clock.now(), config);
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node2",
-                              clock.now(), default_config());
+                              clock.now(), config);
 
   // Report 3 PASSED events (counter = -2 + 3 = +1)
-  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                              default_config());
-  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                              default_config());
-  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                              default_config());
+  for (int i = 0; i < 3; ++i) {
+    storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
+  }
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
@@ -474,11 +475,12 @@ TEST_F(FaultStorageTest, PassedEventIncrementsCounter) {
 TEST_F(FaultStorageTest, HealingDisabledByDefault) {
   rclcpp::Clock clock;
 
-  // Report 1 FAILED event
+  // Report 1 FAILED event -> confirmed (threshold -1)
   storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
                               clock.now(), default_config());
 
-  // Report many PASSED events (counter = -1 + 10 = +9, but healing disabled)
+  // With healing disabled, a heal heartbeat must not downgrade a confirmed fault.
+  // The counter clamps at healing_threshold and the status latches CONFIRMED.
   for (int i = 0; i < 10; ++i) {
     storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
                                 default_config());
@@ -486,7 +488,7 @@ TEST_F(FaultStorageTest, HealingDisabledByDefault) {
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->status, Fault::STATUS_PREPASSED);  // Not HEALED since healing disabled
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // stays confirmed, not silently downgraded
 }
 
 TEST_F(FaultStorageTest, HealingWhenEnabled) {
@@ -614,6 +616,38 @@ TEST_F(FaultStorageTest, HealedFaultCanRecurWithFailedEvents) {
   fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
+}
+
+// Regression for #428 on the in-memory backend: a heal heartbeat must not run the
+// debounce counter off, and confirmed/healed status must latch (one report cannot
+// flip it).
+TEST_F(FaultStorageTest, HeartbeatHealClampedAndStatusLatched) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -1;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                              clock.now(), config);
+  ASSERT_EQ(storage_.get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
+
+  // Long heal heartbeat: counter clamps at healing_threshold, then heals.
+  for (int i = 0; i < 100; ++i) {
+    storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
+  }
+  EXPECT_EQ(storage_.get_fault("FAULT_1")->status, Fault::STATUS_HEALED);
+
+  // Re-confirmation is bounded and the healed status latches until the counter
+  // walks all the way back down to the confirmation threshold.
+  for (int i = 0; i < 3; ++i) {
+    storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                                clock.now(), config);
+    EXPECT_EQ(storage_.get_fault("FAULT_1")->status, Fault::STATUS_HEALED) << "latch broke after " << (i + 1);
+  }
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                              clock.now(), config);
+  EXPECT_EQ(storage_.get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
 }
 
 TEST_F(FaultStorageTest, GetAllFaultsReturnsAllFaults) {

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -578,7 +578,8 @@ TEST_F(SqliteFaultStorageTest, ConfirmedFaultSurvivesHealHeartbeat) {
   rclcpp::Clock clock;
   DebounceConfig config;
   config.confirmation_threshold = -1;
-  config.healing_enabled = false;  // healing_threshold (default 3) still bounds the counter
+  config.healing_enabled = false;
+  config.healing_threshold = 3;  // upper clamp on the counter, even with healing disabled
 
   storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
                                clock.now(), config);

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -589,6 +589,106 @@ TEST_F(SqliteFaultStorageTest, ConfirmedFaultSurvivesHealHeartbeat) {
     storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
     EXPECT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED) << "un-confirmed after " << (i + 1);
   }
+
+  // The counter is now positive (clamped at +3). One FAILED must keep it CONFIRMED, not flip it to
+  // PREPASSED via the `counter > 0` branch - that was the asymmetric-latch bug.
+  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               clock.now(), config);
+  EXPECT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
+}
+
+// Latch must hold in BOTH directions and identically on both backends (regression for the
+// asymmetric per-branch latch). A CONFIRMED fault with a positive counter stays CONFIRMED on FAILED.
+TEST_F(SqliteFaultStorageTest, ConfirmedLatchSurvivesFailedAtPositiveCounter) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  config.healing_threshold = 3;
+  config.critical_immediate_confirm = true;
+
+  // CRITICAL confirms immediately at counter -1.
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_CRITICAL, "crit", "/n",
+                               clock.now(), config);
+  ASSERT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  // PASSED events raise the counter into positive territory; latch keeps it CONFIRMED.
+  for (int i = 0; i < 3; ++i) {
+    storage_->report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  // One normal FAILED: counter still positive, must NOT become PREPASSED.
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                               config);
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+}
+
+// A HEALED fault with a negative counter stays HEALED on PASSED (opposite direction of the bug above).
+TEST_F(SqliteFaultStorageTest, HealedLatchSurvivesPassedAtNegativeCounter) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                               config);
+  for (int i = 0; i < 4; ++i) {  // counter -1 -> +3 -> HEALED
+    storage_->report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_->get_fault("F")->status, Fault::STATUS_HEALED);
+  // FAILED events drive the counter negative while HEALED is latched (not yet at confirmation -3).
+  for (int i = 0; i < 5; ++i) {  // +3 -> -2
+    storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                                 config);
+    ASSERT_EQ(storage_->get_fault("F")->status, Fault::STATUS_HEALED) << "latch broke after " << (i + 1);
+  }
+  // One PASSED: counter goes -2 -> -1, still negative; must stay HEALED, not flip to PREFAILED.
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_HEALED);
+}
+
+// A database written by an older build can hold a runaway counter. It must be clamped back on first
+// touch so re-confirmation is bounded, not ~INT32 events away.
+TEST_F(SqliteFaultStorageTest, RunawayCounterFromOldDbRecovers) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -1;
+  config.healing_threshold = 3;
+
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                               config);
+  // Simulate the old bug: poke a huge counter directly into the DB behind the storage's back.
+  {
+    sqlite3 * raw = nullptr;
+    ASSERT_EQ(sqlite3_open(temp_db_path_.string().c_str(), &raw), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(raw, "UPDATE faults SET debounce_counter = 100000, status = 'PREPASSED'", nullptr, nullptr,
+                           nullptr),
+              SQLITE_OK);
+    sqlite3_close(raw);
+  }
+  // The counter is clamped back into range on first touch, so a bounded number of FAILED events
+  // re-confirms (healing_threshold - confirmation_threshold = 4), not the ~100000 the runaway implied.
+  for (int i = 0; i < 4; ++i) {
+    storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                                 config);
+  }
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+}
+
+TEST_F(SqliteFaultStorageTest, ReclassifyHealedAsCleared) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", clock.now(),
+                               config);
+  for (int i = 0; i < 4; ++i) {
+    storage_->report_fault_event("F", ReportFault::Request::EVENT_PASSED, 0, "", "/n", clock.now(), config);
+  }
+  ASSERT_EQ(storage_->get_fault("F")->status, Fault::STATUS_HEALED);
+
+  EXPECT_EQ(storage_->reclassify_healed_as_cleared(), 1u);
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CLEARED);
 }
 
 TEST_F(SqliteFaultStorageTest, HealingWhenEnabled) {

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -514,24 +514,80 @@ TEST_F(SqliteFaultStorageTest, ConfirmationPersistsAfterReopen) {
 
 TEST_F(SqliteFaultStorageTest, PassedEventIncrementsCounter) {
   rclcpp::Clock clock;
+  // confirmation_threshold = -3 so 2 FAILED stays PREFAILED (not CONFIRMED). A
+  // confirmed fault is latched and would not move to PREPASSED on a heal.
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
 
-  // Report 2 FAILED events
+  // Report 2 FAILED events (counter -2, PREFAILED)
   storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
-                               clock.now(), default_config());
+                               clock.now(), config);
   storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node2",
-                               clock.now(), default_config());
+                               clock.now(), config);
 
-  // Report 3 PASSED events
-  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                               default_config());
-  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                               default_config());
-  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(),
-                               default_config());
+  // Report 3 PASSED events (counter -2 -> +1)
+  for (int i = 0; i < 3; ++i) {
+    storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
+  }
 
   auto fault = storage_->get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->status, Fault::STATUS_PREPASSED);  // Counter > 0
+  EXPECT_EQ(fault->status, Fault::STATUS_PREPASSED);  // Counter > 0, never confirmed so not latched
+}
+
+// Regression for #428: a periodic heal heartbeat on a healthy system used to push
+// the debounce counter toward INT32_MAX, so a real fault then took a huge number of
+// reports to confirm. The counter must clamp at the thresholds, and a confirmed or
+// healed status must latch (one report must not flip it).
+TEST_F(SqliteFaultStorageTest, HeartbeatHealClampedAndStatusLatched) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -1;
+  config.healing_enabled = true;
+  config.healing_threshold = 3;
+
+  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               clock.now(), config);
+  ASSERT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
+
+  // Long heal heartbeat: counter clamps at healing_threshold instead of running off.
+  for (int i = 0; i < 100; ++i) {
+    storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
+  }
+  auto healed = storage_->get_fault("FAULT_1");
+  ASSERT_TRUE(healed.has_value());
+  EXPECT_EQ(healed->status, Fault::STATUS_HEALED);
+
+  // Re-confirmation is now bounded to (healing_threshold - confirmation_threshold)
+  // reports, and the healed status latches until the counter walks all the way down.
+  for (int i = 0; i < 3; ++i) {
+    storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                                 clock.now(), config);
+    EXPECT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_HEALED) << "latch broke after " << (i + 1);
+  }
+  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               clock.now(), config);
+  auto reconfirmed = storage_->get_fault("FAULT_1");
+  ASSERT_TRUE(reconfirmed.has_value());
+  EXPECT_EQ(reconfirmed->status, Fault::STATUS_CONFIRMED);
+}
+
+// A confirmed fault must not be un-confirmed by a heal heartbeat when auto-healing
+// is off, and the counter must stay bounded.
+TEST_F(SqliteFaultStorageTest, ConfirmedFaultSurvivesHealHeartbeat) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -1;
+  config.healing_enabled = false;  // healing_threshold (default 3) still bounds the counter
+
+  storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               clock.now(), config);
+  ASSERT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED);
+
+  for (int i = 0; i < 20; ++i) {
+    storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", clock.now(), config);
+    EXPECT_EQ(storage_->get_fault("FAULT_1")->status, Fault::STATUS_CONFIRMED) << "un-confirmed after " << (i + 1);
+  }
 }
 
 TEST_F(SqliteFaultStorageTest, HealingWhenEnabled) {


### PR DESCRIPTION
## Summary

Fixes the unbounded debounce counter from #428. A periodic heal heartbeat on a healthy system drove the counter toward `INT32_MAX` (it only saturated at the integer limits), so when a real fault arrived it had to count all the way back before confirming - arbitrary confirmation lag.

## Fix

- Clamp the counter to `[confirmation_threshold, healing_threshold]` (an AUTOSAR-DEM-style bounded FDC). Worst-case lag is now `healing_threshold - confirmation_threshold` reports instead of unbounded.
- Add hysteresis (Schmitt trigger): once `CONFIRMED` or `HEALED`, the status latches until the counter walks all the way to the opposite threshold, so a single report can't flip a confirmed fault back to a pending state.
- Applied to both storage backends (`SqliteFaultStorage` and `InMemoryFaultStorage`); the manager uses both.
- No DB schema change.

## Tests

- Updated two tests that encoded the old behaviour (a confirmed fault silently downgrading on a heal).
- Added regression tests for the runaway-clamp and the latch on both backends.
- `colcon test` for `ros2_medkit_fault_manager`: 0 failures. 

Thanks to @evTessellate for the detailed report and the AUTOSAR DEM analysis in #428.

Closes #428