### PR TITLE
feat(opcua): read-only PLC network discovery -> auto_browse

### DIFF
--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(ros2_medkit_opcua_plugin MODULE
   src/device_identity.cpp
   src/node_map.cpp
   src/opcua_poller.cpp
+  src/network_discovery.cpp
+  src/network_discovery_io.cpp
 )
 
 target_include_directories(ros2_medkit_opcua_plugin PRIVATE
@@ -174,6 +176,8 @@ if(BUILD_TESTING)
     src/device_identity.cpp
     src/node_map.cpp
     src/opcua_poller.cpp
+    src/network_discovery.cpp
+    src/network_discovery_io.cpp
     TIMEOUT 240
   )
   target_include_directories(test_opcua_plugin PRIVATE
@@ -264,6 +268,22 @@ if(BUILD_TESTING)
     nlohmann_json::nlohmann_json
   )
   medkit_set_test_domain(test_device_identity)
+
+  # Read-only PLC/OPC-UA network discovery: CIDR expansion, config parse +
+  # validation, dedup / URL-preference / classification, and auto-endpoint
+  # selection. Links only the pure orchestrator (network_discovery.cpp) with
+  # injected fake scan/identify - no network, no open62541, no I/O source.
+  ament_add_gtest(test_network_discovery
+    test/test_network_discovery.cpp
+    src/network_discovery.cpp
+  )
+  target_include_directories(test_network_discovery PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  target_link_libraries(test_network_discovery
+    nlohmann_json::nlohmann_json
+  )
+  medkit_set_test_domain(test_network_discovery)
 
   # ---- test_alarm_server fixture ------------------------------------------
   # Standalone OPC-UA server emitting AlarmConditionType events for
@@ -395,6 +415,8 @@ if(BUILD_TESTING)
       src/device_identity.cpp
       src/node_map.cpp
       src/opcua_poller.cpp
+      src/network_discovery.cpp
+      src/network_discovery_io.cpp
       TIMEOUT 120
     )
     add_dependencies(test_opcua_identity test_alarm_server)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
@@ -370,6 +370,7 @@ ros2_medkit_gateway:
 | `comms_lost_fault_enabled` | `true` | Raise a component-scoped `PLC_COMMS_LOST` fault when the connection stays down (issue #496) |
 | `comms_lost_debounce_ms` | `5000` | Continuous down time before `PLC_COMMS_LOST` is raised (debounces reconnect blips; clamped to [0, 3600000] ms) |
 | `comms_lost_severity` | `ERROR` | SOVD severity bucket for the `PLC_COMMS_LOST` fault |
+| `discovery.enabled` | `false` | Opt-in read-only PLC network discovery (auto endpoint). See below |
 
 ### OPC-UA client security (SecurityPolicy, certificates, user auth)
 
@@ -405,6 +406,62 @@ Notes:
   `reject_untrusted: false`.
 - The encryption backend (OpenSSL) is compiled in; a build without it logs an
   error and refuses any secured profile.
+
+### Read-only PLC network discovery (auto endpoint)
+
+A diag-box plugged into a plant LAN can auto-find an OPC-UA PLC instead of
+requiring a hand-configured `endpoint_url`. Discovery is **opt-in and disabled
+by default**; enabling it runs a bounded, read-only active scan and hands the
+best OPC-UA data server to the normal connect + introspect path.
+
+```yaml
+plugins.opcua.discovery:
+  enabled: false               # master switch (default false)
+  mode: "active"               # active | passive | both (only active implemented)
+  subnets: ["192.168.1.0/24"]  # CIDR list; empty => derive the host's local /24
+  ports: [4840]                # TCP ports probed (4840 = OPC-UA; others = leads)
+  connect_timeout_ms: 600      # per-port TCP connect timeout
+  scan_concurrency: 100        # bounded, polite concurrent connect count
+  identify_timeout_ms: 6000    # per GetEndpoints identify
+  interval_s: 0                # 0 = one-shot at startup (periodic re-scan: TODO)
+  anonymous_none_only: true    # only auto-connect None/Anonymous servers
+```
+
+Environment overrides (Docker / appliance): `OPCUA_DISCOVERY_ENABLED`,
+`OPCUA_DISCOVERY_SUBNETS` (comma-separated CIDRs), `OPCUA_DISCOVERY_INTERVAL_S`.
+
+How it works:
+1. Bounded concurrent TCP connect sweep of the configured ports across the
+   subnet (nothing beyond a connect - no payload sent to non-OPC-UA ports).
+2. For each open `:4840`, a read-only OPC-UA `GetEndpoints` identify extracts
+   the endpoint URL, ApplicationUri, ProductUri, security policies, and whether
+   a None/Anonymous endpoint is offered.
+3. Results are deduplicated by ApplicationUri (fallback ip:port) and classified:
+   OPC-UA **data server** (ApplicationType 0/2, browseable) vs **discovery
+   server / LDS** (type 3, never browsed) vs **non-OPC-UA lead** (e.g. an open
+   `:102` S7comm port, recorded but not identified).
+4. When discovery is on **and no `endpoint_url` is configured**, the plugin
+   auto-selects the best None/Anonymous data server (deterministic, lowest
+   ip:port) and connects to the **scanned ip:port** - not the advertised
+   EndpointUrl, which a server may report as a non-resolvable hostname.
+
+Safety / OT posture:
+- Everything is read-only: TCP connect + `GetEndpoints` only. No writes, no
+  subscriptions, no second long-lived session.
+- An explicitly configured `endpoint_url` (or `OPCUA_ENDPOINT_URL`) always wins;
+  discovery then does nothing, so it never opens a second session on a PLC the
+  plugin already polls.
+- Secured-only servers (no None/Anonymous endpoint) are surfaced in the startup
+  log as leads requiring operator credentials - never auto-connected or probed.
+- The scan is bounded (short connect timeout, capped concurrency) and CIDRs
+  wider than /16 are rejected to prevent an accidental broad sweep.
+
+Note on passive discovery: a stock Siemens S7-1500 neither multicast-announces
+(mDNS `_opcua-tcp._tcp`) nor registers with an OPC-UA LDS, so passive sources
+find nothing there; the active scan is what discovers it. Passive mDNS / LDS
+`FindServers` sources (useful on Kepware / Prosys / GDS estates) and periodic
+re-scan + multi-endpoint registration are planned follow-ups; this iteration
+delivers the active-scan core and single "auto endpoint" mode.
 
 ### Active-condition replay on reconnect (issue #389/#478)
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
@@ -1,0 +1,182 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace ros2_medkit_gateway {
+
+/// One SecurityPolicy / MessageSecurityMode pair offered by a discovered
+/// endpoint. ``mode`` mirrors the OPC-UA MessageSecurityMode enum
+/// (1 = None, 2 = Sign, 3 = SignAndEncrypt).
+struct DiscoverySecurityProfile {
+  std::string policy;  ///< short policy name, e.g. "None", "Basic256Sha256"
+  int mode{0};
+};
+
+/// Result of a read-only OPC-UA GetEndpoints identify on a single server. Plain
+/// struct (no open62541 types) so the discovery orchestrator and its unit tests
+/// are decoupled from the OPC-UA client library.
+struct IdentifyResult {
+  bool ok{false};
+  std::string error;  ///< populated when ok == false
+
+  std::string advertised_url;   ///< EndpointUrl the server advertised (may be unresolvable)
+  std::string application_uri;  ///< server ApplicationUri (stable identity)
+  std::string product_uri;
+  std::string application_name;
+  /// OPC-UA ApplicationType: 0 = Server, 1 = Client, 2 = ClientAndServer,
+  /// 3 = DiscoveryServer (LDS).
+  int application_type{0};
+  std::vector<DiscoverySecurityProfile> security_policies;
+  bool anonymous_none_available{false};  ///< a None + Anonymous endpoint is offered
+};
+
+/// A discovered OPC-UA endpoint, enriched with identify metadata.
+struct DiscoveredEndpoint {
+  std::string ip;
+  uint16_t port{4840};
+  std::string protocol = "opcua";
+
+  /// Connect URL the plugin should use. Always the SCANNED ``ip:port`` because
+  /// a server can advertise a non-resolvable hostname (an LDS on our LAN
+  /// advertised ``opc.tcp://DESKTOP-...``); the advertised value is kept only
+  /// as metadata in ``advertised_url``.
+  std::string endpoint_url;
+  std::string advertised_url;
+
+  std::string application_uri;
+  std::string product_uri;
+  std::string application_name;
+  int application_type{0};
+  std::vector<DiscoverySecurityProfile> security_policies;
+  bool anonymous_none_available{false};
+
+  /// Non-empty when the GetEndpoints identify failed (port was open but the
+  /// OPC-UA handshake did not complete). Such an endpoint is surfaced as a lead
+  /// but is never auto-connected.
+  std::string identify_error;
+
+  /// True when the endpoint is an OPC-UA data server (ApplicationType Server or
+  /// ClientAndServer) - a candidate for auto_browse. A DiscoveryServer (LDS,
+  /// type 3) returns false and is never browsed.
+  bool is_data_server() const {
+    return application_type == 0 || application_type == 2;
+  }
+};
+
+/// ``discovery:`` config block for the opcua plugin. Off by default; active
+/// scan is opt-in and bounded.
+struct DiscoveryConfig {
+  bool enabled{false};
+
+  /// active | passive | both. Only "active" (bounded TCP scan + GetEndpoints)
+  /// is implemented today; passive mDNS / LDS FindServers are a documented
+  /// follow-up. A passive-only mode performs no scanning and finds nothing on a
+  /// stock Siemens network.
+  std::string mode = "active";
+
+  /// Target CIDR subnets for the active scan. Empty => derive the plugin host's
+  /// local /24 at runtime.
+  std::vector<std::string> subnets;
+
+  /// TCP ports probed per host. 4840 is the OPC-UA default; others are recorded
+  /// as leads but not OPC-UA-identified.
+  std::vector<uint16_t> ports{4840};
+
+  int connect_timeout_ms{600};  ///< per-port TCP connect timeout
+  int scan_concurrency{100};    ///< bounded, polite concurrent connect count
+  int identify_timeout_ms{6000};
+
+  /// Re-scan cadence. 0 = one-shot at startup (the only mode implemented in
+  /// this iteration); a positive value is accepted and validated but periodic
+  /// re-scan is a documented follow-up.
+  int interval_s{0};
+
+  /// Only auto-register endpoints that expose a None + Anonymous endpoint (what
+  /// the plugin connects with today). Secured-only servers are surfaced as
+  /// leads requiring operator credentials, never auto-connected.
+  bool anonymous_none_only{true};
+};
+
+/// Probe whether a TCP port is open. Injected so the orchestrator is unit
+/// testable without a network.
+/// @return true if a connection was established within ``timeout_ms``.
+using PortScanFn = std::function<bool(const std::string & ip, uint16_t port, int timeout_ms)>;
+
+/// Read-only OPC-UA GetEndpoints identify against ``opc.tcp://ip:port``.
+using IdentifyFn = std::function<IdentifyResult(const std::string & url, int timeout_ms)>;
+
+/// Expand a CIDR (e.g. "192.168.1.0/24") into its usable host IP strings
+/// (network + broadcast excluded for prefixes < 31). Returns empty and sets
+/// ``*ok = false`` on a malformed CIDR or a prefix wider than /16 (guards
+/// against an accidental full-Internet sweep).
+std::vector<std::string> expand_cidr_hosts(const std::string & cidr, bool * ok = nullptr);
+
+/// Best-effort local /24 derived from the host's first non-loopback,
+/// non-Docker IPv4 interface. Empty when none is found.
+std::string derive_local_cidr();
+
+/// Parse + validate a ``discovery:`` JSON block. Unknown keys and out-of-range
+/// values are reported through ``warn`` (never fatal); recognized values
+/// override the defaults. Ports outside 1..65535, non-positive timeout /
+/// concurrency, and an unknown ``mode`` are rejected back to their defaults
+/// with a warning.
+DiscoveryConfig parse_discovery_config(const nlohmann::json & j, const std::function<void(const std::string &)> & warn);
+
+/// Read-only active-scan discovery orchestrator. Sweeps the configured subnets
+/// for open OPC-UA ports, runs a GetEndpoints identify on each :4840 hit, and
+/// returns a deduplicated, classified endpoint list. All I/O is injected
+/// (scan + identify) so the merge / dedup / URL-preference logic is unit
+/// testable without touching the network.
+class NetworkDiscovery {
+ public:
+  NetworkDiscovery(DiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify);
+
+  /// Run one full discovery pass (blocking). Read-only: TCP connect +
+  /// GetEndpoints only. Deduplicated by ApplicationUri (fallback ip:port),
+  /// sorted deterministically by ip:port.
+  std::vector<DiscoveredEndpoint> run();
+
+  /// Resolve the subnets to scan: configured ``subnets`` if any, else the
+  /// derived local /24. Exposed for logging / tests.
+  std::vector<std::string> resolve_subnets() const;
+
+  /// Pick the best endpoint for single-endpoint "auto endpoint" mode: an
+  /// OPC-UA data server (not an LDS) that identified cleanly and, when
+  /// ``anonymous_none_only``, offers a None + Anonymous endpoint. Deterministic
+  /// (lowest ip:port). Returns nullptr when no candidate qualifies. Pure /
+  /// static so the selection policy is unit tested without a network.
+  static const DiscoveredEndpoint * select_auto_endpoint(const std::vector<DiscoveredEndpoint> & eps,
+                                                         bool anonymous_none_only);
+
+ private:
+  DiscoveryConfig cfg_;
+  PortScanFn scan_;
+  IdentifyFn identify_;
+};
+
+/// Real POSIX TCP connect probe (non-blocking connect + select timeout).
+bool tcp_connect_probe(const std::string & ip, uint16_t port, int timeout_ms);
+
+/// Real read-only OPC-UA GetEndpoints identify via open62541pp.
+IdentifyResult opcua_getendpoints_identify(const std::string & url, int timeout_ms);
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "ros2_medkit_opcua/network_discovery.hpp"
 #include "ros2_medkit_opcua/node_map.hpp"
 #include "ros2_medkit_opcua/opcua_client.hpp"
 #include "ros2_medkit_opcua/opcua_poller.hpp"
@@ -150,6 +151,15 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   // startup; warns when running unsecured.
   void log_security_profile() const;
 
+  // Read-only active-scan discovery. When discovery is enabled and no endpoint
+  // was explicitly configured, run one pass, log a summary, and (if a suitable
+  // None/Anonymous OPC-UA data server is found) set client_config_.endpoint_url
+  // to the discovered ip:port so the existing connect + introspect path adopts
+  // it. Injected scan/identify default to the real POSIX + open62541pp
+  // implementations; tests override them. No-op when discovery is disabled or
+  // an endpoint is already configured.
+  void run_startup_discovery();
+
   // Build JSON response for data endpoint
   nlohmann::json build_data_response(const std::string & entity_id) const;
 
@@ -158,6 +168,18 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   OpcuaClientConfig client_config_;
   PollerConfig poller_config_;
   std::string node_map_path_;
+
+  // Read-only PLC/OPC-UA network discovery (opt-in, default disabled).
+  DiscoveryConfig discovery_config_;
+  // True when the operator pinned endpoint_url via config or OPCUA_ENDPOINT_URL.
+  // Discovery only auto-selects an endpoint when this is false, so it never
+  // overrides an explicit target or opens a second session on a polled PLC.
+  bool endpoint_configured_{false};
+  // Injected discovery I/O; default to the real POSIX / open62541pp probes.
+  // Tests substitute in-memory fakes to exercise the auto-endpoint path without
+  // a network. Set in configure(), consumed in run_startup_discovery().
+  PortScanFn discovery_scan_fn_;
+  IdentifyFn discovery_identify_fn_;
 
   std::unique_ptr<OpcuaClient> client_;
   NodeMap node_map_;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
@@ -1,0 +1,399 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_opcua/network_discovery.hpp"
+
+#include <arpa/inet.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <sys/socket.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+
+namespace {
+
+// Parse "a.b.c.d" into a host-order uint32. Returns false on any malformed
+// octet (out of range, non-numeric, wrong field count).
+bool parse_ipv4(const std::string & s, uint32_t * out) {
+  struct in_addr addr {};
+  if (inet_pton(AF_INET, s.c_str(), &addr) != 1) {
+    return false;
+  }
+  *out = ntohl(addr.s_addr);
+  return true;
+}
+
+std::string ipv4_to_string(uint32_t host_order) {
+  struct in_addr addr {};
+  addr.s_addr = htonl(host_order);
+  char buf[INET_ADDRSTRLEN] = {0};
+  inet_ntop(AF_INET, &addr, buf, sizeof(buf));
+  return std::string(buf);
+}
+
+}  // namespace
+
+std::vector<std::string> expand_cidr_hosts(const std::string & cidr, bool * ok) {
+  const auto fail = [&]() -> std::vector<std::string> {
+    if (ok) {
+      *ok = false;
+    }
+    return {};
+  };
+
+  const auto slash = cidr.find('/');
+  if (slash == std::string::npos) {
+    return fail();
+  }
+  const std::string ip_part = cidr.substr(0, slash);
+  const std::string prefix_part = cidr.substr(slash + 1);
+
+  uint32_t base = 0;
+  if (!parse_ipv4(ip_part, &base)) {
+    return fail();
+  }
+
+  int prefix = -1;
+  try {
+    size_t consumed = 0;
+    prefix = std::stoi(prefix_part, &consumed);
+    if (consumed != prefix_part.size()) {
+      return fail();
+    }
+  } catch (const std::exception &) {
+    return fail();
+  }
+  // Reject a prefix wider than /16 so a typo cannot trigger a multi-million
+  // host Internet sweep. /32 and /31 are handled as degenerate single/paired
+  // ranges below.
+  if (prefix < 16 || prefix > 32) {
+    return fail();
+  }
+
+  if (ok) {
+    *ok = true;
+  }
+
+  const uint32_t host_bits = 32 - static_cast<uint32_t>(prefix);
+  const uint32_t mask = host_bits == 32 ? 0u : (0xFFFFFFFFu << host_bits);
+  const uint32_t network = base & mask;
+
+  std::vector<std::string> hosts;
+  if (prefix >= 31) {
+    // /31 and /32: no network/broadcast reservation - every address is usable.
+    const uint32_t count = host_bits == 0 ? 1u : (1u << host_bits);
+    for (uint32_t i = 0; i < count; ++i) {
+      hosts.push_back(ipv4_to_string(network + i));
+    }
+    return hosts;
+  }
+
+  const uint32_t broadcast = network | ~mask;
+  hosts.reserve(broadcast - network - 1);
+  for (uint32_t addr = network + 1; addr < broadcast; ++addr) {
+    hosts.push_back(ipv4_to_string(addr));
+  }
+  return hosts;
+}
+
+std::string derive_local_cidr() {
+  struct ifaddrs * ifaddr = nullptr;
+  if (getifaddrs(&ifaddr) != 0) {
+    return {};
+  }
+  std::string result;
+  for (struct ifaddrs * ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
+      continue;
+    }
+    if ((ifa->ifa_flags & IFF_LOOPBACK) != 0 || (ifa->ifa_flags & IFF_UP) == 0) {
+      continue;
+    }
+    const std::string name = ifa->ifa_name ? ifa->ifa_name : "";
+    // Skip container / virtual bridges so the box scans the plant LAN, not a
+    // Docker network. Best-effort by common name prefixes.
+    if (name.rfind("docker", 0) == 0 || name.rfind("br-", 0) == 0 || name.rfind("veth", 0) == 0 ||
+        name.rfind("virbr", 0) == 0) {
+      continue;
+    }
+    const auto * sin = reinterpret_cast<const struct sockaddr_in *>(ifa->ifa_addr);
+    const uint32_t host = ntohl(sin->sin_addr.s_addr);
+    const uint32_t network = host & 0xFFFFFF00u;  // /24
+    result = ipv4_to_string(network) + "/24";
+    break;
+  }
+  freeifaddrs(ifaddr);
+  return result;
+}
+
+DiscoveryConfig parse_discovery_config(const nlohmann::json & j,
+                                       const std::function<void(const std::string &)> & warn) {
+  DiscoveryConfig cfg;
+  const auto warn_fn = [&](const std::string & m) {
+    if (warn) {
+      warn(m);
+    }
+  };
+  if (!j.is_object()) {
+    warn_fn("discovery: config is not an object - ignoring");
+    return cfg;
+  }
+
+  static const std::vector<std::string> kKnown = {"enabled",
+                                                  "mode",
+                                                  "subnets",
+                                                  "cidr",
+                                                  "ports",
+                                                  "connect_timeout_ms",
+                                                  "scan_concurrency",
+                                                  "identify_timeout_ms",
+                                                  "interval_s",
+                                                  "anonymous_none_only"};
+  for (const auto & item : j.items()) {
+    if (std::find(kKnown.begin(), kKnown.end(), item.key()) == kKnown.end()) {
+      warn_fn("discovery: unknown key '" + item.key() + "' ignored");
+    }
+  }
+
+  if (j.contains("enabled") && j["enabled"].is_boolean()) {
+    cfg.enabled = j["enabled"].get<bool>();
+  }
+  if (j.contains("mode") && j["mode"].is_string()) {
+    const std::string mode = j["mode"].get<std::string>();
+    if (mode == "active" || mode == "passive" || mode == "both") {
+      cfg.mode = mode;
+      if (mode != "active") {
+        warn_fn("discovery: mode '" + mode +
+                "' - passive sources (mDNS / LDS) are not implemented yet; only active scan runs");
+      }
+    } else {
+      warn_fn("discovery: unknown mode '" + mode + "' - defaulting to 'active'");
+    }
+  }
+
+  // subnets (array) and/or cidr (string or array) both feed the target list.
+  const auto add_subnets = [&](const nlohmann::json & node) {
+    if (node.is_string()) {
+      cfg.subnets.push_back(node.get<std::string>());
+    } else if (node.is_array()) {
+      for (const auto & el : node) {
+        if (el.is_string()) {
+          cfg.subnets.push_back(el.get<std::string>());
+        }
+      }
+    }
+  };
+  if (j.contains("subnets")) {
+    add_subnets(j["subnets"]);
+  }
+  if (j.contains("cidr")) {
+    add_subnets(j["cidr"]);
+  }
+
+  if (j.contains("ports") && j["ports"].is_array()) {
+    std::vector<uint16_t> ports;
+    for (const auto & p : j["ports"]) {
+      if (!p.is_number_integer()) {
+        continue;
+      }
+      const int64_t v = p.get<int64_t>();
+      if (v < 1 || v > 65535) {
+        warn_fn("discovery: port " + std::to_string(v) + " out of range 1..65535 - skipped");
+        continue;
+      }
+      ports.push_back(static_cast<uint16_t>(v));
+    }
+    if (!ports.empty()) {
+      cfg.ports = std::move(ports);
+    }
+  }
+
+  const auto read_positive_int = [&](const char * key, int & target) {
+    if (j.contains(key) && j[key].is_number_integer()) {
+      const int v = j[key].get<int>();
+      if (v > 0) {
+        target = v;
+      } else {
+        warn_fn(std::string("discovery: ") + key + " must be > 0 - keeping default");
+      }
+    }
+  };
+  read_positive_int("connect_timeout_ms", cfg.connect_timeout_ms);
+  read_positive_int("scan_concurrency", cfg.scan_concurrency);
+  read_positive_int("identify_timeout_ms", cfg.identify_timeout_ms);
+
+  if (j.contains("interval_s") && j["interval_s"].is_number_integer()) {
+    const int v = j["interval_s"].get<int>();
+    if (v >= 0) {
+      cfg.interval_s = v;
+    } else {
+      warn_fn("discovery: interval_s must be >= 0 - keeping default (0 = one-shot)");
+    }
+  }
+  if (j.contains("anonymous_none_only") && j["anonymous_none_only"].is_boolean()) {
+    cfg.anonymous_none_only = j["anonymous_none_only"].get<bool>();
+  }
+
+  return cfg;
+}
+
+NetworkDiscovery::NetworkDiscovery(DiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify)
+  : cfg_(std::move(cfg)), scan_(std::move(scan)), identify_(std::move(identify)) {
+}
+
+std::vector<std::string> NetworkDiscovery::resolve_subnets() const {
+  if (!cfg_.subnets.empty()) {
+    return cfg_.subnets;
+  }
+  const std::string local = derive_local_cidr();
+  if (local.empty()) {
+    return {};
+  }
+  return {local};
+}
+
+std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
+  // 1. Build the (ip, port) task list from every resolved subnet.
+  struct Target {
+    std::string ip;
+    uint16_t port;
+  };
+  std::vector<Target> targets;
+  for (const auto & cidr : resolve_subnets()) {
+    bool ok = false;
+    const auto hosts = expand_cidr_hosts(cidr, &ok);
+    if (!ok) {
+      continue;
+    }
+    for (const auto & ip : hosts) {
+      for (const auto port : cfg_.ports) {
+        targets.push_back({ip, port});
+      }
+    }
+  }
+
+  // 2. Bounded-concurrency TCP connect sweep. The scan primitive is injected;
+  // only the polite fan-out lives here.
+  std::vector<Target> open_hits;
+  std::mutex hits_mu;
+  std::atomic<size_t> next{0};
+  const int worker_count = std::max(1, std::min<int>(cfg_.scan_concurrency, static_cast<int>(targets.size())));
+  const auto worker = [&]() {
+    for (;;) {
+      const size_t i = next.fetch_add(1);
+      if (i >= targets.size()) {
+        return;
+      }
+      const Target & t = targets[i];
+      if (scan_(t.ip, t.port, cfg_.connect_timeout_ms)) {
+        std::lock_guard<std::mutex> lk(hits_mu);
+        open_hits.push_back(t);
+      }
+    }
+  };
+  {
+    std::vector<std::thread> pool;
+    pool.reserve(static_cast<size_t>(worker_count));
+    for (int w = 0; w < worker_count; ++w) {
+      pool.emplace_back(worker);
+    }
+    for (auto & th : pool) {
+      th.join();
+    }
+  }
+
+  // Deterministic identify order (lowest ip:port first).
+  std::sort(open_hits.begin(), open_hits.end(), [](const Target & a, const Target & b) {
+    if (a.ip != b.ip) {
+      return a.ip < b.ip;
+    }
+    return a.port < b.port;
+  });
+
+  // 3. Identify OPC-UA hits; dedup by ApplicationUri (fallback ip:port).
+  std::vector<DiscoveredEndpoint> ordered;
+  std::unordered_map<std::string, size_t> by_key;  // dedup key -> index in ordered
+
+  for (const auto & t : open_hits) {
+    DiscoveredEndpoint ep;
+    ep.ip = t.ip;
+    ep.port = t.port;
+    ep.endpoint_url = "opc.tcp://" + t.ip + ":" + std::to_string(t.port);
+
+    if (t.port == 4840) {
+      const IdentifyResult id = identify_(ep.endpoint_url, cfg_.identify_timeout_ms);
+      if (id.ok) {
+        ep.advertised_url = id.advertised_url;
+        ep.application_uri = id.application_uri;
+        ep.product_uri = id.product_uri;
+        ep.application_name = id.application_name;
+        ep.application_type = id.application_type;
+        ep.security_policies = id.security_policies;
+        ep.anonymous_none_available = id.anonymous_none_available;
+      } else {
+        ep.identify_error = id.error;
+      }
+    } else {
+      // Non-OPC-UA OT port: recorded as a lead, no identify.
+      ep.protocol = "unknown";
+    }
+
+    // Dedup: prefer a stable ApplicationUri; a scan on two IPs of the same PLC
+    // then collapses to one entry. Fall back to ip:port when the URI is empty
+    // (identify failed or non-OPC-UA lead) so distinct hosts stay distinct.
+    const std::string key = !ep.application_uri.empty() ? ("uri:" + ep.application_uri) : ("addr:" + ep.endpoint_url);
+    const auto it = by_key.find(key);
+    if (it == by_key.end()) {
+      by_key.emplace(key, ordered.size());
+      ordered.push_back(std::move(ep));
+    }
+    // On a duplicate ApplicationUri we keep the first (lowest ip:port by sort
+    // order) and drop the rest - the primary connect URL should be stable.
+  }
+
+  return ordered;
+}
+
+const DiscoveredEndpoint * NetworkDiscovery::select_auto_endpoint(const std::vector<DiscoveredEndpoint> & eps,
+                                                                  bool anonymous_none_only) {
+  const DiscoveredEndpoint * best = nullptr;
+  for (const auto & ep : eps) {
+    if (ep.protocol != "opcua" || !ep.identify_error.empty()) {
+      continue;
+    }
+    if (!ep.is_data_server()) {
+      continue;  // skip a DiscoveryServer / LDS - nothing to browse
+    }
+    if (anonymous_none_only && !ep.anonymous_none_available) {
+      continue;  // secured-only: surfaced as a lead, never auto-connected
+    }
+    if (best == nullptr || ep.ip < best->ip || (ep.ip == best->ip && ep.port < best->port)) {
+      best = &ep;
+    }
+  }
+  return best;
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
@@ -53,6 +53,20 @@ std::string ipv4_to_string(uint32_t host_order) {
   return std::string(buf);
 }
 
+// Numeric IPv4 compare (e.g. "192.168.1.2" < "192.168.1.10") - a plain string
+// compare gets this wrong lexicographically. Falls back to string compare
+// only when a side fails to parse (should not happen: ip always comes from
+// expand_cidr_hosts / a scanned socket address) so a malformed value still
+// sorts deterministically instead of silently mis-ranking.
+bool ipv4_less(const std::string & a, const std::string & b) {
+  uint32_t a_ip = 0;
+  uint32_t b_ip = 0;
+  if (parse_ipv4(a, &a_ip) && parse_ipv4(b, &b_ip)) {
+    return a_ip < b_ip;
+  }
+  return a < b;
+}
+
 }  // namespace
 
 std::vector<std::string> expand_cidr_hosts(const std::string & cidr, bool * ok) {
@@ -184,9 +198,14 @@ DiscoveryConfig parse_discovery_config(const nlohmann::json & j,
     const std::string mode = j["mode"].get<std::string>();
     if (mode == "active" || mode == "passive" || mode == "both") {
       cfg.mode = mode;
-      if (mode != "active") {
-        warn_fn("discovery: mode '" + mode +
-                "' - passive sources (mDNS / LDS) are not implemented yet; only active scan runs");
+      if (mode == "passive") {
+        warn_fn(
+            "discovery: mode 'passive' - passive sources (mDNS / LDS) are not implemented yet; "
+            "discovery will not run");
+      } else if (mode == "both") {
+        warn_fn(
+            "discovery: mode 'both' - passive sources (mDNS / LDS) are not implemented yet; "
+            "only the active scan runs");
       }
     } else {
       warn_fn("discovery: unknown mode '" + mode + "' - defaulting to 'active'");
@@ -275,6 +294,14 @@ std::vector<std::string> NetworkDiscovery::resolve_subnets() const {
 }
 
 std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
+  // "passive" has no active scan implementation yet (mDNS / LDS FindServers
+  // are a documented follow-up) - a no-op stub rather than silently running
+  // the active scan mode wasn't asked for. parse_discovery_config() already
+  // warns about this at parse time.
+  if (cfg_.mode == "passive") {
+    return {};
+  }
+
   // 1. Build the (ip, port) task list from every resolved subnet.
   struct Target {
     std::string ip;
@@ -324,10 +351,10 @@ std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
     }
   }
 
-  // Deterministic identify order (lowest ip:port first).
+  // Deterministic identify order (numerically lowest ip:port first).
   std::sort(open_hits.begin(), open_hits.end(), [](const Target & a, const Target & b) {
     if (a.ip != b.ip) {
-      return a.ip < b.ip;
+      return ipv4_less(a.ip, b.ip);
     }
     return a.port < b.port;
   });
@@ -389,7 +416,7 @@ const DiscoveredEndpoint * NetworkDiscovery::select_auto_endpoint(const std::vec
     if (anonymous_none_only && !ep.anonymous_none_available) {
       continue;  // secured-only: surfaced as a lead, never auto-connected
     }
-    if (best == nullptr || ep.ip < best->ip || (ep.ip == best->ip && ep.port < best->port)) {
+    if (best == nullptr || ipv4_less(ep.ip, best->ip) || (ep.ip == best->ip && ep.port < best->port)) {
       best = &ep;
     }
   }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
@@ -67,6 +67,36 @@ bool ipv4_less(const std::string & a, const std::string & b) {
   return a < b;
 }
 
+// Bounded fan-out: run ``body(i)`` for every i in [0, count) across at most
+// ``max_workers`` threads (never more than ``count``) that pull indices off a
+// shared atomic cursor. The single primitive backs both the connect sweep and
+// the GetEndpoints identify so they share the same concurrency bound.
+template <typename Body>
+void parallel_for(size_t count, int max_workers, Body && body) {
+  if (count == 0) {
+    return;
+  }
+  const int worker_count = std::max(1, std::min<int>(max_workers, static_cast<int>(count)));
+  std::atomic<size_t> next{0};
+  const auto worker = [&]() {
+    for (;;) {
+      const size_t i = next.fetch_add(1);
+      if (i >= count) {
+        return;
+      }
+      body(i);
+    }
+  };
+  std::vector<std::thread> pool;
+  pool.reserve(static_cast<size_t>(worker_count));
+  for (int w = 0; w < worker_count; ++w) {
+    pool.emplace_back(worker);
+  }
+  for (auto & th : pool) {
+    th.join();
+  }
+}
+
 }  // namespace
 
 std::vector<std::string> expand_cidr_hosts(const std::string & cidr, bool * ok) {
@@ -263,6 +293,16 @@ DiscoveryConfig parse_discovery_config(const nlohmann::json & j,
   read_positive_int("scan_concurrency", cfg.scan_concurrency);
   read_positive_int("identify_timeout_ms", cfg.identify_timeout_ms);
 
+  // Clamp scan_concurrency: every worker is a live thread holding one open
+  // socket, so an unbounded value would exhaust the fd / thread limits on a
+  // wide subnet. kMaxScanConcurrency stays well under a typical 1024 fd ulimit.
+  constexpr int kMaxScanConcurrency = 512;
+  if (cfg.scan_concurrency > kMaxScanConcurrency) {
+    warn_fn("discovery: scan_concurrency " + std::to_string(cfg.scan_concurrency) + " exceeds maximum " +
+            std::to_string(kMaxScanConcurrency) + " - clamping");
+    cfg.scan_concurrency = kMaxScanConcurrency;
+  }
+
   if (j.contains("interval_s") && j["interval_s"].is_number_integer()) {
     const int v = j["interval_s"].get<int>();
     if (v >= 0) {
@@ -325,31 +365,13 @@ std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
   // only the polite fan-out lives here.
   std::vector<Target> open_hits;
   std::mutex hits_mu;
-  std::atomic<size_t> next{0};
-  const int worker_count = std::max(1, std::min<int>(cfg_.scan_concurrency, static_cast<int>(targets.size())));
-  const auto worker = [&]() {
-    for (;;) {
-      const size_t i = next.fetch_add(1);
-      if (i >= targets.size()) {
-        return;
-      }
-      const Target & t = targets[i];
-      if (scan_(t.ip, t.port, cfg_.connect_timeout_ms)) {
-        std::lock_guard<std::mutex> lk(hits_mu);
-        open_hits.push_back(t);
-      }
+  parallel_for(targets.size(), cfg_.scan_concurrency, [&](size_t i) {
+    const Target & t = targets[i];
+    if (scan_(t.ip, t.port, cfg_.connect_timeout_ms)) {
+      std::lock_guard<std::mutex> lk(hits_mu);
+      open_hits.push_back(t);
     }
-  };
-  {
-    std::vector<std::thread> pool;
-    pool.reserve(static_cast<size_t>(worker_count));
-    for (int w = 0; w < worker_count; ++w) {
-      pool.emplace_back(worker);
-    }
-    for (auto & th : pool) {
-      th.join();
-    }
-  }
+  });
 
   // Deterministic identify order (numerically lowest ip:port first).
   std::sort(open_hits.begin(), open_hits.end(), [](const Target & a, const Target & b) {
@@ -359,11 +381,15 @@ std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
     return a.port < b.port;
   });
 
-  // 3. Identify OPC-UA hits; dedup by ApplicationUri (fallback ip:port).
-  std::vector<DiscoveredEndpoint> ordered;
-  std::unordered_map<std::string, size_t> by_key;  // dedup key -> index in ordered
-
-  for (const auto & t : open_hits) {
+  // 3. Identify OPC-UA hits. Each GetEndpoints call blocks up to
+  // identify_timeout_ms, so a sequential loop would take N * timeout on a
+  // subnet where several hosts accept TCP on 4840 but never complete the
+  // handshake. Fan the identify out over the same bounded pool as the connect
+  // sweep, writing each result by index so the deterministic ip:port order
+  // (open_hits was sorted above) survives regardless of completion order.
+  std::vector<DiscoveredEndpoint> built(open_hits.size());
+  parallel_for(open_hits.size(), cfg_.scan_concurrency, [&](size_t i) {
+    const Target & t = open_hits[i];
     DiscoveredEndpoint ep;
     ep.ip = t.ip;
     ep.port = t.port;
@@ -386,13 +412,19 @@ std::vector<DiscoveredEndpoint> NetworkDiscovery::run() {
       // Non-OPC-UA OT port: recorded as a lead, no identify.
       ep.protocol = "unknown";
     }
+    built[i] = std::move(ep);
+  });
 
+  // 4. Dedup by ApplicationUri (fallback ip:port), sequentially over the
+  // deterministic order so the lowest ip:port always wins.
+  std::vector<DiscoveredEndpoint> ordered;
+  std::unordered_map<std::string, size_t> by_key;  // dedup key -> index in ordered
+  for (auto & ep : built) {
     // Dedup: prefer a stable ApplicationUri; a scan on two IPs of the same PLC
     // then collapses to one entry. Fall back to ip:port when the URI is empty
     // (identify failed or non-OPC-UA lead) so distinct hosts stay distinct.
     const std::string key = !ep.application_uri.empty() ? ("uri:" + ep.application_uri) : ("addr:" + ep.endpoint_url);
-    const auto it = by_key.find(key);
-    if (it == by_key.end()) {
+    if (by_key.find(key) == by_key.end()) {
       by_key.emplace(key, ordered.size());
       ordered.push_back(std::move(ep));
     }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
@@ -1,0 +1,118 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Real network I/O for the discovery orchestrator: a bounded POSIX TCP connect
+// probe and a read-only OPC-UA GetEndpoints identify via open62541pp. Split
+// from network_discovery.cpp so the pure merge / dedup logic (and its unit
+// tests) do not link against open62541 or open POSIX sockets.
+
+#include "ros2_medkit_opcua/network_discovery.hpp"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+
+#include <open62541pp/client.hpp>
+#include <open62541pp/types_composed.hpp>
+
+namespace ros2_medkit_gateway {
+
+bool tcp_connect_probe(const std::string & ip, uint16_t port, int timeout_ms) {
+  const int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    return false;
+  }
+
+  // Non-blocking connect + select so a filtered / silent host times out at
+  // ``timeout_ms`` instead of the kernel default (tens of seconds).
+  const int flags = ::fcntl(fd, F_GETFL, 0);
+  ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+  struct sockaddr_in addr {};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  if (::inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) != 1) {
+    ::close(fd);
+    return false;
+  }
+
+  bool connected = false;
+  const int rc = ::connect(fd, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr));
+  if (rc == 0) {
+    connected = true;
+  } else if (errno == EINPROGRESS) {
+    fd_set wset;
+    FD_ZERO(&wset);
+    FD_SET(fd, &wset);
+    struct timeval tv {};
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (timeout_ms % 1000) * 1000;
+    if (::select(fd + 1, nullptr, &wset, nullptr, &tv) > 0) {
+      int so_error = 0;
+      socklen_t len = sizeof(so_error);
+      if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 && so_error == 0) {
+        connected = true;
+      }
+    }
+  }
+
+  ::close(fd);
+  return connected;
+}
+
+IdentifyResult opcua_getendpoints_identify(const std::string & url, int timeout_ms) {
+  IdentifyResult out;
+  try {
+    opcua::Client client;
+    client.config().setTimeout(static_cast<uint32_t>(timeout_ms));
+
+    const std::vector<opcua::EndpointDescription> eps = client.getEndpoints(url);
+    if (eps.empty()) {
+      out.error = "no endpoints returned";
+      return out;
+    }
+
+    for (const auto & ep : eps) {
+      const std::string policy_uri(ep.getSecurityPolicyUri());
+      const auto hash = policy_uri.rfind('#');
+      const std::string policy_name = hash == std::string::npos ? policy_uri : policy_uri.substr(hash + 1);
+      const int mode = static_cast<int>(ep.getSecurityMode());  // 1=None 2=Sign 3=SignAndEncrypt
+      out.security_policies.push_back({policy_name, mode});
+      if (policy_name == "None" && mode == 1 /* UA_MESSAGESECURITYMODE_NONE */) {
+        out.anonymous_none_available = true;
+      }
+    }
+
+    const auto server = eps.front().getServer();
+    out.ok = true;
+    out.advertised_url = std::string(eps.front().getEndpointUrl());
+    out.application_uri = std::string(server.getApplicationUri());
+    out.product_uri = std::string(server.getProductUri());
+    out.application_name = std::string(server.getApplicationName().getText());
+    out.application_type = static_cast<int>(server.getApplicationType());
+  } catch (const std::exception & e) {
+    out.ok = false;
+    out.error = e.what();
+  }
+  return out;
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
@@ -42,9 +42,15 @@ bool tcp_connect_probe(const std::string & ip, uint16_t port, int timeout_ms) {
   }
 
   // Non-blocking connect + select so a filtered / silent host times out at
-  // ``timeout_ms`` instead of the kernel default (tens of seconds).
+  // ``timeout_ms`` instead of the kernel default (tens of seconds). Bail out
+  // on either fcntl() failing: leaving the socket blocking would let a single
+  // filtered host stall the probe for the kernel's default connect timeout,
+  // defeating the bounded-concurrency scan.
   const int flags = ::fcntl(fd, F_GETFL, 0);
-  ::fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+  if (flags == -1 || ::fcntl(fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+    ::close(fd);
+    return false;
+  }
 
   struct sockaddr_in addr {};
   addr.sin_family = AF_INET;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery_io.cpp
@@ -22,6 +22,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -41,7 +42,7 @@ bool tcp_connect_probe(const std::string & ip, uint16_t port, int timeout_ms) {
     return false;
   }
 
-  // Non-blocking connect + select so a filtered / silent host times out at
+  // Non-blocking connect + poll so a filtered / silent host times out at
   // ``timeout_ms`` instead of the kernel default (tens of seconds). Bail out
   // on either fcntl() failing: leaving the socket blocking would let a single
   // filtered host stall the probe for the kernel's default connect timeout,
@@ -65,13 +66,15 @@ bool tcp_connect_probe(const std::string & ip, uint16_t port, int timeout_ms) {
   if (rc == 0) {
     connected = true;
   } else if (errno == EINPROGRESS) {
-    fd_set wset;
-    FD_ZERO(&wset);
-    FD_SET(fd, &wset);
-    struct timeval tv {};
-    tv.tv_sec = timeout_ms / 1000;
-    tv.tv_usec = (timeout_ms % 1000) * 1000;
-    if (::select(fd + 1, nullptr, &wset, nullptr, &tv) > 0) {
+    // poll() rather than select(): select()'s fd_set is capped at FD_SETSIZE
+    // (1024) and FD_SET() on a higher fd is POSIX undefined behaviour (writes
+    // past the stack fd_set, a hard abort under _FORTIFY_SOURCE). A long-running
+    // gateway running many concurrent probes can allocate fds past 1024; poll()
+    // has no such limit.
+    struct pollfd pfd {};
+    pfd.fd = fd;
+    pfd.events = POLLOUT;
+    if (::poll(&pfd, 1, timeout_ms) > 0) {
       int so_error = 0;
       socklen_t len = sizeof(so_error);
       if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) == 0 && so_error == 0) {
@@ -102,8 +105,18 @@ IdentifyResult opcua_getendpoints_identify(const std::string & url, int timeout_
       const std::string policy_name = hash == std::string::npos ? policy_uri : policy_uri.substr(hash + 1);
       const int mode = static_cast<int>(ep.getSecurityMode());  // 1=None 2=Sign 3=SignAndEncrypt
       out.security_policies.push_back({policy_name, mode});
+      // Channel security (None/None) and user authentication are independent in
+      // OPC-UA: a None/None endpoint can still accept only Username/Certificate
+      // tokens. Only mark it anonymous-usable when it also advertises an
+      // Anonymous UserIdentityToken policy; otherwise the anonymous connect
+      // fails at session activation (BadIdentityTokenRejected).
       if (policy_name == "None" && mode == 1 /* UA_MESSAGESECURITYMODE_NONE */) {
-        out.anonymous_none_available = true;
+        for (const auto & token : ep.getUserIdentityTokens()) {
+          if (token.getTokenType() == opcua::UserTokenType::Anonymous) {
+            out.anonymous_none_available = true;
+            break;
+          }
+        }
       }
     }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -155,8 +155,11 @@ OpcuaPlugin::~OpcuaPlugin() {
 
 void OpcuaPlugin::configure(const nlohmann::json & config) {
   if (config.contains("endpoint_url")) {
-    client_config_.endpoint_url = config["endpoint_url"].get<std::string>();
-    endpoint_configured_ = true;
+    const std::string endpoint_url = config["endpoint_url"].get<std::string>();
+    if (!endpoint_url.empty()) {
+      client_config_.endpoint_url = endpoint_url;
+      endpoint_configured_ = true;
+    }
   }
 
   // OPC-UA SecureChannel security + user identity. All opt-in; defaults keep
@@ -290,7 +293,7 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
   }
 
   // Environment variables override YAML config (for Docker)
-  if (auto * env = std::getenv("OPCUA_ENDPOINT_URL")) {
+  if (auto * env = std::getenv("OPCUA_ENDPOINT_URL"); env != nullptr && *env != '\0') {
     client_config_.endpoint_url = env;
     endpoint_configured_ = true;
   }
@@ -1100,8 +1103,9 @@ void OpcuaPlugin::run_startup_discovery() {
     if (!ep.anonymous_none_available) {
       ++secured_only;
     }
-    log_info("OPC-UA discovery: found data server " + ep.endpoint_url + " (uri='" + ep.application_uri + "', product='" +
-             ep.product_uri + "', None/Anonymous=" + (ep.anonymous_none_available ? "yes" : "no") + ")");
+    log_info("OPC-UA discovery: found data server " + ep.endpoint_url + " (uri='" + ep.application_uri +
+             "', product='" + ep.product_uri + "', None/Anonymous=" + (ep.anonymous_none_available ? "yes" : "no") +
+             ")");
   }
   log_info("OPC-UA discovery summary: " + std::to_string(data_servers) + " data server(s), " +
            std::to_string(discovery_servers) + " discovery server(s)/LDS, " + std::to_string(secured_only) +

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -156,6 +156,7 @@ OpcuaPlugin::~OpcuaPlugin() {
 void OpcuaPlugin::configure(const nlohmann::json & config) {
   if (config.contains("endpoint_url")) {
     client_config_.endpoint_url = config["endpoint_url"].get<std::string>();
+    endpoint_configured_ = true;
   }
 
   // OPC-UA SecureChannel security + user identity. All opt-in; defaults keep
@@ -291,6 +292,7 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
   // Environment variables override YAML config (for Docker)
   if (auto * env = std::getenv("OPCUA_ENDPOINT_URL")) {
     client_config_.endpoint_url = env;
+    endpoint_configured_ = true;
   }
   if (auto * env = std::getenv("OPCUA_NODE_MAP_PATH")) {
     node_map_path_ = env;
@@ -348,6 +350,54 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
     client_config_.user_cert_path = env;
   }
 
+  // Read-only PLC/OPC-UA network discovery (opt-in). Parsed + validated with
+  // unknown-key warnings; env overrides follow for Docker/appliance deploys.
+  if (config.contains("discovery")) {
+    discovery_config_ = parse_discovery_config(config["discovery"], [this](const std::string & m) {
+      log_warn(m);
+    });
+  }
+  if (auto * env = std::getenv("OPCUA_DISCOVERY_ENABLED")) {
+    const std::string v = env;
+    discovery_config_.enabled = !(v == "0" || v == "false" || v == "no" || v == "off");
+  }
+  if (auto * env = std::getenv("OPCUA_DISCOVERY_SUBNETS")) {
+    // Comma-separated CIDR list.
+    discovery_config_.subnets.clear();
+    std::string list = env;
+    size_t start = 0;
+    while (start <= list.size()) {
+      const size_t sep = list.find(',', start);
+      std::string cidr = list.substr(start, sep == std::string::npos ? std::string::npos : sep - start);
+      if (!cidr.empty()) {
+        discovery_config_.subnets.push_back(cidr);
+      }
+      if (sep == std::string::npos) {
+        break;
+      }
+      start = sep + 1;
+    }
+  }
+  if (auto * env = std::getenv("OPCUA_DISCOVERY_INTERVAL_S")) {
+    errno = 0;
+    char * end = nullptr;
+    const long v = std::strtol(env, &end, 10);
+    if (end != env && *end == '\0' && errno != ERANGE && v >= 0) {
+      discovery_config_.interval_s = static_cast<int>(v);
+    } else {
+      log_warn(std::string("Ignoring invalid OPCUA_DISCOVERY_INTERVAL_S='") + env + "' (want a non-negative integer)");
+    }
+  }
+
+  // Default the discovery I/O to the real probes; test builds override these
+  // before set_context() to exercise the auto-endpoint path offline.
+  if (!discovery_scan_fn_) {
+    discovery_scan_fn_ = &tcp_connect_probe;
+  }
+  if (!discovery_identify_fn_) {
+    discovery_identify_fn_ = &opcua_getendpoints_identify;
+  }
+
   if (!node_map_path_.empty()) {
     if (!node_map_.load(node_map_path_)) {
       // FATAL: a node map that fails to load or validate (duplicate/colliding
@@ -389,6 +439,8 @@ void OpcuaPlugin::set_context(PluginContext & context) {
       log_info("PLC bridge: " + entry.node_id_str + " -> " + entry.ros2_topic + " (Float32)");
     }
   }
+
+  run_startup_discovery();
 
   log_security_profile();
 
@@ -992,6 +1044,81 @@ void OpcuaPlugin::log_security_profile() const {
   } else {
     log_info(profile);
   }
+}
+
+void OpcuaPlugin::run_startup_discovery() {
+  if (!discovery_config_.enabled) {
+    return;
+  }
+  // Never override an explicitly configured endpoint: discovery must not open a
+  // second session on a PLC the operator already targets (and already polls).
+  if (endpoint_configured_) {
+    log_info("OPC-UA discovery enabled but endpoint_url is explicitly configured (" + client_config_.endpoint_url +
+             "); skipping auto-discovery to avoid a second session.");
+    return;
+  }
+  if (discovery_config_.interval_s > 0) {
+    log_warn("OPC-UA discovery interval_s=" + std::to_string(discovery_config_.interval_s) +
+             " set, but periodic re-scan is not implemented yet; running a one-shot scan at startup.");
+  }
+
+  NetworkDiscovery discovery(discovery_config_, discovery_scan_fn_, discovery_identify_fn_);
+
+  const auto subnets = discovery.resolve_subnets();
+  if (subnets.empty()) {
+    log_warn("OPC-UA discovery: no subnet configured and could not derive a local /24; nothing to scan.");
+    return;
+  }
+  std::string subnet_list;
+  for (const auto & s : subnets) {
+    subnet_list += (subnet_list.empty() ? "" : ", ") + s;
+  }
+  log_info("OPC-UA discovery: read-only active scan of [" + subnet_list + "] on " +
+           std::to_string(discovery_config_.ports.size()) + " port(s)...");
+
+  const std::vector<DiscoveredEndpoint> found = discovery.run();
+
+  // Summarize what was found and what was skipped (leads, LDS, secured-only).
+  size_t data_servers = 0;
+  size_t discovery_servers = 0;
+  size_t secured_only = 0;
+  size_t leads = 0;
+  for (const auto & ep : found) {
+    if (ep.protocol != "opcua") {
+      ++leads;
+      continue;
+    }
+    if (!ep.identify_error.empty()) {
+      ++leads;
+      continue;
+    }
+    if (!ep.is_data_server()) {
+      ++discovery_servers;
+      continue;
+    }
+    ++data_servers;
+    if (!ep.anonymous_none_available) {
+      ++secured_only;
+    }
+    log_info("OPC-UA discovery: found data server " + ep.endpoint_url + " (uri='" + ep.application_uri + "', product='" +
+             ep.product_uri + "', None/Anonymous=" + (ep.anonymous_none_available ? "yes" : "no") + ")");
+  }
+  log_info("OPC-UA discovery summary: " + std::to_string(data_servers) + " data server(s), " +
+           std::to_string(discovery_servers) + " discovery server(s)/LDS, " + std::to_string(secured_only) +
+           " secured-only (need credentials), " + std::to_string(leads) + " non-OPC-UA/unidentified lead(s).");
+
+  const DiscoveredEndpoint * chosen =
+      NetworkDiscovery::select_auto_endpoint(found, discovery_config_.anonymous_none_only);
+  if (chosen == nullptr) {
+    log_warn(
+        "OPC-UA discovery: no auto-connectable None/Anonymous data server found; leaving endpoint at default. "
+        "Secured-only servers require operator credentials.");
+    return;
+  }
+
+  client_config_.endpoint_url = chosen->endpoint_url;
+  log_info("OPC-UA discovery: auto-selected endpoint " + chosen->endpoint_url + " (uri='" + chosen->application_uri +
+           "') - handing to the connect + introspect path.");
 }
 
 nlohmann::json OpcuaPlugin::build_data_response(const std::string & entity_id) const {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
@@ -187,6 +187,17 @@ TEST(ParseDiscoveryConfig, NegativeConcurrencyKeepsDefault) {
   ASSERT_FALSE(warnings.empty());
 }
 
+TEST(ParseDiscoveryConfig, ClampsExcessiveConcurrency) {
+  const nlohmann::json j = {{"scan_concurrency", 100000}};
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  EXPECT_EQ(cfg.scan_concurrency, 512);  // clamped to the sane maximum
+  ASSERT_FALSE(warnings.empty());
+  EXPECT_NE(warnings[0].find("clamping"), std::string::npos);
+}
+
 // --------------------------------------------------------------------------- //
 // NetworkDiscovery::run - reproduces the validated live-network scenario
 // (192.168.1.9 LDS, .10 Siemens S7-1500, .11 S7comm-only) with injected fakes.
@@ -316,6 +327,38 @@ TEST(NetworkDiscoveryRun, DedupsByApplicationUri) {
   ASSERT_EQ(eps.size(), 1u);
   // Lowest ip:port wins (deterministic).
   EXPECT_EQ(eps[0].ip, "192.168.1.10");
+}
+
+TEST(NetworkDiscoveryRun, ParallelIdentifyKeepsDeterministicOrder) {
+  // Many concurrent hits, each with a distinct ApplicationUri. The identify
+  // runs on the bounded pool, but results are written by index so the output
+  // must stay strictly sorted by ip regardless of completion order.
+  std::set<std::string> open;
+  std::map<std::string, IdentifyResult> table;
+  for (int host = 1; host <= 60; ++host) {
+    const std::string ip = "192.168.1." + std::to_string(host);
+    open.insert(ip + ":4840");
+    IdentifyResult r = siemens_identity();
+    r.application_uri = "urn:server-" + std::to_string(host);  // distinct => no dedup
+    r.advertised_url = "opc.tcp://" + ip + ":4840";
+    table.emplace("opc.tcp://" + ip + ":4840", r);
+  }
+  DiscoveryConfig cfg;
+  cfg.enabled = true;
+  cfg.subnets = {"192.168.1.0/24"};
+  cfg.ports = {4840};
+  cfg.scan_concurrency = 32;
+  NetworkDiscovery disc(cfg, make_scan(open), make_identify(table));
+  const auto eps = disc.run();
+
+  ASSERT_EQ(eps.size(), 60u);
+  for (size_t i = 0; i + 1 < eps.size(); ++i) {
+    EXPECT_LT(std::stoi(eps[i].ip.substr(eps[i].ip.rfind('.') + 1)),
+              std::stoi(eps[i + 1].ip.substr(eps[i + 1].ip.rfind('.') + 1)))
+        << "endpoints must stay ip-ordered after the parallel identify";
+  }
+  EXPECT_EQ(eps.front().ip, "192.168.1.1");
+  EXPECT_EQ(eps.back().ip, "192.168.1.60");
 }
 
 TEST(NetworkDiscoveryRun, IdentifyFailureRecordedAsLead) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
@@ -1,0 +1,401 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_opcua/network_discovery.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace ros2_medkit_gateway {
+namespace {
+
+// --------------------------------------------------------------------------- //
+// expand_cidr_hosts
+// --------------------------------------------------------------------------- //
+TEST(ExpandCidr, Slash24ExcludesNetworkAndBroadcast) {
+  bool ok = false;
+  const auto hosts = expand_cidr_hosts("192.168.1.0/24", &ok);
+  EXPECT_TRUE(ok);
+  ASSERT_EQ(hosts.size(), 254u);
+  EXPECT_EQ(hosts.front(), "192.168.1.1");
+  EXPECT_EQ(hosts.back(), "192.168.1.254");
+  // Network and broadcast are excluded.
+  EXPECT_EQ(std::count(hosts.begin(), hosts.end(), "192.168.1.0"), 0);
+  EXPECT_EQ(std::count(hosts.begin(), hosts.end(), "192.168.1.255"), 0);
+}
+
+TEST(ExpandCidr, NonZeroBaseIsMaskedToNetwork) {
+  bool ok = false;
+  const auto hosts = expand_cidr_hosts("192.168.1.37/24", &ok);
+  EXPECT_TRUE(ok);
+  ASSERT_EQ(hosts.size(), 254u);
+  EXPECT_EQ(hosts.front(), "192.168.1.1");
+}
+
+TEST(ExpandCidr, Slash30HasTwoUsableHosts) {
+  bool ok = false;
+  const auto hosts = expand_cidr_hosts("10.0.0.0/30", &ok);
+  EXPECT_TRUE(ok);
+  ASSERT_EQ(hosts.size(), 2u);
+  EXPECT_EQ(hosts[0], "10.0.0.1");
+  EXPECT_EQ(hosts[1], "10.0.0.2");
+}
+
+TEST(ExpandCidr, Slash32IsSingleHost) {
+  bool ok = false;
+  const auto hosts = expand_cidr_hosts("192.168.1.10/32", &ok);
+  EXPECT_TRUE(ok);
+  ASSERT_EQ(hosts.size(), 1u);
+  EXPECT_EQ(hosts[0], "192.168.1.10");
+}
+
+TEST(ExpandCidr, Slash31HasTwoHostsNoReservation) {
+  bool ok = false;
+  const auto hosts = expand_cidr_hosts("192.168.1.0/31", &ok);
+  EXPECT_TRUE(ok);
+  ASSERT_EQ(hosts.size(), 2u);
+  EXPECT_EQ(hosts[0], "192.168.1.0");
+  EXPECT_EQ(hosts[1], "192.168.1.1");
+}
+
+TEST(ExpandCidr, RejectsTooWidePrefix) {
+  bool ok = true;
+  const auto hosts = expand_cidr_hosts("10.0.0.0/8", &ok);
+  EXPECT_FALSE(ok);
+  EXPECT_TRUE(hosts.empty());
+}
+
+TEST(ExpandCidr, RejectsMalformed) {
+  for (const char * bad : {"192.168.1.0", "192.168.1.0/", "192.168.1.0/33", "not.an.ip/24", "192.168.1.0/xx"}) {
+    bool ok = true;
+    const auto hosts = expand_cidr_hosts(bad, &ok);
+    EXPECT_FALSE(ok) << bad;
+    EXPECT_TRUE(hosts.empty()) << bad;
+  }
+}
+
+// --------------------------------------------------------------------------- //
+// parse_discovery_config
+// --------------------------------------------------------------------------- //
+TEST(ParseDiscoveryConfig, DefaultsDisabled) {
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(nlohmann::json::object(), [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  EXPECT_FALSE(cfg.enabled);
+  EXPECT_EQ(cfg.mode, "active");
+  ASSERT_EQ(cfg.ports.size(), 1u);
+  EXPECT_EQ(cfg.ports[0], 4840);
+  EXPECT_TRUE(cfg.anonymous_none_only);
+  EXPECT_EQ(cfg.interval_s, 0);
+}
+
+TEST(ParseDiscoveryConfig, ReadsAllKnownKeys) {
+  const nlohmann::json j = {
+      {"enabled", true},
+      {"mode", "active"},
+      {"subnets", {"192.168.1.0/24", "10.0.0.0/24"}},
+      {"ports", {4840, 4841}},
+      {"connect_timeout_ms", 300},
+      {"scan_concurrency", 64},
+      {"identify_timeout_ms", 2000},
+      {"interval_s", 900},
+      {"anonymous_none_only", false},
+  };
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  EXPECT_TRUE(cfg.enabled);
+  ASSERT_EQ(cfg.subnets.size(), 2u);
+  EXPECT_EQ(cfg.subnets[0], "192.168.1.0/24");
+  ASSERT_EQ(cfg.ports.size(), 2u);
+  EXPECT_EQ(cfg.ports[1], 4841);
+  EXPECT_EQ(cfg.connect_timeout_ms, 300);
+  EXPECT_EQ(cfg.scan_concurrency, 64);
+  EXPECT_EQ(cfg.identify_timeout_ms, 2000);
+  EXPECT_EQ(cfg.interval_s, 900);
+  EXPECT_FALSE(cfg.anonymous_none_only);
+  EXPECT_TRUE(warnings.empty());
+}
+
+TEST(ParseDiscoveryConfig, CidrKeyMergesWithSubnets) {
+  const nlohmann::json j = {{"subnets", {"192.168.1.0/24"}}, {"cidr", "10.0.0.0/24"}};
+  const auto cfg = parse_discovery_config(j, nullptr);
+  ASSERT_EQ(cfg.subnets.size(), 2u);
+  EXPECT_EQ(cfg.subnets[1], "10.0.0.0/24");
+}
+
+TEST(ParseDiscoveryConfig, WarnsOnUnknownKey) {
+  const nlohmann::json j = {{"enabled", true}, {"typpo", 5}};
+  std::vector<std::string> warnings;
+  parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  ASSERT_EQ(warnings.size(), 1u);
+  EXPECT_NE(warnings[0].find("typpo"), std::string::npos);
+}
+
+TEST(ParseDiscoveryConfig, RejectsOutOfRangePortAndKeepsValidOnes) {
+  const nlohmann::json j = {{"ports", {4840, 70000, 0, 502}}};
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  ASSERT_EQ(cfg.ports.size(), 2u);
+  EXPECT_EQ(cfg.ports[0], 4840);
+  EXPECT_EQ(cfg.ports[1], 502);
+  EXPECT_EQ(warnings.size(), 2u);  // 70000 and 0
+}
+
+TEST(ParseDiscoveryConfig, WarnsOnPassiveMode) {
+  const nlohmann::json j = {{"mode", "passive"}};
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  EXPECT_EQ(cfg.mode, "passive");
+  ASSERT_FALSE(warnings.empty());
+}
+
+TEST(ParseDiscoveryConfig, NegativeConcurrencyKeepsDefault) {
+  const nlohmann::json j = {{"scan_concurrency", -5}};
+  std::vector<std::string> warnings;
+  const auto cfg = parse_discovery_config(j, [&](const std::string & m) {
+    warnings.push_back(m);
+  });
+  EXPECT_EQ(cfg.scan_concurrency, 100);  // default retained
+  ASSERT_FALSE(warnings.empty());
+}
+
+// --------------------------------------------------------------------------- //
+// NetworkDiscovery::run - reproduces the validated live-network scenario
+// (192.168.1.9 LDS, .10 Siemens S7-1500, .11 S7comm-only) with injected fakes.
+// --------------------------------------------------------------------------- //
+namespace {
+
+// Fake port scanner backed by a set of open "ip:port" hosts.
+PortScanFn make_scan(std::set<std::string> open) {
+  return [open = std::move(open)](const std::string & ip, uint16_t port, int) {
+    return open.count(ip + ":" + std::to_string(port)) > 0;
+  };
+}
+
+// Fake identify keyed by connect URL.
+IdentifyFn make_identify(std::map<std::string, IdentifyResult> table) {
+  return [table = std::move(table)](const std::string & url, int) -> IdentifyResult {
+    const auto it = table.find(url);
+    if (it != table.end()) {
+      return it->second;
+    }
+    IdentifyResult r;
+    r.error = "unreachable";
+    return r;
+  };
+}
+
+IdentifyResult siemens_identity() {
+  IdentifyResult r;
+  r.ok = true;
+  r.advertised_url = "opc.tcp://192.168.1.10:4840";
+  r.application_uri = "urn:SIMATIC.S7-1500.OPC-UA.Application:Software PLC_1";
+  r.product_uri = "https://www.siemens.com/s7-1500";
+  r.application_name = "SIMATIC.S7-1500.OPC-UA.Application:Software PLC_1";
+  r.application_type = 0;  // Server
+  r.security_policies = {{"None", 1}, {"Basic256Sha256", 2}, {"Basic256Sha256", 3}};
+  r.anonymous_none_available = true;
+  return r;
+}
+
+IdentifyResult lds_identity() {
+  IdentifyResult r;
+  r.ok = true;
+  // The LDS advertised a bare, non-resolvable NetBIOS hostname on our LAN.
+  r.advertised_url = "opc.tcp://DESKTOP-TG98AEV:4840";
+  r.application_uri = "urn:DESKTOP-TG98AEV:UALocalDiscoveryServer";
+  r.product_uri = "http://opcfoundation.org/UA/LocalDiscoveryServer";
+  r.application_name = "UA Local Discovery Server";
+  r.application_type = 3;  // DiscoveryServer / LDS
+  r.security_policies = {{"None", 1}, {"Basic256", 2}};
+  r.anonymous_none_available = true;
+  return r;
+}
+
+DiscoveryConfig scenario_cfg() {
+  DiscoveryConfig cfg;
+  cfg.enabled = true;
+  cfg.subnets = {"192.168.1.0/24"};  // explicit, so no local-interface derivation
+  cfg.ports = {4840, 102};
+  return cfg;
+}
+
+}  // namespace
+
+TEST(NetworkDiscoveryRun, ClassifiesLiveNetworkScenario) {
+  auto scan = make_scan({"192.168.1.9:4840", "192.168.1.10:4840", "192.168.1.10:102", "192.168.1.11:102"});
+  auto identify = make_identify({
+      {"opc.tcp://192.168.1.9:4840", lds_identity()},
+      {"opc.tcp://192.168.1.10:4840", siemens_identity()},
+  });
+  NetworkDiscovery disc(scenario_cfg(), scan, identify);
+  const auto eps = disc.run();
+
+  // 4 endpoints: LDS(.9:4840), Siemens(.10:4840), s7comm lead(.10:102), s7comm lead(.11:102).
+  ASSERT_EQ(eps.size(), 4u);
+
+  const DiscoveredEndpoint * siemens = nullptr;
+  const DiscoveredEndpoint * lds = nullptr;
+  std::vector<const DiscoveredEndpoint *> leads;
+  for (const auto & ep : eps) {
+    if (ep.ip == "192.168.1.10" && ep.port == 4840) {
+      siemens = &ep;
+    } else if (ep.ip == "192.168.1.9" && ep.port == 4840) {
+      lds = &ep;
+    } else if (ep.port == 102) {
+      leads.push_back(&ep);
+    }
+  }
+  ASSERT_NE(siemens, nullptr);
+  ASSERT_NE(lds, nullptr);
+  EXPECT_EQ(leads.size(), 2u);
+
+  // Siemens: OPC-UA data server, None/Anonymous, identified.
+  EXPECT_TRUE(siemens->is_data_server());
+  EXPECT_TRUE(siemens->anonymous_none_available);
+  EXPECT_EQ(siemens->product_uri, "https://www.siemens.com/s7-1500");
+  EXPECT_TRUE(siemens->identify_error.empty());
+
+  // LDS: discovery server, not a data server.
+  EXPECT_FALSE(lds->is_data_server());
+  EXPECT_EQ(lds->application_type, 3);
+
+  // URL preference: connect URL is the SCANNED ip:port even though the LDS
+  // advertised a non-resolvable hostname; the advertised value is kept as meta.
+  EXPECT_EQ(lds->endpoint_url, "opc.tcp://192.168.1.9:4840");
+  EXPECT_EQ(lds->advertised_url, "opc.tcp://DESKTOP-TG98AEV:4840");
+
+  // s7comm leads: non-OPC-UA, recorded but not identified.
+  for (const auto * lead : leads) {
+    EXPECT_EQ(lead->protocol, "unknown");
+    EXPECT_FALSE(lead->is_data_server() && lead->anonymous_none_available);
+  }
+}
+
+TEST(NetworkDiscoveryRun, DedupsByApplicationUri) {
+  // Same PLC reachable on two IPs (dual-homed): one deduped entry by URI.
+  auto scan = make_scan({"192.168.1.10:4840", "192.168.1.20:4840"});
+  auto identify = make_identify({
+      {"opc.tcp://192.168.1.10:4840", siemens_identity()},
+      {"opc.tcp://192.168.1.20:4840", siemens_identity()},
+  });
+  DiscoveryConfig cfg;
+  cfg.enabled = true;
+  cfg.subnets = {"192.168.1.0/24"};
+  cfg.ports = {4840};
+  NetworkDiscovery disc(cfg, scan, identify);
+  const auto eps = disc.run();
+  ASSERT_EQ(eps.size(), 1u);
+  // Lowest ip:port wins (deterministic).
+  EXPECT_EQ(eps[0].ip, "192.168.1.10");
+}
+
+TEST(NetworkDiscoveryRun, IdentifyFailureRecordedAsLead) {
+  auto scan = make_scan({"192.168.1.50:4840"});
+  IdentifyResult bad;
+  bad.error = "BadTimeout";
+  auto identify = make_identify({{"opc.tcp://192.168.1.50:4840", bad}});
+  DiscoveryConfig cfg;
+  cfg.enabled = true;
+  cfg.subnets = {"192.168.1.0/24"};
+  cfg.ports = {4840};
+  NetworkDiscovery disc(cfg, scan, identify);
+  const auto eps = disc.run();
+  ASSERT_EQ(eps.size(), 1u);
+  EXPECT_EQ(eps[0].identify_error, "BadTimeout");
+  EXPECT_EQ(NetworkDiscovery::select_auto_endpoint(eps, true), nullptr);
+}
+
+// --------------------------------------------------------------------------- //
+// select_auto_endpoint
+// --------------------------------------------------------------------------- //
+TEST(SelectAutoEndpoint, PicksAnonymousNoneDataServerSkipsLds) {
+  auto scan = make_scan({"192.168.1.9:4840", "192.168.1.10:4840"});
+  auto identify = make_identify({
+      {"opc.tcp://192.168.1.9:4840", lds_identity()},
+      {"opc.tcp://192.168.1.10:4840", siemens_identity()},
+  });
+  DiscoveryConfig cfg;
+  cfg.enabled = true;
+  cfg.subnets = {"192.168.1.0/24"};
+  cfg.ports = {4840};
+  NetworkDiscovery disc(cfg, scan, identify);
+  const auto eps = disc.run();
+
+  const auto * chosen = NetworkDiscovery::select_auto_endpoint(eps, true);
+  ASSERT_NE(chosen, nullptr);
+  EXPECT_EQ(chosen->ip, "192.168.1.10");  // the Siemens, not the LDS
+}
+
+TEST(SelectAutoEndpoint, SecuredOnlySkippedWhenAnonymousRequired) {
+  DiscoveredEndpoint secured;
+  secured.ip = "192.168.1.30";
+  secured.port = 4840;
+  secured.protocol = "opcua";
+  secured.application_type = 0;
+  secured.anonymous_none_available = false;  // secured-only
+
+  std::vector<DiscoveredEndpoint> eps = {secured};
+  EXPECT_EQ(NetworkDiscovery::select_auto_endpoint(eps, true), nullptr);
+  // With anonymous_none_only relaxed, the secured server becomes selectable.
+  EXPECT_EQ(NetworkDiscovery::select_auto_endpoint(eps, false), &eps[0]);
+}
+
+TEST(SelectAutoEndpoint, LdsNeverSelectedEvenWhenAnonymousRelaxed) {
+  DiscoveredEndpoint lds;
+  lds.ip = "192.168.1.9";
+  lds.port = 4840;
+  lds.protocol = "opcua";
+  lds.application_type = 3;  // LDS
+  lds.anonymous_none_available = true;
+
+  std::vector<DiscoveredEndpoint> eps = {lds};
+  EXPECT_EQ(NetworkDiscovery::select_auto_endpoint(eps, false), nullptr);
+}
+
+TEST(SelectAutoEndpoint, DeterministicLowestAddressWins) {
+  DiscoveredEndpoint a;
+  a.ip = "192.168.1.20";
+  a.port = 4840;
+  a.protocol = "opcua";
+  a.application_type = 0;
+  a.anonymous_none_available = true;
+  DiscoveredEndpoint b = a;
+  b.ip = "192.168.1.10";
+
+  std::vector<DiscoveredEndpoint> eps = {a, b};
+  const auto * chosen = NetworkDiscovery::select_auto_endpoint(eps, true);
+  ASSERT_NE(chosen, nullptr);
+  EXPECT_EQ(chosen->ip, "192.168.1.10");
+}
+
+}  // namespace
+}  // namespace ros2_medkit_gateway


### PR DESCRIPTION
Closes #512

## Summary

Opt-in, read-only OPC-UA network discovery for `ros2_medkit_opcua`: a box on a plant LAN auto-finds a PLC with no configured `endpoint_url` and hands the selected endpoint to the existing connect + nameplate introspect path. **Disabled by default** (no behaviour change).

## Why active scan

Validated on a real Siemens S7-1500: a stock S7-1500 neither multicast-announces (mDNS) nor registers with an LDS, so passive discovery finds nothing. A bounded read-only TCP scan of `:4840` + `GetEndpoints` identify is the only mechanism that discovers it. `getEndpoints()` works in the current open62541pp build; `FindServersOnNetwork`/mDNS are compiled out and deferred.

## What's included

- **`discovery:` config** (default `enabled: false`): `mode`, `subnets`/`cidr` (empty => local /24), `ports` (`[4840]`), `connect_timeout_ms`, `scan_concurrency`, `identify_timeout_ms`, `interval_s` (0=one-shot), `anonymous_none_only`; env overrides `OPCUA_DISCOVERY_*`.
- **Discovery core** (`network_discovery.{hpp,cpp}`): CIDR expand (rejects >/16), bounded concurrent TCP sweep, per-`:4840` `GetEndpoints`, dedup by ApplicationUri, classify (data server / LDS / non-OPC-UA lead), deterministic endpoint selection. Network I/O injected -> logic unit-tested offline. Real I/O in `network_discovery_io.cpp`.
- **Integration**: when discovery is on and no `endpoint_url` is set, scan once at startup and connect to the selected None/Anonymous server's scanned ip:port (servers may advertise non-resolvable hostnames).

## Safety (OT)

Read-only (TCP connect + `GetEndpoints` only; no writes, no subscriptions). Explicit `endpoint_url` always wins (never a second session on a polled PLC). Secured-only servers surfaced as leads, never auto-connected. Bounded scan; CIDRs >/16 rejected.

## Tests

`test_network_discovery` (21 cases: CIDR, config validate, live scenario with fakes, dedup, URL preference, selection). Full `ros2_medkit_opcua` suite green (219/0). `clang-format-18` clean.

## Hardware-tested

On the real S7-1500 LAN: discovered `.10:4840`, identified the Siemens (`urn:SIMATIC.S7-1500...Software PLC_1`, None/Anonymous), classified the LDS at `.9` and used its scanned ip:port, auto-selected `.10`, connected and read the DeviceSet nameplate.

## Deferred

Recursive `auto_browse` tree building (flag parsed but mapping not yet implemented; today the endpoint feeds the nameplate introspect path), multi-endpoint registration, passive sources (mDNS/LDS/`FindServersOnNetwork`), periodic re-scan + persistence.

