### PR TITLE
feat(opcua): route alarms to distinct faults by message substring

### DIFF
--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
@@ -313,6 +313,11 @@ event_alarms:
       - source_node: "ns=3;s=PumpA"      # or match by event SourceNode
         event_type: "ns=0;i=2915"        # and/or EventType (AND-combined)
         fault_code: PLC_PUMP_A_FAULT
+      - match_message: "Overtemperature"  # or match a Message substring - the
+        fault_code: PLC_OVERTEMP          # practical discriminator for PLCs (e.g.
+        severity_override: ERROR          # Siemens S7-1500) whose Program_Alarms
+                                          # share one EventType + SourceNode and
+                                          # differ only by alarm text
     # Append vendor associated values (Siemens Program_Alarm SD_1..SD_n) to the
     # fault description as "label=value".
     associated_values:
@@ -322,7 +327,9 @@ event_alarms:
 ```
 
 Mapping precedence: a mapping with more (non-empty) match fields is matched
-only when all of them equal the observed event; declaration order breaks ties.
+only when all of them match the observed event; declaration order breaks ties.
+`condition_name` / `source_node` / `event_type` are equality matches;
+`match_message` is a case-sensitive substring match on the event Message.
 An event matching no mapping uses the source-level `fault_code`; if that is also
 empty the event is ignored. A mapping-level `severity_override` / `message`
 overrides the source-level one; otherwise the source-level value is inherited.

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
@@ -295,13 +295,14 @@ event_alarms:
   # Simple form: one source -> one fault.
   - alarm_source: "ns=4;s=Alarms.Overpressure"
     entity_id: tank_process
-    fault_code: PLC_OVERPRESSURE
+    fault_code: PLC_TANK_OVERPRESSURE
 
   # Multi-alarm form (issue #389): one source emits many conditions (e.g. the
   # Server object as a catch-all, or one Object owning several Program_Alarms)
   # routed to distinct faults by condition identity. `mappings` are evaluated
-  # in order; the first whose non-empty match fields all equal the observed
-  # event wins, falling back to the source-level `fault_code` (if set).
+  # in order; the first whose non-empty match fields all match the observed
+  # event wins (`match_message` is a substring match, the rest equality),
+  # falling back to the source-level `fault_code` (if set).
   - alarm_source: "ns=0;i=2253"          # Server object (system-wide)
     entity_id: line_1
     fault_code: PLC_GENERIC_ALARM        # catch-all fallback (optional)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -54,8 +54,11 @@ struct AssociatedValueRef {
 /// #389). A single OPC-UA source (e.g. the Server object as a catch-all, or a
 /// real owning Object) can emit many distinct conditions; each mapping routes
 /// a subset to its own SOVD fault. Match fields are AND-combined; an empty
-/// match field is a wildcard. The first mapping whose non-empty match fields
-/// all equal the observed event wins (declaration order = precedence).
+/// match field is a wildcard. ``match_condition_name`` / ``match_source_node``
+/// / ``match_event_type`` are equality matches; ``match_message`` is a
+/// case-sensitive substring match on the event Message. The first mapping whose
+/// non-empty match fields all match the observed event wins (declaration order
+/// = precedence).
 struct AlarmMapping {
   std::string match_condition_name;  // ConditionType.ConditionName (empty = any)
   std::string match_source_node;     // event SourceNode id string (empty = any)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -60,6 +60,7 @@ struct AlarmMapping {
   std::string match_condition_name;  // ConditionType.ConditionName (empty = any)
   std::string match_source_node;     // event SourceNode id string (empty = any)
   std::string match_event_type;      // event EventType id string (empty = any)
+  std::string match_message;         // Message substring (empty = any); case-sensitive contains
 
   std::string fault_code;
   std::string severity_override;
@@ -201,7 +202,8 @@ class NodeMap {
   /// First matching mapping wins; falls back to the source-level fault_code.
   /// Pure / static so the precedence rules are unit-testable without a server.
   static ResolvedAlarm resolve_alarm(const AlarmEventConfig & cfg, const std::string & condition_name,
-                                     const std::string & source_node, const std::string & event_type);
+                                     const std::string & source_node, const std::string & event_type,
+                                     const std::string & message);
 
   /// Get derived SOVD entity definitions
   const std::vector<PlcEntityDef> & entity_defs() const {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
@@ -620,6 +620,7 @@ bool NodeMap::load(const std::string & yaml_path) {
             mapping.match_condition_name = m["condition_name"].as<std::string>("");
             mapping.match_source_node = m["source_node"].as<std::string>("");
             mapping.match_event_type = m["event_type"].as<std::string>("");
+            mapping.match_message = m["match_message"].as<std::string>("");
             mapping.fault_code = *mapping_fault_code;
             mapping.severity_override = m["severity_override"].as<std::string>("");
             mapping.message_override = m["message"].as<std::string>("");
@@ -794,10 +795,15 @@ const AlarmEventConfig * NodeMap::find_event_alarm(const std::string & entity_id
 }
 
 ResolvedAlarm NodeMap::resolve_alarm(const AlarmEventConfig & cfg, const std::string & condition_name,
-                                     const std::string & source_node, const std::string & event_type) {
+                                     const std::string & source_node, const std::string & event_type,
+                                     const std::string & message) {
   ResolvedAlarm out;
-  // First mapping whose non-empty match fields all equal the observed event
-  // wins (declaration order = precedence).
+  // First mapping whose non-empty match fields all match the observed event
+  // wins (declaration order = precedence). condition_name/source_node/event_type
+  // are equality matches; match_message is a case-sensitive substring match on
+  // the event Message - the practical discriminator for PLCs (e.g. Siemens
+  // S7-1500) that emit many Program_Alarms sharing one EventType and SourceNode
+  // and differ only by alarm text.
   for (const auto & m : cfg.mappings) {
     if (!m.match_condition_name.empty() && m.match_condition_name != condition_name) {
       continue;
@@ -806,6 +812,9 @@ ResolvedAlarm NodeMap::resolve_alarm(const AlarmEventConfig & cfg, const std::st
       continue;
     }
     if (!m.match_event_type.empty() && m.match_event_type != event_type) {
+      continue;
+    }
+    if (!m.match_message.empty() && message.find(m.match_message) == std::string::npos) {
       continue;
     }
     out.fault_code = m.fault_code;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
@@ -520,9 +520,9 @@ void OpcuaPoller::read_fallback_replay() {
 
       // Resolve identity to a specific fault. EventType is not available from
       // a state read, so event_type-only mappings will not match here; routing
-      // by condition_name / source_node still works.
+      // by condition_name / source_node / message still works.
       ResolvedAlarm resolved =
-          NodeMap::resolve_alarm(cfg, snap.condition_name, cfg.source_node_id_str, /*event_type=*/"");
+          NodeMap::resolve_alarm(cfg, snap.condition_name, cfg.source_node_id_str, /*event_type=*/"", snap.message);
       if (!resolved.matched) {
         continue;
       }
@@ -720,7 +720,8 @@ void OpcuaPoller::on_event(const AlarmEventConfig & cfg, const std::vector<opcua
   if (values.size() > kFieldConditionName) {
     condition_name = variant_to_string_scalar(values[kFieldConditionName]);
   }
-  ResolvedAlarm resolved = NodeMap::resolve_alarm(cfg, condition_name, source_node.toString(), event_type.toString());
+  ResolvedAlarm resolved =
+      NodeMap::resolve_alarm(cfg, condition_name, source_node.toString(), event_type.toString(), message);
   if (!resolved.matched) {
     // No mapping and no source-level fault_code applies to this condition.
     RCLCPP_DEBUG_STREAM(opcua_poller_logger(),

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
@@ -1564,6 +1564,15 @@ TEST(ResolveAlarmTest, MatchByMessageSubstring) {
   // Empty event message never matches a non-empty match_message -> catch-all.
   auto r4 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "");
   EXPECT_EQ(r4.fault_code, "PLC_PROGRAM_ALARM");
+
+  // Case sensitivity: the substring match is case-sensitive, so a case-mismatched
+  // event must NOT match and falls to the catch-all, while the exact case routes
+  // to the distinct fault. A future case-insensitive find regresses r5 red.
+  cfg.mappings.push_back({"", "", "", "Overtemp", "PLC_ALARM_OVERTEMP", "ERROR", ""});
+  auto r5 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "overtemp fault");
+  EXPECT_EQ(r5.fault_code, "PLC_PROGRAM_ALARM");  // wrong case -> catch-all
+  auto r6 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "Overtemp fault");
+  EXPECT_EQ(r6.fault_code, "PLC_ALARM_OVERTEMP");  // exact case -> distinct fault
 }
 
 TEST_F(NodeMapTest, LoadsMappingsAndAssociatedValues) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
@@ -1470,12 +1470,15 @@ nodes:
 // Issue #389: multi-alarm mapping + associated values.
 // ---------------------------------------------------------------------------
 
+// AlarmMapping brace-init order:
+// {match_condition_name, match_source_node, match_event_type, match_message,
+//  fault_code, severity_override, message_override}
 TEST(ResolveAlarmTest, FallsBackToSourceFaultCode) {
   AlarmEventConfig cfg;
   cfg.entity_id = "tank";
   cfg.fault_code = "PLC_GENERIC";
   cfg.severity_override = "WARNING";
-  auto r = NodeMap::resolve_alarm(cfg, "AnyName", "ns=2;s=Src", "ns=0;i=2915");
+  auto r = NodeMap::resolve_alarm(cfg, "AnyName", "ns=2;s=Src", "ns=0;i=2915", "any msg");
   EXPECT_TRUE(r.matched);
   EXPECT_EQ(r.fault_code, "PLC_GENERIC");
   EXPECT_EQ(r.severity_override, "WARNING");
@@ -1484,7 +1487,7 @@ TEST(ResolveAlarmTest, FallsBackToSourceFaultCode) {
 TEST(ResolveAlarmTest, NoMappingNoFallbackIsUnmatched) {
   AlarmEventConfig cfg;
   cfg.entity_id = "tank";  // no fault_code, no mappings
-  auto r = NodeMap::resolve_alarm(cfg, "X", "Y", "Z");
+  auto r = NodeMap::resolve_alarm(cfg, "X", "Y", "Z", "msg");
   EXPECT_FALSE(r.matched);
 }
 
@@ -1492,20 +1495,20 @@ TEST(ResolveAlarmTest, FirstMatchingMappingWinsByConditionName) {
   AlarmEventConfig cfg;
   cfg.entity_id = "tank";
   cfg.fault_code = "PLC_CATCHALL";
-  cfg.mappings.push_back({/*cond*/ "Overpressure", "", "", "PLC_OVERPRESSURE", "ERROR", "Overpressure!"});
-  cfg.mappings.push_back({/*cond*/ "LowLevel", "", "", "PLC_LOW_LEVEL", "WARNING", "Low level"});
+  cfg.mappings.push_back({/*cond*/ "Overpressure", "", "", "", "PLC_OVERPRESSURE", "ERROR", "Overpressure!"});
+  cfg.mappings.push_back({/*cond*/ "LowLevel", "", "", "", "PLC_LOW_LEVEL", "WARNING", "Low level"});
 
-  auto r1 = NodeMap::resolve_alarm(cfg, "Overpressure", "ns=2;s=Tank", "ns=0;i=2915");
+  auto r1 = NodeMap::resolve_alarm(cfg, "Overpressure", "ns=2;s=Tank", "ns=0;i=2915", "");
   EXPECT_TRUE(r1.matched);
   EXPECT_EQ(r1.fault_code, "PLC_OVERPRESSURE");
   EXPECT_EQ(r1.severity_override, "ERROR");
   EXPECT_EQ(r1.message_override, "Overpressure!");
 
-  auto r2 = NodeMap::resolve_alarm(cfg, "LowLevel", "ns=2;s=Tank", "ns=0;i=2915");
+  auto r2 = NodeMap::resolve_alarm(cfg, "LowLevel", "ns=2;s=Tank", "ns=0;i=2915", "");
   EXPECT_EQ(r2.fault_code, "PLC_LOW_LEVEL");
 
   // Unmatched condition name -> source-level catch-all.
-  auto r3 = NodeMap::resolve_alarm(cfg, "Unknown", "ns=2;s=Tank", "ns=0;i=2915");
+  auto r3 = NodeMap::resolve_alarm(cfg, "Unknown", "ns=2;s=Tank", "ns=0;i=2915", "");
   EXPECT_TRUE(r3.matched);
   EXPECT_EQ(r3.fault_code, "PLC_CATCHALL");
 }
@@ -1513,11 +1516,11 @@ TEST(ResolveAlarmTest, FirstMatchingMappingWinsByConditionName) {
 TEST(ResolveAlarmTest, MatchBySourceNodeAndEventType) {
   AlarmEventConfig cfg;
   cfg.entity_id = "tank";
-  cfg.mappings.push_back({"", "ns=2;s=PumpA", "ns=0;i=2915", "PLC_PUMP_A", "", ""});
+  cfg.mappings.push_back({"", "ns=2;s=PumpA", "ns=0;i=2915", "", "PLC_PUMP_A", "", ""});
   // SourceNode mismatch -> unmatched (no fallback fault_code).
-  EXPECT_FALSE(NodeMap::resolve_alarm(cfg, "X", "ns=2;s=PumpB", "ns=0;i=2915").matched);
+  EXPECT_FALSE(NodeMap::resolve_alarm(cfg, "X", "ns=2;s=PumpB", "ns=0;i=2915", "").matched);
   // Both match.
-  auto r = NodeMap::resolve_alarm(cfg, "X", "ns=2;s=PumpA", "ns=0;i=2915");
+  auto r = NodeMap::resolve_alarm(cfg, "X", "ns=2;s=PumpA", "ns=0;i=2915", "");
   EXPECT_TRUE(r.matched);
   EXPECT_EQ(r.fault_code, "PLC_PUMP_A");
 }
@@ -1527,10 +1530,40 @@ TEST(ResolveAlarmTest, MappingInheritsSourceLevelOverridesWhenUnset) {
   cfg.entity_id = "tank";
   cfg.severity_override = "CRITICAL";
   cfg.message_override = "src-msg";
-  cfg.mappings.push_back({"Cond", "", "", "PLC_X", "", ""});  // no per-mapping overrides
-  auto r = NodeMap::resolve_alarm(cfg, "Cond", "s", "e");
+  cfg.mappings.push_back({"Cond", "", "", "", "PLC_X", "", ""});  // no per-mapping overrides
+  auto r = NodeMap::resolve_alarm(cfg, "Cond", "s", "e", "");
   EXPECT_EQ(r.severity_override, "CRITICAL");
   EXPECT_EQ(r.message_override, "src-msg");
+}
+
+TEST(ResolveAlarmTest, MatchByMessageSubstring) {
+  // A PLC (e.g. Siemens S7-1500) emits many Program_Alarms sharing one
+  // EventType and SourceNode, differing only by alarm text; a case-sensitive
+  // Message substring match splits them into distinct SOVD faults.
+  AlarmEventConfig cfg;
+  cfg.entity_id = "cpu";
+  cfg.fault_code = "PLC_PROGRAM_ALARM";  // source-level catch-all
+  cfg.mappings.push_back({"", "", "", "trigger active", "PLC_ALARM_TRIGGER", "ERROR", ""});
+  cfg.mappings.push_back({"", "", "", "Second alarm", "PLC_ALARM_SECOND", "WARNING", ""});
+
+  // Same EventType + SourceNode for both; only the message differs.
+  auto r1 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "Test Program Alert - trigger active");
+  EXPECT_TRUE(r1.matched);
+  EXPECT_EQ(r1.fault_code, "PLC_ALARM_TRIGGER");
+  EXPECT_EQ(r1.severity_override, "ERROR");
+
+  auto r2 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "Second alarm fired");
+  EXPECT_TRUE(r2.matched);
+  EXPECT_EQ(r2.fault_code, "PLC_ALARM_SECOND");
+
+  // No substring match -> source-level catch-all.
+  auto r3 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "Unrelated text");
+  EXPECT_TRUE(r3.matched);
+  EXPECT_EQ(r3.fault_code, "PLC_PROGRAM_ALARM");
+
+  // Empty event message never matches a non-empty match_message -> catch-all.
+  auto r4 = NodeMap::resolve_alarm(cfg, "", "ns=3;i=1845", "ns=3;i=1805", "");
+  EXPECT_EQ(r4.fault_code, "PLC_PROGRAM_ALARM");
 }
 
 TEST_F(NodeMapTest, LoadsMappingsAndAssociatedValues) {


### PR DESCRIPTION
Adds a `match_message` field to `event_alarms[].mappings` - a case-sensitive substring match on the event Message, AND-combined with the existing `condition_name` / `source_node` / `event_type` matchers. This lets one OPC UA source route alarms that share an EventType and SourceNode (e.g. Program_Alarms from one Siemens S7-1500 FB) to distinct SOVD faults by their text.

- `AlarmMapping` gains `match_message`; `resolve_alarm` takes the event Message and skips a mapping whose non-empty `match_message` is not a substring of it. `condition_name` / `source_node` / `event_type` stay equality matches.
- Parsed from `mappings[].match_message`; the poller passes the live event Message (and the read-path snapshot message).
- README example + unit test (`MatchByMessageSubstring`) covering a match, the catch-all fallback, and an empty message.

Closes #505