### PR TITLE
Fix pluralized lifecycle status operationIds (closes #475)

### DIFF
--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -1620,8 +1620,8 @@ void RESTServer::setup_routes() {
   for (const auto & et_lc :
        std::vector<std::pair<const char *, const char *>>{{"apps", "app"}, {"components", "component"}}) {
     const std::string base_lc = std::string("/") + et_lc.first + "/{" + et_lc.second + "_id}";
-    // e.g. "Apps" / "Components" for operation ID construction
-    const std::string entity_cap = capitalize(std::string(et_lc.first));
+    // e.g. "App" / "Component" for operation ID construction
+    const std::string entity_cap = capitalize(std::string(et_lc.second));
 
     for (const auto & action : {"start", "restart", "force-restart", "shutdown", "force-shutdown"}) {
       std::string action_str = action;

--- a/src/ros2_medkit_integration_tests/test/features/test_docs_endpoint.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_docs_endpoint.test.py
@@ -77,6 +77,18 @@ class TestDocsEndpoint(GatewayTestCase):
             f'Root spec should include /apps path. Paths: {list(paths.keys())}'
         )
 
+        # Lifecycle status operationIds use the singular entity name
+        # (getAppStatus), not the plural collection name (getAppsStatus).
+        self.assertEqual(
+            paths['/apps/{app_id}/status']['get']['operationId'],
+            'getAppStatus')
+        self.assertEqual(
+            paths['/components/{component_id}/status']['get']['operationId'],
+            'getComponentStatus')
+        self.assertEqual(
+            paths['/apps/{app_id}/status/restart']['put']['operationId'],
+            'putAppStatusRestart')
+
     def test_apps_docs_returns_entity_collection_spec(self):
         """GET /apps/docs returns spec for apps collection.
 


### PR DESCRIPTION
# Pull Request

<!-- Thanks for contributing to ros2_medkit! -->

## Summary

Fix #475 by using the singular entity name when constructing lifecycle status operationIds.                                                                          
                                                                                            
Previously the code used et_lc.first ("apps"/"components"), producing names such as getAppsStatus and putAppsStatusRestart. 

This changes the operationId generation to use et_lc.second ("app"/"component"), matching the naming convention used throughout the rest of the API.   
             
---

## Issue

Link the related issue (required):

- closes #475

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Builds under ROS 2 Humble.

No runtime behavioral change. Endpoints, handlers, and responses are unchanged; only the generated OpenAPI operationId values are affected.      

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
