### PR TITLE
test(gateway): fix flaky external-app fault rollup test (report_fault reply race)

### DIFF
--- a/src/ros2_medkit_integration_tests/test/features/test_external_app_fault_rollup.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_external_app_fault_rollup.test.py
@@ -105,6 +105,17 @@ class TestExternalAppFaultRollup(GatewayTestCase):
     def _report_fault(self, times=4):
         """Report the external app's fault under its bare entity id.
 
+        Fire-and-forget, exactly like the production ``fault_reporter`` client
+        (``async_send_request`` with the reply discarded). We deliberately do
+        NOT wait on or assert the service reply: ``wait_for_service`` only
+        confirms the *request* path (client->server) is discovery-matched, not
+        the *reply* path (server->client), so an early round-trip can lose its
+        response even though the fault_manager already recorded the fault
+        ("failed to send response ... client will not receive response").
+        Asserting on that reply made this test flaky under the sanitizer builds'
+        slower discovery. The behavioural assertion is the HTTP rollup poll in
+        the test body, which retries for up to 30s and absorbs that timing.
+
         Reported several times so the negative ``confirmation_threshold``
         latches the fault to CONFIRMED regardless of debounce timing.
         """
@@ -115,16 +126,11 @@ class TestExternalAppFaultRollup(GatewayTestCase):
             req.severity = Fault.SEVERITY_ERROR
             req.description = 'PLC tank level exceeded high limit'
             req.source_id = EXTERNAL_APP
-            future = self._report_client.call_async(req)
-            rclpy.spin_until_future_complete(
-                self._reporter, future, timeout_sec=5.0
-            )
-            self.assertIsNotNone(
-                future.result(), 'report_fault call timed out'
-            )
-            self.assertTrue(
-                future.result().accepted, 'fault_manager rejected the report'
-            )
+            # Fire-and-forget: the request is sent synchronously by call_async;
+            # spin briefly to flush and pace the reports for the debounce, and
+            # intentionally drop the reply future (see docstring).
+            self._report_client.call_async(req)
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
 
     def test_external_app_fault_appears_on_every_rollup(self):
         """The external app's fault surfaces on app, component, function, area.


### PR DESCRIPTION
## Summary

`test_external_app_fault_rollup` reported faults through the `report_fault` service and hard-asserted on the reply. `wait_for_service` only confirms the request path (client to server) is discovery-matched. It does not confirm the reply path (server to client). So an early round-trip can lose its response even though the fault_manager already recorded the fault:

```
[fault_manager] New fault reported: PLC_LEVEL_OVERFLOW
[fault_manager.rclcpp] failed to send response to /fault_manager/report_fault (timeout): client will not receive response
```

Under the sanitizer builds' slower discovery that dropped reply made the assertion fail, so the test was flaky (seen in the TSan job).

The fix reports fire-and-forget, like the production `fault_reporter` client (`async_send_request` with the reply discarded), and relies on the existing HTTP `wait_for_fault` poll (retries for 30s) as the behavioural assertion. The reply is no longer on the critical path.

---

## Issue

- closes #524

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Built `colcon build --packages-up-to ros2_medkit_integration_tests` and ran `test_external_app_fault_rollup` locally 5 times, all green. Both cases pass every run: the rollup test (`test_external_app_fault_appears_on_every_rollup`) and the post-shutdown exit-code check, 0 failures and 0 errors.

The behaviour under test is unchanged: the fault is reported under the bare external-app id and must surface on the app route and every rollup route (component, function, area). Only the way the report is sent changed (fire-and-forget instead of waiting on the reply), which removes the reply-path race that failed under TSan.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed) - no breaking change
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed - test-only change, no public API or docs affected
