### PR TITLE
Fault scope: external Component owns its fault_manager faults (#516)

### DIFF
--- a/docs/config/discovery-options.rst
+++ b/docs/config/discovery-options.rst
@@ -188,6 +188,12 @@ Each layer declares a policy per field-group:
    plugin's ``external: true``. Only omission is a no-op; an explicit value is
    never silently discarded.
 
+   The same tri-state field and merge priority apply to Components: an
+   external Component with no bound child Apps owns its fault-scope by entity
+   id, so an Area or Function hosting it rolls up its faults without a
+   synthetic child App. Components have no ``ros_binding``, so there is no
+   equivalent to the App's R013 contradiction check.
+
 Override per-layer policies in ``gateway_params.yaml``. Empty string means
 "use layer default". Policy values are **case-sensitive** and must be lowercase
 (``authoritative``, ``enrichment``, ``fallback``):

--- a/docs/config/manifest-schema.rst
+++ b/docs/config/manifest-schema.rst
@@ -429,6 +429,7 @@ Schema
        parent_component_id: string # Optional - parent component ID
        depends_on: [string]       # Optional - component IDs this asset depends on
        tags: [string]             # Optional - tags for filtering
+       external: boolean          # Optional - non-ROS external asset (default: false)
        any_other_key: string      # Kept verbatim as an identity extra
 
 Fields
@@ -439,6 +440,11 @@ The identity keys accept the same aliases as the CSV import:
 ``hardware_rev``, and ``firmware_version`` / ``fw`` for ``firmware``. Aliased
 keys land on the typed identity fields, not in the extras. Any scalar key not
 listed above is preserved as an identity extra.
+
+``external`` classifies the asset as a non-ROS device, the same tri-state field
+as on a ``components:`` entry. An external asset with no bound child apps owns
+its fault scope by its own entity id. It is a recognized key, so it classifies
+the Component instead of being kept as an identity extra.
 
 Placement is optional: without ``area`` (and ``namespace``) the asset is
 reachable at ``/components/{id}`` and in the flat component list, but does not

--- a/docs/config/manifest-schema.rst
+++ b/docs/config/manifest-schema.rst
@@ -236,6 +236,7 @@ Schema
        parent_component_id: string  # Optional - parent component
        depends_on: [string]    # Optional - component IDs this depends on
        subcomponents: []       # Optional - nested definitions
+       external: boolean       # Optional - non-ROS external asset (default: false)
 
        identity:               # Optional - asset-identity nameplate
          manufacturer: string        # Vendor / manufacturer name
@@ -321,6 +322,17 @@ Fields
      - [Component]
      - No
      - Nested component definitions
+   * - ``external``
+     - boolean
+     - No
+     - True if the component is a non-ROS external asset (PLC, fieldbus device,
+       any asset a protocol plugin bridges into SOVD). Tri-state: **omitting**
+       ``external:`` leaves it unset, so in hybrid mode it does not clear an
+       ``external`` classification contributed by another discovery layer (e.g. a
+       protocol plugin). An **explicit** value is authoritative and resolves by
+       normal layer priority. An external component with no bound child apps owns
+       its fault_manager faults under its own entity id, so a Function or Area
+       hosting it rolls up its faults without a synthetic child app (#516).
    * - ``identity``
      - object
      - No
@@ -376,6 +388,11 @@ Example
        name: "IMU Sensor"
        type: "sensor"
        area: perception
+
+     # External device component (not a ROS node); owns its faults by entity id
+     - id: line-plc
+       name: "Line PLC"
+       external: true
 
 Assets
 ------

--- a/src/ros2_medkit_gateway/config/examples/external_component_fault_manifest.yaml
+++ b/src/ros2_medkit_gateway/config/examples/external_component_fault_manifest.yaml
@@ -1,0 +1,71 @@
+# Copyright 2026 bburda
+#
+# SOVD manifest fixture for #516: an external Component (a PLC bridged into SOVD
+# by a protocol plugin) owns its fault_manager faults with NO child App located
+# on it. Mirrors the #517 external-App fixture but at the Component level. Also
+# carries AAS-Nameplate identity to confirm identity is orthogonal to the
+# external classification, and an internal (ROS) Component as the guardrail.
+#
+# `plc-diag` is a separate external App used only to pin App external wire
+# parity (test_external_flag_and_identity_on_the_wire) - it is deliberately NOT
+# `is_located_on: s7-plc`. Locating it on the Component would give
+# `s7-plc` a contributing child app, and per the fault-scope rule
+# (ResolveEntitySourceFqnsTest.ExternalComponentWithContributingAppKeepsAppScope)
+# the component's fault scope would then resolve to the app's id/FQN instead of
+# falling back to the component's own bare id
+# (ResolveEntitySourceFqnsTest.ExternalComponentWithNoAppsOwnsFaultsUnderItsOwnId),
+# which would silently break the component/function/area rollup this fixture
+# exists to pin.
+#
+# Used by: test/features/test_external_component_fault_rollup.test.py
+manifest_version: "1.0"
+
+metadata:
+  name: "external-component-fault-rollup"
+  version: "1.0.0"
+  description: "External (non-ROS) Component fault-rollup fixture (#516)"
+
+config:
+  unmanifested_nodes: warn
+  inherit_runtime_resources: true
+
+areas:
+  - id: plc-cell
+    name: "PLC Cell"
+    namespace: /plc_cell
+    description: "Industrial cell hosting a PLC bridged into SOVD"
+
+components:
+  - id: s7-plc
+    name: "Siemens S7 PLC"
+    type: "controller"
+    area: plc-cell
+    external: true
+    description: "Non-ROS PLC introspected by a protocol plugin; owns its faults"
+    identity:
+      manufacturer: "Siemens"
+      model: "S7-1500"
+      order_code: "6ES7515-2AM02-0AB0"
+      serial_number: "SN-PLC-0001"
+      role: "plc"
+  - id: nav-controller
+    name: "Nav Controller"
+    type: "controller"
+    area: plc-cell
+    description: "Internal ROS component (guardrail: must NOT own bare-id faults)"
+    identity:
+      manufacturer: "Acme"
+      model: "NavCtl-1"
+
+apps:
+  - id: plc-diag
+    name: "PLC Diagnostics"
+    external: true
+    description: "External diagnostic app (guards App external wire parity); not located on s7-plc on purpose (see header)"
+
+functions:
+  - id: material_flow
+    name: "Material Flow"
+    category: "process"
+    hosted_by:
+      - s7-plc

--- a/src/ros2_medkit_gateway/config/examples/external_component_fault_manifest.yaml
+++ b/src/ros2_medkit_gateway/config/examples/external_component_fault_manifest.yaml
@@ -1,6 +1,6 @@
-# Copyright 2026 bburda
-#
-# SOVD manifest fixture for #516: an external Component (a PLC bridged into SOVD
+# SOVD System Manifest: External-component fault-rollup fixture (#516)
+# ====================================================================
+# An external Component (a PLC bridged into SOVD
 # by a protocol plugin) owns its fault_manager faults with NO child App located
 # on it. Mirrors the #517 external-App fixture but at the Component level. Also
 # carries AAS-Nameplate identity to confirm identity is orthogonal to the

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/component.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/models/component.hpp
@@ -53,6 +53,12 @@ struct Component {
   std::optional<json> host_metadata;      ///< Host system metadata (for runtime default component)
   AssetIdentity identity;                 ///< Asset-identity nameplate (merged across sources, per-field provenance)
 
+  /// Tri-state: nullopt = no layer classified this component, true = non-ROS
+  /// external asset (PLC/fieldbus/device), false = explicitly a ROS component.
+  /// Mirrors App::external so a device Component owns its fault_manager faults
+  /// without a synthetic child App (#516).
+  std::optional<bool> external;
+
   /**
    * @brief Convert to JSON representation
    * @return JSON object with component data
@@ -98,6 +104,11 @@ struct Component {
     }
     if (!identity.empty()) {
       x_medkit["identity"] = identity.to_json();
+    }
+    // Emit only when effectively external; omitted and explicit-false both leave
+    // the field absent, keeping the wire shape stable (absence == not external).
+    if (external.value_or(false)) {
+      x_medkit["external"] = true;
     }
     j["x-medkit"] = x_medkit;
 
@@ -183,7 +194,8 @@ inline bool operator==(const Component & a, const Component & b) {
          a.description == b.description && a.variant == b.variant && a.tags == b.tags &&
          a.parent_component_id == b.parent_component_id && a.depends_on == b.depends_on &&
          a.contributors == b.contributors && a.services == b.services && a.actions == b.actions &&
-         a.topics == b.topics && a.host_metadata == b.host_metadata && a.identity == b.identity;
+         a.topics == b.topics && a.host_metadata == b.host_metadata && a.identity == b.identity &&
+         a.external == b.external;
 }
 inline bool operator!=(const Component & a, const Component & b) {
   return !(a == b);

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
@@ -103,6 +103,7 @@ inline constexpr std::string_view dto_name<XMedkitArea> = "XMedkitArea";
 //
 // Also used in sub-collection responses (depends-on, subcomponents, hosts, contains, etc.):
 //   missing           <- true when component reference cannot be resolved
+//   external          <- comp.external, non-ROS external asset classification (#516)
 //
 // Note: "parentComponentId" uses camelCase on the wire per discovery_handlers.cpp.
 // "dependsOn" uses camelCase on the wire per discovery_handlers.cpp.
@@ -122,7 +123,8 @@ struct XMedkitComponent {
   // "_provenance"). Free-form JSON so the DTO layer reuses the exact
   // serialization emitted by Component::to_json and consumed by peer parsing.
   std::optional<nlohmann::json> identity;
-  std::optional<bool> missing;  // broken reference sentinel
+  std::optional<bool> missing;   // broken reference sentinel
+  std::optional<bool> external;  // non-ROS external asset classification (#516)
 };
 
 template <>
@@ -132,7 +134,8 @@ inline constexpr auto dto_fields<XMedkitComponent> = std::make_tuple(
     field("dependsOn", &XMedkitComponent::depends_on), field("area", &XMedkitComponent::area),
     field("variant", &XMedkitComponent::variant), field("description", &XMedkitComponent::description),
     field("contributors", &XMedkitComponent::contributors), field("capabilities", &XMedkitComponent::capabilities),
-    field("identity", &XMedkitComponent::identity), field("missing", &XMedkitComponent::missing));
+    field("identity", &XMedkitComponent::identity), field("missing", &XMedkitComponent::missing),
+    field("external", &XMedkitComponent::external));
 
 template <>
 inline constexpr std::string_view dto_name<XMedkitComponent> = "XMedkitComponent";
@@ -149,6 +152,7 @@ inline constexpr std::string_view dto_name<XMedkitComponent> = "XMedkitComponent
 //
 // Also used in sub-collection responses (depends-on, hosts, function-hosts):
 //   missing       <- true when app reference cannot be resolved
+//   external      <- app.external, non-ROS external asset classification (#516/#517)
 // ---------------------------------------------------------------------------
 struct XMedkitApp {
   std::optional<XMedkitRos2> ros2;
@@ -156,14 +160,16 @@ struct XMedkitApp {
   std::optional<bool> is_online;
   std::optional<std::string> component_id;
   std::optional<std::vector<std::string>> contributors;
-  std::optional<bool> missing;  // broken reference sentinel
+  std::optional<bool> missing;   // broken reference sentinel
+  std::optional<bool> external;  // non-ROS external asset classification (#516/#517)
 };
 
 template <>
 inline constexpr auto dto_fields<XMedkitApp> =
     std::make_tuple(field("ros2", &XMedkitApp::ros2), field("source", &XMedkitApp::source),
                     field("is_online", &XMedkitApp::is_online), field("component_id", &XMedkitApp::component_id),
-                    field("contributors", &XMedkitApp::contributors), field("missing", &XMedkitApp::missing));
+                    field("contributors", &XMedkitApp::contributors), field("missing", &XMedkitApp::missing),
+                    field("external", &XMedkitApp::external));
 
 template <>
 inline constexpr std::string_view dto_name<XMedkitApp> = "XMedkitApp";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
@@ -100,7 +100,8 @@ inline constexpr std::string_view dto_name<XMedkitArea> = "XMedkitArea";
 //   description       <- comp.description       (via ext.add())
 //   contributors      <- comp.contributors
 //   capabilities      <- capabilities JSON array (via ext.add())
-//   external          <- comp.external, non-ROS external asset classification; detail + list routes only (#516)
+//   external          <- comp.external, non-ROS external asset classification; emitted true-only on every
+//                        route that carries the component x-medkit, so "absence == not external" holds (#516)
 //
 // Also used in sub-collection responses (depends-on, subcomponents, hosts, contains, etc.):
 //   missing           <- true when component reference cannot be resolved
@@ -149,7 +150,8 @@ inline constexpr std::string_view dto_name<XMedkitComponent> = "XMedkitComponent
 //   ros2.node     <- app.bound_fqn
 //   component_id  <- app.component_id
 //   contributors  <- app.contributors  (detail only)
-//   external      <- app.external, non-ROS external asset classification; detail + list routes only (#516/#517)
+//   external      <- app.external, non-ROS external asset classification; emitted true-only on every route
+//                    that carries the app x-medkit, so "absence == not external" holds (#516/#517)
 //
 // Also used in sub-collection responses (depends-on, hosts, function-hosts):
 //   missing       <- true when app reference cannot be resolved

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
@@ -100,10 +100,10 @@ inline constexpr std::string_view dto_name<XMedkitArea> = "XMedkitArea";
 //   description       <- comp.description       (via ext.add())
 //   contributors      <- comp.contributors
 //   capabilities      <- capabilities JSON array (via ext.add())
+//   external          <- comp.external, non-ROS external asset classification; detail + list routes only (#516)
 //
 // Also used in sub-collection responses (depends-on, subcomponents, hosts, contains, etc.):
 //   missing           <- true when component reference cannot be resolved
-//   external          <- comp.external, non-ROS external asset classification (#516)
 //
 // Note: "parentComponentId" uses camelCase on the wire per discovery_handlers.cpp.
 // "dependsOn" uses camelCase on the wire per discovery_handlers.cpp.
@@ -149,10 +149,10 @@ inline constexpr std::string_view dto_name<XMedkitComponent> = "XMedkitComponent
 //   ros2.node     <- app.bound_fqn
 //   component_id  <- app.component_id
 //   contributors  <- app.contributors  (detail only)
+//   external      <- app.external, non-ROS external asset classification; detail + list routes only (#516/#517)
 //
 // Also used in sub-collection responses (depends-on, hosts, function-hosts):
 //   missing       <- true when app reference cannot be resolved
-//   external      <- app.external, non-ROS external asset classification (#516/#517)
 // ---------------------------------------------------------------------------
 struct XMedkitApp {
   std::optional<XMedkitRos2> ros2;

--- a/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
@@ -50,9 +50,21 @@ void collect_app_fqn(const ThreadSafeEntityCache & cache, const std::string & ap
 
 void collect_component_app_fqns(const ThreadSafeEntityCache & cache, const std::string & comp_id,
                                 std::set<std::string> & out) {
+  std::set<std::string> local;
   for (const auto & app_id : cache.get_apps_for_component(comp_id)) {
-    collect_app_fqn(cache, app_id, out);
+    collect_app_fqn(cache, app_id, local);
   }
+  if (local.empty()) {
+    // No child app contributed a source (no apps, or all unbound/empty-FQN).
+    // An external component owns its fault_manager faults under its own id -
+    // mirrors the external-App rule (#516). A non-external component stays
+    // empty: an unbound ROS component must not claim faults it never reported.
+    auto comp = cache.get_component(comp_id);
+    if (comp && comp->external.value_or(false)) {
+      local.insert(comp_id);
+    }
+  }
+  out.insert(local.begin(), local.end());
 }
 
 void collect_area_app_fqns(const ThreadSafeEntityCache & cache, const std::string & area_id,

--- a/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
@@ -284,9 +284,9 @@ Component ManifestParser::parse_asset(const YAML::Node & node) const {
   // exactly the names the CSV import does (serial / serial_number, ...); any
   // other scalar key is retained verbatim as an extra so operator-specific
   // columns are not lost.
-  static const std::unordered_set<std::string> structural = {"tags",        "parent_component_id", "name",
-                                                             "description", "namespace",           "variant",
-                                                             "type",        "translation_id",      "depends_on"};
+  static const std::unordered_set<std::string> structural = {
+      "tags", "parent_component_id", "name",       "description", "namespace", "variant",
+      "type", "translation_id",      "depends_on", "external"};
 
   AssetEntry entry;
   if (node.IsMap()) {
@@ -343,6 +343,14 @@ Component ManifestParser::parse_asset(const YAML::Node & node) const {
   }
   for (const auto & tag : get_string_vector(node, "tags")) {
     comp.tags.push_back(tag);
+  }
+
+  // An `assets:` entry may classify the device as a non-ROS external asset,
+  // mirroring `parse_component`. Tri-state: an absent key stays nullopt.
+  // `external` is in the `structural` set above so it is not swallowed as an
+  // identity extra (#516).
+  if (node["external"]) {
+    comp.external = node["external"].as<bool>();
   }
 
   return comp;

--- a/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
@@ -255,6 +255,13 @@ Component ManifestParser::parse_component(const YAML::Node & node) const {
   comp.source = "manifest";
   comp.identity = parse_identity(node);
 
+  // Preserve the omitted-vs-explicit distinction: an absent `external:` key
+  // leaves nullopt so the hybrid merge cannot let a stub's default erase a
+  // plugin's introspected classification (#516, mirrors the App rule #517).
+  if (node["external"]) {
+    comp.external = node["external"].as<bool>();
+  }
+
   // Parse type if provided (e.g., "controller", "sensor", "actuator")
   std::string type_val = get_string(node, "type");
   if (!type_val.empty()) {

--- a/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
@@ -263,6 +263,7 @@ void apply_field_group_merge(Entity & target, const Entity & source, FieldGroup 
       case FieldGroup::METADATA:
         merge_scalar(target.source, source.source, res.scalar);
         merge_scalar(target.variant, source.variant, res.scalar);
+        merge_external(target.external, source.external, res.scalar);
         break;
       case FieldGroup::STATUS:
       default:

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -561,6 +561,9 @@ DiscoveryHandlers::get_components(const http::TypedRequest & req) {
       if (!component.identity.empty()) {
         x_medkit_comp.identity = component.identity.to_json();
       }
+      if (component.external.value_or(false)) {
+        x_medkit_comp.external = true;
+      }
       item.x_medkit = x_medkit_comp;
 
       response.items.push_back(std::move(item));
@@ -690,6 +693,9 @@ http::Result<dto::ComponentDetail> DiscoveryHandlers::get_component(const http::
     }
     if (!comp.identity.empty()) {
       x_medkit_comp.identity = comp.identity.to_json();
+    }
+    if (comp.external.value_or(false)) {
+      x_medkit_comp.external = true;
     }
 
     using Cap = CapabilityBuilder::Capability;
@@ -975,6 +981,9 @@ http::Result<dto::Collection<dto::AppListItem>> DiscoveryHandlers::get_apps(cons
         ros2.node = *app.bound_fqn;
         x_medkit_app.ros2 = ros2;
       }
+      if (app.external.value_or(false)) {
+        x_medkit_app.external = true;
+      }
       item.x_medkit = x_medkit_app;
 
       response.items.push_back(std::move(item));
@@ -1112,6 +1121,9 @@ http::Result<dto::AppDetail> DiscoveryHandlers::get_app(const http::TypedRequest
     }
     if (!app.contributors.empty()) {
       x_medkit_app.contributors = sorted_contributors(app.contributors);
+    }
+    if (app.external.value_or(false)) {
+      x_medkit_app.external = true;
     }
     detail.x_medkit = x_medkit_app;
 

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -34,6 +34,22 @@ namespace handlers {
 
 namespace {
 
+/// Emit the x-medkit `external` flag only when the entity is effectively
+/// external (tri-state true). Explicit false and unset both leave the field
+/// absent, so the "absence == not external" wire contract holds. Centralised
+/// here so no call site can leak `external: false` by assigning the raw
+/// optional; every route that carries a Component/App x-medkit calls this (#516).
+void set_x_medkit_external(dto::XMedkitComponent & x_medkit, const std::optional<bool> & external) {
+  if (external.value_or(false)) {
+    x_medkit.external = true;
+  }
+}
+void set_x_medkit_external(dto::XMedkitApp & x_medkit, const std::optional<bool> & external) {
+  if (external.value_or(false)) {
+    x_medkit.external = true;
+  }
+}
+
 /// Check if a capability name is already present in the capabilities array
 bool has_capability(const json & capabilities, const std::string & name) {
   for (const auto & cap : capabilities) {
@@ -336,6 +352,7 @@ DiscoveryHandlers::get_area_components(const http::TypedRequest & req) {
           ros2.ns = component.namespace_path;
           x_medkit_comp.ros2 = ros2;
         }
+        set_x_medkit_external(x_medkit_comp, component.external);
         item.x_medkit = x_medkit_comp;
 
         response.items.push_back(std::move(item));
@@ -490,6 +507,7 @@ DiscoveryHandlers::get_area_contains(const http::TypedRequest & req) {
         ros2.ns = comp.namespace_path;
         x_medkit_comp.ros2 = ros2;
       }
+      set_x_medkit_external(x_medkit_comp, comp.external);
       item.x_medkit = x_medkit_comp;
 
       response.items.push_back(std::move(item));
@@ -561,9 +579,7 @@ DiscoveryHandlers::get_components(const http::TypedRequest & req) {
       if (!component.identity.empty()) {
         x_medkit_comp.identity = component.identity.to_json();
       }
-      if (component.external.value_or(false)) {
-        x_medkit_comp.external = true;
-      }
+      set_x_medkit_external(x_medkit_comp, component.external);
       item.x_medkit = x_medkit_comp;
 
       response.items.push_back(std::move(item));
@@ -694,9 +710,7 @@ http::Result<dto::ComponentDetail> DiscoveryHandlers::get_component(const http::
     if (!comp.identity.empty()) {
       x_medkit_comp.identity = comp.identity.to_json();
     }
-    if (comp.external.value_or(false)) {
-      x_medkit_comp.external = true;
-    }
+    set_x_medkit_external(x_medkit_comp, comp.external);
 
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {
@@ -776,6 +790,7 @@ DiscoveryHandlers::get_subcomponents(const http::TypedRequest & req) {
         ros2.ns = sub.namespace_path;
         x_medkit_comp.ros2 = ros2;
       }
+      set_x_medkit_external(x_medkit_comp, sub.external);
       item.x_medkit = x_medkit_comp;
 
       response.items.push_back(std::move(item));
@@ -850,6 +865,7 @@ http::Result<dto::Collection<dto::AppListItem>> DiscoveryHandlers::get_component
         ros2.node = *app.bound_fqn;
         x_medkit_app.ros2 = ros2;
       }
+      set_x_medkit_external(x_medkit_app, app.external);
       item.x_medkit = x_medkit_app;
 
       response.items.push_back(std::move(item));
@@ -914,6 +930,7 @@ DiscoveryHandlers::get_component_depends_on(const http::TypedRequest & req) {
         if (!dep_opt->source.empty()) {
           x_medkit_comp.source = dep_opt->source;
         }
+        set_x_medkit_external(x_medkit_comp, dep_opt->external);
         item.x_medkit = x_medkit_comp;
       } else {
         item.name = dep_id;
@@ -981,9 +998,7 @@ http::Result<dto::Collection<dto::AppListItem>> DiscoveryHandlers::get_apps(cons
         ros2.node = *app.bound_fqn;
         x_medkit_app.ros2 = ros2;
       }
-      if (app.external.value_or(false)) {
-        x_medkit_app.external = true;
-      }
+      set_x_medkit_external(x_medkit_app, app.external);
       item.x_medkit = x_medkit_app;
 
       response.items.push_back(std::move(item));
@@ -1122,9 +1137,7 @@ http::Result<dto::AppDetail> DiscoveryHandlers::get_app(const http::TypedRequest
     if (!app.contributors.empty()) {
       x_medkit_app.contributors = sorted_contributors(app.contributors);
     }
-    if (app.external.value_or(false)) {
-      x_medkit_app.external = true;
-    }
+    set_x_medkit_external(x_medkit_app, app.external);
     detail.x_medkit = x_medkit_app;
 
     return detail;
@@ -1184,6 +1197,7 @@ http::Result<dto::Collection<dto::AppListItem>> DiscoveryHandlers::get_app_depen
           x_medkit_app.source = dep_opt->source;
         }
         x_medkit_app.is_online = dep_opt->is_online;
+        set_x_medkit_external(x_medkit_app, dep_opt->external);
         item.x_medkit = x_medkit_app;
       } else {
         item.name = dep_id;
@@ -1571,6 +1585,7 @@ http::Result<dto::Collection<dto::AppListItem>> DiscoveryHandlers::get_function_
           ros2.node = *app_opt->bound_fqn;
           x_medkit_app.ros2 = ros2;
         }
+        set_x_medkit_external(x_medkit_app, app_opt->external);
         item.x_medkit = x_medkit_app;
 
         response.items.push_back(std::move(item));

--- a/src/ros2_medkit_gateway/test/test_asset_inventory.cpp
+++ b/src/ros2_medkit_gateway/test/test_asset_inventory.cpp
@@ -368,6 +368,45 @@ assets:
   EXPECT_EQ(comp->identity.provenance.at("model"), "inventory");
 }
 
+TEST(ManifestAssetsTest, ExternalKeyClassifiesAssetComponent) {
+  // An `assets:` entry is the inventory path for non-ROS hardware (#516), so an
+  // explicit `external:` must classify the derived Component instead of being
+  // swallowed as an identity extra. Tri-state is preserved (mirrors parse_component).
+  const std::string yaml = R"(
+manifest_version: "1.0"
+assets:
+  - id: plc_ext
+    manufacturer: Siemens
+    model: S7-1500
+    external: true
+  - id: drive_ros
+    manufacturer: ABB
+    model: ACS880
+    external: false
+  - id: sensor_unset
+    manufacturer: Bosch
+    model: BMI-088
+)";
+  ManifestParser parser;
+  Manifest manifest = parser.parse_string(yaml);
+
+  const Component * plc = find_component(manifest.components, "plc_ext");
+  ASSERT_NE(plc, nullptr);
+  ASSERT_TRUE(plc->external.has_value());
+  EXPECT_TRUE(plc->external.value());
+  // The `external` key must classify, not fall through to identity extras.
+  EXPECT_EQ(plc->identity.extra.count("external"), 0u);
+
+  const Component * drive = find_component(manifest.components, "drive_ros");
+  ASSERT_NE(drive, nullptr);
+  ASSERT_TRUE(drive->external.has_value());
+  EXPECT_FALSE(drive->external.value());
+
+  const Component * sensor = find_component(manifest.components, "sensor_unset");
+  ASSERT_NE(sensor, nullptr);
+  EXPECT_FALSE(sensor->external.has_value());
+}
+
 TEST(ManifestAssetsTest, AreaAndExplicitOverrides) {
   const std::string yaml = R"(
 manifest_version: "1.0"

--- a/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
@@ -445,11 +445,21 @@ TEST_F(DiscoveryHandlersFixtureTest, ListComponentsReturnsMetadata) {
 
   auto result = handlers_->get_components(typed_req);
   auto body = body_json(result);
-  // lidar_unit has parent_component_id, so it's filtered from top-level list
+  // lidar_unit has parent_component_id, so it's filtered from top-level list.
   ASSERT_EQ(body["items"].size(), 2u);
-  EXPECT_EQ(body["items"][0]["id"], "main_ecu");
-  EXPECT_EQ(body["items"][0]["description"], "Vehicle control unit");
-  EXPECT_EQ(body["items"][0]["x-medkit"]["source"], "manifest");
+  // get_components() does not sort; find main_ecu by id rather than assuming order.
+  const auto & items = body["items"];
+  size_t main_ecu_idx = items.size();
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (items[i]["id"] == "main_ecu") {
+      main_ecu_idx = i;
+      break;
+    }
+  }
+  ASSERT_LT(main_ecu_idx, items.size()) << "main_ecu not found in /components list";
+  const auto & main_ecu = items[main_ecu_idx];
+  EXPECT_EQ(main_ecu["description"], "Vehicle control unit");
+  EXPECT_EQ(main_ecu["x-medkit"]["source"], "manifest");
 }
 
 // @verifies REQ_INTEROP_003
@@ -463,7 +473,17 @@ TEST_F(DiscoveryHandlersFixtureTest, ListComponentsIncludesManifestIdentity) {
   auto result = handlers_->get_components(typed_req);
   auto body = body_json(result);
   ASSERT_EQ(body["items"].size(), 2u);
-  const auto & identity = body["items"][0]["x-medkit"]["identity"];
+  // get_components() does not sort; find main_ecu by id rather than assuming order.
+  const auto & items = body["items"];
+  size_t main_ecu_idx = items.size();
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (items[i]["id"] == "main_ecu") {
+      main_ecu_idx = i;
+      break;
+    }
+  }
+  ASSERT_LT(main_ecu_idx, items.size()) << "main_ecu not found in /components list";
+  const auto & identity = items[main_ecu_idx]["x-medkit"]["identity"];
   // Typed fields serialize camelCase (AssetIdentity::to_json).
   EXPECT_EQ(identity["manufacturer"], "Acme Robotics");
   EXPECT_EQ(identity["model"], "ECU-9000");

--- a/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
@@ -98,6 +98,12 @@ components:
     identity:
       manufacturer: "Siemens"
       serial_number: "SN-1"
+  - id: ext_sensor
+    name: "External Sensor"
+    parent_component_id: "main_ecu"
+    external: true
+    identity:
+      manufacturer: "Bosch"
 apps:
   - id: "planner"
     name: "Planner"
@@ -577,8 +583,60 @@ TEST_F(DiscoveryHandlersFixtureTest, GetSubcomponentsReturnsChildren) {
 
   auto result = handlers_->get_subcomponents(typed_req);
   auto body = body_json(result);
+  // main_ecu has two subcomponents: lidar_unit (ROS) and ext_sensor (external).
+  ASSERT_EQ(body["items"].size(), 2u);
+  bool has_lidar = false;
+  bool has_ext_sensor = false;
+  for (const auto & item : body["items"]) {
+    if (item["id"] == "lidar_unit") {
+      has_lidar = true;
+    }
+    if (item["id"] == "ext_sensor") {
+      has_ext_sensor = true;
+    }
+  }
+  EXPECT_TRUE(has_lidar);
+  EXPECT_TRUE(has_ext_sensor);
+}
+
+// A device Component browsed via a relationship/sub-collection route must still
+// read as external (the "absence == not external" invariant), so the external
+// subcomponent carries x-medkit.external while the plain ROS one does not.
+TEST_F(DiscoveryHandlersFixtureTest, SubcomponentsEmitExternalForExternalChild) {
+  httplib::Request req;
+  auto typed_req = make_typed_request(req, "/api/v1/components/main_ecu/subcomponents",
+                                      R"(/api/v1/components/([^/]+)/subcomponents)");
+
+  auto result = handlers_->get_subcomponents(typed_req);
+  auto body = body_json(result);
+  const auto & items = body["items"];
+  size_t ext_idx = items.size();
+  size_t lidar_idx = items.size();
+  for (size_t i = 0; i < items.size(); ++i) {
+    if (items[i]["id"] == "ext_sensor") {
+      ext_idx = i;
+    }
+    if (items[i]["id"] == "lidar_unit") {
+      lidar_idx = i;
+    }
+  }
+  ASSERT_LT(ext_idx, items.size()) << "ext_sensor not found in subcomponents";
+  ASSERT_LT(lidar_idx, items.size()) << "lidar_unit not found in subcomponents";
+  EXPECT_EQ(items[ext_idx]["x-medkit"]["external"], true);
+  EXPECT_FALSE(items[lidar_idx]["x-medkit"].contains("external"));
+}
+
+// The hosts (App) projection must also carry x-medkit.external: ext_plc hosts
+// the external app ext_app, so a consumer browsing hosts sees the classification.
+TEST_F(DiscoveryHandlersFixtureTest, ComponentHostsEmitExternalForExternalApp) {
+  httplib::Request req;
+  auto typed_req = make_typed_request(req, "/api/v1/components/ext_plc/hosts", R"(/api/v1/components/([^/]+)/hosts)");
+
+  auto result = handlers_->get_component_hosts(typed_req);
+  auto body = body_json(result);
   ASSERT_EQ(body["items"].size(), 1u);
-  EXPECT_EQ(body["items"][0]["id"], "lidar_unit");
+  EXPECT_EQ(body["items"][0]["id"], "ext_app");
+  EXPECT_EQ(body["items"][0]["x-medkit"]["external"], true);
 }
 
 // @verifies REQ_INTEROP_005

--- a/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_discovery_handlers.cpp
@@ -92,6 +92,12 @@ components:
     parent_component_id: "main_ecu"
     description: "Lidar aggregation"
     tags: ["sensor"]
+  - id: ext_plc
+    name: "External PLC"
+    external: true
+    identity:
+      manufacturer: "Siemens"
+      serial_number: "SN-1"
 apps:
   - id: "planner"
     name: "Planner"
@@ -104,6 +110,10 @@ apps:
   - id: "standalone"
     name: "Standalone"
     description: "Standalone app without a hosting component"
+  - id: ext_app
+    name: "External App"
+    external: true
+    is_located_on: ext_plc
 functions:
   - id: "navigation"
     name: "Navigation"
@@ -258,7 +268,7 @@ class DiscoveryHandlersFixtureTest : public ::testing::Test {
     auto apps = suite_node_->get_discovery_manager()->discover_apps();
     auto functions = suite_node_->get_discovery_manager()->discover_functions();
 
-    ASSERT_EQ(apps.size(), 3u);
+    ASSERT_EQ(apps.size(), 4u);
     apps[0].is_online = true;
     apps[0].bound_fqn = "/vehicle/main_ecu/planner";
     apps[1].bound_fqn = "/sensors/lidar_unit/mapper";
@@ -436,7 +446,7 @@ TEST_F(DiscoveryHandlersFixtureTest, ListComponentsReturnsMetadata) {
   auto result = handlers_->get_components(typed_req);
   auto body = body_json(result);
   // lidar_unit has parent_component_id, so it's filtered from top-level list
-  ASSERT_EQ(body["items"].size(), 1u);
+  ASSERT_EQ(body["items"].size(), 2u);
   EXPECT_EQ(body["items"][0]["id"], "main_ecu");
   EXPECT_EQ(body["items"][0]["description"], "Vehicle control unit");
   EXPECT_EQ(body["items"][0]["x-medkit"]["source"], "manifest");
@@ -452,7 +462,7 @@ TEST_F(DiscoveryHandlersFixtureTest, ListComponentsIncludesManifestIdentity) {
 
   auto result = handlers_->get_components(typed_req);
   auto body = body_json(result);
-  ASSERT_EQ(body["items"].size(), 1u);
+  ASSERT_EQ(body["items"].size(), 2u);
   const auto & identity = body["items"][0]["x-medkit"]["identity"];
   // Typed fields serialize camelCase (AssetIdentity::to_json).
   EXPECT_EQ(identity["manufacturer"], "Acme Robotics");
@@ -489,6 +499,30 @@ TEST_F(DiscoveryHandlersFixtureTest, GetComponentWithoutIdentityOmitsField) {
   auto result = handlers_->get_component(typed_req);
   auto body = body_json(result);
   EXPECT_FALSE(body["x-medkit"].contains("identity"));
+}
+
+// @verifies REQ_INTEROP_003
+// A manifest component explicitly marked `external: true` surfaces
+// x-medkit.external on the wire (#516).
+TEST_F(DiscoveryHandlersFixtureTest, GetComponentEmitsExternalOnWire) {
+  httplib::Request req;
+  auto typed_req = make_typed_request(req, "/api/v1/components/ext_plc", R"(/api/v1/components/([^/]+))");
+
+  auto result = handlers_->get_component(typed_req);
+  auto body = body_json(result);
+  EXPECT_EQ(body["x-medkit"]["external"], true);
+}
+
+// @verifies REQ_INTEROP_003
+// A ROS-native manifest component omits x-medkit.external entirely (absence
+// means "not external", never emitted as an explicit `false`) (#516).
+TEST_F(DiscoveryHandlersFixtureTest, GetComponentOmitsExternalForRosComponent) {
+  httplib::Request req;
+  auto typed_req = make_typed_request(req, "/api/v1/components/main_ecu", R"(/api/v1/components/([^/]+))");
+
+  auto result = handlers_->get_component(typed_req);
+  auto body = body_json(result);
+  EXPECT_FALSE(body["x-medkit"].contains("external"));
 }
 
 // @verifies REQ_INTEROP_003
@@ -636,7 +670,7 @@ TEST_F(DiscoveryHandlersFixtureTest, ListAppsReturnsSeededMetadata) {
 
   auto result = handlers_->get_apps(typed_req);
   auto body = body_json(result);
-  ASSERT_EQ(body["items"].size(), 3u);
+  ASSERT_EQ(body["items"].size(), 4u);
   EXPECT_EQ(body["items"][0]["id"], "planner");
   EXPECT_EQ(body["items"][0]["x-medkit"]["component_id"], "main_ecu");
   EXPECT_EQ(body["items"][0]["x-medkit"]["is_online"], true);
@@ -651,6 +685,18 @@ TEST_F(DiscoveryHandlersFixtureTest, GetAppUnknownIdReturns404) {
   auto result = handlers_->get_app(typed_req);
   ASSERT_FALSE(result.has_value());
   EXPECT_EQ(result.error().http_status, 404);
+}
+
+// @verifies REQ_INTEROP_003
+// A manifest app explicitly marked `external: true` surfaces
+// x-medkit.external on the wire (#516).
+TEST_F(DiscoveryHandlersFixtureTest, GetAppEmitsExternalOnWire) {
+  httplib::Request req;
+  auto typed_req = make_typed_request(req, "/api/v1/apps/ext_app", R"(/api/v1/apps/([^/]+))");
+
+  auto result = handlers_->get_app(typed_req);
+  auto body = body_json(result);
+  EXPECT_EQ(body["x-medkit"]["external"], true);
 }
 
 // @verifies REQ_INTEROP_003

--- a/src/ros2_medkit_gateway/test/test_discovery_models.cpp
+++ b/src/ros2_medkit_gateway/test/test_discovery_models.cpp
@@ -174,6 +174,29 @@ TEST_F(ComponentModelTest, ToCapabilities_ContainsConfigurationsForNodes) {
   EXPECT_EQ(j["configurations"], "http://localhost:8080/api/v1/components/motor_controller/configurations");
 }
 
+TEST_F(ComponentModelTest, ToJson_OmitsExternalWhenUnsetOrFalse) {
+  // Default: external unset -> field absent (stable wire shape).
+  json j = comp_.to_json();
+  EXPECT_FALSE(j["x-medkit"].contains("external"));
+
+  comp_.external = false;  // explicit ROS component -> still absent
+  json j2 = comp_.to_json();
+  EXPECT_FALSE(j2["x-medkit"].contains("external"));
+}
+
+TEST_F(ComponentModelTest, ToJson_ExternalWhenTrue) {
+  comp_.external = true;
+  json j = comp_.to_json();
+  EXPECT_EQ(j["x-medkit"]["external"], true);
+}
+
+TEST_F(ComponentModelTest, Equality_DistinguishesExternal) {
+  Component other = comp_;
+  ASSERT_EQ(comp_, other);
+  other.external = true;
+  EXPECT_NE(comp_, other);
+}
+
 // =============================================================================
 // App Model Tests
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_dto_contract.cpp
+++ b/src/ros2_medkit_gateway/test/test_dto_contract.cpp
@@ -500,3 +500,35 @@ void check_all(std::index_sequence<I...> /*seq*/) {
 TEST(DtoRegistry, EveryRegisteredDtoRoundTrips) {
   check_all<dto::AllDtos>(std::make_index_sequence<std::tuple_size_v<dto::AllDtos>>{});
 }
+
+// =============================================================================
+// external field contract (#516)
+// =============================================================================
+
+TEST(XMedkitExternalContract, ComponentEmitsExternalWhenSet) {
+  dto::XMedkitComponent c;
+  c.external = true;
+  auto j = dto::JsonWriter<dto::XMedkitComponent>::write(c);
+  ASSERT_TRUE(j.contains("external"));
+  EXPECT_EQ(j["external"], true);
+}
+
+TEST(XMedkitExternalContract, ComponentOmitsExternalWhenUnset) {
+  dto::XMedkitComponent c;  // external nullopt
+  auto j = dto::JsonWriter<dto::XMedkitComponent>::write(c);
+  EXPECT_FALSE(j.contains("external"));
+}
+
+TEST(XMedkitExternalContract, AppEmitsExternalWhenSet) {
+  dto::XMedkitApp a;
+  a.external = true;
+  auto j = dto::JsonWriter<dto::XMedkitApp>::write(a);
+  ASSERT_TRUE(j.contains("external"));
+  EXPECT_EQ(j["external"], true);
+}
+
+TEST(XMedkitExternalContract, AppOmitsExternalWhenUnset) {
+  dto::XMedkitApp a;  // external nullopt
+  auto j = dto::JsonWriter<dto::XMedkitApp>::write(a);
+  EXPECT_FALSE(j.contains("external"));
+}

--- a/src/ros2_medkit_gateway/test/test_handler_context.cpp
+++ b/src/ros2_medkit_gateway/test/test_handler_context.cpp
@@ -1758,6 +1758,80 @@ TEST(ResolveEntitySourceFqnsTest, ExternalAppWithStrayRosBindingOwnsFaultsByBare
   EXPECT_EQ(fqns, std::set<std::string>{"process"});
 }
 
+TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithNoAppsOwnsFaultsUnderItsOwnId) {
+  // The #516 case: a PLC modeled as an external Component with no child App.
+  // It reports faults under its own component id; the scope must be exactly
+  // {its id} so GET /components/<id>/faults is non-empty.
+  ThreadSafeEntityCache cache;
+  Component plc;
+  plc.id = "s7_1500";
+  plc.external = true;
+  cache.update_components({plc});
+
+  auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "s7_1500"));
+  EXPECT_EQ(fqns, std::set<std::string>{"s7_1500"});
+}
+
+TEST(ResolveEntitySourceFqnsTest, NonExternalComponentWithNoAppsStaysEmpty) {
+  // Security guardrail: a non-external Component with no apps must NOT claim its
+  // bare id - an unbound ROS component must not own faults it never reported.
+  ThreadSafeEntityCache cache;
+  Component comp;
+  comp.id = "nav_comp";
+  comp.external = false;
+  cache.update_components({comp});
+
+  auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "nav_comp"));
+  EXPECT_TRUE(fqns.empty());
+}
+
+TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithContributingAppKeepsAppScope) {
+  // An external Component that DOES host a ROS-bound app resolves to the app's
+  // FQN; the component id is NOT added (fallback dormant when apps contribute).
+  ThreadSafeEntityCache cache;
+  Component plc;
+  plc.id = "s7_1500";
+  plc.external = true;
+  cache.update_components({plc});
+  cache.update_apps({make_owned_app("planner", "s7_1500", "planner", "/perception/nav")});
+
+  auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "s7_1500"));
+  EXPECT_EQ(fqns, std::set<std::string>{"/perception/nav/planner"});
+}
+
+TEST(ResolveEntitySourceFqnsTest, FunctionHostingExternalComponentOwnsItsFaults) {
+  // Function.hosted_by lists the device Component directly (Component-host).
+  // The Function rollup must include the external Component's bare id (#516:
+  // no synthetic App needed).
+  ThreadSafeEntityCache cache;
+  Component plc;
+  plc.id = "s7_1500";
+  plc.external = true;
+  cache.update_components({plc});
+  Function f;
+  f.id = "material_flow";
+  f.hosts = {"s7_1500"};
+  cache.update_functions({f});
+
+  auto fqns =
+      HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::FUNCTION, "material_flow"));
+  EXPECT_EQ(fqns, std::set<std::string>{"s7_1500"});
+}
+
+TEST(ResolveEntitySourceFqnsTest, AreaHostingExternalComponentOwnsItsFaults) {
+  // Area rollup walks the same component gate; an external device Component in
+  // the area owns its faults on the area route.
+  ThreadSafeEntityCache cache;
+  Component plc;
+  plc.id = "s7_1500";
+  plc.area = "cell_a";
+  plc.external = true;
+  cache.update_components({plc});
+
+  auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "cell_a"));
+  EXPECT_EQ(fqns, std::set<std::string>{"s7_1500"});
+}
+
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/ros2_medkit_gateway/test/test_manifest_parser.cpp
+++ b/src/ros2_medkit_gateway/test/test_manifest_parser.cpp
@@ -26,6 +26,7 @@
 
 #include "ros2_medkit_gateway/core/discovery/manifest/manifest_parser.hpp"
 
+using ros2_medkit_gateway::Component;
 using ros2_medkit_gateway::discovery::ManifestConfig;
 using ros2_medkit_gateway::discovery::ManifestParser;
 
@@ -293,6 +294,35 @@ apps:
   ASSERT_EQ(manifest.apps.size(), 1);
   ASSERT_TRUE(manifest.apps[0].external.has_value());
   EXPECT_FALSE(manifest.apps[0].external.value());
+}
+
+TEST_F(ManifestParserTest, ParseComponent_ExternalKeyTriState) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+metadata: { name: t, version: "1.0.0" }
+components:
+  - id: plc
+    external: true
+  - id: ros_node
+    external: false
+  - id: unclassified
+)";
+  auto manifest = parser_.parse_string(yaml);
+  ASSERT_EQ(manifest.components.size(), 3u);
+  auto by_id = [&](const std::string & id) -> const Component & {
+    for (const auto & c : manifest.components) {
+      if (c.id == id) {
+        return c;
+      }
+    }
+    ADD_FAILURE() << "component not found: " << id;
+    static Component none;
+    return none;
+  };
+  EXPECT_TRUE(by_id("plc").external.value_or(false));
+  ASSERT_TRUE(by_id("ros_node").external.has_value());
+  EXPECT_FALSE(by_id("ros_node").external.value());
+  EXPECT_FALSE(by_id("unclassified").external.has_value());
 }
 
 TEST_F(ManifestParserTest, ParseFunctions) {

--- a/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
@@ -1513,6 +1513,60 @@ TEST_F(MergePipelineTest, AppExternalField_AuthoritativeExplicitFalseOverridesPl
   EXPECT_FALSE(result.apps[0].external.value()) << "authoritative external: false must override plugin true";
 }
 
+TEST_F(MergePipelineTest, PluginExternalClassificationSurvivesManifestComponentMetadataMerge) {
+  // Manifest stub: declares the component id, no external key -> nullopt.
+  Component manifest_comp = make_component("s7_1500");
+  manifest_comp.source = "manifest";
+
+  // Plugin introspection: same id, classified external.
+  Component plugin_comp = make_component("s7_1500");
+  plugin_comp.external = true;
+  plugin_comp.source = "opcua";
+
+  LayerOutput manifest_out, plugin_out;
+  manifest_out.components.push_back(manifest_comp);
+  plugin_out.components.push_back(plugin_comp);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "manifest", manifest_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::METADATA, MergePolicy::AUTHORITATIVE}}));
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "plugin", plugin_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::METADATA, MergePolicy::ENRICHMENT}}));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.components.size(), 1u);
+  EXPECT_TRUE(result.components[0].external.value_or(false))
+      << "hybrid merge dropped the plugin's external classification";
+  EXPECT_EQ(result.components[0].source, "manifest");
+}
+
+TEST_F(MergePipelineTest, AuthoritativeManifestExternalFalseCorrectsPluginComponent) {
+  Component manifest_comp = make_component("s7_1500");
+  manifest_comp.external = false;  // explicit, authoritative: this IS a ROS node
+  manifest_comp.source = "manifest";
+
+  Component plugin_comp = make_component("s7_1500");
+  plugin_comp.external = true;  // plugin misclassified it
+  plugin_comp.source = "opcua";
+
+  LayerOutput manifest_out, plugin_out;
+  manifest_out.components.push_back(manifest_comp);
+  plugin_out.components.push_back(plugin_comp);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "manifest", manifest_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::METADATA, MergePolicy::AUTHORITATIVE}}));
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "plugin", plugin_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::METADATA, MergePolicy::ENRICHMENT}}));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.components.size(), 1u);
+  ASSERT_TRUE(result.components[0].external.has_value());
+  EXPECT_FALSE(result.components[0].external.value()) << "authoritative external: false must override plugin true";
+}
+
 // --- Area field group merge tests ---
 
 TEST_F(MergePipelineTest, AreaIdentityMerge_ManifestAuthoritativeWinsName) {

--- a/src/ros2_medkit_integration_tests/test/features/test_external_component_fault_rollup.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_external_component_fault_rollup.test.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end regression for #516: external-Component faults across every rollup.
+
+An external Component (``external: true`` - e.g. a PLC bridged into SOVD by a
+protocol plugin) can report faults to the fault_manager under its own entity id
+with NO child App located on it. Fault-scope resolution must fall back to that
+bare id when no app contributes a scope, so the component's faults surface on
+the component route AND on every aggregate route that rolls it up (function,
+area). This mirrors the #517 external-App rule
+(``ResolveEntitySourceFqnsTest.ExternalAppWithStrayRosBindingOwnsFaultsByBareId``)
+one level up the entity hierarchy
+(``ResolveEntitySourceFqnsTest.ExternalComponentWithNoAppsOwnsFaultsUnderItsOwnId``).
+
+The fixture also carries a separate external App (``plc-diag``) that is
+deliberately NOT located on the PLC Component: locating it there would give the
+Component a contributing child app, and the fault scope would resolve to the
+app's id instead of falling back to the component's own bare id
+(``ResolveEntitySourceFqnsTest.ExternalComponentWithContributingAppKeepsAppScope``),
+silently breaking the rollup this test exists to pin. The App instead pins
+``external`` wire parity on the App route.
+
+The fixture's second Component (``nav-controller``) is internal (no
+``external`` key) and has no apps located on it either - the guardrail case
+(``ResolveEntitySourceFqnsTest.NonExternalComponentWithNoAppsStaysEmpty``): an
+unbound ROS component must not claim faults it never reported.
+
+The merge-level preservation is unit-covered
+(``MergePipelineTest.PluginExternalClassificationSurvivesManifestMetadataMerge``)
+and the per-route scope resolution is unit-covered
+(``ResolveEntitySourceFqnsTest.*``). This test pins the full HTTP-stack
+behaviour those two disjoint unit layers never exercise together: report a
+fault under the Component's bare id, then observe it on every rollup route.
+"""
+
+import os
+import unittest
+
+from ament_index_python.packages import get_package_share_directory
+import launch_testing
+import rclpy
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ReportFault
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+
+EXTERNAL_COMPONENT = 's7-plc'
+EXTERNAL_APP = 'plc-diag'
+INTERNAL_COMPONENT = 'nav-controller'
+HOST_FUNCTION = 'material_flow'
+HOST_AREA = 'plc-cell'
+PLC_FAULT = 'PLC_JAM_INFEED'
+NAV_FAULT = 'NAV_STALL'
+
+
+def generate_test_description():
+    manifest_path = os.path.join(
+        get_package_share_directory('ros2_medkit_gateway'),
+        'config', 'examples', 'external_component_fault_manifest.yaml',
+    )
+    return create_test_launch(
+        demo_nodes=[],
+        fault_manager=True,
+        # Negative threshold: the fault confirms after a couple of FAILED
+        # events (see _report_fault, which reports several times).
+        fault_manager_params={'confirmation_threshold': -2},
+        gateway_params={
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': manifest_path,
+            'discovery.manifest_strict_validation': False,
+        },
+    )
+
+
+class TestExternalComponentFaultRollup(GatewayTestCase):
+    """An external Component owns its faults with no child app (#516)."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {EXTERNAL_APP}
+    REQUIRED_AREAS = {HOST_AREA}
+    REQUIRED_FUNCTIONS = {HOST_FUNCTION}
+
+    @classmethod
+    def setUpClass(cls):
+        # Wait for the gateway + discovery (the external component, app, area
+        # and function must exist before we exercise the rollup routes).
+        super().setUpClass()
+        rclpy.init()
+        cls._reporter = Node('external_component_fault_reporter')
+        cls._report_client = cls._reporter.create_client(
+            ReportFault, '/fault_manager/report_fault'
+        )
+        assert cls._report_client.wait_for_service(timeout_sec=15.0), \
+            'report_fault service not available'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    def _report_fault(self, source_id, fault_code, times=4):
+        """Fire-and-forget fault reports.
+
+        Mirror the #517 helper: drop the reply future to avoid
+        sanitizer-timing flakes; report several times so the negative
+        confirmation_threshold latches CONFIRMED.
+        """
+        for _ in range(times):
+            req = ReportFault.Request()
+            req.fault_code = fault_code
+            req.event_type = ReportFault.Request.EVENT_FAILED
+            req.severity = Fault.SEVERITY_ERROR
+            req.source_id = source_id
+            # Fire-and-forget: the request is sent synchronously by
+            # call_async; spin briefly to flush and pace the reports for the
+            # debounce, and intentionally drop the reply future.
+            self._report_client.call_async(req)
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+
+    def test_external_component_owns_faults_on_every_rollup(self):
+        """External Component fault surfaces on component, function, area.
+
+        @verifies REQ_INTEROP_012
+        """
+        self._report_fault(EXTERNAL_COMPONENT, PLC_FAULT)
+
+        # #516: the component's bare-id fault must roll up to every aggregate
+        # route that includes it. Before the fix these rollups were empty
+        # because a non-external component (or one with no contributing app)
+        # never resolved to its own bare id.
+        for endpoint in (
+            f'/components/{EXTERNAL_COMPONENT}',
+            f'/functions/{HOST_FUNCTION}',
+            f'/areas/{HOST_AREA}',
+        ):
+            with self.subTest(rollup=endpoint):
+                fault = self.wait_for_fault(endpoint, PLC_FAULT)
+                self.assertEqual(fault.get('fault_code'), PLC_FAULT)
+
+    def test_internal_component_does_not_own_bare_id_faults(self):
+        """Guardrail: a non-external Component must not claim bare-id faults.
+
+        Race-free: confirm the fault is recorded on the server-wide /faults
+        list first, then assert it is filtered out of the component route.
+        """
+        self._report_fault(INTERNAL_COMPONENT, NAV_FAULT)
+        # wait_for_fault('', NAV_FAULT) polls the server-wide '/faults' list
+        # (it appends '/faults' to the empty entity endpoint), proving the
+        # fault_manager recorded it regardless of scope resolution.
+        self.wait_for_fault('', NAV_FAULT)
+        comp_faults = self.get_json(f'/components/{INTERNAL_COMPONENT}/faults')
+        codes = [f.get('fault_code') for f in comp_faults.get('items', [])]
+        self.assertNotIn(NAV_FAULT, codes)
+
+    def test_external_flag_and_identity_on_the_wire(self):
+        """External flag present on external Component + App, absent internal.
+
+        AAS identity is present on both (orthogonal to external).
+        """
+        comp = self.get_json(f'/components/{EXTERNAL_COMPONENT}')
+        self.assertTrue(comp['x-medkit'].get('external'))
+        self.assertIn('identity', comp['x-medkit'])
+
+        app = self.get_json(f'/apps/{EXTERNAL_APP}')
+        self.assertTrue(app['x-medkit'].get('external'))
+
+        internal = self.get_json(f'/components/{INTERNAL_COMPONENT}')
+        self.assertNotIn('external', internal['x-medkit'])
+        self.assertIn('identity', internal['x-medkit'])
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check all processes exited cleanly (SIGTERM allowed)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_external_component_fault_rollup.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_external_component_fault_rollup.test.py
@@ -39,7 +39,7 @@ The fixture's second Component (``nav-controller``) is internal (no
 unbound ROS component must not claim faults it never reported.
 
 The merge-level preservation is unit-covered
-(``MergePipelineTest.PluginExternalClassificationSurvivesManifestMetadataMerge``)
+(``MergePipelineTest.PluginExternalClassificationSurvivesManifestComponentMetadataMerge``)
 and the per-route scope resolution is unit-covered
 (``ResolveEntitySourceFqnsTest.*``). This test pins the full HTTP-stack
 behaviour those two disjoint unit layers never exercise together: report a


### PR DESCRIPTION
## Summary

An external Component is a non-ROS device (a PLC, a fieldbus node) that a protocol plugin bridges into SOVD. Before this change, such a Component could not own its fault_manager faults. `collect_component_app_fqns` only collected the FQNs of child Apps. A device modeled as a Component with no child App resolved to an empty fault scope. So `GET /components/<device>/faults` returned nothing, and a Function or Area that hosted the device also missed its faults. The only workaround was to add a fake child App per device, only to carry fault ownership.

This change gives Components the same `external` rule that Apps already have:

- `Component` gets an `external` field (tri-state `optional<bool>`, like `App::external`). It is read from the manifest `external:` key and merged across discovery layers with the same rule: a layer that does not set it never clears a value set by another layer (for example a plugin), and an explicit manifest value stays authoritative.
- In fault scope, an external Component whose child Apps contribute no FQNs (including the case of no Apps) owns its own entity id. A non-external Component with no Apps still resolves to an empty scope, so it cannot claim faults it never reported.
- The change is in one helper, so it fixes the Component, Area, and Function rollups at once, plus the plugin fault path.

A Function or Area can now host a device Component directly and roll up its faults. No fake App is needed.

The change also exposes the `external` flag on the REST wire as `x-medkit.external`, for both Components and Apps. Apps did not expose it before. The flag is written only when it is true, so entities that are not external keep the same wire shape as before.

This change is additive. A Component without an explicit `external: true` is treated exactly as before, so existing manifests do not change behavior.

---

## Issue

- closes #516

---

## Type

- [x] New feature or tests

---

## Testing

A new end-to-end launch test drives the real gateway and fault_manager over HTTP:

- an external Component reports a fault under its own id; the fault appears on the component, function, and area routes;
- an internal (ROS) Component reports a fault under its own id; the test first confirms the fault is on the server-wide `/faults` list, then checks that it does not appear on the component route (the guardrail);
- `x-medkit.external` is present on the external Component and App and absent on the internal one; the asset-identity nameplate is present on both.

Unit tests cover the model field, the manifest parse, the cross-layer merge, the fault-scope resolution for the component/area/function routes, the DTO output, and the handler wire output.

Run the end-to-end test:

```
colcon build --packages-up-to ros2_medkit_integration_tests
./scripts/test.sh test_external_component_fault_rollup
```

---

## Checklist

- [x] Breaking changes are clearly described (no breaking changes; the field is additive)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
