### PR TITLE
fix(opcua): thread-safety fix for the REST/poll fault-buffer race

### DIFF
--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -256,8 +256,17 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   // ClearFault are fire-and-forget, so a report sent before the fault_manager
   // service is DDS-matched is dropped. Instead of blocking startup for the sink,
   // buffer the dispatch (preserving report-then-clear order) and flush it on the
-  // next poll once the service is ready. Poll-thread only (send_report_fault /
-  // send_clear_fault via on_alarm_change, flush via the poll callback), no lock.
+  // next poll once the service is ready.
+  //
+  // Accessed from TWO threads: the poll thread (on_alarm_change / on_event_alarm
+  // -> send_*_fault -> send_or_buffer, and publish_values -> flush_pending_reports)
+  // AND the REST thread (the FaultProvider::clear_fault route override ->
+  // send_clear_fault -> send_or_buffer). A push_back that reallocates the vector
+  // while the other thread iterates/reads it is a use-after-free that corrupts the
+  // heap, so every access is serialised by pending_reports_mutex_. The mutex is
+  // never held across the actual dispatch (async_send_request) to keep ROS I/O out
+  // of the critical section.
+  std::mutex pending_reports_mutex_;
   std::vector<std::function<void()>> pending_reports_;
 
   // Tracks which non-numeric nodes have already been warned about (avoids log spam).

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -1196,24 +1196,46 @@ void OpcuaPlugin::send_clear_fault(const std::string & fault_code) {
 void OpcuaPlugin::send_or_buffer(std::function<void()> dispatch) {
   // Bound the buffer so a deployment with no fault_manager cannot grow it
   // without limit; drop the oldest (least relevant) pending dispatch.
+  // Runs on both the poll thread and the REST clear_fault thread, so the vector
+  // mutation is serialised by pending_reports_mutex_.
   constexpr size_t kMaxPendingReports = 256;
-  if (pending_reports_.size() >= kMaxPendingReports) {
-    pending_reports_.erase(pending_reports_.begin());
+  bool dropped_oldest = false;
+  {
+    std::lock_guard<std::mutex> lock(pending_reports_mutex_);
+    if (pending_reports_.size() >= kMaxPendingReports) {
+      pending_reports_.erase(pending_reports_.begin());
+      dropped_oldest = true;
+    }
+    pending_reports_.push_back(std::move(dispatch));
+  }
+  if (dropped_oldest) {
     log_warn("pending fault report buffer full (" + std::to_string(kMaxPendingReports) + "), dropping oldest");
   }
-  pending_reports_.push_back(std::move(dispatch));
   // Drains immediately (in order) if the sink is already matched.
   flush_pending_reports();
 }
 
 void OpcuaPlugin::flush_pending_reports() {
-  if (pending_reports_.empty() || !fault_clients_->report || !fault_clients_->report->service_is_ready()) {
+  // Keep the reports buffered until the sink is discoverable (checked outside the
+  // lock; rclcpp client state is thread-safe).
+  if (!fault_clients_->report || !fault_clients_->report->service_is_ready()) {
     return;
   }
-  for (auto & dispatch : pending_reports_) {
+  // Move the ready batch out under the lock, then dispatch it OUTSIDE the lock so
+  // the vector is never being reallocated by a concurrent send_or_buffer while it
+  // is iterated here (the use-after-free that corrupted the heap), and so the ROS
+  // service call never runs under the mutex.
+  std::vector<std::function<void()>> batch;
+  {
+    std::lock_guard<std::mutex> lock(pending_reports_mutex_);
+    if (pending_reports_.empty()) {
+      return;
+    }
+    batch.swap(pending_reports_);
+  }
+  for (auto & dispatch : batch) {
     dispatch();
   }
-  pending_reports_.clear();
 }
 
 void OpcuaPlugin::create_value_publishers() {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -729,6 +729,25 @@ class RealNodePluginContext : public FakePluginContext {
   rclcpp::Node * node_;
 };
 
+// RAII: pair rclcpp init with a shutdown so global ROS state never leaks into
+// the rest of the process, even if an assertion returns from the test early.
+// Only tears down the init this guard performed.
+struct ScopedRclcpp {
+  const bool owned_;
+  ScopedRclcpp() : owned_(!rclcpp::ok()) {
+    if (owned_) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  ~ScopedRclcpp() {
+    if (owned_ && rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+  ScopedRclcpp(const ScopedRclcpp &) = delete;
+  ScopedRclcpp & operator=(const ScopedRclcpp &) = delete;
+};
+
 // The SOVD DELETE /faults/{code} route lands on FaultProvider::clear_fault(),
 // which buffers a dispatch into pending_reports_ - the SAME vector the poll
 // thread drains in publish_values()/flush_pending_reports(). Before the fix the
@@ -738,9 +757,7 @@ class RealNodePluginContext : public FakePluginContext {
 // test drives that exact path from several threads; it must complete without a
 // crash and is clean under ThreadSanitizer.
 TEST(OpcuaPluginConcurrency, ClearFaultBufferIsThreadSafe) {
-  if (!rclcpp::ok()) {
-    rclcpp::init(0, nullptr);
-  }
+  ScopedRclcpp rclcpp_scope;
   auto node = std::make_shared<rclcpp::Node>("opcua_pending_reports_regression");
 
   const std::string yaml_path = "/tmp/test_opcua_race_nodemap.yaml";

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -22,11 +22,14 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdio>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -705,6 +708,89 @@ auto_alarms:
   EXPECT_FALSE(cfg.auto_clear);                     // param won
   EXPECT_EQ(cfg.entity_id, "yaml_entity");          // untouched by param -> YAML value survives
   std::remove(path.c_str());
+}
+
+// -- Thread-safety regression: pending_reports_ ------------------------------
+
+// A PluginContext that hands the plugin a real rclcpp::Node so set_context()
+// creates the ReportFault / ClearFault service clients. With a null node (the
+// default FakePluginContext) send_clear_fault() short-circuits before touching
+// the pending-reports buffer, so the race below can only be reproduced with a
+// live node.
+class RealNodePluginContext : public FakePluginContext {
+ public:
+  explicit RealNodePluginContext(rclcpp::Node * node) : node_(node) {
+  }
+  rclcpp::Node * node() const override {
+    return node_;
+  }
+
+ private:
+  rclcpp::Node * node_;
+};
+
+// The SOVD DELETE /faults/{code} route lands on FaultProvider::clear_fault(),
+// which buffers a dispatch into pending_reports_ - the SAME vector the poll
+// thread drains in publish_values()/flush_pending_reports(). Before the fix the
+// buffer had no lock, so concurrent clear_fault() calls (REST worker threads)
+// reallocating the vector while another thread iterated it corrupted the heap
+// (the crash observed in libros2_medkit_opcua_plugin.so under UI load). This
+// test drives that exact path from several threads; it must complete without a
+// crash and is clean under ThreadSanitizer.
+TEST(OpcuaPluginConcurrency, ClearFaultBufferIsThreadSafe) {
+  if (!rclcpp::ok()) {
+    rclcpp::init(0, nullptr);
+  }
+  auto node = std::make_shared<rclcpp::Node>("opcua_pending_reports_regression");
+
+  const std::string yaml_path = "/tmp/test_opcua_race_nodemap.yaml";
+  {
+    std::ofstream f(yaml_path);
+    f << R"(
+area_id: race_plc
+component_id: race_runtime
+nodes:
+  - node_id: "ns=2;i=1"
+    entity_id: tank
+    data_name: level
+    data_type: float
+)";
+  }
+
+  OpcuaPlugin plugin;
+  nlohmann::json config;
+  config["node_map_path"] = yaml_path;
+  // Nothing listening: connect fails fast (ECONNREFUSED) and the poll thread
+  // keeps retrying in the background while it drains the buffer each cycle.
+  config["endpoint_url"] = "opc.tcp://127.0.0.1:1";
+  config["poll_interval_ms"] = 100;
+  plugin.configure(config);
+
+  RealNodePluginContext ctx(node.get());
+  ctx.entities["tank"] = {SovdEntityType::APP, "tank", "/race_plc", "/race_plc/race_runtime/tank"};
+  plugin.set_context(ctx);
+
+  std::atomic<bool> stop{false};
+  std::vector<std::thread> threads;
+  for (int t = 0; t < 6; ++t) {
+    threads.emplace_back([&plugin, &stop, t] {
+      int i = 0;
+      while (!stop.load(std::memory_order_relaxed)) {
+        // No fault_manager is running, so service_is_ready() stays false and the
+        // dispatches accumulate/evict in pending_reports_ - maximising buffer churn.
+        plugin.clear_fault("tank", "RACE_" + std::to_string(t) + "_" + std::to_string(i++ & 0x3f));
+      }
+    });
+  }
+
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  stop.store(true, std::memory_order_relaxed);
+  for (auto & th : threads) {
+    th.join();
+  }
+
+  plugin.shutdown();
+  SUCCEED();
 }
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -33,6 +33,10 @@
 #include <unordered_map>
 #include <vector>
 
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/srv/clear_fault.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/plugins/ros_plugin_context.hpp"
 
@@ -748,17 +752,72 @@ struct ScopedRclcpp {
   ScopedRclcpp & operator=(const ScopedRclcpp &) = delete;
 };
 
+// RAII: owns the executor and its spin thread so cleanup cannot be skipped by an
+// early ASSERT return. stop() is called explicitly before the plugin/nodes are
+// torn down so no entity is destroyed while the executor is still spinning it.
+struct ScopedExecutorSpin {
+  rclcpp::executors::MultiThreadedExecutor executor;
+  std::thread thread;
+  explicit ScopedExecutorSpin(const std::vector<rclcpp::Node::SharedPtr> & nodes) {
+    for (const auto & node : nodes) {
+      executor.add_node(node);
+    }
+    thread = std::thread([this] {
+      executor.spin();
+    });
+  }
+  void stop() {
+    executor.cancel();
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+  ~ScopedExecutorSpin() {
+    stop();
+  }
+  ScopedExecutorSpin(const ScopedExecutorSpin &) = delete;
+  ScopedExecutorSpin & operator=(const ScopedExecutorSpin &) = delete;
+};
+
 // The SOVD DELETE /faults/{code} route lands on FaultProvider::clear_fault(),
 // which buffers a dispatch into pending_reports_ - the SAME vector the poll
 // thread drains in publish_values()/flush_pending_reports(). Before the fix the
-// buffer had no lock, so concurrent clear_fault() calls (REST worker threads)
-// reallocating the vector while another thread iterated it corrupted the heap
-// (the crash observed in libros2_medkit_opcua_plugin.so under UI load). This
-// test drives that exact path from several threads; it must complete without a
-// crash and is clean under ThreadSanitizer.
+// buffer had no lock, so a push_back that reallocated the vector while another
+// thread iterated/swapped it corrupted the heap (the crash observed in
+// libros2_medkit_opcua_plugin.so under UI load).
+//
+// The buffer has two locked paths that must BOTH be raced: the push_back/erase
+// in send_or_buffer() and the batch.swap(pending_reports_) drain in
+// flush_pending_reports(). The drain only runs once report->service_is_ready()
+// is true, so the test stands up a real ReportFault/ClearFault server (a stub
+// fault_manager) to open that gate; only then does every clear_fault() both push
+// into the buffer AND swap it out under concurrent pushes from the other worker
+// threads. It must complete without heap corruption and is clean under
+// ThreadSanitizer - the DDS/rclcpp machinery it drives is covered by
+// tsan_suppressions.txt, the same paths the gateway service tests exercise.
 TEST(OpcuaPluginConcurrency, ClearFaultBufferIsThreadSafe) {
   ScopedRclcpp rclcpp_scope;
   auto node = std::make_shared<rclcpp::Node>("opcua_pending_reports_regression");
+
+  // Stub fault_manager on a second node. ReportFault existing is what flips the
+  // plugin's report client to ready so flush_pending_reports() gets past its
+  // early return; ClearFault counts the flushed dispatches so the test can prove
+  // the drain (swap) path actually ran - a guard against the sink silently never
+  // matching, which would drop coverage back to push-only.
+  auto fault_manager = std::make_shared<rclcpp::Node>("opcua_pending_reports_faultmgr");
+  std::atomic<int> cleared_received{0};
+  auto report_srv = fault_manager->create_service<ros2_medkit_msgs::srv::ReportFault>(
+      "/fault_manager/report_fault", [](const std::shared_ptr<ros2_medkit_msgs::srv::ReportFault::Request>,
+                                        std::shared_ptr<ros2_medkit_msgs::srv::ReportFault::Response> res) {
+        res->accepted = true;
+      });
+  auto clear_srv = fault_manager->create_service<ros2_medkit_msgs::srv::ClearFault>(
+      "/fault_manager/clear_fault",
+      [&cleared_received](const std::shared_ptr<ros2_medkit_msgs::srv::ClearFault::Request>,
+                          std::shared_ptr<ros2_medkit_msgs::srv::ClearFault::Response> res) {
+        cleared_received.fetch_add(1, std::memory_order_relaxed);
+        res->success = true;
+      });
 
   const std::string yaml_path = "/tmp/test_opcua_race_nodemap.yaml";
   {
@@ -777,8 +836,9 @@ nodes:
   OpcuaPlugin plugin;
   nlohmann::json config;
   config["node_map_path"] = yaml_path;
-  // Nothing listening: connect fails fast (ECONNREFUSED) and the poll thread
-  // keeps retrying in the background while it drains the buffer each cycle.
+  // Nothing listening on the OPC-UA side: connect fails fast (ECONNREFUSED) and
+  // the poll thread keeps retrying in the background. The fault sink above, not
+  // the (dead) endpoint, is what drives the drain path.
   config["endpoint_url"] = "opc.tcp://127.0.0.1:1";
   config["poll_interval_ms"] = 100;
   plugin.configure(config);
@@ -787,14 +847,31 @@ nodes:
   ctx.entities["tank"] = {SovdEntityType::APP, "tank", "/race_plc", "/race_plc/race_runtime/tank"};
   plugin.set_context(ctx);
 
+  // Executor spins the plugin node and the stub fault_manager so requests flow
+  // and the sink is discoverable; added after set_context() so it picks up the
+  // clients the plugin just created.
+  ScopedExecutorSpin spinner({node, fault_manager});
+
+  // Wait until the stub server is discoverable. A probe client on the SAME node
+  // stands in for the plugin's (private) report client; service_is_ready() reads
+  // the RMW graph directly, so it flips without racing the spinning executor's
+  // wait set.
+  auto probe = node->create_client<ros2_medkit_msgs::srv::ReportFault>("/fault_manager/report_fault");
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (!probe->service_is_ready() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_TRUE(probe->service_is_ready()) << "stub ReportFault server never became discoverable";
+
   std::atomic<bool> stop{false};
   std::vector<std::thread> threads;
   for (int t = 0; t < 6; ++t) {
     threads.emplace_back([&plugin, &stop, t] {
       int i = 0;
       while (!stop.load(std::memory_order_relaxed)) {
-        // No fault_manager is running, so service_is_ready() stays false and the
-        // dispatches accumulate/evict in pending_reports_ - maximising buffer churn.
+        // Sink is ready, so each call pushes into pending_reports_ AND drains it
+        // via flush_pending_reports() -> batch.swap(): worker threads race
+        // push_back against swap on the shared buffer.
         plugin.clear_fault("tank", "RACE_" + std::to_string(t) + "_" + std::to_string(i++ & 0x3f));
       }
     });
@@ -806,8 +883,15 @@ nodes:
     th.join();
   }
 
+  // Stop the executor before any node/client is destroyed to avoid a teardown
+  // race between the spin thread and entity destruction.
+  spinner.stop();
   plugin.shutdown();
-  SUCCEED();
+
+  // Proves the drain path was actually exercised (not silently skipped by an
+  // unmatched sink): the buffer was swapped out and dispatched to the server.
+  EXPECT_GT(cleared_received.load(std::memory_order_relaxed), 0)
+      << "flush_pending_reports never dispatched - swap-vs-push path not covered";
 }
 
 }  // namespace ros2_medkit_gateway


### PR DESCRIPTION
## Problem
Under UI load the OPC-UA gateway crashed with heap-corruption signatures (GPF /
SIGILL / bad-pointer segfault) inside `libros2_medkit_opcua_plugin.so`. Root
cause is a data race on `pending_reports_`, the fire-and-forget fault
report/clear buffer: it is mutated by the poll thread (`publish_values`,
`on_alarm_change`/`on_event_alarm`) AND by the REST thread
(`FaultProvider::clear_fault` -> `send_clear_fault` -> `send_or_buffer`) with no
lock. A `push_back` that reallocates the vector while the other thread iterates
it is a use-after-free that corrupts the heap.

## Fix
Guard every access with a mutex. `flush_pending_reports` swaps the ready batch
out under the lock and dispatches it outside, so the vector is never reallocated
mid-iteration and the ROS service call never runs under the lock.

## Test
`OpcuaPluginConcurrency.ClearFaultBufferIsThreadSafe`: six threads drive the
REST `clear_fault` path against the running poll thread. It segfaults on the
unsynchronized code (verified) and passes with the fix. Full unit suite green.
