### PR TITLE
Add ros2_medkit_fault_detection to the Docker image workspace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ COPY src/ros2_medkit_cmake/ ${COLCON_WS}/src/ros2_medkit_cmake/
 # Copy core packages
 COPY src/ros2_medkit_msgs/ ${COLCON_WS}/src/ros2_medkit_msgs/
 COPY src/ros2_medkit_serialization/ ${COLCON_WS}/src/ros2_medkit_serialization/
+COPY src/ros2_medkit_fault_detection/ ${COLCON_WS}/src/ros2_medkit_fault_detection/
 COPY src/ros2_medkit_gateway/ ${COLCON_WS}/src/ros2_medkit_gateway/
 COPY src/ros2_medkit_fault_manager/ ${COLCON_WS}/src/ros2_medkit_fault_manager/
 COPY src/ros2_medkit_fault_reporter/ ${COLCON_WS}/src/ros2_medkit_fault_reporter/


### PR DESCRIPTION
The Docker image workspace copies packages with explicit COPY lines and was missing the new `ros2_medkit_fault_detection` package, so the image build failed since it merged: rosdep could not resolve the key and `ros2_medkit_opcua` failed at find_package. The publish workflow only runs on push to main, so PR CI did not catch it.

Adds the missing COPY line (placed with the core packages, before the plugins that depend on it). Audited the rest of the list: the only other package not copied is `ros2_medkit_integration_tests`, which is test-only and intentionally excluded (`BUILD_TESTING=OFF`).

Tested: full local `docker build --build-arg ROS_DISTRO=jazzy` completes end to end; `ros2_medkit_opcua` builds and both packages are present in the runtime install tree.
