### PR TITLE
feat(opcua): recursive auto_browse -> SOVD tree from OPC UA address space

### DIFF
--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(ros2_medkit_opcua_plugin MODULE
   src/opcua_poller.cpp
   src/network_discovery.cpp
   src/network_discovery_io.cpp
+  src/address_space_browser.cpp
 )
 
 target_include_directories(ros2_medkit_opcua_plugin PRIVATE
@@ -178,6 +179,7 @@ if(BUILD_TESTING)
     src/opcua_poller.cpp
     src/network_discovery.cpp
     src/network_discovery_io.cpp
+    src/address_space_browser.cpp
     TIMEOUT 240
   )
   target_include_directories(test_opcua_plugin PRIVATE
@@ -284,6 +286,35 @@ if(BUILD_TESTING)
     nlohmann_json::nlohmann_json
   )
   medkit_set_test_domain(test_network_discovery)
+
+  # auto_browse: recursive address-space walker tests, against an injected
+  # fake AutoBrowseSource - no network, no server. node_map.cpp is link-only
+  # (NodeMapEntry / NodeMap::parse_node_id). opcua_client.cpp is link-only too:
+  # OpcuaClientBrowseSource (address_space_browser.hpp) is a polymorphic type
+  # with every override defined inline, so its vtable is emitted in any TU
+  # that uses it (Itanium ABI key-function rule) and needs OpcuaClient's
+  # symbols to resolve, even though the tests exercise AutoBrowser only
+  # through the injected fake and never construct an OpcuaClientBrowseSource.
+  ament_add_gtest(test_address_space_browser
+    test/test_address_space_browser.cpp
+    src/address_space_browser.cpp
+    src/node_map.cpp
+    src/opcua_client.cpp
+  )
+  target_include_directories(test_address_space_browser PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+  )
+  medkit_target_dependencies(test_address_space_browser
+    ros2_medkit_gateway
+    ros2_medkit_fault_detection
+    rclcpp
+  )
+  target_link_libraries(test_address_space_browser
+    open62541pp::open62541pp
+    nlohmann_json::nlohmann_json
+    yaml-cpp::yaml-cpp
+  )
+  medkit_set_test_domain(test_address_space_browser)
 
   # ---- test_alarm_server fixture ------------------------------------------
   # Standalone OPC-UA server emitting AlarmConditionType events for
@@ -417,6 +448,7 @@ if(BUILD_TESTING)
       src/opcua_poller.cpp
       src/network_discovery.cpp
       src/network_discovery_io.cpp
+      src/address_space_browser.cpp
       TIMEOUT 120
     )
     add_dependencies(test_opcua_identity test_alarm_server)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/README.md
@@ -7,7 +7,9 @@ Follows the same plugin pattern as `ros2_medkit_graph_provider`: implements `Gat
 ## What it does
 
 - Connects to any OPC-UA capable PLC server over `opc.tcp`
-- Emits SOVD entities (area, component, apps) from a YAML-driven node map
+- Emits SOVD entities (area, component, apps) from a YAML-driven node map, or
+  discovers them automatically by browsing the live address space
+  (`auto_browse`, see below) - zero node-map config required
 - Exposes PLC values as the `x-plc-data` vendor collection
 - Allows writing setpoints via `x-plc-operations` with type-aware coercion and range validation
 - Reports the connection state and poll metrics via `x-plc-status`
@@ -346,6 +348,76 @@ curl -X POST http://localhost:8080/api/v1/apps/tank_process/operations/acknowled
 
 See `design/index.rst` for the full state machine table and vendor matrix.
 
+### auto_browse (zero-config discovery)
+
+Instead of (or on top of) a hand-written `nodes:` list, the plugin can build
+the SOVD entity tree itself by recursively browsing the connected server's
+address space. This is what makes a discovered endpoint (see the discovery
+plugin) usable with no PLC-specific config at all: `endpoint_url` +
+`auto_browse: true` is enough.
+
+The walk starts at the standard `Objects` folder (`i=85`, which is where the
+OPC-UA DI companion namespace also hangs `DeviceSet`) and recurses forward
+along hierarchical references:
+
+- **Object** nodes become a path segment; an Object becomes its own SOVD App
+  only once it (directly) owns at least one supported Variable - a pure
+  folder Object with only child Objects is walked through but never shows up
+  as an entity of its own. Hierarchy is preserved in the generated
+  `entity_id`/name as a path (e.g. `plc_1_db_test` / `PLC_1 / DB_Test`), not
+  as a separate parent-entity field - the plugin's SOVD model stays the flat
+  Area -> Component -> App tree it already produces from a hand-written node
+  map.
+- **Variable** nodes become data points. Their DataType is read and mapped to
+  a medkit `data_type` (`Boolean`->`bool`; `SByte`/`Byte`/`Int16`/`UInt16`/
+  `Int32`/`UInt32`/`Int64`/`UInt64`->`int`; `Float`/`Double`->`float`;
+  `String`/`DateTime`->`string`); anything else (structured/enumerated/vendor
+  types) is skipped, not guessed at.
+- Noise filtering: ns=0 (the standard/infrastructure namespace - the `Server`
+  object, `ServerCapabilities`, `Types`, `Views`, ...) is denied by default so
+  it never enters the tree, while the DI/vendor namespaces underneath
+  `Objects` are walked normally. A depth limit and a total-node budget bound
+  the walk against a pathological or very large address space; hitting either
+  logs an operator warning that the resulting tree may be incomplete.
+- **Read-only.** auto_browse never writes to the server, and every
+  auto-discovered data point loads with `writable: false` - promoting a
+  specific point to writable is a deliberate, reviewed decision made via an
+  explicit `nodes:` entry.
+- **Explicit config always wins.** An auto-browsed entry for a NodeId that
+  already has a hand-written `nodes:` entry is dropped; auto_browse only fills
+  in what the node map does not already cover (or the whole tree, when there
+  is no node map at all).
+
+Enable it either in the node-map YAML:
+
+```yaml
+auto_browse: true   # all-default knobs (root=Objects folder, depth 8, 5000 nodes, deny ns=0)
+
+# or with explicit knobs:
+auto_browse:
+  enabled: true
+  root_nodes: ["i=85"]        # default: Objects folder. Point elsewhere (e.g. a
+                               # specific DeviceSet/Object) to scope the walk.
+  max_depth: 8                # recursion depth cap from a root (1..64)
+  max_nodes: 5000              # total node budget for the walk (1..200000)
+  namespace_allow: []          # non-empty = only these namespaces are eligible
+  namespace_deny: [0]          # ignored when namespace_allow is set
+  read_initial_values: true    # read each candidate Variable once; drop it if
+                                # the read fails (reachability check)
+```
+
+or purely via the plugin's ROS param / JSON config, which is what lets a
+discovered endpoint go straight to a populated tree with no node-map file:
+
+```yaml
+plugins.opcua.endpoint_url: "opc.tcp://192.168.1.10:4840"
+plugins.opcua.auto_browse: true   # or the same map form as above
+```
+
+The JSON/ROS-param form takes precedence over whatever the node-map YAML's
+`auto_browse:` block set, mirroring how environment variables override the
+rest of the plugin's YAML config.
+
 ### Gateway Parameters
 
 ```yaml
@@ -356,12 +428,14 @@ ros2_medkit_gateway:
     plugins.opcua.node_map_path: "/path/to/nodes.yaml"
     plugins.opcua.poll_interval_ms: 1000
     plugins.opcua.prefer_subscriptions: false
+    plugins.opcua.auto_browse: true
 ```
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `endpoint_url` | `opc.tcp://localhost:4840` | OPC-UA server endpoint |
-| `node_map_path` | (none) | Path to node map YAML (required) |
+| `node_map_path` | (none) | Path to node map YAML (optional when `auto_browse` is enabled - see above) |
+| `auto_browse` | `false` | Boolean or object; recursively discover the SOVD tree from the live address space instead of (or in addition to) `node_map_path` - see above |
 | `poll_interval_ms` | `1000` | Polling interval in ms (clamped to [100, 60000]) |
 | `prefer_subscriptions` | `false` | Use OPC-UA subscriptions instead of polling |
 | `subscription_interval_ms` | `500` | Publishing interval for OPC-UA subscriptions when `prefer_subscriptions: true` |

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
@@ -1,0 +1,154 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "ros2_medkit_opcua/node_map.hpp"
+#include "ros2_medkit_opcua/opcua_client.hpp"
+
+namespace ros2_medkit_gateway {
+
+/// Read-only access to an OPC-UA address space, as needed by ``AutoBrowser``.
+/// Abstracts away the live client so the recursive walk (hierarchy mapping,
+/// type inference, depth/node caps, namespace filtering, entity/data-name
+/// derivation) is unit-testable with an injected fake - no server, no
+/// network. ``OpcuaClientBrowseSource`` below is the real implementation.
+class AutoBrowseSource {
+ public:
+  virtual ~AutoBrowseSource() = default;
+
+  /// Browse the forward-hierarchical Object/Variable children of ``parent``.
+  /// Empty on failure or when the node has no such children.
+  virtual std::vector<OpcuaClient::BrowseChild> browse_children(const opcua::NodeId & parent) = 0;
+
+  /// Resolve a Variable node's DataType to an OPC-UA builtin scalar type name
+  /// ("Boolean", "Int32", "Float", ...), or "" when the type is not a
+  /// supported scalar (structured/enum/vendor type) or the read failed.
+  virtual std::string read_type_name(const opcua::NodeId & variable_node) = 0;
+
+  /// Best-effort read of a Variable's current value, used only as an
+  /// optional reachability check (see ``AutoBrowseConfig::read_initial_values``).
+  /// ``std::nullopt`` means the read failed (Bad status / not connected).
+  virtual std::optional<OpcuaValue> read_initial_value(const opcua::NodeId & variable_node) = 0;
+};
+
+/// ``AutoBrowseSource`` backed by a live ``OpcuaClient`` session.
+class OpcuaClientBrowseSource : public AutoBrowseSource {
+ public:
+  explicit OpcuaClientBrowseSource(OpcuaClient & client) : client_(client) {
+  }
+
+  std::vector<OpcuaClient::BrowseChild> browse_children(const opcua::NodeId & parent) override {
+    return client_.browse_detailed(parent);
+  }
+
+  std::string read_type_name(const opcua::NodeId & variable_node) override {
+    return client_.read_variable_type_name(variable_node);
+  }
+
+  std::optional<OpcuaValue> read_initial_value(const opcua::NodeId & variable_node) override {
+    auto result = client_.read_value(variable_node);
+    if (!result.good) {
+      return std::nullopt;
+    }
+    return result.value;
+  }
+
+ private:
+  OpcuaClient & client_;
+};
+
+/// Result of one ``AutoBrowser::browse()`` call.
+struct AutoBrowseResult {
+  /// NodeMapEntry per discovered, type-supported Variable. entity_id /
+  /// data_name / display_name / ros2_topic are already fully derived; the
+  /// caller only needs to merge these into a NodeMap
+  /// (``NodeMap::merge_auto_browsed_entries``).
+  std::vector<NodeMapEntry> entries;
+
+  /// Total address-space nodes considered (root(s) + every child seen during
+  /// the walk, whether or not it passed the namespace filter or ended up
+  /// mapped).
+  std::size_t nodes_visited{0};
+
+  /// True when ``AutoBrowseConfig::max_nodes`` was reached before the walk
+  /// finished - the tree may be incomplete.
+  bool node_cap_hit{false};
+
+  /// True when ``AutoBrowseConfig::max_depth`` was reached on at least one
+  /// branch - that branch's descendants were not explored.
+  bool depth_cap_hit{false};
+};
+
+/// Recursive OPC-UA address-space walker: given a connected session (via
+/// ``AutoBrowseSource``) and an ``AutoBrowseConfig``, builds the set of
+/// NodeMapEntry that ``NodeMap::merge_auto_browsed_entries`` folds into the
+/// SOVD entity tree. Read-only - never writes to the server.
+///
+/// Mapping rule: an Object node becomes a SOVD entity (App) only when it has
+/// at least one directly-owned Variable child with a supported scalar type;
+/// pure organizational Objects (folders with only child Objects) are walked
+/// through but never become an entity of their own. Hierarchy is preserved in
+/// the generated entity_id/display name as a path (e.g. "plc_1_db_test" /
+/// "PLC_1 / DB_Test") rather than as a separate parent-entity field, matching
+/// the existing flat Area -> Component -> App SOVD model this plugin already
+/// produces from a hand-written node map.
+class AutoBrowser {
+ public:
+  AutoBrowser(AutoBrowseSource & source, AutoBrowseConfig config);
+
+  /// Run the walk from every configured root and return the merged result.
+  AutoBrowseResult browse();
+
+  // -- Pure helpers, exposed for direct unit testing --
+
+  /// True when ``ns`` is eligible to become an entity/data point (and to be
+  /// recursed into) under ``cfg``'s namespace_allow/namespace_deny.
+  static bool namespace_allowed(uint16_t ns, const AutoBrowseConfig & cfg);
+
+  /// Map an OPC-UA builtin type name (as returned by
+  /// ``AutoBrowseSource::read_type_name``) to a medkit data_type
+  /// ("bool"/"int"/"float"/"string"), or "" when unsupported.
+  static std::string map_opcua_type(const std::string & opcua_type_name);
+
+  /// Sanitize one path segment (BrowseName or DisplayName) into a valid SOVD
+  /// id / ROS 2 topic segment: lowercase ascii alnum + '_'/'-' only, never
+  /// starts with a digit, "_unnamed" when empty.
+  static std::string sanitize_segment(const std::string & s);
+
+  /// Join sanitized path segments into an entity_id ("plc_1_db_test").
+  /// Empty ``segments`` (a root node with variables directly on it) maps to
+  /// "root".
+  static std::string join_entity_id(const std::vector<std::string> & segments);
+
+  /// Join raw (unsanitized) DisplayName path segments into a human-readable
+  /// entity name ("PLC_1 / DB_Test"). Empty ``segments`` maps to "Root".
+  static std::string join_display_name(const std::vector<std::string> & segments);
+
+ private:
+  void visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
+                    const std::vector<std::string> & path_names, int depth, AutoBrowseResult & result,
+                    std::unordered_set<std::string> & seen_entity_ids);
+
+  AutoBrowseSource & source_;
+  AutoBrowseConfig config_;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
@@ -143,8 +143,9 @@ class AutoBrowser {
   static std::string join_display_name(const std::vector<std::string> & segments);
 
  private:
-  void visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids, int depth,
-                    AutoBrowseResult & result, std::unordered_set<std::string> & seen_entity_ids);
+  void visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
+                    const std::vector<std::string> & path_display, int depth, AutoBrowseResult & result,
+                    std::unordered_set<std::string> & seen_entity_ids, std::unordered_set<std::string> & visited_nodes);
 
   AutoBrowseSource & source_;
   AutoBrowseConfig config_;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
@@ -83,9 +83,9 @@ struct AutoBrowseResult {
   /// (``NodeMap::merge_auto_browsed_entries``).
   std::vector<NodeMapEntry> entries;
 
-  /// Total address-space nodes considered (root(s) + every child seen during
-  /// the walk, whether or not it passed the namespace filter or ended up
-  /// mapped).
+  /// Total children considered across the walk (the configured root(s)
+  /// themselves are not counted, only their descendants), whether or not a
+  /// child passed the namespace filter or ended up mapped.
   std::size_t nodes_visited{0};
 
   /// True when ``AutoBrowseConfig::max_nodes`` was reached before the walk
@@ -143,9 +143,8 @@ class AutoBrowser {
   static std::string join_display_name(const std::vector<std::string> & segments);
 
  private:
-  void visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
-                    const std::vector<std::string> & path_names, int depth, AutoBrowseResult & result,
-                    std::unordered_set<std::string> & seen_entity_ids);
+  void visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids, int depth,
+                    AutoBrowseResult & result, std::unordered_set<std::string> & seen_entity_ids);
 
   AutoBrowseSource & source_;
   AutoBrowseConfig config_;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -123,6 +123,7 @@ struct NodeMapEntry {
   std::string node_id_str;          // OPC-UA node ID string (e.g., "ns=1;s=TankLevel")
   opcua::NodeId node_id;            // Parsed NodeId
   std::string entity_id;            // SOVD entity this belongs to (e.g., "tank_process")
+  std::string entity_display_name;  // Human-readable entity name (auto_browse path); "" for hand-written
   std::string data_name;            // Data point name (e.g., "tank_level")
   std::string display_name;         // Human-readable name
   std::string unit;                 // Unit of measurement (e.g., "mm", "C", "bar")

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -144,6 +144,53 @@ struct NodeMapEntry {
   }
 };
 
+/// Configuration for the recursive OPC-UA address-space walker (auto_browse).
+/// Populated either from the node-map YAML's ``auto_browse:`` block (bool or
+/// map) or overlaid from the plugin's ``plugins.opcua.auto_browse`` JSON/ROS
+/// param - see ``OpcuaPlugin::configure``. Consumed by ``AutoBrowser``
+/// (address_space_browser.hpp) once the client has a live session.
+struct AutoBrowseConfig {
+  bool enabled{false};
+
+  /// Node IDs to start the walk from, in NodeMap::parse_node_id string form.
+  /// Default is the standard Objects folder (``i=85``); every well-formed
+  /// server organizes its instance tree underneath it, including the OPC-UA
+  /// DI ``DeviceSet`` folder used to reach a PLC's nameplate + process data.
+  std::vector<std::string> root_node_ids{"i=85"};
+
+  /// Recursion depth cap measured from a root node (root's direct children
+  /// are depth 1). Guards against a pathological / cyclic address space.
+  int max_depth{8};
+
+  /// Total node budget for one browse() call (root nodes + every child
+  /// considered, whether or not it is namespace-filtered). Once reached the
+  /// walk stops descending further and the caller is warned that the tree may
+  /// be incomplete.
+  std::size_t max_nodes{5000};
+
+  /// Namespace allow-list. When non-empty, only these namespace indices are
+  /// eligible to become entities/data points (and to be recursed into);
+  /// ``namespace_deny`` is ignored. Empty (default) means "allow all except
+  /// denied".
+  std::vector<uint16_t> namespace_allow;
+
+  /// Namespace deny-list, applied only when ``namespace_allow`` is empty.
+  /// Defaults to ``{0}``: ns=0 is the standard/infrastructure namespace
+  /// (Server object, ServerCapabilities, Types, Views, ...) which is pure
+  /// noise for entity discovery. Root nodes passed explicitly in
+  /// ``root_node_ids`` are never filtered, even if their namespace is denied.
+  std::vector<uint16_t> namespace_deny{0};
+
+  /// When true, each candidate Variable is read once during the walk and
+  /// dropped from the result if the read fails (Bad status) - a
+  /// reachability/access check that filters out nodes whose DataType
+  /// resolves but whose Value is not actually gettable (write-only nodes,
+  /// permission-denied, etc). When false, the extra round-trip is skipped and
+  /// every type-matched Variable is kept, which is faster to start up on very
+  /// large trees.
+  bool read_initial_values{true};
+};
+
 /// SOVD entity definition derived from the node map
 struct PlcEntityDef {
   std::string id;
@@ -231,8 +278,29 @@ class NodeMap {
 
   /// Whether auto-browse mode is enabled
   bool auto_browse() const {
-    return auto_browse_;
+    return auto_browse_config_.enabled;
   }
+
+  /// Full auto_browse configuration (root nodes, depth/node caps, namespace
+  /// filter, ...), loaded from the node-map YAML's ``auto_browse:`` block.
+  const AutoBrowseConfig & auto_browse_config() const {
+    return auto_browse_config_;
+  }
+
+  /// Mutable access so ``OpcuaPlugin::configure`` can overlay the plugin's
+  /// ``plugins.opcua.auto_browse`` JSON/ROS param on top of whatever the
+  /// node-map YAML declared (JSON wins - same precedence the env-var
+  /// overrides use for the rest of the plugin config).
+  AutoBrowseConfig & mutable_auto_browse_config() {
+    return auto_browse_config_;
+  }
+
+  /// Merge entries discovered by a live ``AutoBrowser`` walk into the map.
+  /// An auto-browsed entry whose ``node_id_str`` already has an explicit
+  /// (YAML ``nodes:``) mapping is dropped - explicit config always wins.
+  /// Rebuilds ``entity_defs_`` when at least one entry was added.
+  /// @return number of entries actually added.
+  std::size_t merge_auto_browsed_entries(std::vector<NodeMapEntry> entries);
 
   /// Parse an OPC-UA node ID string into an `opcua::NodeId`.
   ///
@@ -270,7 +338,7 @@ class NodeMap {
   std::string area_name_ = "PLC Systems";
   std::string component_id_ = "openplc_runtime";
   std::string component_name_ = "OpenPLC Runtime";
-  bool auto_browse_{false};
+  AutoBrowseConfig auto_browse_config_;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_client.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_client.hpp
@@ -139,6 +139,35 @@ class OpcuaClient {
   /// @return Vector of child node ID strings (e.g., "ns=1;s=TankLevel")
   std::vector<std::string> browse(const opcua::NodeId & parent_node);
 
+  /// One forward-hierarchical child returned by ``browse_detailed`` - the
+  /// address-space walker (auto_browse, address_space_browser.hpp) needs the
+  /// BrowseName, DisplayName and NodeClass to build the SOVD entity tree, not
+  /// just the NodeId that plain ``browse()`` returns.
+  struct BrowseChild {
+    opcua::NodeId node_id;
+    uint16_t browse_name_ns{0};
+    std::string browse_name;
+    std::string display_name;
+    opcua::NodeClass node_class{opcua::NodeClass::Unspecified};
+  };
+
+  /// Browse forward hierarchical (Object/Variable only) children of
+  /// ``parent_node``, server-side filtered to those two node classes and
+  /// following BrowseNext continuation points automatically. Only local
+  /// nodes are returned (cross-server references are dropped - there is
+  /// nothing on this session to read their attributes from). Empty vector on
+  /// failure or when not connected.
+  std::vector<BrowseChild> browse_detailed(const opcua::NodeId & parent_node);
+
+  /// Read the DataType attribute of a Variable node and resolve it to the
+  /// OPC-UA builtin scalar type name ("Boolean", "SByte", "Byte", "Int16",
+  /// "UInt16", "Int32", "UInt32", "Int64", "UInt64", "Float", "Double",
+  /// "String", "DateTime") when the DataType is a ns=0 builtin identified
+  /// numerically. Returns an empty string for structured / enumerated /
+  /// vendor-defined types (auto_browse treats those as unsupported and skips
+  /// the variable) and when not connected or the read fails.
+  std::string read_variable_type_name(const opcua::NodeId & variable_node);
+
   /// Read a single value
   ReadResult read_value(const opcua::NodeId & node_id);
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -34,6 +34,8 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -156,11 +158,21 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   void create_value_publishers();
 
   // Run the recursive OPC-UA address-space walk (auto_browse) against the
-  // now-connected client and merge the discovered entries into node_map_.
-  // Requires a live session; called once from set_context() right after a
-  // successful connect(), before the poller/publishers are built from
-  // node_map_. No-op (never called) when auto_browse is disabled.
+  // now-connected client and merge the discovered entries into node_map_, then
+  // (re)create value publishers for any new entries. Requires a live session.
+  // Called from set_context() right after the initial connect(), and again from
+  // the poll thread on every reconnect via maybe_rebrowse_on_reconnect(). The
+  // merge into node_map_ is serialized against the REST read paths by
+  // node_map_mutex_. No-op (never called) when auto_browse is disabled.
   void run_auto_browse();
+
+  // Poll-thread hook (from publish_values): re-run auto_browse when the client
+  // has established a new session since the last walk. Covers the field case
+  // where the gateway starts before the PLC is reachable (initial connect
+  // fails, so the initial walk is skipped) and the PLC only comes up later, as
+  // well as a PLC restart. Idempotent: merge drops already-mapped node ids and
+  // create_value_publishers() skips existing topics.
+  void maybe_rebrowse_on_reconnect();
 
   // Log the effective OPC-UA security profile (policy / mode / user auth) at
   // startup; warns when running unsecured.
@@ -198,6 +210,21 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
 
   std::unique_ptr<OpcuaClient> client_;
   NodeMap node_map_;
+
+  // Guards the mutable parts of node_map_ (entries / indices / entity_defs)
+  // that auto_browse rewrites on reconnect against the REST read paths. The
+  // re-walk runs on the poll thread and takes the unique lock only for the
+  // merge; the poller's own node_map_ reads share that thread, so they need no
+  // lock. Read handlers on the HTTP thread take a shared lock for as long as
+  // they hold pointers/refs into node_map_.
+  mutable std::shared_mutex node_map_mutex_;
+
+  // OpcuaClient::connection_generation the last auto_browse walk ran against (0
+  // = never walked). The poll thread re-walks when the live generation differs,
+  // mirroring device_identity_generation_. Written on the set_context thread
+  // (initial walk, happens-before the poller starts) then only on the poll
+  // thread, so no atomic is needed.
+  uint64_t auto_browse_generation_{0};
 
   // INV2: asset-identity nameplate read once per session from the server's
   // device-info (ServerStatus/BuildInfo + optional OPC-UA DI nameplate) on the

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "ros2_medkit_opcua/address_space_browser.hpp"
 #include "ros2_medkit_opcua/network_discovery.hpp"
 #include "ros2_medkit_opcua/node_map.hpp"
 #include "ros2_medkit_opcua/opcua_client.hpp"
@@ -146,6 +147,20 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
 
   // Publish PLC values to ROS 2 topics (called after each poll)
   void publish_values(const PollSnapshot & snap);
+
+  // Create the per-entry ROS 2 Float32 publishers for numeric node map
+  // entries. Called from set_context() AFTER connect()+run_auto_browse() so
+  // that auto-discovered entries also get a publisher (moved out of its
+  // original inline position, which ran before the node map could contain
+  // anything auto_browse added).
+  void create_value_publishers();
+
+  // Run the recursive OPC-UA address-space walk (auto_browse) against the
+  // now-connected client and merge the discovered entries into node_map_.
+  // Requires a live session; called once from set_context() right after a
+  // successful connect(), before the poller/publishers are built from
+  // node_map_. No-op (never called) when auto_browse is disabled.
+  void run_auto_browse();
 
   // Log the effective OPC-UA security profile (policy / mode / user auth) at
   // startup; warns when running unsecured.

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
@@ -1,0 +1,240 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_opcua/address_space_browser.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_map>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace ros2_medkit_gateway {
+
+namespace {
+
+inline rclcpp::Logger auto_browse_logger() {
+  static auto logger = rclcpp::get_logger("opcua.auto_browse");
+  return logger;
+}
+
+}  // namespace
+
+AutoBrowser::AutoBrowser(AutoBrowseSource & source, AutoBrowseConfig config)
+  : source_(source), config_(std::move(config)) {
+}
+
+bool AutoBrowser::namespace_allowed(uint16_t ns, const AutoBrowseConfig & cfg) {
+  if (!cfg.namespace_allow.empty()) {
+    return std::find(cfg.namespace_allow.begin(), cfg.namespace_allow.end(), ns) != cfg.namespace_allow.end();
+  }
+  return std::find(cfg.namespace_deny.begin(), cfg.namespace_deny.end(), ns) == cfg.namespace_deny.end();
+}
+
+std::string AutoBrowser::map_opcua_type(const std::string & opcua_type_name) {
+  static const std::unordered_map<std::string, std::string> kMap = {
+      {"Boolean", "bool"}, {"SByte", "int"},     {"Byte", "int"},        {"Int16", "int"},  {"UInt16", "int"},
+      {"Int32", "int"},    {"UInt32", "int"},    {"Int64", "int"},       {"UInt64", "int"}, {"Float", "float"},
+      {"Double", "float"}, {"String", "string"}, {"DateTime", "string"},
+  };
+  const auto it = kMap.find(opcua_type_name);
+  return it == kMap.end() ? std::string{} : it->second;
+}
+
+std::string AutoBrowser::sanitize_segment(const std::string & s) {
+  if (s.empty()) {
+    return "_unnamed";
+  }
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    const unsigned char uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc) != 0) {
+      out += static_cast<char>(std::tolower(uc));
+    } else if (c == '_' || c == '-') {
+      out += c;
+    } else {
+      out += '_';
+    }
+  }
+  if (out.empty()) {
+    return "_unnamed";
+  }
+  if (std::isdigit(static_cast<unsigned char>(out[0])) != 0) {
+    out.insert(out.begin(), '_');
+  }
+  return out;
+}
+
+std::string AutoBrowser::join_entity_id(const std::vector<std::string> & segments) {
+  if (segments.empty()) {
+    return "root";
+  }
+  std::string out;
+  for (const auto & seg : segments) {
+    if (!out.empty()) {
+      out += '_';
+    }
+    out += sanitize_segment(seg);
+  }
+  return out;
+}
+
+std::string AutoBrowser::join_display_name(const std::vector<std::string> & segments) {
+  if (segments.empty()) {
+    return "Root";
+  }
+  std::string out;
+  for (const auto & seg : segments) {
+    if (!out.empty()) {
+      out += " / ";
+    }
+    out += seg;
+  }
+  return out;
+}
+
+namespace {
+
+// entity_id must stay unique across the whole walk (it doubles as a SOVD
+// path segment / ROS 2 topic segment); a collision after sanitization (two
+// differently-named branches folding to the same slug) gets a numeric
+// suffix, deterministic by first-seen order.
+std::string unique_entity_id(const std::string & candidate, std::unordered_set<std::string> & seen) {
+  if (seen.insert(candidate).second) {
+    return candidate;
+  }
+  for (int suffix = 2;; ++suffix) {
+    std::string next = candidate + "_" + std::to_string(suffix);
+    if (seen.insert(next).second) {
+      return next;
+    }
+  }
+}
+
+}  // namespace
+
+void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
+                               const std::vector<std::string> & path_names, int depth, AutoBrowseResult & result,
+                               std::unordered_set<std::string> & seen_entity_ids) {
+  if (depth > config_.max_depth) {
+    result.depth_cap_hit = true;
+    return;
+  }
+  if (result.nodes_visited >= config_.max_nodes) {
+    result.node_cap_hit = true;
+    return;
+  }
+
+  const auto children = source_.browse_children(node);
+
+  std::vector<NodeMapEntry> local_entries;
+  std::unordered_set<std::string> seen_data_names;
+
+  for (const auto & child : children) {
+    if (result.nodes_visited >= config_.max_nodes) {
+      result.node_cap_hit = true;
+      break;
+    }
+    ++result.nodes_visited;
+
+    if (!namespace_allowed(child.browse_name_ns, config_)) {
+      continue;  // infra/denied namespace: neither mapped nor recursed into
+    }
+
+    const std::string display = child.display_name.empty() ? child.browse_name : child.display_name;
+
+    if (child.node_class == opcua::NodeClass::Object) {
+      std::vector<std::string> next_ids = path_ids;
+      next_ids.push_back(child.browse_name.empty() ? display : child.browse_name);
+      std::vector<std::string> next_names = path_names;
+      next_names.push_back(display);
+      visit_object(child.node_id, next_ids, next_names, depth + 1, result, seen_entity_ids);
+    } else if (child.node_class == opcua::NodeClass::Variable) {
+      const std::string opcua_type = source_.read_type_name(child.node_id);
+      const std::string medkit_type = map_opcua_type(opcua_type);
+      if (medkit_type.empty()) {
+        RCLCPP_DEBUG(auto_browse_logger(), "auto_browse: skipping %s (%s) - unsupported/unresolved DataType",
+                     child.node_id.toString().c_str(), display.c_str());
+        continue;
+      }
+      if (config_.read_initial_values && !source_.read_initial_value(child.node_id).has_value()) {
+        RCLCPP_DEBUG(auto_browse_logger(), "auto_browse: skipping %s (%s) - Value not readable",
+                     child.node_id.toString().c_str(), display.c_str());
+        continue;
+      }
+
+      NodeMapEntry entry;
+      entry.node_id_str = child.node_id.toString();
+      entry.node_id = child.node_id;
+      entry.data_name = sanitize_segment(child.browse_name.empty() ? display : child.browse_name);
+      // Keep data_name unique within this entity, same collision rule as
+      // entity_id (deterministic numeric suffix by first-seen order).
+      if (!seen_data_names.insert(entry.data_name).second) {
+        int suffix = 2;
+        std::string base = entry.data_name;
+        while (!seen_data_names.insert(base + "_" + std::to_string(suffix)).second) {
+          ++suffix;
+        }
+        entry.data_name = base + "_" + std::to_string(suffix);
+      }
+      entry.display_name = display;
+      entry.data_type = medkit_type;
+      // auto_browse never marks a point writable: without a human reviewing
+      // the mapping there is no basis for exposing a write surface on a PLC
+      // actuator. Promote specific points to writable via an explicit
+      // node_map `nodes:` entry (which always takes precedence).
+      entry.writable = false;
+      local_entries.push_back(std::move(entry));
+    }
+    // Other node classes cannot reach here - browse_children already
+    // server-side filters to Object | Variable.
+  }
+
+  if (!local_entries.empty()) {
+    const std::string entity_id = unique_entity_id(join_entity_id(path_ids), seen_entity_ids);
+    for (auto & entry : local_entries) {
+      entry.entity_id = entity_id;
+      entry.ros2_topic = "/plc/" + entity_id + "/" + entry.data_name;
+      result.entries.push_back(std::move(entry));
+    }
+  }
+}
+
+AutoBrowseResult AutoBrowser::browse() {
+  AutoBrowseResult result;
+  std::unordered_set<std::string> seen_entity_ids;
+
+  for (const auto & root_str : config_.root_node_ids) {
+    const opcua::NodeId root = NodeMap::parse_node_id(root_str);
+    visit_object(root, {}, {}, 0, result, seen_entity_ids);
+  }
+
+  if (result.node_cap_hit) {
+    RCLCPP_WARN(auto_browse_logger(),
+                "auto_browse: node cap (%zu) reached - address-space walk truncated, the SOVD tree may be "
+                "incomplete; raise auto_browse.max_nodes if this server has a larger address space",
+                config_.max_nodes);
+  }
+  if (result.depth_cap_hit) {
+    RCLCPP_WARN(auto_browse_logger(),
+                "auto_browse: depth cap (%d) reached on at least one branch - some nested objects were not "
+                "explored; raise auto_browse.max_depth if this server nests deeper",
+                config_.max_depth);
+  }
+
+  return result;
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
@@ -107,6 +107,28 @@ std::string AutoBrowser::join_display_name(const std::vector<std::string> & segm
 
 namespace {
 
+// A sanitized SOVD segment keeps '-' (valid in a SOVD id), but '-' is illegal
+// in a ROS 2 topic token, which must match [A-Za-z_][A-Za-z0-9_]*. Map every
+// char that is not alnum or '_' (including '-' and '.') to '_' so the
+// auto-generated /plc topic is always a valid ROS 2 name. Mirrors the
+// hand-written path's sanitize_topic_segment in node_map.cpp; the SOVD
+// entity_id / data_name keep their '-'.
+std::string to_topic_segment(const std::string & s) {
+  if (s.empty()) {
+    return "_unnamed";
+  }
+  std::string out = s;
+  for (char & c : out) {
+    if (std::isalnum(static_cast<unsigned char>(c)) == 0 && c != '_') {
+      c = '_';
+    }
+  }
+  if (std::isdigit(static_cast<unsigned char>(out[0])) != 0) {
+    out.insert(out.begin(), '_');
+  }
+  return out;
+}
+
 // entity_id must stay unique across the whole walk (it doubles as a SOVD
 // path segment / ROS 2 topic segment); a collision after sanitization (two
 // differently-named branches folding to the same slug) gets a numeric
@@ -125,8 +147,18 @@ std::string unique_entity_id(const std::string & candidate, std::unordered_set<s
 
 }  // namespace
 
-void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids, int depth,
-                               AutoBrowseResult & result, std::unordered_set<std::string> & seen_entity_ids) {
+void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
+                               const std::vector<std::string> & path_display, int depth, AutoBrowseResult & result,
+                               std::unordered_set<std::string> & seen_entity_ids,
+                               std::unordered_set<std::string> & visited_nodes) {
+  // HierarchicalReferences (Organizes included, includeSubtypes=true) can form
+  // shared subtrees or cycles: a node reachable from two parents, or one
+  // referencing an ancestor. Without a visited set the walk would re-descend
+  // the same subtree, inflating nodes_visited until the node cap trips and
+  // silently truncates unrelated branches. Skip a node already walked.
+  if (!visited_nodes.insert(node.toString()).second) {
+    return;
+  }
   if (depth > config_.max_depth) {
     result.depth_cap_hit = true;
     return;
@@ -157,7 +189,11 @@ void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std
     if (child.node_class == opcua::NodeClass::Object) {
       std::vector<std::string> next_ids = path_ids;
       next_ids.push_back(child.browse_name.empty() ? display : child.browse_name);
-      visit_object(child.node_id, next_ids, depth + 1, result, seen_entity_ids);
+      // Parallel raw-DisplayName path, kept unsanitized for the human-readable
+      // entity name ("PLC_1 / DB_Test").
+      std::vector<std::string> next_display = path_display;
+      next_display.push_back(display);
+      visit_object(child.node_id, next_ids, next_display, depth + 1, result, seen_entity_ids, visited_nodes);
     } else if (child.node_class == opcua::NodeClass::Variable) {
       const std::string opcua_type = source_.read_type_name(child.node_id);
       const std::string medkit_type = map_opcua_type(opcua_type);
@@ -201,9 +237,15 @@ void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std
 
   if (!local_entries.empty()) {
     const std::string entity_id = unique_entity_id(join_entity_id(path_ids), seen_entity_ids);
+    // Human-readable entity name = the raw DisplayName path ("PLC_1 / DB_Test").
+    // Without this, discovery falls back to title-casing the slug in
+    // build_entity_defs, discarding the server's real DisplayNames.
+    const std::string entity_display = join_display_name(path_display);
     for (auto & entry : local_entries) {
       entry.entity_id = entity_id;
-      entry.ros2_topic = "/plc/" + entity_id + "/" + entry.data_name;
+      entry.entity_display_name = entity_display;
+      // The SOVD entity_id / data_name may contain '-'; the ROS 2 topic must not.
+      entry.ros2_topic = "/plc/" + to_topic_segment(entity_id) + "/" + to_topic_segment(entry.data_name);
       result.entries.push_back(std::move(entry));
     }
   }
@@ -212,10 +254,13 @@ void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std
 AutoBrowseResult AutoBrowser::browse() {
   AutoBrowseResult result;
   std::unordered_set<std::string> seen_entity_ids;
+  // Shared across all roots so a node reachable from more than one configured
+  // root is still walked only once.
+  std::unordered_set<std::string> visited_nodes;
 
   for (const auto & root_str : config_.root_node_ids) {
     const opcua::NodeId root = NodeMap::parse_node_id(root_str);
-    visit_object(root, {}, 0, result, seen_entity_ids);
+    visit_object(root, {}, {}, 0, result, seen_entity_ids, visited_nodes);
   }
 
   if (result.node_cap_hit) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
@@ -125,9 +125,8 @@ std::string unique_entity_id(const std::string & candidate, std::unordered_set<s
 
 }  // namespace
 
-void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids,
-                               const std::vector<std::string> & path_names, int depth, AutoBrowseResult & result,
-                               std::unordered_set<std::string> & seen_entity_ids) {
+void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std::string> & path_ids, int depth,
+                               AutoBrowseResult & result, std::unordered_set<std::string> & seen_entity_ids) {
   if (depth > config_.max_depth) {
     result.depth_cap_hit = true;
     return;
@@ -158,9 +157,7 @@ void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std
     if (child.node_class == opcua::NodeClass::Object) {
       std::vector<std::string> next_ids = path_ids;
       next_ids.push_back(child.browse_name.empty() ? display : child.browse_name);
-      std::vector<std::string> next_names = path_names;
-      next_names.push_back(display);
-      visit_object(child.node_id, next_ids, next_names, depth + 1, result, seen_entity_ids);
+      visit_object(child.node_id, next_ids, depth + 1, result, seen_entity_ids);
     } else if (child.node_class == opcua::NodeClass::Variable) {
       const std::string opcua_type = source_.read_type_name(child.node_id);
       const std::string medkit_type = map_opcua_type(opcua_type);
@@ -218,7 +215,7 @@ AutoBrowseResult AutoBrowser::browse() {
 
   for (const auto & root_str : config_.root_node_ids) {
     const opcua::NodeId root = NodeMap::parse_node_id(root_str);
-    visit_object(root, {}, {}, 0, result, seen_entity_ids);
+    visit_object(root, {}, 0, result, seen_entity_ids);
   }
 
   if (result.node_cap_hit) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
@@ -174,10 +174,6 @@ bool NodeMap::load(const std::string & yaml_path) {
     if (root["component_name"]) {
       component_name_ = root["component_name"].as<std::string>();
     }
-    if (root["auto_browse"]) {
-      auto_browse_ = root["auto_browse"].as<bool>();
-    }
-
     // Node entries. The ``nodes:`` section is optional: a config may declare
     // only ``event_alarms:`` (native AlarmCondition subscriptions with no
     // scalar data points to poll). The final emptiness check below rejects a
@@ -286,6 +282,114 @@ bool NodeMap::load(const std::string & yaml_path) {
       }
       return s;
     };
+    // Warn on keys a block-style loader does not recognise so a future typo
+    // (e.g. ``severty:``) is surfaced instead of silently dropped. Shared by
+    // the ``auto_browse:`` map form below and the ``event_alarms:`` loader.
+    auto warn_unknown_keys = [logger](const YAML::Node & node, const std::string & context,
+                                      std::initializer_list<const char *> known) {
+      if (!node.IsMap()) {
+        return;
+      }
+      for (const auto & kv : node) {
+        std::string key;
+        try {
+          key = kv.first.as<std::string>();
+        } catch (const YAML::Exception &) {
+          continue;
+        }
+        const bool recognised = std::any_of(known.begin(), known.end(), [&key](const char * k) {
+          return key == k;
+        });
+        if (!recognised) {
+          RCLCPP_WARN(logger, "%s: unknown key '%s' - ignored", context.c_str(), key.c_str());
+        }
+      }
+    };
+
+    // ``auto_browse:`` - either a plain bool (back-compat: enable/disable with
+    // all-default knobs) or a map with the full AutoBrowseConfig schema. Only
+    // overwrite defaults for keys that are actually present, so a partial map
+    // (e.g. just ``max_depth:``) does not silently reset the rest.
+    if (root["auto_browse"]) {
+      const auto ab = root["auto_browse"];
+      if (ab.IsMap()) {
+        auto_browse_config_.enabled = parse_bool(ab["enabled"], true, "auto_browse.enabled", "auto_browse");
+        if (ab["root_nodes"]) {
+          if (ab["root_nodes"].IsSequence()) {
+            auto_browse_config_.root_node_ids.clear();
+            for (const auto & r : ab["root_nodes"]) {
+              try {
+                auto_browse_config_.root_node_ids.push_back(r.as<std::string>());
+              } catch (const YAML::Exception &) {
+                RCLCPP_WARN(logger, "auto_browse.root_nodes: non-string entry - skipping");
+              }
+            }
+          } else {
+            RCLCPP_WARN(logger, "auto_browse.root_nodes: must be a sequence - ignoring");
+          }
+        }
+        if (ab["max_depth"]) {
+          const auto d =
+              parse_int64(ab["max_depth"], auto_browse_config_.max_depth, "auto_browse.max_depth", "auto_browse");
+          if (d >= 1 && d <= 64) {
+            auto_browse_config_.max_depth = static_cast<int>(d);
+          } else {
+            RCLCPP_WARN(logger, "auto_browse.max_depth=%lld out of range [1,64] - keeping default %d",
+                        static_cast<long long>(d), auto_browse_config_.max_depth);
+          }
+        }
+        if (ab["max_nodes"]) {
+          const auto n = parse_int64(ab["max_nodes"], static_cast<std::int64_t>(auto_browse_config_.max_nodes),
+                                     "auto_browse.max_nodes", "auto_browse");
+          if (n >= 1 && n <= 200000) {
+            auto_browse_config_.max_nodes = static_cast<std::size_t>(n);
+          } else {
+            RCLCPP_WARN(logger, "auto_browse.max_nodes=%lld out of range [1,200000] - keeping default %zu",
+                        static_cast<long long>(n), auto_browse_config_.max_nodes);
+          }
+        }
+        auto parse_ns_list = [logger](const YAML::Node & seq, const char * field) -> std::vector<uint16_t> {
+          std::vector<uint16_t> out;
+          if (!seq || !seq.IsSequence()) {
+            if (seq) {
+              RCLCPP_WARN(logger, "auto_browse.%s: must be a sequence - ignoring", field);
+            }
+            return out;
+          }
+          for (const auto & v : seq) {
+            try {
+              const auto n = v.as<int>();
+              if (n < 0 || n > 65535) {
+                RCLCPP_WARN(logger, "auto_browse.%s: namespace index %d out of range [0,65535] - skipping", field, n);
+                continue;
+              }
+              out.push_back(static_cast<uint16_t>(n));
+            } catch (const YAML::Exception &) {
+              RCLCPP_WARN(logger, "auto_browse.%s: non-integer namespace index - skipping", field);
+            }
+          }
+          return out;
+        };
+        if (ab["namespace_allow"]) {
+          auto_browse_config_.namespace_allow = parse_ns_list(ab["namespace_allow"], "namespace_allow");
+        }
+        if (ab["namespace_deny"]) {
+          auto_browse_config_.namespace_deny = parse_ns_list(ab["namespace_deny"], "namespace_deny");
+        }
+        auto_browse_config_.read_initial_values =
+            parse_bool(ab["read_initial_values"], auto_browse_config_.read_initial_values,
+                       "auto_browse.read_initial_values", "auto_browse");
+        warn_unknown_keys(ab, "auto_browse",
+                          {"enabled", "root_nodes", "max_depth", "max_nodes", "namespace_allow", "namespace_deny",
+                           "read_initial_values"});
+      } else {
+        try {
+          auto_browse_config_.enabled = ab.as<bool>();
+        } catch (const YAML::Exception &) {
+          RCLCPP_WARN(logger, "auto_browse: must be a boolean or a map - ignoring");
+        }
+      }
+    }
 
     for (size_t i = 0; has_nodes && i < nodes.size(); ++i) {
       const auto & n = nodes[i];
@@ -598,28 +702,8 @@ bool NodeMap::load(const std::string & yaml_path) {
         }
         return validate_severity(*sev, context);
       };
-      // Warn on keys the event_alarms loader does not recognise so a future
-      // typo (e.g. ``severty:``) is surfaced instead of silently dropped.
-      auto warn_unknown_keys = [logger](const YAML::Node & node, const std::string & context,
-                                        std::initializer_list<const char *> known) {
-        if (!node.IsMap()) {
-          return;
-        }
-        for (const auto & kv : node) {
-          std::string key;
-          try {
-            key = kv.first.as<std::string>();
-          } catch (const YAML::Exception &) {
-            continue;
-          }
-          const bool recognised = std::any_of(known.begin(), known.end(), [&key](const char * k) {
-            return key == k;
-          });
-          if (!recognised) {
-            RCLCPP_WARN(logger, "%s: unknown key '%s' - ignored", context.c_str(), key.c_str());
-          }
-        }
-      };
+      // warn_unknown_keys is defined earlier in this function (shared with
+      // the auto_browse: map loader above).
       for (size_t i = 0; i < event_alarms_node.size(); ++i) {
         const auto & a = event_alarms_node[i];
         if (!a["alarm_source"] || !a["entity_id"]) {
@@ -815,12 +899,14 @@ bool NodeMap::load(const std::string & yaml_path) {
       }
     }
 
-    // A config that declares neither a 'nodes:' section nor any event alarms
-    // carries no mappings and is almost always a mistake (wrong file / typo).
-    // A present-but-empty 'nodes:' section is still a valid config.
-    if (!has_nodes && event_alarms_.empty()) {
+    // A config that declares neither a 'nodes:' section, any event alarms, nor
+    // auto_browse carries no mappings and is almost always a mistake (wrong
+    // file / typo). A present-but-empty 'nodes:' section is still valid, and
+    // an auto_browse-only file (zero-config discovery: the whole tree is
+    // filled by the live address-space walk) is valid too.
+    if (!has_nodes && event_alarms_.empty() && !auto_browse_config_.enabled) {
       RCLCPP_ERROR(rclcpp::get_logger("opcua.node_map"),
-                   "Node map has neither 'nodes:' nor 'event_alarms:' entries - nothing to map");
+                   "Node map has neither 'nodes:', 'event_alarms:' nor 'auto_browse:' entries - nothing to map");
       entity_defs_.clear();
       return false;
     }
@@ -934,6 +1020,27 @@ const NodeMapEntry * NodeMap::find_by_node_id(const std::string & node_id_str) c
     return &entries_[it->second];
   }
   return nullptr;
+}
+
+std::size_t NodeMap::merge_auto_browsed_entries(std::vector<NodeMapEntry> entries) {
+  std::size_t added = 0;
+  for (auto & entry : entries) {
+    // Explicit (YAML ``nodes:``) mappings always win: an auto-browsed entry
+    // for a node_id that is already mapped is silently dropped rather than
+    // overwriting the hand-authored entity_id/data_name/alarm config.
+    if (node_id_index_.count(entry.node_id_str) > 0) {
+      continue;
+    }
+    const std::size_t idx = entries_.size();
+    node_id_index_[entry.node_id_str] = idx;
+    entity_index_[entry.entity_id].push_back(idx);
+    entries_.push_back(std::move(entry));
+    ++added;
+  }
+  if (added > 0) {
+    build_entity_defs();
+  }
+  return added;
 }
 
 // Test / back-compat only: the live fault-evaluation path is

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/node_map.cpp
@@ -1078,6 +1078,10 @@ void NodeMap::build_entity_defs() {
     if (def.id.empty()) {
       def.id = entry.entity_id;
       def.component_id = component_id_;
+      // auto_browse supplies the raw DisplayName path ("PLC_1 / DB_Test") as the
+      // human-readable name; hand-written entries leave it empty and fall back to
+      // the title-cased slug below.
+      def.name = entry.entity_display_name;
     }
     def.data_names.push_back(entry.data_name);
     if (entry.writable) {
@@ -1101,23 +1105,26 @@ void NodeMap::build_entity_defs() {
     def.has_faults = true;
   }
 
-  // Build human-readable names from IDs
+  // Build human-readable names from IDs for entries without an explicit
+  // (auto_browse) DisplayName path.
   for (auto & [id, def] : defs) {
-    // Convert snake_case to Title Case
-    std::string name;
-    bool capitalize = true;
-    for (char c : id) {
-      if (c == '_') {
-        name += ' ';
-        capitalize = true;
-      } else if (capitalize) {
-        name += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-        capitalize = false;
-      } else {
-        name += c;
+    if (def.name.empty()) {
+      // Convert snake_case to Title Case
+      std::string name;
+      bool capitalize = true;
+      for (char c : id) {
+        if (c == '_') {
+          name += ' ';
+          capitalize = true;
+        } else if (capitalize) {
+          name += static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+          capitalize = false;
+        } else {
+          name += c;
+        }
       }
+      def.name = name;
     }
-    def.name = name;
     entity_defs_.push_back(std::move(def));
   }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
@@ -161,7 +161,12 @@ OpcuaValue variant_to_value(const opcua::Variant & var) {
     const auto tp = var.getScalarCopy<opcua::DateTime>().toTimePoint<std::chrono::system_clock>();
     const std::time_t tt = std::chrono::system_clock::to_time_t(tp);
     std::tm tm_utc{};
-    gmtime_r(&tt, &tm_utc);
+    if (gmtime_r(&tt, &tm_utc) == nullptr) {
+      // Out-of-range timestamp (e.g. a corrupt/garbage DateTime value from
+      // the server) - surface as unsupported rather than formatting an
+      // uninitialized std::tm.
+      return std::string("<invalid DateTime>");
+    }
     char buf[32];
     const size_t n = std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
     return std::string(buf, n);

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
@@ -17,7 +17,9 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <chrono>
 #include <cstring>
+#include <ctime>
 #include <deque>
 #include <fstream>
 #include <set>
@@ -150,6 +152,19 @@ OpcuaValue variant_to_value(const opcua::Variant & var) {
   }
   if (var.isType<opcua::String>()) {
     return std::string(var.getScalarCopy<opcua::String>());
+  }
+  if (var.isType<opcua::DateTime>()) {
+    // Surfaced as an ISO-8601 UTC string (medkit has no native timestamp
+    // OpcuaValue slot). Exercised by auto_browse's DateTime->"string"
+    // mapping (e.g. a "TIMESTAMP" field on an alarm DB) and by any
+    // hand-written node_map entry that points at a DateTime node.
+    const auto tp = var.getScalarCopy<opcua::DateTime>().toTimePoint<std::chrono::system_clock>();
+    const std::time_t tt = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm_utc{};
+    gmtime_r(&tt, &tm_utc);
+    char buf[32];
+    const size_t n = std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+    return std::string(buf, n);
   }
   return std::string("<unsupported type>");
 }
@@ -608,6 +623,99 @@ std::vector<std::string> OpcuaClient::browse(const opcua::NodeId & parent_node) 
   }
 
   return result;
+}
+
+namespace {
+
+// Resolve a ns=0 numeric DataType identifier to its OPC-UA builtin scalar
+// type name. Only the types the plugin's four medkit data types
+// (bool/int/float/string) can represent are named here; every other
+// identifier (structured/enumerated/vendor types, or anything not in this
+// table) returns empty so auto_browse skips the variable as unsupported.
+//
+// A lookup table (not a switch on opcua::DataTypeId) deliberately: that enum
+// has hundreds of generated members (every OPC-UA Part 6 DataType, most
+// irrelevant to a scalar PLC point) and this project's ROS2MedkitWarnings
+// promotes -Wswitch-enum to an error, which would force listing all of them.
+std::string builtin_data_type_name(uint32_t numeric_id) {
+  static const std::unordered_map<uint32_t, std::string> kBuiltinNames = {
+      {static_cast<uint32_t>(opcua::DataTypeId::Boolean), "Boolean"},
+      {static_cast<uint32_t>(opcua::DataTypeId::SByte), "SByte"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Byte), "Byte"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Int16), "Int16"},
+      {static_cast<uint32_t>(opcua::DataTypeId::UInt16), "UInt16"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Int32), "Int32"},
+      {static_cast<uint32_t>(opcua::DataTypeId::UInt32), "UInt32"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Int64), "Int64"},
+      {static_cast<uint32_t>(opcua::DataTypeId::UInt64), "UInt64"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Float), "Float"},
+      {static_cast<uint32_t>(opcua::DataTypeId::Double), "Double"},
+      {static_cast<uint32_t>(opcua::DataTypeId::String), "String"},
+      {static_cast<uint32_t>(opcua::DataTypeId::DateTime), "DateTime"},
+  };
+  const auto it = kBuiltinNames.find(numeric_id);
+  return it == kBuiltinNames.end() ? std::string{} : it->second;
+}
+
+}  // namespace
+
+std::vector<OpcuaClient::BrowseChild> OpcuaClient::browse_detailed(const opcua::NodeId & parent_node) {
+  std::lock_guard<std::mutex> lock(impl_->client_mutex);
+  std::vector<BrowseChild> result;
+
+  if (!impl_->connected) {
+    return result;
+  }
+
+  try {
+    opcua::Node node(impl_->client, parent_node);
+    // Server-side node-class filter: only Object/Variable references come
+    // back, so Methods (ConditionRefresh, Acknowledge, ...), ReferenceTypes,
+    // DataTypes etc. never enter the walk. BrowseResultMask::All returns
+    // BrowseName + DisplayName + NodeClass in the same round trip as the
+    // NodeId, so the caller never needs a follow-up read per child.
+    auto refs = node.browseReferences(opcua::BrowseDirection::Forward, opcua::ReferenceTypeId::HierarchicalReferences,
+                                      true, opcua::NodeClass::Object | opcua::NodeClass::Variable);
+    result.reserve(refs.size());
+    for (auto & ref : refs) {
+      const auto & expanded = ref.getNodeId();
+      if (!expanded.isLocal()) {
+        continue;  // reference to another server - nothing to read here
+      }
+      BrowseChild child;
+      child.node_id = expanded.getNodeId();
+      const auto bn = ref.getBrowseName();
+      child.browse_name_ns = bn.getNamespaceIndex();
+      child.browse_name = std::string(bn.getName());
+      child.display_name = std::string(ref.getDisplayName().getText());
+      child.node_class = ref.getNodeClass();
+      result.push_back(std::move(child));
+    }
+  } catch (const opcua::BadStatus & e) {
+    maybe_mark_disconnected(impl_->connected, impl_->generation, e);
+  }
+
+  return result;
+}
+
+std::string OpcuaClient::read_variable_type_name(const opcua::NodeId & variable_node) {
+  std::lock_guard<std::mutex> lock(impl_->client_mutex);
+
+  if (!impl_->connected) {
+    return {};
+  }
+
+  try {
+    opcua::Node node(impl_->client, variable_node);
+    const auto data_type = node.readDataType();
+    if (data_type.getNamespaceIndex() != 0 || data_type.getIdentifierType() != opcua::NodeIdType::Numeric) {
+      return {};  // vendor/custom/enum type - not a scalar builtin
+    }
+    return builtin_data_type_name(data_type.getIdentifierAs<uint32_t>());
+  } catch (const opcua::BadStatus & e) {
+    maybe_mark_disconnected(impl_->connected, impl_->generation, e);
+    return {};
+  }
 }
 
 ReadResult OpcuaClient::read_value(const opcua::NodeId & node_id) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -25,10 +25,12 @@
 #include <ros2_medkit_gateway/core/http/error_codes.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cctype>
 #include <cerrno>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>
@@ -137,6 +139,31 @@ bool is_valid_path_segment(const std::string & s) {
   return std::all_of(s.begin(), s.end(), [](unsigned char c) {
     return std::isalnum(c) || c == '_' || c == '-';
   });
+}
+
+// Parse a JSON array of namespace indices for auto_browse's
+// namespace_allow/namespace_deny knobs. Out-of-range or non-integer entries
+// are skipped with a warning rather than aborting the whole config.
+std::vector<uint16_t> parse_json_ns_list(const nlohmann::json & arr, const char * field,
+                                         const std::function<void(const std::string &)> & warn) {
+  std::vector<uint16_t> out;
+  if (!arr.is_array()) {
+    warn(std::string("plugins.opcua.auto_browse.") + field + " must be an array - ignoring");
+    return out;
+  }
+  for (const auto & v : arr) {
+    if (!v.is_number_integer()) {
+      warn(std::string("plugins.opcua.auto_browse.") + field + ": non-integer namespace index - skipping");
+      continue;
+    }
+    const auto n = v.get<int64_t>();
+    if (n < 0 || n > 65535) {
+      warn(std::string("plugins.opcua.auto_browse.") + field + ": namespace index out of range [0,65535] - skipping");
+      continue;
+    }
+    out.push_back(static_cast<uint16_t>(n));
+  }
+  return out;
 }
 }  // namespace
 
@@ -415,6 +442,79 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
     }
     log_info("Loaded node map with " + std::to_string(node_map_.entries().size()) + " entries from: " + node_map_path_);
   }
+
+  // plugins.opcua.auto_browse (ROS param / JSON config). Overlays on top of
+  // whatever the node-map YAML's `auto_browse:` block set (or the all-default
+  // AutoBrowseConfig when there is no node map at all) - the same
+  // "JSON/env wins over file" precedence the rest of this function uses.
+  // This is what makes zero-config discovery possible: no node_map_path,
+  // just `endpoint_url` (from discovery, PR #509) + `auto_browse: true`.
+  if (config.contains("auto_browse")) {
+    auto warn = [this](const std::string & msg) {
+      log_warn(msg);
+    };
+    auto & ab_cfg = node_map_.mutable_auto_browse_config();
+    const auto & ab = config["auto_browse"];
+    if (ab.is_boolean()) {
+      ab_cfg.enabled = ab.get<bool>();
+    } else if (ab.is_object()) {
+      ab_cfg.enabled = ab.value("enabled", true);
+      if (ab.contains("root_nodes")) {
+        if (ab["root_nodes"].is_array()) {
+          ab_cfg.root_node_ids.clear();
+          for (const auto & r : ab["root_nodes"]) {
+            if (r.is_string()) {
+              ab_cfg.root_node_ids.push_back(r.get<std::string>());
+            } else {
+              warn("plugins.opcua.auto_browse.root_nodes: non-string entry - skipping");
+            }
+          }
+        } else {
+          warn("plugins.opcua.auto_browse.root_nodes must be an array - ignoring");
+        }
+      }
+      if (ab.contains("max_depth")) {
+        const auto d = ab["max_depth"].get<int64_t>();
+        if (d >= 1 && d <= 64) {
+          ab_cfg.max_depth = static_cast<int>(d);
+        } else {
+          warn("plugins.opcua.auto_browse.max_depth out of range [1,64] - keeping current value");
+        }
+      }
+      if (ab.contains("max_nodes")) {
+        const auto n = ab["max_nodes"].get<int64_t>();
+        if (n >= 1 && n <= 200000) {
+          ab_cfg.max_nodes = static_cast<size_t>(n);
+        } else {
+          warn("plugins.opcua.auto_browse.max_nodes out of range [1,200000] - keeping current value");
+        }
+      }
+      if (ab.contains("namespace_allow")) {
+        ab_cfg.namespace_allow = parse_json_ns_list(ab["namespace_allow"], "namespace_allow", warn);
+      }
+      if (ab.contains("namespace_deny")) {
+        ab_cfg.namespace_deny = parse_json_ns_list(ab["namespace_deny"], "namespace_deny", warn);
+      }
+      if (ab.contains("read_initial_values")) {
+        ab_cfg.read_initial_values = ab["read_initial_values"].get<bool>();
+      }
+      static const std::array<const char *, 6> kKnownKeys{"enabled",   "root_nodes",      "max_depth",
+                                                          "max_nodes", "namespace_allow", "namespace_deny"};
+      for (const auto & [key, value] : ab.items()) {
+        (void)value;
+        if (key == "read_initial_values") {
+          continue;
+        }
+        if (std::find_if(kKnownKeys.begin(), kKnownKeys.end(), [&key](const char * k) {
+              return key == k;
+            }) == kKnownKeys.end()) {
+          warn("plugins.opcua.auto_browse: unknown key '" + key + "' - ignored");
+        }
+      }
+    } else {
+      log_warn("plugins.opcua.auto_browse must be a boolean or an object - ignoring");
+    }
+  }
 }
 
 void OpcuaPlugin::set_context(PluginContext & context) {
@@ -430,17 +530,6 @@ void OpcuaPlugin::set_context(PluginContext & context) {
   if (node) {
     fault_clients_->report = node->create_client<ros2_medkit_msgs::srv::ReportFault>("/fault_manager/report_fault");
     fault_clients_->clear = node->create_client<ros2_medkit_msgs::srv::ClearFault>("/fault_manager/clear_fault");
-
-    // Create ROS 2 publishers for numeric PLC values only (skip string-typed entries)
-    for (const auto & entry : node_map_.entries()) {
-      if (entry.data_type == "string") {
-        log_info("PLC bridge: skipping non-numeric " + entry.node_id_str + " (data_type=" + entry.data_type + ")");
-        continue;
-      }
-      publishers_[entry.node_id_str] =
-          node->create_publisher<std_msgs::msg::Float32>(entry.ros2_topic, rclcpp::SensorDataQoS());
-      log_info("PLC bridge: " + entry.node_id_str + " -> " + entry.ros2_topic + " (Float32)");
-    }
   }
 
   run_startup_discovery();
@@ -449,9 +538,19 @@ void OpcuaPlugin::set_context(PluginContext & context) {
 
   if (client_->connect(client_config_)) {
     log_info("Connected to OPC-UA server: " + client_config_.endpoint_url);
+    // auto_browse needs a live session to walk the address space, so it can
+    // only run here - after connect(), before the node map is consumed to
+    // build publishers/poller below.
+    if (node_map_.auto_browse_config().enabled) {
+      run_auto_browse();
+    }
   } else {
     log_warn("Failed to connect to OPC-UA server: " + client_config_.endpoint_url);
   }
+
+  // Publisher creation moved here (was originally before connect()) so that
+  // any entries auto_browse just merged into node_map_ also get a publisher.
+  create_value_publishers();
 
   poller_ = std::make_unique<OpcuaPoller>(*client_, node_map_);
   poller_->set_alarm_callback(
@@ -949,6 +1048,37 @@ void OpcuaPlugin::flush_pending_reports() {
     dispatch();
   }
   pending_reports_.clear();
+}
+
+void OpcuaPlugin::create_value_publishers() {
+  auto * node = ctx_ ? ctx_->node() : nullptr;
+  if (!node) {
+    return;
+  }
+  // Create ROS 2 publishers for numeric PLC values only (skip string-typed entries)
+  for (const auto & entry : node_map_.entries()) {
+    if (publishers_.count(entry.node_id_str) > 0) {
+      continue;  // already created (e.g. a previous call before a reconnect)
+    }
+    if (entry.data_type == "string") {
+      log_info("PLC bridge: skipping non-numeric " + entry.node_id_str + " (data_type=" + entry.data_type + ")");
+      continue;
+    }
+    publishers_[entry.node_id_str] =
+        node->create_publisher<std_msgs::msg::Float32>(entry.ros2_topic, rclcpp::SensorDataQoS());
+    log_info("PLC bridge: " + entry.node_id_str + " -> " + entry.ros2_topic + " (Float32)");
+  }
+}
+
+void OpcuaPlugin::run_auto_browse() {
+  OpcuaClientBrowseSource source(*client_);
+  AutoBrowser browser(source, node_map_.auto_browse_config());
+  AutoBrowseResult result = browser.browse();
+  const size_t added = node_map_.merge_auto_browsed_entries(std::move(result.entries));
+  log_info("auto_browse: walked " + std::to_string(result.nodes_visited) + " address-space nodes, added " +
+           std::to_string(added) + " data points (" + std::to_string(node_map_.entity_defs().size()) +
+           " entities total)" + (result.node_cap_hit ? " [node cap reached - tree may be incomplete]" : "") +
+           (result.depth_cap_hit ? " [depth cap reached on at least one branch]" : ""));
 }
 
 void OpcuaPlugin::publish_values(const PollSnapshot & snap) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -33,6 +33,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <mutex>
+#include <shared_mutex>
 #include <sstream>
 #include <stdexcept>
 
@@ -638,6 +640,9 @@ IntrospectionResult OpcuaPlugin::introspect(const IntrospectionInput & /*input*/
   log_info("introspect() called - generating PLC entities");
   IntrospectionResult result;
 
+  // Serialize against an auto_browse re-walk (poll thread) rebuilding node_map_.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
+
   Area area;
   area.id = node_map_.area_id();
   area.name = node_map_.area_name();
@@ -731,6 +736,8 @@ void OpcuaPlugin::handle_plc_data(const PluginRequest & req, PluginResponse & re
     return;
   }
 
+  // Held across build_data_response too (it reads node_map_ without locking).
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto entries = node_map_.entries_for_entity(entity_id);
   if (entries.empty()) {
     res.send_error(404, ERR_RESOURCE_NOT_FOUND, "No PLC data mapped for entity: " + entity_id);
@@ -758,6 +765,8 @@ void OpcuaPlugin::handle_plc_data_single(const PluginRequest & req, PluginRespon
     return;
   }
 
+  // Held for as long as ``entry`` (a pointer into node_map_) is dereferenced.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto * entry = node_map_.find_by_data_name(entity_id, data_name);
   if (!entry) {
     res.send_error(404, ERR_RESOURCE_NOT_FOUND, "Data point not found: " + data_name + " in entity: " + entity_id);
@@ -819,6 +828,9 @@ void OpcuaPlugin::handle_plc_operations(const PluginRequest & req, PluginRespons
     data_name = op_name;
   }
 
+  // Held for as long as ``entry`` (a pointer into node_map_) is dereferenced,
+  // including across the OPC-UA write below.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto * entry = node_map_.find_by_data_name(entity_id, data_name);
   if (!entry) {
     res.send_error(404, ERR_RESOURCE_NOT_FOUND, "Operation not found: " + op_name + " in entity: " + entity_id);
@@ -883,6 +895,7 @@ void OpcuaPlugin::handle_plc_status(const PluginRequest & req, PluginResponse & 
     return;
   }
 
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto snap = poller_->snapshot();
 
   nlohmann::json j;
@@ -1085,12 +1098,40 @@ void OpcuaPlugin::create_value_publishers() {
 void OpcuaPlugin::run_auto_browse() {
   OpcuaClientBrowseSource source(*client_);
   AutoBrowser browser(source, node_map_.auto_browse_config());
+  // The address-space walk is a series of blocking OPC-UA round-trips - do it
+  // without the lock so it never stalls the REST read handlers.
   AutoBrowseResult result = browser.browse();
-  const size_t added = node_map_.merge_auto_browsed_entries(std::move(result.entries));
+
+  size_t added = 0;
+  size_t entity_count = 0;
+  {
+    // Serialize the mutation (entries / indices / entity_defs rebuild) against
+    // the HTTP read handlers, which take the shared lock.
+    std::unique_lock<std::shared_mutex> lock(node_map_mutex_);
+    added = node_map_.merge_auto_browsed_entries(std::move(result.entries));
+    entity_count = node_map_.entity_defs().size();
+  }
+  // Publishers for any newly merged entries (idempotent via publishers_.count).
+  // Safe without the node_map_ lock: the poll thread is the sole writer and we
+  // are on it (or in single-threaded set_context startup).
+  create_value_publishers();
+  auto_browse_generation_ = client_->connection_generation();
+
   log_info("auto_browse: walked " + std::to_string(result.nodes_visited) + " address-space nodes, added " +
-           std::to_string(added) + " data points (" + std::to_string(node_map_.entity_defs().size()) +
-           " entities total)" + (result.node_cap_hit ? " [node cap reached - tree may be incomplete]" : "") +
+           std::to_string(added) + " data points (" + std::to_string(entity_count) + " entities total)" +
+           (result.node_cap_hit ? " [node cap reached - tree may be incomplete]" : "") +
            (result.depth_cap_hit ? " [depth cap reached on at least one branch]" : ""));
+}
+
+void OpcuaPlugin::maybe_rebrowse_on_reconnect() {
+  if (!node_map_.auto_browse_config().enabled || !client_ || !client_->is_connected()) {
+    return;
+  }
+  const uint64_t generation = client_->connection_generation();
+  if (generation == auto_browse_generation_) {
+    return;  // already walked this session
+  }
+  run_auto_browse();
 }
 
 void OpcuaPlugin::publish_values(const PollSnapshot & snap) {
@@ -1100,6 +1141,9 @@ void OpcuaPlugin::publish_values(const PollSnapshot & snap) {
   // Poll-thread hook: drain any fault reports buffered before fault_manager was
   // discovered, so a late sink still receives them.
   flush_pending_reports();
+  // Poll-thread hook: (re)run auto_browse after a fresh session so a PLC that
+  // came up (or restarted) after the initial connect still gets walked.
+  maybe_rebrowse_on_reconnect();
   for (const auto & [node_id, value] : snap.values) {
     auto pub_it = publishers_.find(node_id);
     if (pub_it == publishers_.end()) {
@@ -1317,6 +1361,8 @@ tl::expected<dto::DataListResult, DataProviderErrorInfo> OpcuaPlugin::list_data(
     return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::Internal, "plugin not initialized", 503});
   }
 
+  // Held while the returned pointers into node_map_ are dereferenced below.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto entries = node_map_.entries_for_entity(entity_id);
   if (entries.empty()) {
     return tl::make_unexpected(
@@ -1360,6 +1406,8 @@ tl::expected<dto::DataValue, DataProviderErrorInfo> OpcuaPlugin::read_data(const
     return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::Internal, "plugin not initialized", 503});
   }
 
+  // Held while ``entry`` (a pointer into node_map_) is dereferenced below.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto * entry = node_map_.find_by_data_name(entity_id, resource_name);
   if (!entry) {
     return tl::make_unexpected(DataProviderErrorInfo{
@@ -1403,6 +1451,9 @@ tl::expected<dto::DataWriteResult, DataProviderErrorInfo> OpcuaPlugin::write_dat
     return tl::make_unexpected(DataProviderErrorInfo{DataProviderError::Internal, "plugin not initialized", 503});
   }
 
+  // Held for as long as ``entry`` (a pointer into node_map_) is dereferenced,
+  // including across the OPC-UA write below.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto * entry = node_map_.find_by_data_name(entity_id, resource_name);
   if (!entry) {
     return tl::make_unexpected(DataProviderErrorInfo{
@@ -1454,6 +1505,8 @@ tl::expected<dto::Collection<dto::OperationItem>, OperationProviderErrorInfo>
 OpcuaPlugin::list_operations(const std::string & entity_id) {
   dto::Collection<dto::OperationItem> collection;
 
+  // Held while iterating node_map_ defs / entries (auto_browse may rebuild them).
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   for (const auto & def : node_map_.entity_defs()) {
     if (def.id != entity_id) {
       continue;
@@ -1605,6 +1658,9 @@ OpcuaPlugin::execute_operation(const std::string & entity_id, const std::string 
     data_name = operation_name;
   }
 
+  // Held for as long as ``entry`` (a pointer into node_map_) is dereferenced,
+  // including across the OPC-UA write below.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
   auto * entry = node_map_.find_by_data_name(entity_id, data_name);
   if (!entry) {
     return tl::make_unexpected(OperationProviderErrorInfo{OperationProviderError::OperationNotFound,

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -474,19 +474,27 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
         }
       }
       if (ab.contains("max_depth")) {
-        const auto d = ab["max_depth"].get<int64_t>();
-        if (d >= 1 && d <= 64) {
-          ab_cfg.max_depth = static_cast<int>(d);
+        if (!ab["max_depth"].is_number_integer()) {
+          warn("plugins.opcua.auto_browse.max_depth must be an integer - keeping current value");
         } else {
-          warn("plugins.opcua.auto_browse.max_depth out of range [1,64] - keeping current value");
+          const auto d = ab["max_depth"].get<int64_t>();
+          if (d >= 1 && d <= 64) {
+            ab_cfg.max_depth = static_cast<int>(d);
+          } else {
+            warn("plugins.opcua.auto_browse.max_depth out of range [1,64] - keeping current value");
+          }
         }
       }
       if (ab.contains("max_nodes")) {
-        const auto n = ab["max_nodes"].get<int64_t>();
-        if (n >= 1 && n <= 200000) {
-          ab_cfg.max_nodes = static_cast<size_t>(n);
+        if (!ab["max_nodes"].is_number_integer()) {
+          warn("plugins.opcua.auto_browse.max_nodes must be an integer - keeping current value");
         } else {
-          warn("plugins.opcua.auto_browse.max_nodes out of range [1,200000] - keeping current value");
+          const auto n = ab["max_nodes"].get<int64_t>();
+          if (n >= 1 && n <= 200000) {
+            ab_cfg.max_nodes = static_cast<size_t>(n);
+          } else {
+            warn("plugins.opcua.auto_browse.max_nodes out of range [1,200000] - keeping current value");
+          }
         }
       }
       if (ab.contains("namespace_allow")) {
@@ -496,7 +504,11 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
         ab_cfg.namespace_deny = parse_json_ns_list(ab["namespace_deny"], "namespace_deny", warn);
       }
       if (ab.contains("read_initial_values")) {
-        ab_cfg.read_initial_values = ab["read_initial_values"].get<bool>();
+        if (ab["read_initial_values"].is_boolean()) {
+          ab_cfg.read_initial_values = ab["read_initial_values"].get<bool>();
+        } else {
+          warn("plugins.opcua.auto_browse.read_initial_values must be a boolean - keeping current value");
+        }
       }
       static const std::array<const char *, 6> kKnownKeys{"enabled",   "root_nodes",      "max_depth",
                                                           "max_nodes", "namespace_allow", "namespace_deny"};

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
@@ -1,0 +1,479 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Unit tests for the recursive OPC-UA address-space walker (auto_browse).
+// Exercises AutoBrowser against an injected FakeAutoBrowseSource - an
+// in-memory tree, no network, no server - covering hierarchy mapping, type
+// inference, depth/node caps, namespace filtering and node_map precedence.
+
+#include "ros2_medkit_opcua/address_space_browser.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+
+namespace {
+
+OpcuaClient::BrowseChild make_child(const std::string & node_id_str, uint16_t bn_ns, const std::string & browse_name,
+                                    const std::string & display_name, opcua::NodeClass node_class) {
+  OpcuaClient::BrowseChild c;
+  c.node_id = NodeMap::parse_node_id(node_id_str);
+  c.browse_name_ns = bn_ns;
+  c.browse_name = browse_name;
+  c.display_name = display_name;
+  c.node_class = node_class;
+  return c;
+}
+
+// In-memory AutoBrowseSource: an explicit parent(NodeId string) -> children
+// tree, a NodeId-string -> OPC-UA type-name map, and a set of node ids whose
+// Value read is made to fail (for the read_initial_values gate).
+class FakeAutoBrowseSource : public AutoBrowseSource {
+ public:
+  void add_child(const opcua::NodeId & parent, const OpcuaClient::BrowseChild & child) {
+    tree_[parent.toString()].push_back(child);
+  }
+  void set_type(const opcua::NodeId & node, std::string type_name) {
+    types_[node.toString()] = std::move(type_name);
+  }
+  void set_unreadable(const opcua::NodeId & node) {
+    unreadable_.insert(node.toString());
+  }
+
+  std::vector<OpcuaClient::BrowseChild> browse_children(const opcua::NodeId & parent) override {
+    ++browse_calls;
+    auto it = tree_.find(parent.toString());
+    return it == tree_.end() ? std::vector<OpcuaClient::BrowseChild>{} : it->second;
+  }
+
+  std::string read_type_name(const opcua::NodeId & variable_node) override {
+    auto it = types_.find(variable_node.toString());
+    return it == types_.end() ? std::string{} : it->second;
+  }
+
+  std::optional<OpcuaValue> read_initial_value(const opcua::NodeId & variable_node) override {
+    if (unreadable_.count(variable_node.toString()) > 0) {
+      return std::nullopt;
+    }
+    return OpcuaValue{1.0};
+  }
+
+  int browse_calls{0};
+
+ private:
+  std::unordered_map<std::string, std::vector<OpcuaClient::BrowseChild>> tree_;
+  std::unordered_map<std::string, std::string> types_;
+  std::unordered_set<std::string> unreadable_;
+};
+
+const NodeMapEntry * find_entry(const std::vector<NodeMapEntry> & entries, const std::string & node_id_str) {
+  auto it = std::find_if(entries.begin(), entries.end(), [&](const NodeMapEntry & e) {
+    return e.node_id_str == node_id_str;
+  });
+  return it == entries.end() ? nullptr : &(*it);
+}
+
+}  // namespace
+
+// -- Hierarchy mapping + type inference --------------------------------
+
+TEST(AutoBrowserTest, MapsObjectHierarchyToEntityAndVariablesToDataPoints) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto plc1 = NodeMap::parse_node_id("ns=2;s=PLC_1");
+  const auto db_test = NodeMap::parse_node_id("ns=2;s=DB_Test");
+  const auto level = NodeMap::parse_node_id("ns=2;s=DB_Test.Level");
+  const auto running = NodeMap::parse_node_id("ns=2;s=DB_Test.Running");
+
+  source.add_child(root, make_child("ns=2;s=PLC_1", 2, "PLC_1", "PLC_1", opcua::NodeClass::Object));
+  source.add_child(plc1, make_child("ns=2;s=DB_Test", 2, "DB_Test", "DB_Test", opcua::NodeClass::Object));
+  source.add_child(db_test, make_child("ns=2;s=DB_Test.Level", 2, "Level", "Level", opcua::NodeClass::Variable));
+  source.add_child(db_test, make_child("ns=2;s=DB_Test.Running", 2, "Running", "Running", opcua::NodeClass::Variable));
+  source.set_type(level, "Float");
+  source.set_type(running, "Boolean");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 2u);
+  const auto * level_entry = find_entry(result.entries, level.toString());
+  const auto * running_entry = find_entry(result.entries, running.toString());
+  ASSERT_NE(level_entry, nullptr);
+  ASSERT_NE(running_entry, nullptr);
+
+  EXPECT_EQ(level_entry->entity_id, "plc_1_db_test");
+  EXPECT_EQ(level_entry->data_name, "level");
+  EXPECT_EQ(level_entry->display_name, "Level");
+  EXPECT_EQ(level_entry->data_type, "float");
+  EXPECT_EQ(level_entry->ros2_topic, "/plc/plc_1_db_test/level");
+  EXPECT_FALSE(level_entry->writable);
+
+  EXPECT_EQ(running_entry->entity_id, "plc_1_db_test");
+  EXPECT_EQ(running_entry->data_name, "running");
+  EXPECT_EQ(running_entry->data_type, "bool");
+
+  EXPECT_FALSE(result.node_cap_hit);
+  EXPECT_FALSE(result.depth_cap_hit);
+}
+
+TEST(AutoBrowserTest, PureObjectsWithoutVariablesDoNotBecomeEntities) {
+  // PLC_1 -> Empty (Object, no variables anywhere under it) should never
+  // appear as an entity_id/App; it is only a path segment.
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto plc1 = NodeMap::parse_node_id("ns=2;s=PLC_1");
+  const auto empty = NodeMap::parse_node_id("ns=2;s=Empty");
+
+  source.add_child(root, make_child("ns=2;s=PLC_1", 2, "PLC_1", "PLC_1", opcua::NodeClass::Object));
+  source.add_child(plc1, make_child("ns=2;s=Empty", 2, "Empty", "Empty", opcua::NodeClass::Object));
+  (void)empty;  // no children registered - a genuinely empty subtree
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_TRUE(result.entries.empty());
+}
+
+// -- Variable -> data point type inference (map_opcua_type) -------------
+
+TEST(AutoBrowserTest, MapsSupportedOpcuaBuiltinTypes) {
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Boolean"), "bool");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("SByte"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Byte"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Int16"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("UInt16"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Int32"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("UInt32"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Int64"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("UInt64"), "int");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Float"), "float");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Double"), "float");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("String"), "string");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("DateTime"), "string");
+}
+
+TEST(AutoBrowserTest, UnsupportedTypesMapToEmpty) {
+  EXPECT_EQ(AutoBrowser::map_opcua_type("Guid"), "");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("ByteString"), "");
+  EXPECT_EQ(AutoBrowser::map_opcua_type("SomeStructuredType"), "");
+  EXPECT_EQ(AutoBrowser::map_opcua_type(""), "");
+}
+
+TEST(AutoBrowserTest, VariableWithUnsupportedTypeIsSkipped) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto guid_var = NodeMap::parse_node_id("ns=2;s=SomeGuid");
+  const auto ok_var = NodeMap::parse_node_id("ns=2;s=Ok");
+
+  source.add_child(root, make_child("ns=2;s=SomeGuid", 2, "SomeGuid", "SomeGuid", opcua::NodeClass::Variable));
+  source.add_child(root, make_child("ns=2;s=Ok", 2, "Ok", "Ok", opcua::NodeClass::Variable));
+  source.set_type(guid_var, "Guid");
+  source.set_type(ok_var, "Int32");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].node_id_str, ok_var.toString());
+  // Variables directly on the root (empty path) fall back to entity_id "root".
+  EXPECT_EQ(result.entries[0].entity_id, "root");
+}
+
+// -- read_initial_values gate --------------------------------------------
+
+TEST(AutoBrowserTest, UnreadableVariableSkippedWhenReadInitialValuesEnabled) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto var = NodeMap::parse_node_id("ns=2;s=Broken");
+
+  source.add_child(root, make_child("ns=2;s=Broken", 2, "Broken", "Broken", opcua::NodeClass::Variable));
+  source.set_type(var, "Float");
+  source.set_unreadable(var);
+
+  AutoBrowseConfig cfg;
+  cfg.read_initial_values = true;
+  AutoBrowser browser_gated(source, cfg);
+  EXPECT_TRUE(browser_gated.browse().entries.empty());
+
+  cfg.read_initial_values = false;
+  AutoBrowser browser_ungated(source, cfg);
+  EXPECT_EQ(browser_ungated.browse().entries.size(), 1u);
+}
+
+// -- Depth cap -------------------------------------------------------------
+
+TEST(AutoBrowserTest, DepthCapStopsDescentAndIsReported) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+
+  // Chain: root -> L1 -> L2 -> L3 -> L4 (Variable at the end)
+  opcua::NodeId parent = root;
+  for (int i = 1; i <= 4; ++i) {
+    const std::string id = "ns=2;s=Level" + std::to_string(i);
+    const auto node_class = (i == 4) ? opcua::NodeClass::Variable : opcua::NodeClass::Object;
+    source.add_child(parent, make_child(id, 2, "Level" + std::to_string(i), "Level" + std::to_string(i), node_class));
+    parent = NodeMap::parse_node_id(id);
+    if (i < 4) {
+      source.set_type(parent, "");  // objects have no type; harmless
+    } else {
+      source.set_type(parent, "Float");
+    }
+  }
+
+  AutoBrowseConfig cfg;
+  cfg.max_depth = 2;  // root's children are depth 1; Level3 (depth 3) is already over budget
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_TRUE(result.entries.empty());
+  EXPECT_TRUE(result.depth_cap_hit);
+}
+
+TEST(AutoBrowserTest, DepthWithinBudgetIsNotReportedAsCapHit) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto obj = NodeMap::parse_node_id("ns=2;s=Obj");
+  const auto var = NodeMap::parse_node_id("ns=2;s=Obj.Var");
+  source.add_child(root, make_child("ns=2;s=Obj", 2, "Obj", "Obj", opcua::NodeClass::Object));
+  source.add_child(obj, make_child("ns=2;s=Obj.Var", 2, "Var", "Var", opcua::NodeClass::Variable));
+  source.set_type(var, "Int32");
+
+  AutoBrowseConfig cfg;
+  cfg.max_depth = 8;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_EQ(result.entries.size(), 1u);
+  EXPECT_FALSE(result.depth_cap_hit);
+}
+
+// -- Node cap ---------------------------------------------------------------
+
+TEST(AutoBrowserTest, NodeCapTruncatesWalkAndIsReported) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  for (int i = 0; i < 20; ++i) {
+    const std::string id = "ns=2;s=Var" + std::to_string(i);
+    source.add_child(
+        root, make_child(id, 2, "Var" + std::to_string(i), "Var" + std::to_string(i), opcua::NodeClass::Variable));
+    source.set_type(NodeMap::parse_node_id(id), "Int32");
+  }
+
+  AutoBrowseConfig cfg;
+  cfg.max_nodes = 5;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_LE(result.entries.size(), 5u);
+  EXPECT_TRUE(result.node_cap_hit);
+}
+
+// -- Namespace filtering -----------------------------------------------
+
+TEST(AutoBrowserTest, DefaultDenyListSkipsNamespaceZeroInfraNodes) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto server_obj = NodeMap::parse_node_id("i=2253");  // ns=0 Server object
+  const auto device_set = NodeMap::parse_node_id("ns=3;s=DeviceSet");
+  const auto plc_var = NodeMap::parse_node_id("ns=3;s=DeviceSet.Var");
+
+  // ns=0 "Server" child: must be skipped by the default deny={0} filter, so
+  // its own children (which would otherwise be a variable) never get visited.
+  source.add_child(root, make_child("i=2253", 0, "Server", "Server", opcua::NodeClass::Object));
+  source.add_child(server_obj,
+                   make_child("i=9999", 0, "ShouldNeverBeVisited", "ShouldNeverBeVisited", opcua::NodeClass::Variable));
+
+  // ns=3 (vendor/DI) "DeviceSet" child: allowed by default.
+  source.add_child(root, make_child("ns=3;s=DeviceSet", 3, "DeviceSet", "DeviceSet", opcua::NodeClass::Object));
+  source.add_child(device_set, make_child("ns=3;s=DeviceSet.Var", 3, "Var", "Var", opcua::NodeClass::Variable));
+  source.set_type(plc_var, "Int32");
+
+  AutoBrowseConfig cfg;  // default namespace_deny = {0}
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].node_id_str, plc_var.toString());
+  EXPECT_EQ(browser.namespace_allowed(0, cfg), false);
+  EXPECT_EQ(browser.namespace_allowed(3, cfg), true);
+}
+
+TEST(AutoBrowserTest, NamespaceAllowListOverridesDenyList) {
+  AutoBrowseConfig cfg;
+  cfg.namespace_allow = {3};
+  cfg.namespace_deny = {};  // irrelevant while allow-list is set
+  EXPECT_TRUE(AutoBrowser::namespace_allowed(3, cfg));
+  EXPECT_FALSE(AutoBrowser::namespace_allowed(0, cfg));
+  EXPECT_FALSE(AutoBrowser::namespace_allowed(4, cfg));
+}
+
+// -- Entity id / segment sanitization ------------------------------------
+
+TEST(AutoBrowserTest, SanitizeSegmentLowercasesAndReplacesInvalidChars) {
+  EXPECT_EQ(AutoBrowser::sanitize_segment("DB_Test"), "db_test");
+  EXPECT_EQ(AutoBrowser::sanitize_segment("Line-A"), "line-a");
+  EXPECT_EQ(AutoBrowser::sanitize_segment("Tag.With.Dots"), "tag_with_dots");
+  EXPECT_EQ(AutoBrowser::sanitize_segment("3Phase"), "_3phase");
+  EXPECT_EQ(AutoBrowser::sanitize_segment(""), "_unnamed");
+}
+
+TEST(AutoBrowserTest, JoinEntityIdEmptyFallsBackToRoot) {
+  EXPECT_EQ(AutoBrowser::join_entity_id({}), "root");
+  EXPECT_EQ(AutoBrowser::join_entity_id({"PLC_1", "DB_Test"}), "plc_1_db_test");
+}
+
+TEST(AutoBrowserTest, JoinDisplayNameEmptyFallsBackToRoot) {
+  EXPECT_EQ(AutoBrowser::join_display_name({}), "Root");
+  EXPECT_EQ(AutoBrowser::join_display_name({"PLC_1", "DB_Test"}), "PLC_1 / DB_Test");
+}
+
+TEST(AutoBrowserTest, CollidingSanitizedEntityIdsGetDeterministicSuffix) {
+  // "Line.A" (dot -> '_') and "Line_A" both sanitize to "line_a"; the second
+  // branch encountered must not silently merge into the first's data points.
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto branch_a = NodeMap::parse_node_id("ns=2;s=Line.A");
+  const auto branch_b = NodeMap::parse_node_id("ns=2;s=Line_A");
+  const auto var_a = NodeMap::parse_node_id("ns=2;s=Line.A.X");
+  const auto var_b = NodeMap::parse_node_id("ns=2;s=Line_A.X");
+
+  source.add_child(root, make_child("ns=2;s=Line.A", 2, "Line.A", "Line.A", opcua::NodeClass::Object));
+  source.add_child(root, make_child("ns=2;s=Line_A", 2, "Line_A", "Line_A", opcua::NodeClass::Object));
+  source.add_child(branch_a, make_child("ns=2;s=Line.A.X", 2, "X", "X", opcua::NodeClass::Variable));
+  source.add_child(branch_b, make_child("ns=2;s=Line_A.X", 2, "X", "X", opcua::NodeClass::Variable));
+  source.set_type(var_a, "Int32");
+  source.set_type(var_b, "Int32");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 2u);
+  std::unordered_set<std::string> entity_ids;
+  for (const auto & e : result.entries) {
+    entity_ids.insert(e.entity_id);
+  }
+  EXPECT_EQ(entity_ids.size(), 2u) << "colliding sanitized entity ids must be disambiguated, not merged";
+}
+
+// -- Multiple configured roots ----------------------------------------
+
+TEST(AutoBrowserTest, MultipleRootsAreAllWalked) {
+  FakeAutoBrowseSource source;
+  const auto root_a = NodeMap::parse_node_id("ns=2;s=RootA");
+  const auto root_b = NodeMap::parse_node_id("ns=2;s=RootB");
+  const auto var_a = NodeMap::parse_node_id("ns=2;s=RootA.V");
+  const auto var_b = NodeMap::parse_node_id("ns=2;s=RootB.V");
+
+  source.add_child(root_a, make_child("ns=2;s=RootA.V", 2, "V", "V", opcua::NodeClass::Variable));
+  source.add_child(root_b, make_child("ns=2;s=RootB.V", 2, "V", "V", opcua::NodeClass::Variable));
+  source.set_type(var_a, "Int32");
+  source.set_type(var_b, "Int32");
+
+  AutoBrowseConfig cfg;
+  cfg.root_node_ids = {"ns=2;s=RootA", "ns=2;s=RootB"};
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_EQ(result.entries.size(), 2u);
+}
+
+// -- node_map precedence (explicit config wins over auto_browse) --------
+
+TEST(NodeMapAutoBrowseMergeTest, ExplicitNodeMapEntryTakesPrecedenceOverAutoBrowsed) {
+  NodeMap node_map;
+  const std::string yaml_path = "/tmp/test_auto_browse_precedence.yaml";
+  {
+    std::ofstream f(yaml_path);
+    f << R"(
+component_id: test_plc
+auto_browse: true
+nodes:
+  - node_id: "ns=2;s=DB_Test.Level"
+    entity_id: hand_authored_entity
+    data_name: hand_authored_name
+    data_type: float
+    writable: true
+)";
+  }
+  ASSERT_TRUE(node_map.load(yaml_path));
+  EXPECT_TRUE(node_map.auto_browse());
+  ASSERT_EQ(node_map.entries().size(), 1u);
+
+  std::vector<NodeMapEntry> auto_entries;
+  NodeMapEntry collide;
+  collide.node_id_str = "ns=2;s=DB_Test.Level";  // same node as the explicit entry above
+  collide.node_id = NodeMap::parse_node_id(collide.node_id_str);
+  collide.entity_id = "auto_browsed_entity";
+  collide.data_name = "auto_browsed_name";
+  collide.data_type = "float";
+  auto_entries.push_back(collide);
+
+  NodeMapEntry new_one;
+  new_one.node_id_str = "ns=2;s=DB_Test.Running";
+  new_one.node_id = NodeMap::parse_node_id(new_one.node_id_str);
+  new_one.entity_id = "auto_browsed_entity";
+  new_one.data_name = "running";
+  new_one.data_type = "bool";
+  auto_entries.push_back(new_one);
+
+  const std::size_t added = node_map.merge_auto_browsed_entries(std::move(auto_entries));
+  EXPECT_EQ(added, 1u);  // only "Running" was added; "Level" was dropped (collision)
+  ASSERT_EQ(node_map.entries().size(), 2u);
+
+  const auto * level = node_map.find_by_node_id("ns=2;s=DB_Test.Level");
+  ASSERT_NE(level, nullptr);
+  EXPECT_EQ(level->entity_id, "hand_authored_entity");
+  EXPECT_EQ(level->data_name, "hand_authored_name");
+  EXPECT_TRUE(level->writable);
+
+  const auto * running = node_map.find_by_node_id("ns=2;s=DB_Test.Running");
+  ASSERT_NE(running, nullptr);
+  EXPECT_EQ(running->entity_id, "auto_browsed_entity");
+}
+
+TEST(NodeMapAutoBrowseMergeTest, AutoBrowseOnlyConfigWithNoNodesSectionIsValid) {
+  NodeMap node_map;
+  const std::string yaml_path = "/tmp/test_auto_browse_only.yaml";
+  {
+    std::ofstream f(yaml_path);
+    f << R"(
+component_id: test_plc
+auto_browse:
+  max_depth: 5
+  max_nodes: 1000
+  namespace_deny: [0]
+  read_initial_values: false
+)";
+  }
+  ASSERT_TRUE(node_map.load(yaml_path));
+  EXPECT_TRUE(node_map.auto_browse());
+  EXPECT_EQ(node_map.auto_browse_config().max_depth, 5);
+  EXPECT_EQ(node_map.auto_browse_config().max_nodes, 1000u);
+  EXPECT_FALSE(node_map.auto_browse_config().read_initial_values);
+  EXPECT_TRUE(node_map.entries().empty());
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
@@ -411,6 +411,83 @@ TEST(AutoBrowserTest, CollidingSanitizedEntityIdsGetDeterministicSuffix) {
   EXPECT_EQ(entity_ids.size(), 2u) << "colliding sanitized entity ids must be disambiguated, not merged";
 }
 
+// -- ROS 2 topic safety (hyphens) --------------------------------------
+
+TEST(AutoBrowserTest, HyphenatedNamesYieldValidRos2TopicButKeepSovdHyphen) {
+  // '-' is valid in a SOVD id but illegal in a ROS 2 topic token. Common PLC
+  // tags like "Line-A" / "Flow-Rate" must still produce a valid /plc topic.
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto line = NodeMap::parse_node_id("ns=2;s=Line-A");
+  const auto flow = NodeMap::parse_node_id("ns=2;s=Line-A.Flow-Rate");
+  source.add_child(root, make_child("ns=2;s=Line-A", 2, "Line-A", "Line-A", opcua::NodeClass::Object));
+  source.add_child(line,
+                   make_child("ns=2;s=Line-A.Flow-Rate", 2, "Flow-Rate", "Flow-Rate", opcua::NodeClass::Variable));
+  source.set_type(flow, "Float");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 1u);
+  const auto & e = result.entries[0];
+  // SOVD id / data_name keep the hyphen ...
+  EXPECT_EQ(e.entity_id, "line-a");
+  EXPECT_EQ(e.data_name, "flow-rate");
+  // ... but the ROS 2 topic must be a valid name (no '-').
+  EXPECT_EQ(e.ros2_topic, "/plc/line_a/flow_rate");
+}
+
+// -- Cyclic / shared subtree guard (visited-NodeId set) -----------------
+
+TEST(AutoBrowserTest, CyclicHierarchyIsWalkedOnceAndTerminates) {
+  // root -> A (Object, owns a Variable) -> B (Object) -> back to A (cycle via a
+  // HierarchicalReference). Without a visited set the walk would re-descend A
+  // until the node cap trips; with it, each Object is entered exactly once.
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto a = NodeMap::parse_node_id("ns=2;s=A");
+  const auto b = NodeMap::parse_node_id("ns=2;s=B");
+  const auto var = NodeMap::parse_node_id("ns=2;s=A.V");
+  source.add_child(root, make_child("ns=2;s=A", 2, "A", "A", opcua::NodeClass::Object));
+  source.add_child(a, make_child("ns=2;s=A.V", 2, "V", "V", opcua::NodeClass::Variable));
+  source.add_child(a, make_child("ns=2;s=B", 2, "B", "B", opcua::NodeClass::Object));
+  source.add_child(b, make_child("ns=2;s=A", 2, "A", "A", opcua::NodeClass::Object));  // B -> A back-edge
+  source.set_type(var, "Int32");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  EXPECT_FALSE(result.node_cap_hit);
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].entity_id, "a");
+  // browse_children entered once each for root, A, B - never A twice.
+  EXPECT_EQ(source.browse_calls, 3);
+}
+
+// -- Human-readable entity display name (join_display_name in the walk) --
+
+TEST(AutoBrowserTest, AttachesHumanReadableEntityDisplayNamePath) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto plc1 = NodeMap::parse_node_id("ns=2;s=PLC_1");
+  const auto db_test = NodeMap::parse_node_id("ns=2;s=DB_Test");
+  const auto level = NodeMap::parse_node_id("ns=2;s=DB_Test.Level");
+  source.add_child(root, make_child("ns=2;s=PLC_1", 2, "PLC_1", "PLC_1", opcua::NodeClass::Object));
+  source.add_child(plc1, make_child("ns=2;s=DB_Test", 2, "DB_Test", "DB_Test", opcua::NodeClass::Object));
+  source.add_child(db_test, make_child("ns=2;s=DB_Test.Level", 2, "Level", "Level", opcua::NodeClass::Variable));
+  source.set_type(level, "Float");
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_EQ(result.entries[0].entity_id, "plc_1_db_test");
+  EXPECT_EQ(result.entries[0].entity_display_name, "PLC_1 / DB_Test");
+}
+
 // -- Multiple configured roots ----------------------------------------
 
 TEST(AutoBrowserTest, MultipleRootsAreAllWalked) {
@@ -499,6 +576,26 @@ auto_browse:
   EXPECT_EQ(node_map.auto_browse_config().max_nodes, 1000u);
   EXPECT_FALSE(node_map.auto_browse_config().read_initial_values);
   EXPECT_TRUE(node_map.entries().empty());
+}
+
+TEST(NodeMapAutoBrowseMergeTest, EntityDefNameUsesAutoBrowsedDisplayNamePath) {
+  // An auto-browsed entry carries the raw DisplayName path; build_entity_defs
+  // must surface it as the entity name instead of title-casing the slug.
+  NodeMap node_map;
+  std::vector<NodeMapEntry> auto_entries;
+  NodeMapEntry entry;
+  entry.node_id_str = "ns=2;s=DB_Test.Level";
+  entry.node_id = NodeMap::parse_node_id(entry.node_id_str);
+  entry.entity_id = "plc_1_db_test";
+  entry.entity_display_name = "PLC_1 / DB_Test";
+  entry.data_name = "level";
+  entry.data_type = "float";
+  auto_entries.push_back(entry);
+
+  ASSERT_EQ(node_map.merge_auto_browsed_entries(std::move(auto_entries)), 1u);
+  ASSERT_EQ(node_map.entity_defs().size(), 1u);
+  EXPECT_EQ(node_map.entity_defs()[0].id, "plc_1_db_test");
+  EXPECT_EQ(node_map.entity_defs()[0].name, "PLC_1 / DB_Test");
 }
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
@@ -22,6 +22,9 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <atomic>
+#include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <string>
@@ -29,9 +32,39 @@
 #include <unordered_set>
 #include <vector>
 
+#include <unistd.h>
+
 namespace ros2_medkit_gateway {
 
 namespace {
+
+// RAII-scoped YAML fixture written to a unique path under the system temp
+// dir (PID + per-process counter, so two test binaries - or two tests in the
+// same binary - never collide on the same file), removed on scope exit.
+class TempYamlFile {
+ public:
+  explicit TempYamlFile(const std::string & contents) {
+    static std::atomic<int> counter{0};
+    path_ = (std::filesystem::temp_directory_path() / ("ros2_medkit_opcua_test_" + std::to_string(::getpid()) + "_" +
+                                                       std::to_string(counter.fetch_add(1)) + ".yaml"))
+                .string();
+    std::ofstream f(path_);
+    f << contents;
+  }
+  ~TempYamlFile() {
+    std::error_code ec;
+    std::filesystem::remove(path_, ec);
+  }
+  TempYamlFile(const TempYamlFile &) = delete;
+  TempYamlFile & operator=(const TempYamlFile &) = delete;
+
+  const std::string & path() const {
+    return path_;
+  }
+
+ private:
+  std::string path_;
+};
 
 OpcuaClient::BrowseChild make_child(const std::string & node_id_str, uint16_t bn_ns, const std::string & browse_name,
                                     const std::string & display_name, opcua::NodeClass node_class) {
@@ -404,10 +437,7 @@ TEST(AutoBrowserTest, MultipleRootsAreAllWalked) {
 
 TEST(NodeMapAutoBrowseMergeTest, ExplicitNodeMapEntryTakesPrecedenceOverAutoBrowsed) {
   NodeMap node_map;
-  const std::string yaml_path = "/tmp/test_auto_browse_precedence.yaml";
-  {
-    std::ofstream f(yaml_path);
-    f << R"(
+  const TempYamlFile yaml_file(R"(
 component_id: test_plc
 auto_browse: true
 nodes:
@@ -416,9 +446,8 @@ nodes:
     data_name: hand_authored_name
     data_type: float
     writable: true
-)";
-  }
-  ASSERT_TRUE(node_map.load(yaml_path));
+)");
+  ASSERT_TRUE(node_map.load(yaml_file.path()));
   EXPECT_TRUE(node_map.auto_browse());
   ASSERT_EQ(node_map.entries().size(), 1u);
 
@@ -456,19 +485,15 @@ nodes:
 
 TEST(NodeMapAutoBrowseMergeTest, AutoBrowseOnlyConfigWithNoNodesSectionIsValid) {
   NodeMap node_map;
-  const std::string yaml_path = "/tmp/test_auto_browse_only.yaml";
-  {
-    std::ofstream f(yaml_path);
-    f << R"(
+  const TempYamlFile yaml_file(R"(
 component_id: test_plc
 auto_browse:
   max_depth: 5
   max_nodes: 1000
   namespace_deny: [0]
   read_initial_values: false
-)";
-  }
-  ASSERT_TRUE(node_map.load(yaml_path));
+)");
+  ASSERT_TRUE(node_map.load(yaml_file.path()));
   EXPECT_TRUE(node_map.auto_browse());
   EXPECT_EQ(node_map.auto_browse_config().max_depth, 5);
   EXPECT_EQ(node_map.auto_browse_config().max_nodes, 1000u);


### PR DESCRIPTION
Closes #513

## Summary

Implements real recursive `auto_browse` for the OPC-UA plugin: given a connected endpoint, walk the address space and build the SOVD tree (components + data points) with no hand-written node_map. The `auto_browse` flag was parsed but unused (no-op) - now it works. Composes with the discovery PR (#509): discovered endpoint + `auto_browse` => full tree, zero config.

## What's included

- **`AutoBrowser`** (`address_space_browser.{hpp,cpp}`): recursive walker over an injectable `AutoBrowseSource` (testable with no server). Object nodes -> SOVD entities (only once they own a supported Variable; pure folders are walked through), Variables -> data points with DataType inferred to bool/int/float/string; hierarchy preserved via entity-id paths.
- **`OpcuaClient`**: `browse_detailed()` (Object|Variable filter, BrowseNext handled) + `read_variable_type_name()`. Fixes a real bug: `variant_to_value()` had no `DateTime` case (always `<unsupported type>`) -> now ISO-8601 UTC.
- **`NodeMap`**: `AutoBrowseConfig` (root_nodes default `[i=85]`, max_depth 8, max_nodes 5000, namespace allow/deny default deny `[0]`, read_initial_values) from the node-map `auto_browse:` block or `plugins.opcua.auto_browse` param; explicit `nodes:` win on collision.
- **`OpcuaPlugin`**: runs the walk once after connect, publishers created after so discovered points get topics.

## Safety

Read-only; every auto-browsed point is `writable: false`; depth/node caps with warn-on-truncation.

## Tests

`test_address_space_browser` + `NodeMapAutoBrowseMergeTest` (hierarchy, type inference, depth/node caps, ns filtering, id collision, precedence); full suite green; `clang-format-18` clean; unique test domain.

## Hardware-tested

Real Siemens S7-1500 (`opc.tcp://192.168.1.10:4840`, Anonymous), NO node_map file, only `plugins.opcua.auto_browse: true`: walked 110 nodes -> 17 data points across 5 entities (Software PLC_1 nameplate with live values, DB_Test `trigger`/`level`/`trigger2`, RTG1SysInfo, FB_Alarm pa/pa2).

