### PR TITLE
ci: arm64 multi-arch image (tag/dispatch gated)

### DIFF
--- a/.github/workflows/docker-publish-multiarch.yml
+++ b/.github/workflows/docker-publish-multiarch.yml
@@ -138,8 +138,9 @@ jobs:
                       type=semver,pattern={{version}}
                       # major.minor (v1.2.3 -> 1.2)
                       type=semver,pattern={{major}}.{{minor}}
-                      # always publish latest for release / dispatch
-                      type=raw,value=latest
+                      # latest only on a stable release tag (vX.Y.Z with no
+                      # pre-release suffix); skips -rc/-alpha tags and dispatch
+                      type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
                       # sha for traceability
                       type=sha,prefix=sha-,format=short
 

--- a/.github/workflows/docker-publish-multiarch.yml
+++ b/.github/workflows/docker-publish-multiarch.yml
@@ -1,0 +1,156 @@
+# Multi-arch (linux/amd64 + linux/arm64) image publish for the gateway.
+#
+# Gated on release tags and manual dispatch only - NOT on pull_request or
+# push-to-main. Per-PR / push-to-main CI still runs the amd64-only
+# docker-publish.yml, which stays fast (no emulated arm64 on every change).
+#
+# Each arch builds on its own NATIVE runner (arm64 on ubuntu-24.04-arm), so
+# there is no QEMU emulation. Each arch is pushed by digest, then the merge
+# job stitches the per-arch digests of a given ROS distro into one multi-arch
+# manifest list and tags it. Mirrors the ros2_medkit_web_ui docker-publish.yml
+# pattern, extended with the ros_distro build-arg dimension.
+
+name: Docker Publish (multi-arch, release)
+
+on:
+    push:
+        tags:
+            - 'v*'
+    workflow_dispatch:
+
+env:
+    REGISTRY: ghcr.io
+
+jobs:
+    build:
+        runs-on: ${{ matrix.runner }}
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                ros_distro: [jazzy, humble, lyrical]
+                platform:
+                    - linux/amd64
+                    - linux/arm64
+                # `include` merges the runner key into every matrix combination
+                # whose platform matches - amd64 -> ubuntu-24.04, arm64 ->
+                # ubuntu-24.04-arm (native arm runner, free for public repos).
+                include:
+                    - platform: linux/amd64
+                      runner: ubuntu-24.04
+                    - platform: linux/arm64
+                      runner: ubuntu-24.04-arm
+
+        steps:
+            - name: Prepare platform pair
+              run: |
+                  platform=${{ matrix.platform }}
+                  echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (labels)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }}
+
+            - name: Build and push by digest
+              id: build
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  platforms: ${{ matrix.platform }}
+                  build-args: ROS_DISTRO=${{ matrix.ros_distro }}
+                  labels: ${{ steps.meta.outputs.labels }}
+                  # Separate cache scope per distro+arch so jobs do not evict each other.
+                  cache-from: type=gha,scope=${{ matrix.ros_distro }}-${{ env.PLATFORM_PAIR }}
+                  cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}-${{ env.PLATFORM_PAIR }}
+                  # Push each arch by digest; the merge job creates and tags the manifest list.
+                  outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }},push-by-digest=true,name-canonical=true,push=true
+
+            - name: Export digest
+              run: |
+                  mkdir -p /tmp/digests
+                  digest="${{ steps.build.outputs.digest }}"
+                  touch "/tmp/digests/${digest#sha256:}"
+
+            - name: Upload digest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: digests-${{ matrix.ros_distro }}-${{ env.PLATFORM_PAIR }}
+                  path: /tmp/digests/*
+                  if-no-files-found: error
+                  retention-days: 1
+
+    # Merge the per-arch digests of each ROS distro into one multi-arch manifest
+    # list and tag it. One merge job per distro (matrix), each pulling only its
+    # own digests-<distro>-* artifacts.
+    merge:
+        runs-on: ubuntu-latest
+        needs:
+            - build
+        permissions:
+            contents: read
+            packages: write
+        strategy:
+            fail-fast: false
+            matrix:
+                ros_distro: [jazzy, humble, lyrical]
+        steps:
+            - name: Download digests
+              uses: actions/download-artifact@v4
+              with:
+                  path: /tmp/digests
+                  pattern: digests-${{ matrix.ros_distro }}-*
+                  merge-multiple: true
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ${{ env.REGISTRY }}
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (tags, labels)
+              id: meta
+              uses: docker/metadata-action@v5
+              with:
+                  images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }}
+                  tags: |
+                      # version tag (v1.2.3 -> 1.2.3)
+                      type=semver,pattern={{version}}
+                      # major.minor (v1.2.3 -> 1.2)
+                      type=semver,pattern={{major}}.{{minor}}
+                      # always publish latest for release / dispatch
+                      type=raw,value=latest
+                      # sha for traceability
+                      type=sha,prefix=sha-,format=short
+
+            - name: Create multi-arch manifest list
+              working-directory: /tmp/digests
+              run: |
+                  docker buildx imagetools create \
+                    $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+                    $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }}@sha256:%s ' *)
+
+            - name: Inspect manifest
+              run: |
+                  docker buildx imagetools inspect \
+                    ${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }}:${{ steps.meta.outputs.version }}


### PR DESCRIPTION
Adds a native-runner multi-arch (linux/amd64 + linux/arm64) image publish for the gateway.

## What
- New workflow `.github/workflows/docker-publish-multiarch.yml`.
- Builds each arch on its own native runner (arm64 on `ubuntu-24.04-arm`, no QEMU), pushes by digest, then a per-distro merge job stitches the digests into one multi-arch manifest and tags it.
- Mirrors the `ros2_medkit_web_ui` digest + manifest-merge pattern, extended with the `ros_distro` build-arg dimension (jazzy, humble, lyrical).

## Gating
- Triggers on `push` to `v*` tags and `workflow_dispatch` ONLY. NOT on pull_request or push-to-main.
- The existing `docker-publish.yml` (amd64-only, push-to-main) is left untouched, so per-PR / push-to-main CI stays fast (no emulated arm64 on every change).

## Feasibility
- Verified `ros:{jazzy,humble,lyrical}-ros-base` all publish `linux/arm64/v8` manifests, so arm64 builds are feasible. No base-image blocker.
