### PR TITLE
Stop an unresponsive parameter node from hanging the REST API (#531)

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -550,6 +550,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_configuration_manager gateway_ros2)
   medkit_set_test_domain(test_configuration_manager)
 
+  # Ros2ParameterTransport round-trip timeout coverage (#531): a
+  # discoverable-but-unresponsive node's parameter service must not hang the
+  # transport forever.
+  ament_add_gtest(test_ros2_parameter_transport test/test_ros2_parameter_transport.cpp)
+  target_link_libraries(test_ros2_parameter_transport gateway_ros2)
+  medkit_set_test_domain(test_ros2_parameter_transport)
+
   find_package(std_msgs REQUIRED)
 
   # Add DiscoveryManager tests
@@ -1034,6 +1041,7 @@ if(BUILD_TESTING)
       test_generic_client_compat
       test_operation_manager
       test_configuration_manager
+      test_ros2_parameter_transport
       test_discovery_manager
       test_runtime_discovery
       test_tls_config

--- a/src/ros2_medkit_gateway/design/index.rst
+++ b/src/ros2_medkit_gateway/design/index.rst
@@ -561,7 +561,7 @@ Each entry below is tagged with the static library it compiles into:
    - Runs on configurable host and port with CORS support
 
 5. **ConfigurationManager** ``[gateway_core]`` - Routes SOVD configuration CRUD through ``ParameterTransport``
-   - Manager body is middleware-neutral; ``Ros2ParameterTransport`` adapter performs the ``rclcpp::SyncParametersClient`` calls
+   - Manager body is middleware-neutral; ``Ros2ParameterTransport`` adapter performs the ``rclcpp::AsyncParametersClient`` calls (explicit ``spin_until_future_complete`` so a service TIMEOUT is distinguished from a successful-but-empty response)
    - Lists / gets / sets individual parameter values with type conversion
    - Provides parameter descriptors (description, constraints, read-only flag)
    - The transport caches parameter clients per node for efficiency

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/configuration_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/configuration_manager.hpp
@@ -30,7 +30,7 @@ using json = nlohmann::json;
  * @brief Application service for ROS 2 node parameters.
  *
  * Pure C++; ROS-side I/O is performed by the injected ParameterTransport
- * adapter (typically Ros2ParameterTransport). All rclcpp::SyncParametersClient
+ * adapter (typically Ros2ParameterTransport). All rclcpp::AsyncParametersClient
  * usage, the rclcpp::Parameter defaults cache, the negative-cache for
  * unreachable nodes, the spin_mutex serialising parameter-client spins, and
  * the JSON <-> rclcpp::ParameterValue conversion helpers live in the adapter.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/parameter_transport.hpp
@@ -79,10 +79,6 @@ class ParameterTransport {
   /// Service availability check (same semantics as today's negative cache).
   virtual bool is_node_available(const std::string & node_name) const = 0;
 
-  /// Drop client/cached state for a given node (called by the manager when
-  /// reset / refresh is requested).
-  virtual void invalidate(const std::string & node_name) = 0;
-
   /// Tear down all cached clients before rclcpp::shutdown(). Idempotent.
   virtual void shutdown() = 0;
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -86,7 +86,12 @@ class Ros2ParameterTransport : public ParameterTransport {
 
   /// Cache default values for a node (called on first access).
   /// @pre spin_mutex_ must be held by the caller.
-  void cache_default_values(const std::string & node_name);
+  /// @return true if the node's own round-trip failed/timed out (service not
+  ///         discoverable, or list/get IPC threw) so the caller can short-circuit
+  ///         WITHOUT depending on the negative-cache TTL (which is a no-op when
+  ///         negative_cache_ttl_sec_ == 0). false if defaults were cached, were
+  ///         already cached, or the transport is shutting down.
+  bool cache_default_values(const std::string & node_name);
 
   /// Check if a node is in the negative cache (recently unavailable).
   bool is_node_unavailable(const std::string & node_name) const;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -78,7 +78,6 @@ class Ros2ParameterTransport : public ParameterTransport {
   ParameterResult list_defaults(const std::string & node_name) override;
 
   bool is_node_available(const std::string & node_name) const override;
-  void invalidate(const std::string & node_name) override;
   void shutdown() override;
 
  private:

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -34,10 +34,17 @@ namespace ros2_medkit_gateway::ros2 {
 /**
  * @brief rclcpp adapter implementing ParameterTransport.
  *
- * Owns the rclcpp::SyncParametersClient cache, the rclcpp::Parameter defaults
+ * Owns the rclcpp::AsyncParametersClient cache, the rclcpp::Parameter defaults
  * cache, the negative-cache for unreachable nodes, the spin_mutex serialising
  * parameter-client spins, and the JSON <-> rclcpp::ParameterValue conversion
  * helpers that previously lived inside ConfigurationManager.
+ *
+ * Uses AsyncParametersClient + explicit spin_until_future_complete (not the
+ * SyncParametersClient) so a service TIMEOUT is distinguished from a
+ * successful-but-EMPTY response via rclcpp::FutureReturnCode. The sync client
+ * collapses SUCCESS-with-empty-result and TIMEOUT into the same empty vector,
+ * which caused a false-positive that negative-cached a HEALTHY node on a legit
+ * empty get (e.g. a param undeclared between list and get) - see #531.
  *
  * The adapter exposes only the neutral ParameterTransport surface to the
  * manager; all rclcpp types stay confined to this translation unit.
@@ -47,8 +54,8 @@ class Ros2ParameterTransport : public ParameterTransport {
   /**
    * @param node Non-owning ROS node used to declare parameters and to derive
    *             the gateway's own FQN for the self-node short circuit.
-   * @param service_timeout_sec Timeout for SyncParametersClient::wait_for_service
-   *                            and underlying parameter-service calls.
+   * @param service_timeout_sec Timeout for AsyncParametersClient::wait_for_service
+   *                            and each spin_until_future_complete round trip.
    * @param negative_cache_ttl_sec How long an unavailable node remains in the
    *                               negative cache before another IPC attempt.
    *                               Set to 0 to disable.
@@ -81,8 +88,18 @@ class Ros2ParameterTransport : public ParameterTransport {
   void shutdown() override;
 
  private:
-  /// Get or create a cached SyncParametersClient for the given node.
-  std::shared_ptr<rclcpp::SyncParametersClient> get_param_client(const std::string & node_name);
+  /// Get or create a cached AsyncParametersClient for the given node.
+  std::shared_ptr<rclcpp::AsyncParametersClient> get_param_client(const std::string & node_name);
+
+  /// Spin param_node_ until `future` resolves or the service timeout elapses.
+  /// The ONLY place a parameter round trip blocks; makes TIMEOUT explicit.
+  /// @pre spin_mutex_ must be held by the caller (single spin on param_node_).
+  /// @return TIMEOUT   - the node did not answer within service_timeout_sec;
+  ///         SUCCESS   - future.get() is valid (its result may legitimately be
+  ///                     an EMPTY vector: not-found / unset / raced);
+  ///         INTERRUPTED - transport shutting down (or param_node_ gone).
+  template <typename FutureT>
+  rclcpp::FutureReturnCode spin_for(const FutureT & future);
 
   /// Cache default values for a node (called on first access).
   /// @pre spin_mutex_ must be held by the caller.
@@ -140,8 +157,8 @@ class Ros2ParameterTransport : public ParameterTransport {
   std::map<std::string, std::map<std::string, rclcpp::Parameter>> default_values_;
 
   /// Mutex to serialize spin operations on param_node_.
-  /// SyncParametersClient::wait_for_service/get_parameters/etc spin param_node_
-  /// internally via spin_node_until_future_complete which is NOT thread-safe.
+  /// spin_for() drives spin_until_future_complete on param_node_, which is NOT
+  /// thread-safe against a concurrent spin on the same node.
   /// Declared BEFORE param_node_ so it outlives the node during destruction.
   mutable std::timed_mutex spin_mutex_;
 
@@ -149,9 +166,9 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Created once in constructor - must be in DDS graph early for fast service discovery.
   std::shared_ptr<rclcpp::Node> param_node_;
 
-  /// Cached SyncParametersClient per target node.
+  /// Cached AsyncParametersClient per target node.
   mutable std::mutex clients_mutex_;
-  std::map<std::string, std::shared_ptr<rclcpp::SyncParametersClient>> param_clients_;
+  std::map<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;
 
   /// Maximum entries in negative cache before hard eviction.
   static constexpr size_t kMaxNegativeCacheSize = 500;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -148,16 +148,29 @@ std::shared_ptr<rclcpp::AsyncParametersClient> Ros2ParameterTransport::get_param
 
 template <typename FutureT>
 rclcpp::FutureReturnCode Ros2ParameterTransport::spin_for(const FutureT & future) {
+  // Copy the node shared_ptr ONCE under clients_mutex_ and spin the local copy.
+  // spin_mutex_ (held by the caller) serialises spins in the normal case, but
+  // shutdown() has a degraded path: if it cannot acquire spin_mutex_ within
+  // kShutdownTimeout it resets param_node_ anyway. Reading the member directly here
+  // would then race that reset (concurrent access to the same shared_ptr instance =
+  // UB). shutdown() clears param_clients_ and resets param_node_ under clients_mutex_,
+  // so taking clients_mutex_ synchronises the read; the local copy also keeps the node
+  // alive for the whole spin even if shutdown resets the member mid-call (#531).
+  std::shared_ptr<rclcpp::Node> node;
+  {
+    std::lock_guard<std::mutex> lock(clients_mutex_);
+    node = param_node_;
+  }
   // Guard against spinning a torn-down node (shutdown races with an in-flight op).
-  if (shutdown_requested_.load() || !param_node_) {
+  if (shutdown_requested_.load() || !node) {
     return rclcpp::FutureReturnCode::INTERRUPTED;
   }
-  // Free-function overload spins a fresh SingleThreadedExecutor over param_node_
+  // Free-function overload spins a fresh SingleThreadedExecutor over the node
   // (collecting all current entities, including a just-created client) for up to
   // service_timeout_sec, then tears it down - no persistent executor to reconcile
   // with param_node_'s teardown. Serialised by spin_mutex_ (held by the caller),
-  // so only one spin runs on param_node_ at a time.
-  return rclcpp::spin_until_future_complete(param_node_, future, get_service_timeout());
+  // so only one spin runs on the node at a time.
+  return rclcpp::spin_until_future_complete(node, future, get_service_timeout());
 }
 
 ParameterResult Ros2ParameterTransport::list_own_parameters() {
@@ -1004,8 +1017,15 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
     }
 
     if (param_names.empty()) {
-      // Genuine zero-parameter node (responsive, SUCCESS with empty names). Nothing to
-      // cache; leave uncached and do NOT mark.
+      // Genuine zero-parameter node (responsive, SUCCESS with empty names). This is a
+      // STABLE, authoritative fact, so memoize an EMPTY defaults map: get_default then
+      // returns NOT_FOUND (not NO_DEFAULTS_CACHED) and subsequent list/get/reset calls
+      // do not re-round-trip under spin_mutex_ forever. Only a TIMEOUT must avoid caching
+      // (poison-avoidance); a SUCCESS-empty is safe to cache (#531).
+      std::lock_guard<std::mutex> lock(defaults_mutex_);
+      if (default_values_.find(node_name) == default_values_.end()) {
+        default_values_[node_name] = {};
+      }
       return false;
     }
 
@@ -1023,13 +1043,10 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       parameters = get_future.get();
     }
 
-    if (parameters.empty()) {
-      // Responsive node but no values came back (unset / undeclared / raced). Do NOT
-      // cache an empty map and do NOT mark - leave uncached so a later call retries
-      // once the values exist (#531).
-      return false;
-    }
-
+    // SUCCESS with values (or a responsive node that returned an empty set - unset /
+    // undeclared / raced): both are authoritative, so cache the resulting map. An empty
+    // map here is a genuine SUCCESS-empty and is SAFE to memoize (unlike the TIMEOUT
+    // branches above, which must not cache to avoid permanent poison) (#531).
     std::map<std::string, rclcpp::Parameter> node_defaults;
     for (const auto & param : parameters) {
       node_defaults[param.get_name()] = param;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -71,21 +71,6 @@ bool Ros2ParameterTransport::is_node_available(const std::string & node_name) co
   return !is_node_unavailable(node_name);
 }
 
-void Ros2ParameterTransport::invalidate(const std::string & node_name) {
-  {
-    std::unique_lock<std::shared_mutex> lock(negative_cache_mutex_);
-    unavailable_nodes_.erase(node_name);
-  }
-  {
-    std::lock_guard<std::mutex> lock(defaults_mutex_);
-    default_values_.erase(node_name);
-  }
-  {
-    std::lock_guard<std::mutex> lock(clients_mutex_);
-    param_clients_.erase(node_name);
-  }
-}
-
 std::optional<std::unique_lock<std::timed_mutex>>
 Ros2ParameterTransport::try_acquire_spin_lock(ParameterResult & result) {
   auto timeout = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -271,13 +256,22 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
         return result;
       }
 
-      auto param_names = client->list_parameters({}, 0);
-      parameters = client->get_parameters(param_names.names);
+      std::vector<std::string> param_names;
+      try {
+        auto list_result = client->list_parameters({}, 0, get_service_timeout());
+        param_names = list_result.names;
+        parameters = client->get_parameters(param_names, get_service_timeout());
+      } catch (const std::exception &) {
+        // Discoverable-but-unresponsive node: negative-cache so the next
+        // request fails fast instead of waiting the full timeout again (#531).
+        mark_node_unavailable(node_name);
+        throw;
+      }
 
-      if (parameters.empty() && !param_names.names.empty()) {
-        for (const auto & name : param_names.names) {
+      if (parameters.empty() && !param_names.empty()) {
+        for (const auto & name : param_names) {
           try {
-            auto single_params = client->get_parameters({name});
+            auto single_params = client->get_parameters({name}, get_service_timeout());
             if (!single_params.empty()) {
               parameters.push_back(single_params[0]);
             }
@@ -353,7 +347,23 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
         return result;
       }
 
-      auto param_names = client->list_parameters({param_name}, 1);
+      rcl_interfaces::msg::ListParametersResult param_names;
+      std::vector<rclcpp::Parameter> parameters;
+      try {
+        param_names = client->list_parameters({param_name}, 1, get_service_timeout());
+        if (!param_names.names.empty()) {
+          parameters = client->get_parameters({param_name}, get_service_timeout());
+          if (!parameters.empty()) {
+            descriptors = client->describe_parameters({param_name}, get_service_timeout());
+          }
+        }
+      } catch (const std::exception &) {
+        // Discoverable-but-unresponsive node: negative-cache so the next
+        // request fails fast instead of waiting the full timeout again (#531).
+        mark_node_unavailable(node_name);
+        throw;
+      }
+
       if (param_names.names.empty()) {
         result.success = false;
         result.error_message = "Parameter not found: " + param_name;
@@ -361,7 +371,6 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
         return result;
       }
 
-      auto parameters = client->get_parameters({param_name});
       if (parameters.empty()) {
         result.success = false;
         result.error_message = "Failed to get parameter: " + param_name;
@@ -370,7 +379,6 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
       }
 
       param = parameters[0];
-      descriptors = client->describe_parameters({param_name});
     }  // spin_mutex_ released.
 
     json param_obj;
@@ -465,16 +473,34 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       return result;
     }
 
-    auto current_params = client->get_parameters({param_name});
+    std::vector<rclcpp::Parameter> current_params;
+    try {
+      current_params = client->get_parameters({param_name}, get_service_timeout());
+    } catch (const std::exception &) {
+      // Discoverable-but-unresponsive node: negative-cache so the next
+      // request fails fast instead of waiting the full timeout again (#531).
+      mark_node_unavailable(node_name);
+      throw;
+    }
     rclcpp::ParameterType hint_type = rclcpp::ParameterType::PARAMETER_NOT_SET;
     if (!current_params.empty()) {
       hint_type = current_params[0].get_type();
     }
 
+    // json_to_parameter_value throws on bad CLIENT input (e.g. malformed
+    // value for the parameter's type) - deliberately NOT wrapped by the
+    // node-round-trip try/catch above/below so a bad client value never
+    // negative-caches a healthy node (#531).
     rclcpp::ParameterValue param_value = json_to_parameter_value(value, hint_type);
     rclcpp::Parameter param(param_name, param_value);
 
-    auto results = client->set_parameters({param});
+    std::vector<rcl_interfaces::msg::SetParametersResult> results;
+    try {
+      results = client->set_parameters({param}, get_service_timeout());
+    } catch (const std::exception &) {
+      mark_node_unavailable(node_name);
+      throw;
+    }
     if (results.empty() || !results[0].successful) {
       result.success = false;
       result.error_message = results.empty() ? "Failed to set parameter" : results[0].reason;
@@ -828,15 +854,23 @@ void Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       return;
     }
 
-    auto param_names = client->list_parameters({}, 0);
-
+    std::vector<std::string> param_names;
     std::vector<rclcpp::Parameter> parameters;
-    parameters = client->get_parameters(param_names.names);
+    try {
+      auto list_result = client->list_parameters({}, 0, get_service_timeout());
+      param_names = list_result.names;
+      parameters = client->get_parameters(param_names, get_service_timeout());
+    } catch (const std::exception &) {
+      // Discoverable-but-unresponsive node: negative-cache so the next
+      // request fails fast instead of waiting the full timeout again (#531).
+      mark_node_unavailable(node_name);
+      throw;
+    }
 
-    if (parameters.empty() && !param_names.names.empty()) {
-      for (const auto & name : param_names.names) {
+    if (parameters.empty() && !param_names.empty()) {
+      for (const auto & name : param_names) {
         try {
-          auto single_params = client->get_parameters({name});
+          auto single_params = client->get_parameters({name}, get_service_timeout());
           if (!single_params.empty()) {
             parameters.push_back(single_params[0]);
           }

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -288,9 +288,22 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
       }
 
       if (parameters.empty() && !param_names.empty()) {
+        // get_parameters came back empty even though list_parameters gave us names.
+        // Retry per-name (works around batch quirks), but under ONE shared deadline:
+        // each get_parameters({name}) burns a full timeout on a stuck node, so an
+        // unbounded loop would hold spin_mutex_ N x timeout and starve concurrent
+        // healthy-node callers. Cap the whole fallback at ~1x service_timeout_sec (#531).
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::duration_cast<std::chrono::steady_clock::duration>(get_service_timeout());
         for (const auto & name : param_names) {
+          // duration<double> (seconds), not steady_clock::duration: the latter is
+          // std::chrono::nanoseconds, which binds the PROTECTED get_parameters overload.
+          const std::chrono::duration<double> remaining = deadline - std::chrono::steady_clock::now();
+          if (remaining <= std::chrono::duration<double>::zero()) {
+            break;
+          }
           try {
-            auto single_params = client->get_parameters({name}, get_service_timeout());
+            auto single_params = client->get_parameters({name}, remaining);
             if (!single_params.empty()) {
               parameters.push_back(single_params[0]);
             }
@@ -300,6 +313,20 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
             }
           }
         }
+      }
+
+      if (parameters.empty() && !param_names.empty()) {
+        // list_parameters returned names but every get_parameters came back empty.
+        // get_parameters (unlike list_parameters) does NOT throw on timeout - it
+        // returns an empty vector - so all-empty after non-empty names is a value-read
+        // timeout, not an empty node. Report it as such (503) instead of a misleading
+        // success=[] (#531). A genuinely zero-parameter node returns empty param_names
+        // and never reaches here.
+        mark_node_unavailable(node_name);
+        result.success = false;
+        result.error_message = "Parameter service did not respond for node: " + node_name;
+        result.error_code = ParameterErrorCode::TIMEOUT;
+        return result;
       }
     }  // spin_mutex_ released - JSON building is lock-free.
 
@@ -392,9 +419,16 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
       }
 
       if (parameters.empty()) {
+        // list_parameters returned the name (so the parameter exists) but
+        // get_parameters came back empty. get_parameters does NOT throw on timeout -
+        // it returns an empty vector - and a responsive node returns one entry per
+        // requested name (even for an unset param), so empty-after-found means the
+        // node timed out on the value read. Report TIMEOUT (503) + negative-cache,
+        // not INTERNAL_ERROR (500) (#531).
+        mark_node_unavailable(node_name);
         result.success = false;
-        result.error_message = "Failed to get parameter: " + param_name;
-        result.error_code = ParameterErrorCode::INTERNAL_ERROR;
+        result.error_message = "Parameter service did not respond for node: " + node_name;
+        result.error_code = ParameterErrorCode::TIMEOUT;
         return result;
       }
 
@@ -512,15 +546,16 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
     std::vector<rclcpp::Parameter> current_params;
     try {
       current_params = client->get_parameters({param_name}, get_service_timeout());
-    } catch (const std::exception &) {
-      // Discoverable-but-unresponsive node: the bounded round-trip timed out.
-      // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
-      // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
-      mark_node_unavailable(node_name);
-      result.success = false;
-      result.error_message = "Parameter service did not respond for node: " + node_name;
-      result.error_code = ParameterErrorCode::TIMEOUT;
-      return result;
+    } catch (const std::exception & e) {
+      // Best-effort type-hint read only. get_parameters returns empty (does NOT throw)
+      // on timeout, and an empty result here is AMBIGUOUS - the param may simply not
+      // exist yet, OR the read timed out - so it is NOT the write-timeout discriminator
+      // (the set_parameters results below are). On the rare throw, log and continue
+      // with no type hint rather than failing the write (#531).
+      if (node_) {
+        RCLCPP_DEBUG(node_->get_logger(), "Pre-read of '%s' on node '%s' failed (continuing without type hint): %s",
+                     param_name.c_str(), node_name.c_str(), e.what());
+      }
     }
     rclcpp::ParameterType hint_type = rclcpp::ParameterType::PARAMETER_NOT_SET;
     if (!current_params.empty()) {
@@ -538,35 +573,49 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
     try {
       results = client->set_parameters({param}, get_service_timeout());
     } catch (const std::exception &) {
-      // Discoverable-but-unresponsive node: the bounded round-trip timed out.
-      // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
-      // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
-      //
-      // At-least-once ambiguity: a TIMEOUT/503 here does NOT guarantee the set did
-      // NOT apply on the node - the request may have been delivered and executed
-      // with only the response lost. Callers must re-read the parameter to confirm
-      // the effective value rather than assuming the write was rejected.
+      // Rare: set_parameters usually returns an empty results vector (handled below)
+      // rather than throwing on timeout. If it does throw, treat it the same -
+      // negative-cache and report TIMEOUT (503), not 500 (#531).
       mark_node_unavailable(node_name);
       result.success = false;
       result.error_message = "Parameter service did not respond for node: " + node_name;
       result.error_code = ParameterErrorCode::TIMEOUT;
       return result;
     }
-    if (results.empty() || !results[0].successful) {
+
+    if (results.empty()) {
+      // set_parameters returned an empty results vector. Like get_parameters it does
+      // NOT throw on timeout - a responsive node returns one SetParametersResult per
+      // param - so empty results = the write round-trip timed out. This is the ONLY
+      // reliable write-timeout discriminator (the pre-read above is best-effort and its
+      // empty is ambiguous). Report TIMEOUT (503) + negative-cache, not INTERNAL_ERROR
+      // (500) - pre-fix a fully-unresponsive node returned 500 with no negative cache,
+      // leaving #531 fully live on writes (#531).
+      //
+      // At-least-once ambiguity: a TIMEOUT/503 here does NOT guarantee the set did NOT
+      // apply on the node - the request may have been delivered and executed with only
+      // the response lost. Callers must re-read the parameter to confirm the effective
+      // value rather than assuming the write was rejected.
+      mark_node_unavailable(node_name);
       result.success = false;
-      result.error_message = results.empty() ? "Failed to set parameter" : results[0].reason;
-      if (!results.empty()) {
-        const auto & reason = results[0].reason;
-        if (reason.find("read-only") != std::string::npos || reason.find("read only") != std::string::npos ||
-            reason.find("is read_only") != std::string::npos) {
-          result.error_code = ParameterErrorCode::READ_ONLY;
-        } else if (reason.find("type") != std::string::npos) {
-          result.error_code = ParameterErrorCode::TYPE_MISMATCH;
-        } else {
-          result.error_code = ParameterErrorCode::INVALID_VALUE;
-        }
+      result.error_message = "Parameter service did not respond for node: " + node_name;
+      result.error_code = ParameterErrorCode::TIMEOUT;
+      return result;
+    }
+
+    if (!results[0].successful) {
+      // Legitimate rejection by a RESPONSIVE node (read-only / type / invalid value):
+      // classify by reason, NOT a timeout.
+      result.success = false;
+      result.error_message = results[0].reason;
+      const auto & reason = results[0].reason;
+      if (reason.find("read-only") != std::string::npos || reason.find("read only") != std::string::npos ||
+          reason.find("is read_only") != std::string::npos) {
+        result.error_code = ParameterErrorCode::READ_ONLY;
+      } else if (reason.find("type") != std::string::npos) {
+        result.error_code = ParameterErrorCode::TYPE_MISMATCH;
       } else {
-        result.error_code = ParameterErrorCode::INTERNAL_ERROR;
+        result.error_code = ParameterErrorCode::INVALID_VALUE;
       }
       return result;
     }
@@ -919,9 +968,20 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
     }
 
     if (parameters.empty() && !param_names.empty()) {
+      // Bounded per-name fallback under ONE shared deadline: each get_parameters({name})
+      // burns a full timeout on a stuck node, so an unbounded loop would hold spin_mutex_
+      // N x timeout. Cap the whole fallback at ~1x service_timeout_sec (#531).
+      const auto deadline = std::chrono::steady_clock::now() +
+                            std::chrono::duration_cast<std::chrono::steady_clock::duration>(get_service_timeout());
       for (const auto & name : param_names) {
+        // duration<double> (seconds), not steady_clock::duration: the latter is
+        // std::chrono::nanoseconds, which binds the PROTECTED get_parameters overload.
+        const std::chrono::duration<double> remaining = deadline - std::chrono::steady_clock::now();
+        if (remaining <= std::chrono::duration<double>::zero()) {
+          break;
+        }
         try {
-          auto single_params = client->get_parameters({name}, get_service_timeout());
+          auto single_params = client->get_parameters({name}, remaining);
           if (!single_params.empty()) {
             parameters.push_back(single_params[0]);
           }
@@ -936,6 +996,17 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
           }
         }
       }
+    }
+
+    if (parameters.empty() && !param_names.empty()) {
+      // list_parameters returned names but every get_parameters came back empty
+      // (get_parameters returns empty on timeout, it does not throw). Do NOT cache an
+      // empty defaults map: default_values_ is never invalidated, so an empty map would
+      // permanently poison this node - get_default / reset would return NOT_FOUND
+      // forever even after it recovers. Leave it uncached and negative-cache so a later
+      // (post-TTL) request retries (#531).
+      mark_node_unavailable(node_name);
+      return true;
     }
 
     std::map<std::string, rclcpp::Parameter> node_defaults;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -242,7 +242,19 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
       }
 
       // Cache default values first (gives node extra time for DDS service discovery).
+      // This is itself a bounded round-trip that marks the node unavailable on
+      // timeout. Short-circuit here if it just did so, rather than spending a
+      // SECOND up-to-service_timeout_sec_ round-trip below: holding spin_mutex_
+      // across both would exceed the acquisition margin granted by
+      // try_acquire_spin_lock() and spuriously TIMEOUT a concurrent request to a
+      // different, healthy node (#531).
       cache_default_values(node_name);
+      if (is_node_unavailable(node_name)) {
+        result.success = false;
+        result.error_message = "Parameter service not available for node: " + node_name;
+        result.error_code = ParameterErrorCode::SERVICE_UNAVAILABLE;
+        return result;
+      }
 
       if (!client->wait_for_service(get_service_timeout())) {
         result.success = false;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -132,7 +132,7 @@ void Ros2ParameterTransport::mark_node_unavailable(const std::string & node_name
   }
 }
 
-std::shared_ptr<rclcpp::SyncParametersClient> Ros2ParameterTransport::get_param_client(const std::string & node_name) {
+std::shared_ptr<rclcpp::AsyncParametersClient> Ros2ParameterTransport::get_param_client(const std::string & node_name) {
   std::lock_guard<std::mutex> lock(clients_mutex_);
   auto it = param_clients_.find(node_name);
   if (it != param_clients_.end()) {
@@ -141,9 +141,23 @@ std::shared_ptr<rclcpp::SyncParametersClient> Ros2ParameterTransport::get_param_
   if (!param_node_) {
     return nullptr;
   }
-  auto client = std::make_shared<rclcpp::SyncParametersClient>(param_node_, node_name);
+  auto client = std::make_shared<rclcpp::AsyncParametersClient>(param_node_, node_name);
   param_clients_[node_name] = client;
   return client;
+}
+
+template <typename FutureT>
+rclcpp::FutureReturnCode Ros2ParameterTransport::spin_for(const FutureT & future) {
+  // Guard against spinning a torn-down node (shutdown races with an in-flight op).
+  if (shutdown_requested_.load() || !param_node_) {
+    return rclcpp::FutureReturnCode::INTERRUPTED;
+  }
+  // Free-function overload spins a fresh SingleThreadedExecutor over param_node_
+  // (collecting all current entities, including a just-created client) for up to
+  // service_timeout_sec, then tears it down - no persistent executor to reconcile
+  // with param_node_'s teardown. Serialised by spin_mutex_ (held by the caller),
+  // so only one spin runs on param_node_ at a time.
+  return rclcpp::spin_until_future_complete(param_node_, future, get_service_timeout());
 }
 
 ParameterResult Ros2ParameterTransport::list_own_parameters() {
@@ -272,61 +286,52 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
       }
 
       std::vector<std::string> param_names;
-      try {
-        auto list_result = client->list_parameters({}, 0, get_service_timeout());
-        param_names = list_result.names;
-        parameters = client->get_parameters(param_names, get_service_timeout());
-      } catch (const std::exception &) {
-        // Discoverable-but-unresponsive node: the bounded round-trip timed out.
-        // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
-        // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
-        mark_node_unavailable(node_name);
-        result.success = false;
-        result.error_message = "Parameter service did not respond for node: " + node_name;
-        result.error_code = ParameterErrorCode::TIMEOUT;
-        return result;
-      }
-
-      if (parameters.empty() && !param_names.empty()) {
-        // get_parameters came back empty even though list_parameters gave us names.
-        // Retry per-name (works around batch quirks), but under ONE shared deadline:
-        // each get_parameters({name}) burns a full timeout on a stuck node, so an
-        // unbounded loop would hold spin_mutex_ N x timeout and starve concurrent
-        // healthy-node callers. Cap the whole fallback at ~1x service_timeout_sec (#531).
-        const auto deadline = std::chrono::steady_clock::now() +
-                              std::chrono::duration_cast<std::chrono::steady_clock::duration>(get_service_timeout());
-        for (const auto & name : param_names) {
-          // duration<double> (seconds), not steady_clock::duration: the latter is
-          // std::chrono::nanoseconds, which binds the PROTECTED get_parameters overload.
-          const std::chrono::duration<double> remaining = deadline - std::chrono::steady_clock::now();
-          if (remaining <= std::chrono::duration<double>::zero()) {
-            break;
-          }
-          try {
-            auto single_params = client->get_parameters({name}, remaining);
-            if (!single_params.empty()) {
-              parameters.push_back(single_params[0]);
-            }
-          } catch (const std::exception & e) {
-            if (node_) {
-              RCLCPP_DEBUG(node_->get_logger(), "Failed to get param '%s': %s", name.c_str(), e.what());
-            }
-          }
+      {
+        auto list_future = client->list_parameters({}, 0);
+        auto rc = spin_for(list_future);
+        if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+          // The node did not answer the list request in time (explicit TIMEOUT, not
+          // an ambiguous empty vector). Negative-cache it and report 503 (#531).
+          mark_node_unavailable(node_name);
+          result.success = false;
+          result.error_message = "Parameter service did not respond for node: " + node_name;
+          result.error_code = ParameterErrorCode::TIMEOUT;
+          return result;
         }
+        if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+          // INTERRUPTED: transport is shutting down. Do NOT mark (node is fine).
+          result.success = false;
+          result.error_message = "Parameter query interrupted for node: " + node_name;
+          result.error_code = ParameterErrorCode::SHUT_DOWN;
+          return result;
+        }
+        param_names = list_future.get().names;
       }
 
-      if (parameters.empty() && !param_names.empty()) {
-        // list_parameters returned names but every get_parameters came back empty.
-        // get_parameters (unlike list_parameters) does NOT throw on timeout - it
-        // returns an empty vector - so all-empty after non-empty names is a value-read
-        // timeout, not an empty node. Report it as such (503) instead of a misleading
-        // success=[] (#531). A genuinely zero-parameter node returns empty param_names
-        // and never reaches here.
-        mark_node_unavailable(node_name);
-        result.success = false;
-        result.error_message = "Parameter service did not respond for node: " + node_name;
-        result.error_code = ParameterErrorCode::TIMEOUT;
-        return result;
+      // Empty names on SUCCESS = a genuine zero-parameter node -> success=[], no mark.
+      if (!param_names.empty()) {
+        auto get_future = client->get_parameters(param_names);
+        auto rc = spin_for(get_future);
+        if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+          mark_node_unavailable(node_name);
+          result.success = false;
+          result.error_message = "Parameter service did not respond for node: " + node_name;
+          result.error_code = ParameterErrorCode::TIMEOUT;
+          return result;
+        }
+        if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+          result.success = false;
+          result.error_message = "Parameter query interrupted for node: " + node_name;
+          result.error_code = ParameterErrorCode::SHUT_DOWN;
+          return result;
+        }
+        // SUCCESS: the batch result is authoritative. It may hold fewer entries than
+        // param_names (params raced/undeclared between list and get) or even be empty
+        // ("listed but not currently gettable") - that is a LEGIT response from a
+        // responsive node, returned as-is, NOT a timeout. No mark. The Sync-era
+        // per-name fallback (which existed only to disambiguate a timeout-induced
+        // empty batch) is gone: TIMEOUT is now explicit above (#531).
+        parameters = get_future.get();
       }
     }  // spin_mutex_ released - JSON building is lock-free.
 
@@ -393,60 +398,84 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
         return result;
       }
 
-      rcl_interfaces::msg::ListParametersResult param_names;
-      std::vector<rclcpp::Parameter> parameters;
-      try {
-        param_names = client->list_parameters({param_name}, 1, get_service_timeout());
-        if (!param_names.names.empty()) {
-          parameters = client->get_parameters({param_name}, get_service_timeout());
+      // Confirm the parameter exists via list. TIMEOUT -> node unreachable (503);
+      // SUCCESS with empty names -> the parameter genuinely does not exist (NOT_FOUND,
+      // node is responsive so NO mark).
+      std::vector<std::string> found_names;
+      {
+        auto list_future = client->list_parameters({param_name}, 1);
+        auto rc = spin_for(list_future);
+        if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+          mark_node_unavailable(node_name);
+          result.success = false;
+          result.error_message = "Parameter service did not respond for node: " + node_name;
+          result.error_code = ParameterErrorCode::TIMEOUT;
+          return result;
         }
-      } catch (const std::exception &) {
-        // Discoverable-but-unresponsive node: the bounded round-trip timed out.
-        // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
-        // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
-        mark_node_unavailable(node_name);
-        result.success = false;
-        result.error_message = "Parameter service did not respond for node: " + node_name;
-        result.error_code = ParameterErrorCode::TIMEOUT;
-        return result;
+        if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+          result.success = false;
+          result.error_message = "Parameter query interrupted for node: " + node_name;
+          result.error_code = ParameterErrorCode::SHUT_DOWN;
+          return result;
+        }
+        found_names = list_future.get().names;
       }
 
-      if (param_names.names.empty()) {
+      if (found_names.empty()) {
         result.success = false;
         result.error_message = "Parameter not found: " + param_name;
         result.error_code = ParameterErrorCode::NOT_FOUND;
         return result;
       }
 
+      // Read the value. TIMEOUT -> node unreachable (503) + mark. SUCCESS with an
+      // EMPTY result -> the node answered but has no value for this name (unset /
+      // raced / undeclared between list and get): that is NOT a timeout, so treat it
+      // as NOT_FOUND and DO NOT mark the (responsive) node. Distinguishing these two
+      // is the whole point of the async client - the sync client returned the same
+      // empty vector for both and wrongly 503'd the healthy node (#531).
+      std::vector<rclcpp::Parameter> parameters;
+      {
+        auto get_future = client->get_parameters({param_name});
+        auto rc = spin_for(get_future);
+        if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+          mark_node_unavailable(node_name);
+          result.success = false;
+          result.error_message = "Parameter service did not respond for node: " + node_name;
+          result.error_code = ParameterErrorCode::TIMEOUT;
+          return result;
+        }
+        if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+          result.success = false;
+          result.error_message = "Parameter query interrupted for node: " + node_name;
+          result.error_code = ParameterErrorCode::SHUT_DOWN;
+          return result;
+        }
+        parameters = get_future.get();
+      }
+
       if (parameters.empty()) {
-        // list_parameters returned the name (so the parameter exists) but
-        // get_parameters came back empty. get_parameters does NOT throw on timeout -
-        // it returns an empty vector - and a responsive node returns one entry per
-        // requested name (even for an unset param), so empty-after-found means the
-        // node timed out on the value read. Report TIMEOUT (503) + negative-cache,
-        // not INTERNAL_ERROR (500) (#531).
-        mark_node_unavailable(node_name);
         result.success = false;
-        result.error_message = "Parameter service did not respond for node: " + node_name;
-        result.error_code = ParameterErrorCode::TIMEOUT;
+        result.error_message = "Parameter not currently set: " + param_name;
+        result.error_code = ParameterErrorCode::NOT_FOUND;
         return result;
       }
 
       param = parameters[0];
 
-      // describe_parameters is NON-ESSENTIAL: it only feeds the optional
-      // description / read_only descriptor fields. The value above is the
-      // essential result and is already in hand, so a timeout HERE must degrade
-      // gracefully (keep the value, skip the descriptor) rather than discard a
-      // good read and negative-cache an otherwise-live node. Deliberately its
-      // own try/catch, OUTSIDE the mark-on-timeout block above (#531).
-      try {
-        descriptors = client->describe_parameters({param_name}, get_service_timeout());
-      } catch (const std::exception & e) {
-        if (node_) {
-          RCLCPP_WARN(node_->get_logger(),
-                      "describe_parameters timed out for '%s' on node '%s'; returning value without descriptor: %s",
-                      param_name.c_str(), node_name.c_str(), e.what());
+      // describe_parameters is NON-ESSENTIAL (only feeds the optional description /
+      // read_only fields). Best-effort: only use it if the round trip SUCCEEDs;
+      // a TIMEOUT or interruption here just skips the descriptor - never mark, never
+      // fail, keep the value we already have (#531).
+      {
+        auto desc_future = client->describe_parameters({param_name});
+        if (spin_for(desc_future) == rclcpp::FutureReturnCode::SUCCESS) {
+          descriptors = desc_future.get();
+        } else if (node_) {
+          RCLCPP_DEBUG(node_->get_logger(),
+                       "describe_parameters did not complete for '%s' on node '%s'; "
+                       "returning value without descriptor",
+                       param_name.c_str(), node_name.c_str());
         }
       }
     }  // spin_mutex_ released.
@@ -543,18 +572,18 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       return result;
     }
 
+    // Pre-read the current value purely to derive a type hint. Best-effort: a TIMEOUT
+    // or empty result here just leaves hint_type NOT_SET (json_to_parameter_value then
+    // infers from the JSON). Do NOT mark on the pre-read - it is not the authoritative
+    // write-timeout signal (the set below is) (#531).
     std::vector<rclcpp::Parameter> current_params;
-    try {
-      current_params = client->get_parameters({param_name}, get_service_timeout());
-    } catch (const std::exception & e) {
-      // Best-effort type-hint read only. get_parameters returns empty (does NOT throw)
-      // on timeout, and an empty result here is AMBIGUOUS - the param may simply not
-      // exist yet, OR the read timed out - so it is NOT the write-timeout discriminator
-      // (the set_parameters results below are). On the rare throw, log and continue
-      // with no type hint rather than failing the write (#531).
-      if (node_) {
-        RCLCPP_DEBUG(node_->get_logger(), "Pre-read of '%s' on node '%s' failed (continuing without type hint): %s",
-                     param_name.c_str(), node_name.c_str(), e.what());
+    {
+      auto get_future = client->get_parameters({param_name});
+      if (spin_for(get_future) == rclcpp::FutureReturnCode::SUCCESS) {
+        current_params = get_future.get();
+      } else if (node_) {
+        RCLCPP_DEBUG(node_->get_logger(), "Pre-read of '%s' on node '%s' did not complete (continuing without hint)",
+                     param_name.c_str(), node_name.c_str());
       }
     }
     rclcpp::ParameterType hint_type = rclcpp::ParameterType::PARAMETER_NOT_SET;
@@ -562,44 +591,46 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       hint_type = current_params[0].get_type();
     }
 
-    // json_to_parameter_value throws on bad CLIENT input (e.g. malformed
-    // value for the parameter's type) - deliberately NOT wrapped by the
-    // node-round-trip try/catch above/below so a bad client value never
-    // negative-caches a healthy node (#531).
+    // json_to_parameter_value can throw on bad CLIENT input (e.g. malformed value for
+    // the parameter's type). It runs OUTSIDE any mark scope so a bad client value never
+    // negative-caches a healthy node; the outer catch maps a throw to INTERNAL_ERROR.
     rclcpp::ParameterValue param_value = json_to_parameter_value(value, hint_type);
     rclcpp::Parameter param(param_name, param_value);
 
     std::vector<rcl_interfaces::msg::SetParametersResult> results;
-    try {
-      results = client->set_parameters({param}, get_service_timeout());
-    } catch (const std::exception &) {
-      // Rare: set_parameters usually returns an empty results vector (handled below)
-      // rather than throwing on timeout. If it does throw, treat it the same -
-      // negative-cache and report TIMEOUT (503), not 500 (#531).
-      mark_node_unavailable(node_name);
-      result.success = false;
-      result.error_message = "Parameter service did not respond for node: " + node_name;
-      result.error_code = ParameterErrorCode::TIMEOUT;
-      return result;
+    {
+      auto set_future = client->set_parameters({param});
+      auto rc = spin_for(set_future);
+      if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+        // The node did not answer the write in time (explicit TIMEOUT). Negative-cache
+        // and report 503, not 500 (#531).
+        //
+        // At-least-once ambiguity: a TIMEOUT/503 here does NOT guarantee the set did NOT
+        // apply on the node - the request may have been delivered and executed with only
+        // the response lost. Callers must re-read the parameter to confirm the effective
+        // value rather than assuming the write was rejected.
+        mark_node_unavailable(node_name);
+        result.success = false;
+        result.error_message = "Parameter service did not respond for node: " + node_name;
+        result.error_code = ParameterErrorCode::TIMEOUT;
+        return result;
+      }
+      if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+        result.success = false;
+        result.error_message = "Parameter set interrupted for node: " + node_name;
+        result.error_code = ParameterErrorCode::SHUT_DOWN;
+        return result;
+      }
+      results = set_future.get();
     }
 
     if (results.empty()) {
-      // set_parameters returned an empty results vector. Like get_parameters it does
-      // NOT throw on timeout - a responsive node returns one SetParametersResult per
-      // param - so empty results = the write round-trip timed out. This is the ONLY
-      // reliable write-timeout discriminator (the pre-read above is best-effort and its
-      // empty is ambiguous). Report TIMEOUT (503) + negative-cache, not INTERNAL_ERROR
-      // (500) - pre-fix a fully-unresponsive node returned 500 with no negative cache,
-      // leaving #531 fully live on writes (#531).
-      //
-      // At-least-once ambiguity: a TIMEOUT/503 here does NOT guarantee the set did NOT
-      // apply on the node - the request may have been delivered and executed with only
-      // the response lost. Callers must re-read the parameter to confirm the effective
-      // value rather than assuming the write was rejected.
-      mark_node_unavailable(node_name);
+      // SUCCESS but no result: a responsive node returns one SetParametersResult per
+      // param, so an empty results vector on SUCCESS is a node-side anomaly, NOT a
+      // timeout. Report INTERNAL_ERROR and do NOT mark the (responsive) node (#531).
       result.success = false;
-      result.error_message = "Parameter service did not respond for node: " + node_name;
-      result.error_code = ParameterErrorCode::TIMEOUT;
+      result.error_message = "Set parameter returned no result for: " + param_name;
+      result.error_code = ParameterErrorCode::INTERNAL_ERROR;
       return result;
     }
 
@@ -955,58 +986,48 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
     }
 
     std::vector<std::string> param_names;
-    std::vector<rclcpp::Parameter> parameters;
-    try {
-      auto list_result = client->list_parameters({}, 0, get_service_timeout());
-      param_names = list_result.names;
-      parameters = client->get_parameters(param_names, get_service_timeout());
-    } catch (const std::exception &) {
-      // Discoverable-but-unresponsive node: negative-cache so the next
-      // request fails fast instead of waiting the full timeout again (#531).
-      mark_node_unavailable(node_name);
-      throw;
-    }
-
-    if (parameters.empty() && !param_names.empty()) {
-      // Bounded per-name fallback under ONE shared deadline: each get_parameters({name})
-      // burns a full timeout on a stuck node, so an unbounded loop would hold spin_mutex_
-      // N x timeout. Cap the whole fallback at ~1x service_timeout_sec (#531).
-      const auto deadline = std::chrono::steady_clock::now() +
-                            std::chrono::duration_cast<std::chrono::steady_clock::duration>(get_service_timeout());
-      for (const auto & name : param_names) {
-        // duration<double> (seconds), not steady_clock::duration: the latter is
-        // std::chrono::nanoseconds, which binds the PROTECTED get_parameters overload.
-        const std::chrono::duration<double> remaining = deadline - std::chrono::steady_clock::now();
-        if (remaining <= std::chrono::duration<double>::zero()) {
-          break;
-        }
-        try {
-          auto single_params = client->get_parameters({name}, remaining);
-          if (!single_params.empty()) {
-            parameters.push_back(single_params[0]);
-          }
-        } catch (const std::exception & e) {
-          // Log the per-parameter fetch failure rather than dropping it
-          // silently. A silent drop here surfaces later as
-          // NO_DEFAULTS_CACHED with no diagnostic for the operator.
-          if (node_) {
-            RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 5000,
-                                 "Failed to fetch default value for parameter '%s' on node '%s': %s", name.c_str(),
-                                 node_name.c_str(), e.what());
-          }
-        }
+    {
+      auto list_future = client->list_parameters({}, 0);
+      auto rc = spin_for(list_future);
+      if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+        // Node did not answer: negative-cache and short-circuit. Crucially, do NOT
+        // cache anything - caching an empty map on a timeout would permanently poison
+        // default_values_ (never invalidated) so get_default/reset return NOT_FOUND
+        // forever even after the node recovers (#531).
+        mark_node_unavailable(node_name);
+        return true;
       }
+      if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+        return true;  // INTERRUPTED (shutting down): short-circuit, no mark, no cache
+      }
+      param_names = list_future.get().names;
     }
 
-    if (parameters.empty() && !param_names.empty()) {
-      // list_parameters returned names but every get_parameters came back empty
-      // (get_parameters returns empty on timeout, it does not throw). Do NOT cache an
-      // empty defaults map: default_values_ is never invalidated, so an empty map would
-      // permanently poison this node - get_default / reset would return NOT_FOUND
-      // forever even after it recovers. Leave it uncached and negative-cache so a later
-      // (post-TTL) request retries (#531).
-      mark_node_unavailable(node_name);
-      return true;
+    if (param_names.empty()) {
+      // Genuine zero-parameter node (responsive, SUCCESS with empty names). Nothing to
+      // cache; leave uncached and do NOT mark.
+      return false;
+    }
+
+    std::vector<rclcpp::Parameter> parameters;
+    {
+      auto get_future = client->get_parameters(param_names);
+      auto rc = spin_for(get_future);
+      if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
+        mark_node_unavailable(node_name);
+        return true;  // timed out on the value read: do NOT cache (no empty-map poison)
+      }
+      if (rc != rclcpp::FutureReturnCode::SUCCESS) {
+        return true;
+      }
+      parameters = get_future.get();
+    }
+
+    if (parameters.empty()) {
+      // Responsive node but no values came back (unset / undeclared / raced). Do NOT
+      // cache an empty map and do NOT mark - leave uncached so a later call retries
+      // once the values exist (#531).
+      return false;
     }
 
     std::map<std::string, rclcpp::Parameter> node_defaults;
@@ -1021,10 +1042,15 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       }
     }
   } catch (const std::exception & e) {
+    // Defensive: no parameter round trip is expected to throw now (TIMEOUT/INTERRUPTED
+    // are explicit FutureReturnCodes and future.get() on SUCCESS does not throw). Any
+    // unexpected throw short-circuits without caching; do NOT mark (not proven a node
+    // timeout).
     if (node_) {
-      RCLCPP_ERROR(node_->get_logger(), "Failed to cache defaults for node '%s': %s", node_name.c_str(), e.what());
+      RCLCPP_ERROR(node_->get_logger(), "Unexpected error caching defaults for node '%s': %s", node_name.c_str(),
+                   e.what());
     }
-    return true;  // round-trip threw (timeout / unreachable): caller short-circuits
+    return true;
   }
   return false;  // defaults cached successfully
 }

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -274,10 +274,14 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
         param_names = list_result.names;
         parameters = client->get_parameters(param_names, get_service_timeout());
       } catch (const std::exception &) {
-        // Discoverable-but-unresponsive node: negative-cache so the next
-        // request fails fast instead of waiting the full timeout again (#531).
+        // Discoverable-but-unresponsive node: the bounded round-trip timed out.
+        // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
+        // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
         mark_node_unavailable(node_name);
-        throw;
+        result.success = false;
+        result.error_message = "Parameter service did not respond for node: " + node_name;
+        result.error_code = ParameterErrorCode::TIMEOUT;
+        return result;
       }
 
       if (parameters.empty() && !param_names.empty()) {
@@ -370,10 +374,14 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
           }
         }
       } catch (const std::exception &) {
-        // Discoverable-but-unresponsive node: negative-cache so the next
-        // request fails fast instead of waiting the full timeout again (#531).
+        // Discoverable-but-unresponsive node: the bounded round-trip timed out.
+        // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
+        // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
         mark_node_unavailable(node_name);
-        throw;
+        result.success = false;
+        result.error_message = "Parameter service did not respond for node: " + node_name;
+        result.error_code = ParameterErrorCode::TIMEOUT;
+        return result;
       }
 
       if (param_names.names.empty()) {
@@ -489,10 +497,14 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
     try {
       current_params = client->get_parameters({param_name}, get_service_timeout());
     } catch (const std::exception &) {
-      // Discoverable-but-unresponsive node: negative-cache so the next
-      // request fails fast instead of waiting the full timeout again (#531).
+      // Discoverable-but-unresponsive node: the bounded round-trip timed out.
+      // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
+      // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
       mark_node_unavailable(node_name);
-      throw;
+      result.success = false;
+      result.error_message = "Parameter service did not respond for node: " + node_name;
+      result.error_code = ParameterErrorCode::TIMEOUT;
+      return result;
     }
     rclcpp::ParameterType hint_type = rclcpp::ParameterType::PARAMETER_NOT_SET;
     if (!current_params.empty()) {
@@ -510,8 +522,14 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
     try {
       results = client->set_parameters({param}, get_service_timeout());
     } catch (const std::exception &) {
+      // Discoverable-but-unresponsive node: the bounded round-trip timed out.
+      // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
+      // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
       mark_node_unavailable(node_name);
-      throw;
+      result.success = false;
+      result.error_message = "Parameter service did not respond for node: " + node_name;
+      result.error_code = ParameterErrorCode::TIMEOUT;
+      return result;
     }
     if (results.empty() || !results[0].successful) {
       result.success = false;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -242,14 +242,17 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
       }
 
       // Cache default values first (gives node extra time for DDS service discovery).
-      // This is itself a bounded round-trip that marks the node unavailable on
-      // timeout. Short-circuit here if it just did so, rather than spending a
-      // SECOND up-to-service_timeout_sec_ round-trip below: holding spin_mutex_
-      // across both would exceed the acquisition margin granted by
+      // This is itself a bounded round-trip. If it just failed/timed out, short-circuit
+      // rather than spending a SECOND up-to-service_timeout_sec_ round-trip below:
+      // holding spin_mutex_ across both would exceed the acquisition margin granted by
       // try_acquire_spin_lock() and spuriously TIMEOUT a concurrent request to a
       // different, healthy node (#531).
-      cache_default_values(node_name);
-      if (is_node_unavailable(node_name)) {
+      //
+      // Gate on cache_default_values' own return value, NOT is_node_unavailable():
+      // the negative cache is a no-op when negative_cache_ttl_sec_ == 0 (a documented,
+      // in-range "disabled" value), so is_node_unavailable() would always be false there
+      // and the cap would silently break, reintroducing the ~2x-timeout hold.
+      if (cache_default_values(node_name)) {
         result.success = false;
         result.error_message = "Parameter service not available for node: " + node_name;
         result.error_code = ParameterErrorCode::SERVICE_UNAVAILABLE;
@@ -369,9 +372,6 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
         param_names = client->list_parameters({param_name}, 1, get_service_timeout());
         if (!param_names.names.empty()) {
           parameters = client->get_parameters({param_name}, get_service_timeout());
-          if (!parameters.empty()) {
-            descriptors = client->describe_parameters({param_name}, get_service_timeout());
-          }
         }
       } catch (const std::exception &) {
         // Discoverable-but-unresponsive node: the bounded round-trip timed out.
@@ -399,6 +399,22 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
       }
 
       param = parameters[0];
+
+      // describe_parameters is NON-ESSENTIAL: it only feeds the optional
+      // description / read_only descriptor fields. The value above is the
+      // essential result and is already in hand, so a timeout HERE must degrade
+      // gracefully (keep the value, skip the descriptor) rather than discard a
+      // good read and negative-cache an otherwise-live node. Deliberately its
+      // own try/catch, OUTSIDE the mark-on-timeout block above (#531).
+      try {
+        descriptors = client->describe_parameters({param_name}, get_service_timeout());
+      } catch (const std::exception & e) {
+        if (node_) {
+          RCLCPP_WARN(node_->get_logger(),
+                      "describe_parameters timed out for '%s' on node '%s'; returning value without descriptor: %s",
+                      param_name.c_str(), node_name.c_str(), e.what());
+        }
+      }
     }  // spin_mutex_ released.
 
     json param_obj;
@@ -525,6 +541,11 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       // Discoverable-but-unresponsive node: the bounded round-trip timed out.
       // Negative-cache it (next request fails fast) and report TIMEOUT so the REST
       // layer returns 503 (node unavailable), not 500 INTERNAL_ERROR (#531).
+      //
+      // At-least-once ambiguity: a TIMEOUT/503 here does NOT guarantee the set did
+      // NOT apply on the node - the request may have been delivered and executed
+      // with only the response lost. Callers must re-read the parameter to confirm
+      // the effective value rather than assuming the write was rejected.
       mark_node_unavailable(node_name);
       result.success = false;
       result.error_message = "Parameter service did not respond for node: " + node_name;
@@ -857,22 +878,22 @@ rclcpp::ParameterValue Ros2ParameterTransport::json_to_parameter_value(const jso
   return rclcpp::ParameterValue(value.dump());
 }
 
-void Ros2ParameterTransport::cache_default_values(const std::string & node_name) {
+bool Ros2ParameterTransport::cache_default_values(const std::string & node_name) {
   {
     std::lock_guard<std::mutex> lock(defaults_mutex_);
     if (default_values_.find(node_name) != default_values_.end()) {
-      return;
+      return false;  // already cached from a prior successful round-trip
     }
   }
 
   if (is_node_unavailable(node_name)) {
-    return;
+    return true;  // already negative-cached: caller should short-circuit
   }
 
   try {
     auto client = get_param_client(node_name);
     if (!client) {
-      return;
+      return false;  // transport shutting down, not a node-availability signal
     }
 
     if (!client->wait_for_service(get_service_timeout())) {
@@ -881,7 +902,7 @@ void Ros2ParameterTransport::cache_default_values(const std::string & node_name)
                     node_name.c_str());
       }
       mark_node_unavailable(node_name);
-      return;
+      return true;  // service not discoverable: the round-trip cannot proceed
     }
 
     std::vector<std::string> param_names;
@@ -932,7 +953,9 @@ void Ros2ParameterTransport::cache_default_values(const std::string & node_name)
     if (node_) {
       RCLCPP_ERROR(node_->get_logger(), "Failed to cache defaults for node '%s': %s", node_name.c_str(), e.what());
     }
+    return true;  // round-trip threw (timeout / unreachable): caller short-circuits
   }
+  return false;  // defaults cached successfully
 }
 
 }  // namespace ros2_medkit_gateway::ros2

--- a/src/ros2_medkit_gateway/test/test_configuration_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_configuration_manager.cpp
@@ -452,8 +452,8 @@ TEST_F(TestConfigurationManager, test_concurrent_parameter_access) {
 TEST_F(TestConfigurationManager, test_concurrent_parameter_operations_no_executor_error) {
   // Regression test: concurrent parameter operations must not cause
   // "Node has already been added to an executor" error.
-  // SyncParametersClient internally spins param_node_ - without proper
-  // serialization, concurrent calls would cause executor conflicts.
+  // spin_for() spins param_node_ (via spin_until_future_complete) - without
+  // proper serialization, concurrent calls would cause executor conflicts.
 
   node_->declare_parameter("concurrent_test_int", 0);
   node_->declare_parameter("concurrent_test_str", std::string("init"));

--- a/src/ros2_medkit_gateway/test/test_configuration_manager_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_configuration_manager_routing.cpp
@@ -159,10 +159,6 @@ class MockParameterTransport : public ParameterTransport {
     return true;
   }
 
-  void invalidate(const std::string & node_name) override {
-    invalidated_.push_back(node_name);
-  }
-
   void shutdown() override {
     ++shutdown_calls_;
   }
@@ -201,7 +197,6 @@ class MockParameterTransport : public ParameterTransport {
   std::string last_get_default_node_, last_get_default_name_;
   std::string last_list_defaults_node_;
   std::vector<SetCall> set_history_;
-  std::vector<std::string> invalidated_;
 
   int list_calls_ = 0;
   int get_calls_ = 0;

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -246,3 +246,32 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, GetParameterTimeoutMapsTo503N
       << "an unresponsive node must map to a 503 (node-unavailable) error code, got "
       << static_cast<int>(result.error_code);
 }
+
+// The list_parameters single-round-trip cap must hold even with the negative
+// cache DISABLED (negative_cache_ttl_sec == 0, a documented in-range value).
+// is_node_unavailable() is always false when the TTL is 0, so gating the cap on
+// it would silently let list_parameters do a SECOND round-trip and hold
+// spin_mutex_ ~2x service_timeout_sec. The cap is instead driven by
+// cache_default_values' own return value, which is TTL-independent (#531).
+//
+// Uses a dedicated transport with a 1.0s timeout so the 1x (~1s) vs 2x (~2s)
+// hold is cleanly separable: the < 1.8s assertion passes only if the second
+// round-trip is skipped. Shares the fixture's already-spinning unresponsive
+// node and client node.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersCapHoldsWithNegativeCacheDisabled) {
+  constexpr double kServiceTimeoutSec = 1.0;
+  constexpr double kNegativeCacheDisabled = 0.0;
+  auto ttl0_transport =
+      std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), kServiceTimeoutSec, kNegativeCacheDisabled);
+
+  auto start = std::chrono::steady_clock::now();
+  auto result = ttl0_transport->list_parameters(kUnresponsiveNodeName);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_FALSE(result.success);
+  EXPECT_LT(elapsed, std::chrono::milliseconds(1800))
+      << "with the negative cache disabled the spin_mutex_ hold must still be capped at ~1x "
+         "service_timeout_sec (single round-trip, ~1s), not ~2x (~2s) - elapsed(ms)="
+      << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+  EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR);
+}

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -22,12 +22,15 @@
 // pool.
 
 #include <gtest/gtest.h>
+#include <rcl_interfaces/msg/parameter_type.hpp>
 #include <rcl_interfaces/srv/describe_parameters.hpp>
 #include <rcl_interfaces/srv/get_parameter_types.hpp>
 #include <rcl_interfaces/srv/get_parameters.hpp>
 #include <rcl_interfaces/srv/list_parameters.hpp>
 #include <rcl_interfaces/srv/set_parameters.hpp>
 #include <rcl_interfaces/srv/set_parameters_atomically.hpp>
+
+#include <cstddef>
 
 #include <atomic>
 #include <chrono>
@@ -250,14 +253,16 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, GetParameterTimeoutMapsTo503N
 // The list_parameters single-round-trip cap must hold even with the negative
 // cache DISABLED (negative_cache_ttl_sec == 0, a documented in-range value).
 // is_node_unavailable() is always false when the TTL is 0, so gating the cap on
-// it would silently let list_parameters do a SECOND round-trip and hold
-// spin_mutex_ ~2x service_timeout_sec. The cap is instead driven by
-// cache_default_values' own return value, which is TTL-independent (#531).
+// it would silently let list_parameters do a SECOND round-trip. The cap is
+// instead driven by cache_default_values' own return value, which is
+// TTL-independent (#531).
 //
-// Uses a dedicated transport with a 1.0s timeout so the 1x (~1s) vs 2x (~2s)
-// hold is cleanly separable: the < 1.8s assertion passes only if the second
-// round-trip is skipped. Shares the fixture's already-spinning unresponsive
-// node and client node.
+// Timing-INDEPENDENT assertion (does not flake under TSan/ASan, which triple
+// ctest timeouts): the error CLASS is the proxy for which path ran.
+// cache_default_values short-circuits with SERVICE_UNAVAILABLE, so seeing
+// SERVICE_UNAVAILABLE proves the short-circuit fired (single round-trip). If the
+// cap were defeated (second round-trip), list_parameters' own catch would set
+// TIMEOUT instead. A generous outer time bound is kept only as a sanity net.
 TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersCapHoldsWithNegativeCacheDisabled) {
   constexpr double kServiceTimeoutSec = 1.0;
   constexpr double kNegativeCacheDisabled = 0.0;
@@ -269,9 +274,230 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersCapHoldsWithNeg
   auto elapsed = std::chrono::steady_clock::now() - start;
 
   EXPECT_FALSE(result.success);
-  EXPECT_LT(elapsed, std::chrono::milliseconds(1800))
-      << "with the negative cache disabled the spin_mutex_ hold must still be capped at ~1x "
-         "service_timeout_sec (single round-trip, ~1s), not ~2x (~2s) - elapsed(ms)="
-      << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
+  EXPECT_EQ(result.error_code, ParameterErrorCode::SERVICE_UNAVAILABLE)
+      << "with the negative cache disabled the cache_default_values short-circuit must still fire "
+         "(SERVICE_UNAVAILABLE); TIMEOUT would mean the cap was defeated and a second round-trip ran";
+  EXPECT_LT(elapsed, std::chrono::seconds(5)) << "sanity: still bounded";
+}
+
+// ---------------------------------------------------------------------------
+// list_parameters RESPONDS, get_parameters / set_parameters BLOCK.
+//
+// This is the coverage the fully-unresponsive fixture above CANNOT provide:
+// SyncParametersClient::get_parameters and set_parameters do NOT throw on
+// timeout - they return an EMPTY vector (only list_parameters throws). So the
+// mark-on-timeout catch blocks never fire for get/set; the timeout has to be
+// detected via "empty response when names were requested". A node that answers
+// list_parameters (so the transport gets past the first call) but stalls on the
+// value read/write is exactly what exercises those empty-result paths (#531).
+// ---------------------------------------------------------------------------
+class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test {
+ protected:
+  static constexpr const char * kNodeName = "list_responds_getset_stuck_node";
+  static constexpr const char * kParamName = "sample_param";
+
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override {
+    rclcpp::NodeOptions options;
+    options.start_parameter_services(false);
+    node_ = std::make_shared<rclcpp::Node>(kNodeName, options);
+
+    // list_parameters ALWAYS responds with one name, so the transport always
+    // gets past the first round-trip call and reaches get/set.
+    list_parameters_service_ = node_->create_service<rcl_interfaces::srv::ListParameters>(
+        "~/list_parameters", [](const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> /*request*/,
+                                std::shared_ptr<rcl_interfaces::srv::ListParameters::Response> response) {
+          response->result.names.push_back(kParamName);
+        });
+
+    // get_parameters: blocks while block_get_ is set (client times out -> empty),
+    // otherwise returns one INTEGER value per requested name (responsive).
+    get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
+        "~/get_parameters", [this](const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
+                                   std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> response) {
+          while (block_get_.load() && !release_all_.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          }
+          if (release_all_.load()) {
+            return;
+          }
+          for (size_t i = 0; i < request->names.size(); ++i) {
+            rcl_interfaces::msg::ParameterValue value;
+            value.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+            value.integer_value = 42;
+            response->values.push_back(value);
+          }
+        });
+
+    // set_parameters: blocks while block_set_ is set (client times out -> empty),
+    // otherwise returns one successful result per param (responsive).
+    set_parameters_service_ = node_->create_service<rcl_interfaces::srv::SetParameters>(
+        "~/set_parameters", [this](const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> request,
+                                   std::shared_ptr<rcl_interfaces::srv::SetParameters::Response> response) {
+          while (block_set_.load() && !release_all_.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          }
+          if (release_all_.load()) {
+            return;
+          }
+          for (size_t i = 0; i < request->parameters.size(); ++i) {
+            rcl_interfaces::msg::SetParametersResult result;
+            result.successful = true;
+            response->results.push_back(result);
+          }
+        });
+
+    // describe_parameters / get_parameter_types / set_parameters_atomically only
+    // need to exist so wait_for_service() succeeds; they respond instantly empty.
+    describe_parameters_service_ = node_->create_service<rcl_interfaces::srv::DescribeParameters>(
+        "~/describe_parameters",
+        [](const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> /*request*/,
+           std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Response> /*response*/) {});
+    get_parameter_types_service_ = node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
+        "~/get_parameter_types", [](const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> /*request*/,
+                                    std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Response> /*response*/) {});
+    set_parameters_atomically_service_ = node_->create_service<rcl_interfaces::srv::SetParametersAtomically>(
+        "~/set_parameters_atomically",
+        [](const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> /*request*/,
+           std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Response> /*response*/) {});
+
+    client_node_ = std::make_shared<rclcpp::Node>("test_listresponds_client_node");
+
+    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(node_);
+    spin_thread_running_ = true;
+    spin_thread_ = std::thread([this]() {
+      while (spin_thread_running_) {
+        executor_->spin_some(std::chrono::milliseconds(10));
+      }
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+
+  void TearDown() override {
+    release_all_ = true;  // unstick any blocked callback first
+    executor_->cancel();
+    spin_thread_running_ = false;
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    executor_->remove_node(node_);
+    executor_.reset();
+    list_parameters_service_.reset();
+    get_parameters_service_.reset();
+    set_parameters_service_.reset();
+    describe_parameters_service_.reset();
+    get_parameter_types_service_.reset();
+    set_parameters_atomically_service_.reset();
+    node_.reset();
+    client_node_.reset();
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  rclcpp::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::DescribeParameters>::SharedPtr describe_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr get_parameter_types_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr set_parameters_atomically_service_;
+
+  std::atomic<bool> block_get_{false};
+  std::atomic<bool> block_set_{false};
+  std::atomic<bool> release_all_{false};
+
+  std::shared_ptr<rclcpp::Node> client_node_;
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::atomic<bool> spin_thread_running_{false};
+};
+
+// (a) get_parameter: list responds (param exists) but get_parameters returns
+// empty (timeout). Must map to a 503-class code (TIMEOUT), NOT INTERNAL_ERROR
+// (500), and negative-cache the node. Before this fix the empty-get branch was
+// INTERNAL_ERROR because get_parameters never throws on timeout (#531).
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, GetParameterEmptyGetAfterFoundNameIsTimeout) {
+  block_get_ = true;
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto result = transport->get_parameter(kNodeName, kParamName);
+
+  EXPECT_FALSE(result.success);
+  EXPECT_EQ(result.error_code, ParameterErrorCode::TIMEOUT)
+      << "empty get_parameters after a found name is a value-read timeout, got " << static_cast<int>(result.error_code);
   EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR);
+  EXPECT_FALSE(transport->is_node_available(kNodeName)) << "the get timeout must negative-cache the node";
+}
+
+// (b) set_parameter: pre-read responds (fast type hint), but set_parameters
+// returns empty (timeout). Must map to TIMEOUT (503) + negative-cache, NOT
+// INTERNAL_ERROR (500). This is the #531-fully-live-on-writes path: pre-fix a
+// fully-unresponsive node's set returned 500 with no negative cache.
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, SetParameterEmptyResultsIsTimeoutNotInternalError) {
+  block_get_ = false;  // pre-read (type hint) responds quickly
+  block_set_ = true;   // the actual write stalls
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto result = transport->set_parameter(kNodeName, kParamName, nlohmann::json(7));
+
+  EXPECT_FALSE(result.success);
+  EXPECT_EQ(result.error_code, ParameterErrorCode::TIMEOUT)
+      << "empty set_parameters results is a write timeout, got " << static_cast<int>(result.error_code);
+  EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR);
+  EXPECT_FALSE(transport->is_node_available(kNodeName)) << "the set timeout must negative-cache the node";
+}
+
+// (c) list_parameters op: defaults already cached (so cache_default_values does
+// not short-circuit), then get_parameters stalls on the MAIN round-trip. The
+// all-empty-after-names result must be reported as TIMEOUT, not a misleading
+// success=[] (#531). Asserting TIMEOUT (not SERVICE_UNAVAILABLE) pins the main
+// round-trip path specifically, distinct from the cache_default_values gate.
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ListParametersEmptyGetAfterNamesIsTimeoutNotEmptySuccess) {
+  block_get_ = false;  // fully responsive first
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto first = transport->list_parameters(kNodeName);
+  ASSERT_TRUE(first.success) << "responsive node must list successfully and cache defaults first";
+
+  block_get_ = true;  // now stall value reads
+  auto second = transport->list_parameters(kNodeName);
+
+  EXPECT_FALSE(second.success);
+  EXPECT_EQ(second.error_code, ParameterErrorCode::TIMEOUT)
+      << "list returned names but all gets came back empty: must be TIMEOUT (main round-trip), got "
+      << static_cast<int>(second.error_code);
+}
+
+// Recovery: a node negative-cached on a get timeout must recover once it becomes
+// responsive again and the TTL expires - it must NOT be 503'd forever. Also
+// pins Fix 4 (no empty-defaults poison): cache_default_values must NOT have
+// committed an empty defaults map on the timeout, or get_default would return
+// NOT_FOUND forever; after recovery get_default returns the real value.
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, MarkedNodeRecoversAfterTtlExpires) {
+  constexpr double kServiceTimeoutSec = 0.5;
+  constexpr double kShortTtlSec = 0.4;
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), kServiceTimeoutSec, kShortTtlSec);
+
+  block_get_ = true;
+  auto stalled = transport->list_parameters(kNodeName);
+  EXPECT_FALSE(stalled.success);
+  EXPECT_FALSE(transport->is_node_available(kNodeName)) << "get timeout must negative-cache the node";
+
+  // Node becomes responsive again; wait past the negative-cache TTL.
+  block_get_ = false;
+  std::this_thread::sleep_for(std::chrono::milliseconds(700));
+
+  auto recovered = transport->list_parameters(kNodeName);
+  EXPECT_TRUE(recovered.success) << "a marked node must recover after the TTL expires, not stay 503 forever";
+
+  // Fix 4: defaults were NOT poisoned with an empty map on the earlier timeout,
+  // so after recovery the real default is retrievable (not NOT_FOUND forever).
+  auto def = transport->get_default(kNodeName, kParamName);
+  EXPECT_TRUE(def.success) << "get_default must return the real default after recovery, not a poisoned empty cache";
 }

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -226,3 +226,23 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, SecondCallShortCircuitsViaNeg
   EXPECT_LT(elapsed, std::chrono::milliseconds(100))
       << "second call must hit the negative cache and fail fast, not re-attempt the 0.5s IPC timeout";
 }
+
+// A round-trip timeout against an unresponsive node must map to a
+// node-unavailable error code (TIMEOUT / SERVICE_UNAVAILABLE -> HTTP 503), NOT
+// INTERNAL_ERROR (-> HTTP 500). Before the fix the inner round-trip catch
+// rethrew into the operation's outer catch, which set INTERNAL_ERROR and thus
+// wrongly surfaced a 500 for what is really "the node isn't answering" (#531).
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, GetParameterTimeoutMapsTo503NotInternalError) {
+  auto start = std::chrono::steady_clock::now();
+  auto result = transport_->get_parameter(kUnresponsiveNodeName, "some_param");
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_FALSE(result.success);
+  EXPECT_LT(elapsed, std::chrono::seconds(5)) << "get_parameter() must be bounded by service_timeout_sec";
+  EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR)
+      << "a node round-trip timeout must not be reported as INTERNAL_ERROR (would map to HTTP 500)";
+  EXPECT_TRUE(result.error_code == ParameterErrorCode::TIMEOUT ||
+              result.error_code == ParameterErrorCode::SERVICE_UNAVAILABLE)
+      << "an unresponsive node must map to a 503 (node-unavailable) error code, got "
+      << static_cast<int>(result.error_code);
+}

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -1,0 +1,215 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression coverage for #531: a discoverable-but-unresponsive node's
+// parameter service must not be able to hang Ros2ParameterTransport forever.
+// Before the fix, client->list_parameters(...)/get_parameters(...)/etc. were
+// called with no timeout, so rclcpp defaulted to waiting forever once
+// wait_for_service() had already succeeded (i.e. the service exists in the
+// ROS graph but its callback never replies in time). That held spin_mutex_
+// and an HTTP worker forever, eventually exhausting the whole gateway thread
+// pool.
+
+#include <gtest/gtest.h>
+#include <rcl_interfaces/srv/describe_parameters.hpp>
+#include <rcl_interfaces/srv/get_parameter_types.hpp>
+#include <rcl_interfaces/srv/get_parameters.hpp>
+#include <rcl_interfaces/srv/list_parameters.hpp>
+#include <rcl_interfaces/srv/set_parameters.hpp>
+#include <rcl_interfaces/srv/set_parameters_atomically.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <thread>
+
+#include "ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp"
+
+using namespace ros2_medkit_gateway;
+
+namespace {
+
+constexpr const char * kUnresponsiveNodeName = "unresponsive_param_node";
+
+}  // namespace
+
+class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestSuite() {
+    rclcpp::shutdown();
+  }
+
+  void SetUp() override {
+    // The node under test: parameter services are NOT auto-started by
+    // rclcpp::Node (start_parameter_services(false)); instead we hand-roll a
+    // ListParameters service whose callback blocks well past the transport's
+    // service timeout, simulating a node that IS discoverable (the service
+    // exists in the ROS graph, so wait_for_service() succeeds immediately)
+    // but never actually answers a request in time.
+    //
+    // The callback blocks on release_blocking_callback_ rather than a fixed
+    // sleep: it never completes on its own during the assertions below
+    // (proving the client-side call is bounded purely by
+    // Ros2ParameterTransport's own timeout, not by how long the server takes
+    // to reply), while still letting TearDown release it immediately so the
+    // test suite doesn't pay a long fixed delay every run.
+    rclcpp::NodeOptions unresponsive_options;
+    unresponsive_options.start_parameter_services(false);
+    unresponsive_node_ = std::make_shared<rclcpp::Node>(kUnresponsiveNodeName, unresponsive_options);
+
+    list_parameters_service_ = unresponsive_node_->create_service<rcl_interfaces::srv::ListParameters>(
+        "~/list_parameters", [this](const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> /*request*/,
+                                    std::shared_ptr<rcl_interfaces::srv::ListParameters::Response> /*response*/) {
+          while (!release_blocking_callback_.load()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          }
+        });
+
+    // The remaining parameter services just need to exist in the ROS graph
+    // so that wait_for_service() (which only probes service discovery, not
+    // responsiveness) succeeds regardless of which underlying client it
+    // checks. They are not expected to be invoked by the scenarios below
+    // since list_parameters is the first remote call in the round trip and
+    // it never returns within the bounded timeout.
+    get_parameters_service_ = unresponsive_node_->create_service<rcl_interfaces::srv::GetParameters>(
+        "~/get_parameters", [](const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> /*request*/,
+                               std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> /*response*/) {});
+    set_parameters_service_ = unresponsive_node_->create_service<rcl_interfaces::srv::SetParameters>(
+        "~/set_parameters", [](const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> /*request*/,
+                               std::shared_ptr<rcl_interfaces::srv::SetParameters::Response> /*response*/) {});
+    describe_parameters_service_ = unresponsive_node_->create_service<rcl_interfaces::srv::DescribeParameters>(
+        "~/describe_parameters",
+        [](const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> /*request*/,
+           std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Response> /*response*/) {});
+    get_parameter_types_service_ = unresponsive_node_->create_service<rcl_interfaces::srv::GetParameterTypes>(
+        "~/get_parameter_types", [](const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> /*request*/,
+                                    std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Response> /*response*/) {});
+    set_parameters_atomically_service_ =
+        unresponsive_node_->create_service<rcl_interfaces::srv::SetParametersAtomically>(
+            "~/set_parameters_atomically",
+            [](const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> /*request*/,
+               std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Response> /*response*/) {});
+
+    // Client-side node handed to the transport (used only for logging / the
+    // self-node FQN short-circuit). Ros2ParameterTransport creates and owns
+    // its own internal node for the actual SyncParametersClient IPC, so this
+    // node does not need to be spun for parameter round trips to proceed.
+    client_node_ = std::make_shared<rclcpp::Node>("test_param_transport_client_node");
+
+    // Small service_timeout_sec so the test proves boundedness quickly.
+    // Generous negative_cache_ttl_sec so the negative-cache scenario below
+    // is guaranteed to hit the cache rather than re-attempting IPC.
+    transport_ = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+    // Spin the unresponsive node so its service callback can be dispatched
+    // when a request arrives.
+    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(unresponsive_node_);
+    spin_thread_running_ = true;
+    spin_thread_ = std::thread([this]() {
+      while (spin_thread_running_) {
+        executor_->spin_some(std::chrono::milliseconds(10));
+      }
+    });
+
+    // Give the service time to register in the ROS graph before the test
+    // starts issuing requests (avoids a flaky wait_for_service failure that
+    // would mask the scenario under test).
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+
+  void TearDown() override {
+    // Release any in-flight blocking service callback first so the spin
+    // thread can drain and exit promptly.
+    release_blocking_callback_ = true;
+    spin_thread_running_ = false;
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    executor_->cancel();
+    executor_->remove_node(unresponsive_node_);
+    transport_.reset();
+    executor_.reset();
+    list_parameters_service_.reset();
+    get_parameters_service_.reset();
+    set_parameters_service_.reset();
+    describe_parameters_service_.reset();
+    get_parameter_types_service_.reset();
+    set_parameters_atomically_service_.reset();
+    unresponsive_node_.reset();
+    client_node_.reset();
+  }
+
+  std::shared_ptr<rclcpp::Node> unresponsive_node_;
+  rclcpp::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::DescribeParameters>::SharedPtr describe_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr get_parameter_types_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr set_parameters_atomically_service_;
+  std::atomic<bool> release_blocking_callback_{false};
+
+  std::shared_ptr<rclcpp::Node> client_node_;
+  std::shared_ptr<ros2::Ros2ParameterTransport> transport_;
+
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::atomic<bool> spin_thread_running_{false};
+};
+
+// GREEN (post-fix) behavior: a request against a discoverable-but-never-
+// responding node's parameter service returns a bounded-time error instead
+// of hanging forever.
+//
+// RED (pre-fix) would have been: this call blocks until the service replies,
+// which in this fixture is only released by TearDown - i.e. it would not
+// return during the test body at all. That cannot be safely exercised in a
+// test that must terminate on its own (the point of #531 is precisely that
+// nothing bounds it), so instead this asserts the call completes well within
+// a small multiple of service_timeout_sec (0.5s) - which is only possible
+// because get_service_timeout() is now threaded through every
+// SyncParametersClient call in the round trip.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersReturnsBoundedErrorInsteadOfHanging) {
+  auto start = std::chrono::steady_clock::now();
+  auto result = transport_->list_parameters(kUnresponsiveNodeName);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_FALSE(result.success);
+  EXPECT_LT(elapsed, std::chrono::seconds(5))
+      << "list_parameters() against an unresponsive-but-discoverable node must be bounded by "
+         "service_timeout_sec, not block until the server replies (or forever, pre-fix)";
+}
+
+// A second, immediate call against the same node must short-circuit via the
+// negative cache (mark_node_unavailable() populated it on the first call's
+// round-trip failure) rather than paying the timeout again.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, SecondCallShortCircuitsViaNegativeCache) {
+  auto first_result = transport_->list_parameters(kUnresponsiveNodeName);
+  ASSERT_FALSE(first_result.success);
+  ASSERT_FALSE(transport_->is_node_available(kUnresponsiveNodeName))
+      << "first round-trip failure must negative-cache the node (#531)";
+
+  auto start = std::chrono::steady_clock::now();
+  auto second_result = transport_->list_parameters(kUnresponsiveNodeName);
+  auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_FALSE(second_result.success);
+  EXPECT_LT(elapsed, std::chrono::milliseconds(100))
+      << "second call must hit the negative cache and fail fast, not re-attempt the 0.5s IPC timeout";
+}

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -111,7 +111,7 @@ class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
 
     // Client-side node handed to the transport (used only for logging / the
     // self-node FQN short-circuit). Ros2ParameterTransport creates and owns
-    // its own internal node for the actual SyncParametersClient IPC, so this
+    // its own internal node for the actual AsyncParametersClient IPC, so this
     // node does not need to be spun for parameter round trips to proceed.
     client_node_ = std::make_shared<rclcpp::Node>("test_param_transport_client_node");
 
@@ -190,8 +190,8 @@ class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
 // test that must terminate on its own (the point of #531 is precisely that
 // nothing bounds it), so instead this asserts the call completes well within
 // a small multiple of service_timeout_sec (0.5s) - which is only possible
-// because get_service_timeout() is now threaded through every
-// SyncParametersClient call in the round trip.
+// because get_service_timeout() bounds each spin_until_future_complete round
+// trip.
 //
 // list_parameters() also short-circuits after its internal
 // cache_default_values() round-trip marks the node unavailable, so the whole
@@ -281,15 +281,18 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersCapHoldsWithNeg
 }
 
 // ---------------------------------------------------------------------------
-// list_parameters RESPONDS, get_parameters / set_parameters BLOCK.
+// list_parameters RESPONDS, get_parameters / set_parameters BLOCK (or answer
+// empty).
 //
-// This is the coverage the fully-unresponsive fixture above CANNOT provide:
-// SyncParametersClient::get_parameters and set_parameters do NOT throw on
-// timeout - they return an EMPTY vector (only list_parameters throws). So the
-// mark-on-timeout catch blocks never fire for get/set; the timeout has to be
-// detected via "empty response when names were requested". A node that answers
-// list_parameters (so the transport gets past the first call) but stalls on the
-// value read/write is exactly what exercises those empty-result paths (#531).
+// This is the coverage the fully-unresponsive fixture above CANNOT provide.
+// The transport uses AsyncParametersClient + spin_until_future_complete, so a
+// get/set that times out yields FutureReturnCode::TIMEOUT while a get/set that
+// answers with an empty result yields SUCCESS - two distinct outcomes the
+// (removed) SyncParametersClient collapsed into the same empty vector. A node
+// that answers list (so the transport gets past the first call) but blocks the
+// value read/write exercises the TIMEOUT path; the same node answering the get
+// with an EMPTY value (get_returns_empty_) exercises the SUCCESS-empty path -
+// which must NOT be mistaken for a timeout (#531).
 // ---------------------------------------------------------------------------
 class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test {
  protected:
@@ -316,16 +319,19 @@ class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test
           response->result.names.push_back(kParamName);
         });
 
-    // get_parameters: blocks while block_get_ is set (client times out -> empty),
-    // otherwise returns one INTEGER value per requested name (responsive).
+    // get_parameters: blocks while block_get_ is set (client times out -> empty).
+    // When get_returns_empty_ is set it RESPONDS immediately with an EMPTY values
+    // vector (responsive, but no value) - the crucial discriminator between a genuine
+    // "not currently gettable" and a timeout. Otherwise returns one INTEGER value per
+    // requested name (responsive).
     get_parameters_service_ = node_->create_service<rcl_interfaces::srv::GetParameters>(
         "~/get_parameters", [this](const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> request,
                                    std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> response) {
           while (block_get_.load() && !release_all_.load()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
           }
-          if (release_all_.load()) {
-            return;
+          if (release_all_.load() || get_returns_empty_.load()) {
+            return;  // respond with an empty values vector (fast, responsive)
           }
           for (size_t i = 0; i < request->names.size(); ++i) {
             rcl_interfaces::msg::ParameterValue value;
@@ -410,6 +416,7 @@ class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test
 
   std::atomic<bool> block_get_{false};
   std::atomic<bool> block_set_{false};
+  std::atomic<bool> get_returns_empty_{false};
   std::atomic<bool> release_all_{false};
 
   std::shared_ptr<rclcpp::Node> client_node_;
@@ -418,10 +425,10 @@ class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test
   std::atomic<bool> spin_thread_running_{false};
 };
 
-// (a) get_parameter: list responds (param exists) but get_parameters returns
-// empty (timeout). Must map to a 503-class code (TIMEOUT), NOT INTERNAL_ERROR
-// (500), and negative-cache the node. Before this fix the empty-get branch was
-// INTERNAL_ERROR because get_parameters never throws on timeout (#531).
+// (a) get_parameter: list responds (param exists) but get_parameters never
+// answers (blocked). spin_for returns FutureReturnCode::TIMEOUT, which must map
+// to a 503-class code (TIMEOUT), NOT INTERNAL_ERROR (500), and negative-cache
+// the node (#531).
 TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, GetParameterEmptyGetAfterFoundNameIsTimeout) {
   block_get_ = true;
   auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
@@ -430,15 +437,16 @@ TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, GetParameterEmptyGetAf
 
   EXPECT_FALSE(result.success);
   EXPECT_EQ(result.error_code, ParameterErrorCode::TIMEOUT)
-      << "empty get_parameters after a found name is a value-read timeout, got " << static_cast<int>(result.error_code);
+      << "a blocked get_parameters after a found name is a value-read timeout, got "
+      << static_cast<int>(result.error_code);
   EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR);
   EXPECT_FALSE(transport->is_node_available(kNodeName)) << "the get timeout must negative-cache the node";
 }
 
 // (b) set_parameter: pre-read responds (fast type hint), but set_parameters
-// returns empty (timeout). Must map to TIMEOUT (503) + negative-cache, NOT
-// INTERNAL_ERROR (500). This is the #531-fully-live-on-writes path: pre-fix a
-// fully-unresponsive node's set returned 500 with no negative cache.
+// never answers (blocked). spin_for TIMEOUT must map to TIMEOUT (503) +
+// negative-cache, NOT INTERNAL_ERROR (500). This is the #531-fully-live-on-writes
+// path: pre-fix a fully-unresponsive node's set returned 500 with no negative cache.
 TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, SetParameterEmptyResultsIsTimeoutNotInternalError) {
   block_get_ = false;  // pre-read (type hint) responds quickly
   block_set_ = true;   // the actual write stalls
@@ -448,14 +456,14 @@ TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, SetParameterEmptyResul
 
   EXPECT_FALSE(result.success);
   EXPECT_EQ(result.error_code, ParameterErrorCode::TIMEOUT)
-      << "empty set_parameters results is a write timeout, got " << static_cast<int>(result.error_code);
+      << "a blocked set_parameters is a write timeout, got " << static_cast<int>(result.error_code);
   EXPECT_NE(result.error_code, ParameterErrorCode::INTERNAL_ERROR);
   EXPECT_FALSE(transport->is_node_available(kNodeName)) << "the set timeout must negative-cache the node";
 }
 
 // (c) list_parameters op: defaults already cached (so cache_default_values does
-// not short-circuit), then get_parameters stalls on the MAIN round-trip. The
-// all-empty-after-names result must be reported as TIMEOUT, not a misleading
+// not short-circuit), then get_parameters stalls on the MAIN round-trip
+// (spin_for TIMEOUT). Must be reported as TIMEOUT (503), not a misleading
 // success=[] (#531). Asserting TIMEOUT (not SERVICE_UNAVAILABLE) pins the main
 // round-trip path specifically, distinct from the cache_default_values gate.
 TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ListParametersEmptyGetAfterNamesIsTimeoutNotEmptySuccess) {
@@ -470,7 +478,7 @@ TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ListParametersEmptyGet
 
   EXPECT_FALSE(second.success);
   EXPECT_EQ(second.error_code, ParameterErrorCode::TIMEOUT)
-      << "list returned names but all gets came back empty: must be TIMEOUT (main round-trip), got "
+      << "list returned names but the value read timed out: must be TIMEOUT (main round-trip), got "
       << static_cast<int>(second.error_code);
 }
 
@@ -500,4 +508,52 @@ TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, MarkedNodeRecoversAfte
   // so after recovery the real default is retrievable (not NOT_FOUND forever).
   auto def = transport->get_default(kNodeName, kParamName);
   EXPECT_TRUE(def.success) << "get_default must return the real default after recovery, not a poisoned empty cache";
+}
+
+// ---------------------------------------------------------------------------
+// THE discriminating test (the async refactor's reason to exist).
+//
+// A node whose get_parameters service RESPONDS but returns an EMPTY values
+// vector (responsive, NOT blocked - e.g. the param was undeclared/raced between
+// list and get) must be treated as "not found", NOT as a timeout. The node is
+// HEALTHY and must stay available (never negative-cached / 503'd).
+//
+// The pre-async (SyncParametersClient) code CANNOT tell this responsive-empty
+// apart from a timeout - both collapse to the same empty vector - so it wrongly
+// marks the node and returns TIMEOUT/503. This test FAILS against that code
+// (base=RED) and PASSES with the AsyncParametersClient + FutureReturnCode
+// refactor, where SUCCESS-with-empty is distinct from TIMEOUT (#531).
+// ---------------------------------------------------------------------------
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, GetParameterResponsiveEmptyIsNotFoundNotMarked) {
+  block_get_ = false;         // do NOT block: the node answers promptly...
+  get_returns_empty_ = true;  // ...but with an empty values vector (responsive)
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto result = transport->get_parameter(kNodeName, kParamName);
+
+  EXPECT_FALSE(result.success);
+  EXPECT_EQ(result.error_code, ParameterErrorCode::NOT_FOUND)
+      << "a responsive node that answers get with an empty value is NOT_FOUND, not a timeout; got "
+      << static_cast<int>(result.error_code);
+  EXPECT_NE(result.error_code, ParameterErrorCode::TIMEOUT);
+  EXPECT_TRUE(transport->is_node_available(kNodeName))
+      << "a responsive-but-empty get must NOT negative-cache the healthy node (the pre-async "
+         "code wrongly marks it here)";
+}
+
+// The list op form of the same discriminator: a responsive node that answers get
+// with an empty values vector must yield success=[] with the node still available,
+// NOT a 503 / negative-cache. Pre-async this responsive-empty was marked + 503'd.
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ListParametersResponsiveEmptyGetIsEmptySuccessNotMarked) {
+  block_get_ = false;
+  get_returns_empty_ = true;
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto result = transport->list_parameters(kNodeName);
+
+  EXPECT_TRUE(result.success) << "responsive node (empty get) must return success, not a 503; error_code="
+                              << static_cast<int>(result.error_code);
+  EXPECT_TRUE(result.data.is_array());
+  EXPECT_TRUE(result.data.empty()) << "no gettable values -> empty parameter list";
+  EXPECT_TRUE(transport->is_node_available(kNodeName)) << "a responsive-but-empty get must NOT negative-cache the node";
 }

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -557,3 +557,36 @@ TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ListParametersResponsi
   EXPECT_TRUE(result.data.empty()) << "no gettable values -> empty parameter list";
   EXPECT_TRUE(transport->is_node_available(kNodeName)) << "a responsive-but-empty get must NOT negative-cache the node";
 }
+
+// A genuine SUCCESS-empty (responsive node, empty defaults) is a STABLE, authoritative
+// fact and must be MEMOIZED, so:
+//   - get_default returns NOT_FOUND (empty map cached), NOT NO_DEFAULTS_CACHED, and
+//   - the second call answers from the cache WITHOUT another round trip.
+// Only a TIMEOUT must avoid caching (poison-avoidance). This is the polish that restores
+// memoization the async refactor had over-broadly dropped (#531).
+TEST_F(TestRos2ParameterTransportListRespondsGetSetStuck, ResponsiveEmptyMemoizesEmptyDefaults) {
+  get_returns_empty_ = true;  // responsive node whose get returns an empty value set
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, 60.0);
+
+  auto listed = transport->list_parameters(kNodeName);
+  ASSERT_TRUE(listed.success);
+  ASSERT_TRUE(transport->is_node_available(kNodeName));
+
+  // The empty defaults map was cached, so get_default is NOT_FOUND (not NO_DEFAULTS_CACHED).
+  auto def = transport->get_default(kNodeName, kParamName);
+  EXPECT_FALSE(def.success);
+  EXPECT_EQ(def.error_code, ParameterErrorCode::NOT_FOUND)
+      << "a genuine SUCCESS-empty must memoize an empty defaults map (NOT_FOUND), not leave it "
+         "uncached (NO_DEFAULTS_CACHED); got "
+      << static_cast<int>(def.error_code);
+
+  // Block the node: a cached map means get_default must NOT re-round-trip (which would now
+  // time out) - it answers from the cache, so still NOT_FOUND and the node stays available.
+  block_get_ = true;
+  auto def_cached = transport->get_default(kNodeName, kParamName);
+  EXPECT_FALSE(def_cached.success);
+  EXPECT_EQ(def_cached.error_code, ParameterErrorCode::NOT_FOUND)
+      << "get_default must answer from the cached empty map, not re-round-trip; got "
+      << static_cast<int>(def_cached.error_code);
+  EXPECT_TRUE(transport->is_node_available(kNodeName)) << "no re-round-trip means the node is never marked";
+}

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -135,14 +135,18 @@ class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
   }
 
   void TearDown() override {
-    // Release any in-flight blocking service callback first so the spin
-    // thread can drain and exit promptly.
+    // Release any in-flight blocking service callback first so the spin loop
+    // (spin_some, not a blocking spin()) can drain and the spin thread exit.
     release_blocking_callback_ = true;
+    // Documented MultiThreadedExecutor teardown order: cancel -> join spin
+    // thread -> reset executor -> reset nodes. cancel() before join is safe
+    // here because the loop is a spin_some poll gated on spin_thread_running_,
+    // so it exits regardless; cancel() also unblocks any in-flight spin_some.
+    executor_->cancel();
     spin_thread_running_ = false;
     if (spin_thread_.joinable()) {
       spin_thread_.join();
     }
-    executor_->cancel();
     executor_->remove_node(unresponsive_node_);
     transport_.reset();
     executor_.reset();
@@ -185,6 +189,12 @@ class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
 // a small multiple of service_timeout_sec (0.5s) - which is only possible
 // because get_service_timeout() is now threaded through every
 // SyncParametersClient call in the round trip.
+//
+// list_parameters() also short-circuits after its internal
+// cache_default_values() round-trip marks the node unavailable, so the whole
+// call is bounded by ~1x service_timeout_sec (one round-trip), not ~2x (#531).
+// The tighter 2s assertion documents that single-round-trip cap; the 5s bound
+// is the documented outer safety limit.
 TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersReturnsBoundedErrorInsteadOfHanging) {
   auto start = std::chrono::steady_clock::now();
   auto result = transport_->list_parameters(kUnresponsiveNodeName);
@@ -194,6 +204,9 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersReturnsBoundedE
   EXPECT_LT(elapsed, std::chrono::seconds(5))
       << "list_parameters() against an unresponsive-but-discoverable node must be bounded by "
          "service_timeout_sec, not block until the server replies (or forever, pre-fix)";
+  EXPECT_LT(elapsed, std::chrono::seconds(2))
+      << "list_parameters() must cap the spin_mutex_ hold at ~1x service_timeout_sec (single "
+         "round-trip) by short-circuiting once cache_default_values marks the node unavailable";
 }
 
 // A second, immediate call against the same node must short-circuit via the

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -76,6 +76,10 @@ medkit_target_dependencies(demo_param_beacon_node rclcpp)
 add_executable(managed_lifecycle demo_nodes/managed_lifecycle_node.cpp)
 medkit_target_dependencies(managed_lifecycle rclcpp rclcpp_lifecycle)
 
+add_executable(demo_unresponsive_param_node demo_nodes/unresponsive_param_node.cpp)
+target_include_directories(demo_unresponsive_param_node PRIVATE ${_demo_include_dir})
+medkit_target_dependencies(demo_unresponsive_param_node rclcpp rcl_interfaces)
+
 install(TARGETS
   demo_engine_temp_sensor
   demo_rpm_sensor
@@ -89,6 +93,7 @@ install(TARGETS
   demo_beacon_publisher
   demo_param_beacon_node
   managed_lifecycle
+  demo_unresponsive_param_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
@@ -139,12 +139,14 @@ int main(int argc, char ** argv) {
   {
     auto node = std::make_shared<UnresponsiveParamNode>();
 
-    // MultiThreadedExecutor (not the SingleThreadedExecutor other demo nodes
-    // use): several test HTTP workers can each trigger a concurrent
-    // list_parameters round trip against this node, and each must get its
-    // own blocked worker thread here rather than queuing behind a single
-    // stuck one - matching the "several requests genuinely in flight at
-    // once" scenario the /health-stays-responsive test exercises.
+    // MultiThreadedExecutor is not strictly required: the gateway's
+    // Ros2ParameterTransport serializes all parameter round trips behind a
+    // single process-wide spin_mutex_, so only one ~/list_parameters RPC is
+    // ever in flight at this node at a time and a SingleThreadedExecutor
+    // would behave identically. The concurrency the /health test stresses
+    // lives in the gateway (std::async fan-out contending on that
+    // spin_mutex_), not in ROS-service dispatch here. Kept multi-threaded
+    // only as harmless future-proofing.
     rclcpp::executors::MultiThreadedExecutor executor;
     executor.add_node(node);
 

--- a/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
@@ -159,8 +159,17 @@ int main(int argc, char ** argv) {
         }
         // EINTR can theoretically fire; retry.
       }
-      // Flip rclcpp::ok() to false first so the blocking list_parameters
-      // callback notices and returns; only then ask the executor to stop.
+      // DELIBERATE ORDER - shutdown() BEFORE cancel(), the reverse of the
+      // standard demo-node teardown (cancel -> join -> reset). The
+      // ~/list_parameters callback above blocks its executor worker in
+      // `while (rclcpp::ok())`, so the usual cancel()-first pattern would
+      // deadlock here: cancel() does not interrupt a callback that is already
+      // running, ok() would still be true, the callback would never return,
+      // and spin()/cancel()/join would all hang (forcing a SIGKILL
+      // escalation). Calling rclcpp::shutdown() first flips ok() to false,
+      // which unblocks the callback so it returns; only then is it safe to
+      // cancel() the (now idle) executor. This is why the post-shutdown e2e
+      // check sees clean exit codes instead of a SIGKILL.
       rclcpp::shutdown();
       executor.cancel();
     });

--- a/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/unresponsive_param_node.cpp
@@ -1,0 +1,179 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file unresponsive_param_node.cpp
+ * @brief Demo node whose parameter service is discoverable but never replies
+ *
+ * Regression fixture for #531 (end-to-end counterpart of
+ * ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp). Parameter
+ * services are NOT auto-started (`start_parameter_services(false)`);
+ * instead all six are created manually so that a `SyncParametersClient`'s
+ * `wait_for_service()` succeeds immediately (the services genuinely exist
+ * in the ROS graph), while `~/list_parameters` - the first round-trip call
+ * the gateway makes - never returns.
+ *
+ * Used by test_param_service_hang.test.py to prove the gateway's REST API
+ * stays responsive - bounded 503 errors instead of hanging forever - when a
+ * backing node's parameter service is discoverable but unresponsive.
+ */
+
+#include <csignal>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include <rcl_interfaces/srv/describe_parameters.hpp>
+#include <rcl_interfaces/srv/get_parameter_types.hpp>
+#include <rcl_interfaces/srv/get_parameters.hpp>
+#include <rcl_interfaces/srv/list_parameters.hpp>
+#include <rcl_interfaces/srv/set_parameters.hpp>
+#include <rcl_interfaces/srv/set_parameters_atomically.hpp>
+
+#include <rclcpp/rclcpp.hpp>
+
+class UnresponsiveParamNode : public rclcpp::Node {
+ public:
+  UnresponsiveParamNode() : Node("unresponsive_param_node", rclcpp::NodeOptions().start_parameter_services(false)) {
+    list_parameters_service_ = create_service<rcl_interfaces::srv::ListParameters>(
+        "~/list_parameters", [](const std::shared_ptr<rcl_interfaces::srv::ListParameters::Request> /*request*/,
+                                std::shared_ptr<rcl_interfaces::srv::ListParameters::Response> /*response*/) {
+          // Never actually replies. Loops on rclcpp::ok() (not a fixed
+          // sleep) rather than a condition variable tied to node state, so
+          // it needs no member access at all: main() flips rclcpp::ok() to
+          // false on SIGINT/SIGTERM before asking the executor to stop, so
+          // this callback - and therefore the process - still exits
+          // promptly instead of hanging the executor forever.
+          while (rclcpp::ok()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          }
+        });
+
+    // The remaining parameter services only need to exist in the ROS graph
+    // so that wait_for_service() (discovery only, not responsiveness)
+    // succeeds for every SyncParametersClient call the gateway might issue.
+    // They are not expected to be invoked in practice: list_parameters is
+    // the first round-trip call in the gateway's configuration round trip
+    // and it never returns within the gateway's bounded timeout.
+    get_parameters_service_ = create_service<rcl_interfaces::srv::GetParameters>(
+        "~/get_parameters", [](const std::shared_ptr<rcl_interfaces::srv::GetParameters::Request> /*request*/,
+                               std::shared_ptr<rcl_interfaces::srv::GetParameters::Response> /*response*/) {});
+    set_parameters_service_ = create_service<rcl_interfaces::srv::SetParameters>(
+        "~/set_parameters", [](const std::shared_ptr<rcl_interfaces::srv::SetParameters::Request> /*request*/,
+                               std::shared_ptr<rcl_interfaces::srv::SetParameters::Response> /*response*/) {});
+    describe_parameters_service_ = create_service<rcl_interfaces::srv::DescribeParameters>(
+        "~/describe_parameters",
+        [](const std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Request> /*request*/,
+           std::shared_ptr<rcl_interfaces::srv::DescribeParameters::Response> /*response*/) {});
+    get_parameter_types_service_ = create_service<rcl_interfaces::srv::GetParameterTypes>(
+        "~/get_parameter_types", [](const std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Request> /*request*/,
+                                    std::shared_ptr<rcl_interfaces::srv::GetParameterTypes::Response> /*response*/) {});
+    set_parameters_atomically_service_ = create_service<rcl_interfaces::srv::SetParametersAtomically>(
+        "~/set_parameters_atomically",
+        [](const std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Request> /*request*/,
+           std::shared_ptr<rcl_interfaces::srv::SetParametersAtomically::Response> /*response*/) {});
+
+    RCLCPP_INFO(get_logger(),
+                "UnresponsiveParamNode started: parameter services are registered but "
+                "list_parameters will never reply (regression fixture for #531)");
+  }
+
+  ~UnresponsiveParamNode() override {
+    list_parameters_service_.reset();
+    get_parameters_service_.reset();
+    set_parameters_service_.reset();
+    describe_parameters_service_.reset();
+    get_parameter_types_service_.reset();
+    set_parameters_atomically_service_.reset();
+  }
+
+  UnresponsiveParamNode(const UnresponsiveParamNode &) = delete;
+  UnresponsiveParamNode & operator=(const UnresponsiveParamNode &) = delete;
+  UnresponsiveParamNode(UnresponsiveParamNode &&) = delete;
+  UnresponsiveParamNode & operator=(UnresponsiveParamNode &&) = delete;
+
+ private:
+  rclcpp::Service<rcl_interfaces::srv::ListParameters>::SharedPtr list_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameters>::SharedPtr get_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParameters>::SharedPtr set_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::DescribeParameters>::SharedPtr describe_parameters_service_;
+  rclcpp::Service<rcl_interfaces::srv::GetParameterTypes>::SharedPtr get_parameter_types_service_;
+  rclcpp::Service<rcl_interfaces::srv::SetParametersAtomically>::SharedPtr set_parameters_atomically_service_;
+};
+
+int main(int argc, char ** argv) {
+  // Deliberately NOT ros2_medkit_integration_tests::run_demo_node(): that
+  // helper calls rclcpp::shutdown() only after executor.spin() has already
+  // returned, which works for every other demo node but would deadlock this
+  // one - the list_parameters callback above blocks the executor's worker on
+  // rclcpp::ok(), so shutdown() must be called BEFORE the executor is asked
+  // to stop, not after, or spin() never returns.
+  //
+  // Same building block as run_demo_node() otherwise: block SIGINT/SIGTERM
+  // up front and consume them on a dedicated sigwait thread (a normal thread
+  // context) rather than rclcpp's own async-signal-context handler, which is
+  // what makes it safe to call rclcpp::shutdown() from that thread at all.
+  sigset_t mask;
+  sigset_t old_mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  if (pthread_sigmask(SIG_BLOCK, &mask, &old_mask) != 0) {
+    return 1;
+  }
+
+  rclcpp::init(argc, argv, rclcpp::InitOptions(), rclcpp::SignalHandlerOptions::None);
+
+  {
+    auto node = std::make_shared<UnresponsiveParamNode>();
+
+    // MultiThreadedExecutor (not the SingleThreadedExecutor other demo nodes
+    // use): several test HTTP workers can each trigger a concurrent
+    // list_parameters round trip against this node, and each must get its
+    // own blocked worker thread here rather than queuing behind a single
+    // stuck one - matching the "several requests genuinely in flight at
+    // once" scenario the /health-stays-responsive test exercises.
+    rclcpp::executors::MultiThreadedExecutor executor;
+    executor.add_node(node);
+
+    std::thread signal_thread([&mask, &executor] {
+      int signum = 0;
+      while (true) {
+        const int rc = sigwait(&mask, &signum);
+        if (rc == 0) {
+          break;
+        }
+        // EINTR can theoretically fire; retry.
+      }
+      // Flip rclcpp::ok() to false first so the blocking list_parameters
+      // callback notices and returns; only then ask the executor to stop.
+      rclcpp::shutdown();
+      executor.cancel();
+    });
+
+    executor.spin();
+
+    if (signal_thread.joinable()) {
+      signal_thread.join();
+    }
+
+    executor.remove_node(node);
+    node.reset();
+  }
+
+  // rclcpp::shutdown() already ran on the signal thread above.
+  pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+  return 0;
+}

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/launch_helpers.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/launch_helpers.py
@@ -59,6 +59,9 @@ DEMO_NODE_REGISTRY = {
     # the "active" lifecycle state (-> status "ready"). Distinct node name so it
     # can run alongside the unconfigured 'managed_lifecycle' in the same test.
     'managed_lifecycle_active': ('managed_lifecycle', 'managed_lifecycle_active', ''),
+    # Regression fixture (#531): parameter services are discoverable
+    # (wait_for_service succeeds) but list_parameters never replies.
+    'unresponsive_param': ('demo_unresponsive_param_node', 'unresponsive_param', ''),
 }
 
 # Convenience groupings for callers that want subsets of demo nodes.

--- a/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end regression coverage for #531.
+
+A discoverable-but-unresponsive node's parameter service must not be able to
+hang the gateway's REST API.
+
+Unit/component coverage already proves Ros2ParameterTransport itself bounds
+every SyncParametersClient call (see
+ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp). What is proven
+here is the actual user-facing symptom: against a real gateway process
+talking to a real (discoverable but never-replying) demo node over the ROS 2
+graph, `/configurations` returns a bounded error instead of hanging, and -
+critically - unrelated endpoints like `/health` keep answering even while
+several such calls are in flight at once, instead of the whole gateway
+freezing until restart (the pre-fix symptom: unbounded parameter round trips
+pinned HTTP worker threads forever, eventually exhausting the pool).
+
+Test ordering matters here (hence the numeric ``test_NN_`` prefixes,
+overriding unittest's default alphabetical order only incidentally - they
+also happen to already sort correctly): test_01 deliberately runs on a cold
+Ros2ParameterTransport negative cache so its concurrent calls exercise
+genuine ~parameter_service_timeout_sec round trips (the real point of the
+worker-pool-exhaustion proof). By the time test_02 runs, test_01's calls
+have already negative-cached this node, so test_02 legitimately - and still
+correctly - observes a fast cache-hit failure rather than a fresh round
+trip; both are "bounded, not hanging", which is what test_02 asserts.
+"""
+
+import threading
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+APP_ID = 'unresponsive_param'
+
+# Must exceed server.http_thread_pool_size (6, see gateway_params.yaml) so the
+# concurrent /configurations calls can actually pin every HTTP worker at once.
+CONCURRENT_STUCK_REQUESTS = 8
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=[APP_ID],
+        fault_manager=False,
+    )
+
+
+class TestParamServiceHang(GatewayTestCase):
+    """Proves an unresponsive parameter service cannot hang the REST API."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {APP_ID}
+
+    def test_01_health_stays_responsive_under_stuck_node(self):
+        """/health must keep answering while /configurations calls are stuck.
+
+        This is the actual #531 user-facing symptom. Before the fix, an
+        unbounded SyncParametersClient round trip held its HTTP worker
+        thread forever; enough concurrent requests against an unresponsive
+        node's parameter service would eventually pin every worker in the
+        pool, and the entire REST API - including endpoints with nothing to
+        do with parameters, like /health - would stop answering until the
+        gateway process was restarted.
+
+        Reproduces that precondition directly: fire more concurrent
+        /configurations requests against the unresponsive node than there
+        are HTTP workers (server.http_thread_pool_size defaults to 6), then,
+        while they are still in flight, assert /health answers within a
+        short, fixed client-side timeout. After the fix each stuck call is
+        bounded by parameter_service_timeout_sec, so workers free up in time
+        for /health to get one; pre-fix this call would simply never
+        return.
+
+        Runs first (see module docstring) so every one of the 8 concurrent
+        calls below hits a cold negative cache and genuinely blocks for a
+        real round trip - not a cache hit - which is what actually pressures
+        the worker pool.
+        """
+        stuck_threads = []
+        # +1 party for this (main) thread: all hammer threads block here
+        # until every one of them has started and is about to issue its
+        # request, then release together. A plain time.sleep() before
+        # starting the /health probe cannot guarantee that - Python thread
+        # startup is scheduler-dependent, and a health check that races
+        # ahead of the hammer threads reaching the server would under-stress
+        # the pool and produce a falsely reassuring near-zero elapsed time.
+        release_barrier = threading.Barrier(CONCURRENT_STUCK_REQUESTS + 1)
+
+        def hammer_configurations():
+            release_barrier.wait()
+            try:
+                requests.get(
+                    f'{self.BASE_URL}/apps/{APP_ID}/configurations',
+                    timeout=20,
+                )
+            except requests.exceptions.RequestException:
+                # The point of this thread is to occupy a worker for a
+                # bounded time, not to assert on its own outcome - test_02
+                # below covers the bounded-error response shape directly.
+                pass
+
+        for _ in range(CONCURRENT_STUCK_REQUESTS):
+            thread = threading.Thread(target=hammer_configurations, daemon=True)
+            stuck_threads.append(thread)
+            thread.start()
+
+        try:
+            # Release all hammer threads to fire their requests together.
+            release_barrier.wait(timeout=10)
+
+            # Small fixed buffer for the just-released requests to actually
+            # reach the server and occupy HTTP workers before probing
+            # /health, so the pool is genuinely under pressure rather than
+            # /health racing them to a free worker before any of them start
+            # blocking. Comfortably smaller than the ~2s bound each stuck
+            # call is held to, so it does not eat into the 5s /health budget.
+            time.sleep(0.3)
+
+            start = time.monotonic()
+            response = requests.get(f'{self.BASE_URL}/health', timeout=5)
+            elapsed = time.monotonic() - start
+        except requests.exceptions.RequestException as e:
+            self.fail(
+                f'/health did not respond within 5s while '
+                f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations '
+                f'calls were stuck against the unresponsive node: {e}'
+            )
+        finally:
+            for thread in stuck_threads:
+                thread.join(timeout=25)
+
+        print(
+            f'GET /health returned {response.status_code} in {elapsed:.2f}s '
+            f'while {CONCURRENT_STUCK_REQUESTS} concurrent /configurations '
+            'calls were stuck against the unresponsive node'
+        )
+        self.assertEqual(
+            response.status_code, 200,
+            f'/health returned {response.status_code} while the pool was '
+            'under pressure from stuck /configurations calls'
+        )
+        self.assertLess(
+            elapsed, 5.0,
+            f'/health took {elapsed:.1f}s to respond while '
+            f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations calls '
+            'were stuck - the REST API must stay responsive, not queue '
+            'behind the unresponsive node'
+        )
+
+    def test_02_configurations_returns_bounded_error_not_hang(self):
+        """GET /{app}/configurations against an unresponsive node fails fast.
+
+        Before the fix, the underlying SyncParametersClient calls had no
+        timeout, so this request would hang forever once the node's
+        list_parameters service accepted the call but never replied. The
+        client-side `timeout=15` below would turn that hang into a
+        requests.exceptions.Timeout (a test failure/error) rather than a
+        passing 503 - the request only reaches the `expected_status=503`
+        assertion at all because the gateway bounds the round trip itself
+        (parameter_service_timeout_sec, default 2.0s) and returns a SOVD
+        error instead of blocking.
+
+        By the time this runs, test_01's concurrent calls have already
+        negative-cached this node (see module docstring), so this request
+        is expected to return near-instantly via that cache rather than
+        paying a fresh round trip - a fast cache hit is exactly the kind of
+        "bounded, not hanging" behavior this test is asserting, and is
+        itself proof the negative cache introduced by the #531 fix works
+        end-to-end, not just in the component test.
+        """
+        start = time.monotonic()
+        data = self.get_json(
+            f'/apps/{APP_ID}/configurations',
+            timeout=15,
+            expected_status=503,
+        )
+        elapsed = time.monotonic() - start
+        print(f'GET /apps/{APP_ID}/configurations returned 503 in {elapsed:.2f}s')
+
+        self.assertLess(
+            elapsed, 10.0,
+            'GET /configurations against an unresponsive node took '
+            f'{elapsed:.1f}s - expected a bounded failure well within the '
+            'parameter service timeout, not a near-timeout rescue by the '
+            'test client itself'
+        )
+        # x-medkit-* vendor codes are remapped to the SOVD vendor-error
+        # envelope on the wire (see write_generic_error in
+        # http/detail/primitives.cpp): error_code stays a generic SOVD code,
+        # the precise vendor code moves to vendor_code.
+        self.assertEqual(data.get('error_code'), 'vendor-error')
+        self.assertEqual(data.get('vendor_code'), 'x-medkit-ros2-node-unavailable')
+        self.assertIn('entity_id', data.get('parameters', {}))
+        self.assertEqual(data['parameters']['entity_id'], APP_ID)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check all processes exited cleanly (SIGTERM allowed).
+
+        Covers the demo node's own shutdown path too: its list_parameters
+        callback blocks the executor on rclcpp::ok(), so this also proves
+        the node's custom SIGTERM handling (see unresponsive_param_node.cpp)
+        actually unblocks it and exits cleanly instead of requiring a
+        SIGKILL escalation.
+        """
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
@@ -140,6 +140,16 @@ class TestParamServiceHang(GatewayTestCase):
             start = time.monotonic()
             response = requests.get(f'{self.BASE_URL}/health', timeout=30)
             elapsed = time.monotonic() - start
+        except threading.BrokenBarrierError:
+            # release_barrier.wait(timeout=10) tripped its own timeout (or the
+            # barrier was otherwise broken): not all hammer threads reached the
+            # rendezvous. Turn this into a clear failure instead of an opaque
+            # BrokenBarrierError traceback that would ERROR the test.
+            self.fail(
+                f'hammer threads did not reach the barrier within 10s '
+                f'(expected {CONCURRENT_STUCK_REQUESTS} + 1 parties) - could '
+                'not stress the HTTP worker pool as intended'
+            )
         except requests.exceptions.RequestException as e:
             self.fail(
                 f'/health did not respond within 30s while '

--- a/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
@@ -87,7 +87,7 @@ class TestParamServiceHang(GatewayTestCase):
         /configurations requests against the unresponsive node than there
         are HTTP workers (server.http_thread_pool_size defaults to 6), then,
         while they are still in flight, assert /health answers within a
-        short, fixed client-side timeout. After the fix each stuck call is
+        bounded client-side timeout. After the fix each stuck call is
         bounded by parameter_service_timeout_sec, so workers free up in time
         for /health to get one; pre-fix this call would simply never
         return.
@@ -134,15 +134,15 @@ class TestParamServiceHang(GatewayTestCase):
             # /health, so the pool is genuinely under pressure rather than
             # /health racing them to a free worker before any of them start
             # blocking. Comfortably smaller than the ~2s bound each stuck
-            # call is held to, so it does not eat into the 5s /health budget.
+            # call is held to, so it does not eat into the /health budget.
             time.sleep(0.3)
 
             start = time.monotonic()
-            response = requests.get(f'{self.BASE_URL}/health', timeout=5)
+            response = requests.get(f'{self.BASE_URL}/health', timeout=30)
             elapsed = time.monotonic() - start
         except requests.exceptions.RequestException as e:
             self.fail(
-                f'/health did not respond within 5s while '
+                f'/health did not respond within 30s while '
                 f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations '
                 f'calls were stuck against the unresponsive node: {e}'
             )
@@ -160,8 +160,14 @@ class TestParamServiceHang(GatewayTestCase):
             f'/health returned {response.status_code} while the pool was '
             'under pressure from stuck /configurations calls'
         )
+        # 30s (not a tighter bound) deliberately: pre-fix this /health call
+        # was a TRUE infinite hang - no worker ever frees while the stuck
+        # round trips hold them - so any bound well under the 120s CTest
+        # TIMEOUT cleanly distinguishes "fixed" from "broken". 30s removes
+        # sanitizer-CI flake risk (TSan slows this thread/lock-heavy path,
+        # inflating the ~2s round trip) with zero loss of rigor.
         self.assertLess(
-            elapsed, 5.0,
+            elapsed, 30.0,
             f'/health took {elapsed:.1f}s to respond while '
             f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations calls '
             'were stuck - the REST API must stay responsive, not queue '

--- a/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_param_service_hang.test.py
@@ -21,23 +21,31 @@ hang the gateway's REST API.
 Unit/component coverage already proves Ros2ParameterTransport itself bounds
 every SyncParametersClient call (see
 ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp). What is proven
-here is the actual user-facing symptom: against a real gateway process
-talking to a real (discoverable but never-replying) demo node over the ROS 2
-graph, `/configurations` returns a bounded error instead of hanging, and -
-critically - unrelated endpoints like `/health` keep answering even while
-several such calls are in flight at once, instead of the whole gateway
-freezing until restart (the pre-fix symptom: unbounded parameter round trips
-pinned HTTP worker threads forever, eventually exhausting the pool).
+here is the actual user-facing symptom against a real gateway process talking
+to a real (discoverable but never-replying) demo node over the ROS 2 graph.
 
-Test ordering matters here (hence the numeric ``test_NN_`` prefixes,
-overriding unittest's default alphabetical order only incidentally - they
-also happen to already sort correctly): test_01 deliberately runs on a cold
-Ros2ParameterTransport negative cache so its concurrent calls exercise
-genuine ~parameter_service_timeout_sec round trips (the real point of the
-worker-pool-exhaustion proof). By the time test_02 runs, test_01's calls
-have already negative-cached this node, so test_02 legitimately - and still
-correctly - observes a fast cache-hit failure rather than a fresh round
-trip; both are "bounded, not hanging", which is what test_02 asserts.
+The REAL gate is ``test_01_fresh_configurations_request_is_bounded_not_hung``.
+It MUST run first, on a cold Ros2ParameterTransport: the shared ``spin_mutex_``
+is free and this node is not yet negative-cached, so a single ``/configurations``
+GET grabs the free lock and, pre-fix (SyncParametersClient calls with no
+timeout), blocks FOREVER inside cache_default_values waiting for a reply the
+node never sends - nothing else holds the lock, so there is no acquisition-
+timeout rescue and the request simply never returns. The client-side timeout
+then fires and fails the test (RED). Post-fix the round trip is bounded by
+``parameter_service_timeout_sec`` and the gateway returns a 503 in ~2s (GREEN).
+This test was verified RED against the unfixed transport (timeouts removed) and
+GREEN with the fix.
+
+``test_02_health_stays_responsive_under_concurrent_config_calls`` is a
+SECONDARY smoke test, deliberately NOT the hang gate. Because the shared
+``spin_mutex_`` already serialised parameter round trips even pre-fix, ``/health``
+stays responsive under concurrent single-node ``/configurations`` calls in BOTH
+the fixed and unfixed builds (only one worker ever wedges; the rest time out on
+lock acquisition and free up), so this check cannot distinguish fixed from
+broken - test_01 does that. By the time test_02 runs, test_01 has already
+negative-cached the node, so its concurrent calls return fast via that cache;
+what it asserts is only the weaker property that the REST API keeps serving
+unrelated endpoints while several parameter calls are in flight.
 """
 
 import threading
@@ -54,9 +62,10 @@ from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
 APP_ID = 'unresponsive_param'
 
-# Must exceed server.http_thread_pool_size (6, see gateway_params.yaml) so the
-# concurrent /configurations calls can actually pin every HTTP worker at once.
-CONCURRENT_STUCK_REQUESTS = 8
+# More concurrent config calls than server.http_thread_pool_size (6, see
+# gateway_params.yaml). Post test_01 these are fast negative-cache hits, so this
+# no longer pins every worker - it just exercises concurrent request handling.
+CONCURRENT_CONFIG_REQUESTS = 8
 
 
 def generate_test_description():
@@ -72,40 +81,96 @@ class TestParamServiceHang(GatewayTestCase):
     MIN_EXPECTED_APPS = 1
     REQUIRED_APPS = {APP_ID}
 
-    def test_01_health_stays_responsive_under_stuck_node(self):
-        """/health must keep answering while /configurations calls are stuck.
+    def test_01_fresh_configurations_request_is_bounded_not_hung(self):
+        """A single FRESH /configurations GET must return a bounded 503, not hang.
 
-        This is the actual #531 user-facing symptom. Before the fix, an
-        unbounded SyncParametersClient round trip held its HTTP worker
-        thread forever; enough concurrent requests against an unresponsive
-        node's parameter service would eventually pin every worker in the
-        pool, and the entire REST API - including endpoints with nothing to
-        do with parameters, like /health - would stop answering until the
-        gateway process was restarted.
+        THIS is the #531 gate (see module docstring). It runs first (the
+        ``test_01_`` prefix orders it ahead of the smoke test), so the
+        gateway's Ros2ParameterTransport is in its initial state for this
+        node: the shared spin_mutex_ is free and the node is not yet
+        negative-cached.
 
-        Reproduces that precondition directly: fire more concurrent
-        /configurations requests against the unresponsive node than there
-        are HTTP workers (server.http_thread_pool_size defaults to 6), then,
-        while they are still in flight, assert /health answers within a
-        bounded client-side timeout. After the fix each stuck call is
-        bounded by parameter_service_timeout_sec, so workers free up in time
-        for /health to get one; pre-fix this call would simply never
-        return.
+        Pre-fix, the underlying SyncParametersClient calls carried NO timeout,
+        so this one fresh request grabs the free lock, enters
+        cache_default_values -> list_parameters, and blocks FOREVER waiting
+        for a reply the unresponsive node never sends. Nothing else holds the
+        lock, so there is no acquisition-timeout rescue - the request never
+        returns, the client-side timeout below fires, and the test fails (RED).
 
-        Runs first (see module docstring) so every one of the 8 concurrent
-        calls below hits a cold negative cache and genuinely blocks for a
-        real round trip - not a cache hit - which is what actually pressures
-        the worker pool.
+        Post-fix, every SyncParametersClient call is bounded by
+        parameter_service_timeout_sec (default 2.0s): cache_default_values'
+        round trip times out, the node is negative-cached, and list_parameters
+        short-circuits, so the gateway returns a 503 SOVD error in ~2s (GREEN).
+
+        Running first also means THIS request is what negative-caches the node
+        for the following smoke test.
         """
-        stuck_threads = []
-        # +1 party for this (main) thread: all hammer threads block here
-        # until every one of them has started and is about to issue its
-        # request, then release together. A plain time.sleep() before
-        # starting the /health probe cannot guarantee that - Python thread
-        # startup is scheduler-dependent, and a health check that races
-        # ahead of the hammer threads reaching the server would under-stress
-        # the pool and produce a falsely reassuring near-zero elapsed time.
-        release_barrier = threading.Barrier(CONCURRENT_STUCK_REQUESTS + 1)
+        try:
+            start = time.monotonic()
+            response = requests.get(
+                f'{self.BASE_URL}/apps/{APP_ID}/configurations',
+                timeout=15,
+            )
+            elapsed = time.monotonic() - start
+        except requests.exceptions.RequestException as e:
+            self.fail(
+                'GET /configurations against a fresh unresponsive node did '
+                f'not return within the 15s client timeout ({e}) - the gateway '
+                'is not bounding the parameter round trip: the request hung '
+                'instead of returning a 503 (#531 regression).'
+            )
+
+        print(
+            f'GET /apps/{APP_ID}/configurations returned '
+            f'{response.status_code} in {elapsed:.2f}s (fresh, uncontended)'
+        )
+        self.assertEqual(
+            response.status_code, 503,
+            f'expected 503 (node unavailable), got {response.status_code}'
+        )
+        # Bounded well under the 15s client timeout: a fresh round trip is
+        # ~parameter_service_timeout_sec (2s); 10s leaves generous slack for
+        # sanitizer CI without letting a near-hang masquerade as a pass.
+        self.assertLess(
+            elapsed, 10.0,
+            'fresh /configurations against an unresponsive node took '
+            f'{elapsed:.1f}s - expected a bounded failure within a small '
+            'multiple of parameter_service_timeout_sec, not a near-timeout '
+            'rescue by the test client itself'
+        )
+        # x-medkit-* vendor codes are remapped to the SOVD vendor-error
+        # envelope on the wire (see write_generic_error in
+        # http/detail/primitives.cpp): error_code stays a generic SOVD code,
+        # the precise vendor code moves to vendor_code.
+        data = response.json()
+        self.assertEqual(data.get('error_code'), 'vendor-error')
+        self.assertEqual(data.get('vendor_code'), 'x-medkit-ros2-node-unavailable')
+        self.assertIn('entity_id', data.get('parameters', {}))
+        self.assertEqual(data['parameters']['entity_id'], APP_ID)
+
+    def test_02_health_stays_responsive_under_concurrent_config_calls(self):
+        """SMOKE: /health keeps answering with several /configurations in flight.
+
+        Secondary coverage, NOT the #531 gate (test_01 is - see module
+        docstring). This does not and cannot prove "no worker ever frees":
+        even pre-fix the shared spin_mutex_ serialises parameter round trips,
+        so under N concurrent single-node /configurations only one worker
+        wedges while the rest time out on lock acquisition and free up, and
+        /health is served either way. It asserts only the weaker, still-useful
+        property that the REST API stays responsive while several parameter
+        calls are in flight.
+
+        By the time this runs, test_01 has already negative-cached the node,
+        so these concurrent calls return fast via that cache rather than
+        blocking on fresh round trips - which is itself end-to-end proof the
+        negative cache works, just not a hang gate.
+        """
+        config_threads = []
+        # +1 party for this (main) thread: all hammer threads block at the
+        # barrier until every one has started, then release together, so the
+        # concurrent requests actually overlap rather than trickling out under
+        # scheduler-dependent thread startup.
+        release_barrier = threading.Barrier(CONCURRENT_CONFIG_REQUESTS + 1)
 
         def hammer_configurations():
             release_barrier.wait()
@@ -115,26 +180,22 @@ class TestParamServiceHang(GatewayTestCase):
                     timeout=20,
                 )
             except requests.exceptions.RequestException:
-                # The point of this thread is to occupy a worker for a
-                # bounded time, not to assert on its own outcome - test_02
-                # below covers the bounded-error response shape directly.
+                # These threads exist only to put concurrent requests in
+                # flight; test_01 already asserted the response shape.
                 pass
 
-        for _ in range(CONCURRENT_STUCK_REQUESTS):
+        for _ in range(CONCURRENT_CONFIG_REQUESTS):
             thread = threading.Thread(target=hammer_configurations, daemon=True)
-            stuck_threads.append(thread)
+            config_threads.append(thread)
             thread.start()
 
         try:
             # Release all hammer threads to fire their requests together.
             release_barrier.wait(timeout=10)
 
-            # Small fixed buffer for the just-released requests to actually
-            # reach the server and occupy HTTP workers before probing
-            # /health, so the pool is genuinely under pressure rather than
-            # /health racing them to a free worker before any of them start
-            # blocking. Comfortably smaller than the ~2s bound each stuck
-            # call is held to, so it does not eat into the /health budget.
+            # Small fixed buffer so the just-released requests actually reach
+            # the server and occupy workers before probing /health, rather than
+            # /health racing them to a free worker.
             time.sleep(0.3)
 
             start = time.monotonic()
@@ -147,88 +208,39 @@ class TestParamServiceHang(GatewayTestCase):
             # BrokenBarrierError traceback that would ERROR the test.
             self.fail(
                 f'hammer threads did not reach the barrier within 10s '
-                f'(expected {CONCURRENT_STUCK_REQUESTS} + 1 parties) - could '
-                'not stress the HTTP worker pool as intended'
+                f'(expected {CONCURRENT_CONFIG_REQUESTS} + 1 parties) - could '
+                'not put the concurrent /configurations calls in flight'
             )
         except requests.exceptions.RequestException as e:
             self.fail(
                 f'/health did not respond within 30s while '
-                f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations '
-                f'calls were stuck against the unresponsive node: {e}'
+                f'{CONCURRENT_CONFIG_REQUESTS} concurrent /configurations '
+                f'calls were in flight against the unresponsive node: {e}'
             )
         finally:
-            for thread in stuck_threads:
+            for thread in config_threads:
                 thread.join(timeout=25)
 
         print(
             f'GET /health returned {response.status_code} in {elapsed:.2f}s '
-            f'while {CONCURRENT_STUCK_REQUESTS} concurrent /configurations '
-            'calls were stuck against the unresponsive node'
+            f'while {CONCURRENT_CONFIG_REQUESTS} concurrent /configurations '
+            'calls were in flight against the unresponsive node'
         )
         self.assertEqual(
             response.status_code, 200,
-            f'/health returned {response.status_code} while the pool was '
-            'under pressure from stuck /configurations calls'
+            f'/health returned {response.status_code} while '
+            f'{CONCURRENT_CONFIG_REQUESTS} concurrent /configurations calls '
+            'were in flight'
         )
-        # 30s (not a tighter bound) deliberately: pre-fix this /health call
-        # was a TRUE infinite hang - no worker ever frees while the stuck
-        # round trips hold them - so any bound well under the 120s CTest
-        # TIMEOUT cleanly distinguishes "fixed" from "broken". 30s removes
-        # sanitizer-CI flake risk (TSan slows this thread/lock-heavy path,
-        # inflating the ~2s round trip) with zero loss of rigor.
+        # Generous 30s bound: removes sanitizer-CI flake risk (TSan slows this
+        # thread/lock-heavy path) while still comfortably under the 120s CTest
+        # TIMEOUT. This is a responsiveness smoke check, not the hang gate.
         self.assertLess(
             elapsed, 30.0,
             f'/health took {elapsed:.1f}s to respond while '
-            f'{CONCURRENT_STUCK_REQUESTS} concurrent /configurations calls '
-            'were stuck - the REST API must stay responsive, not queue '
-            'behind the unresponsive node'
+            f'{CONCURRENT_CONFIG_REQUESTS} concurrent /configurations calls '
+            'were in flight - the REST API must stay responsive'
         )
-
-    def test_02_configurations_returns_bounded_error_not_hang(self):
-        """GET /{app}/configurations against an unresponsive node fails fast.
-
-        Before the fix, the underlying SyncParametersClient calls had no
-        timeout, so this request would hang forever once the node's
-        list_parameters service accepted the call but never replied. The
-        client-side `timeout=15` below would turn that hang into a
-        requests.exceptions.Timeout (a test failure/error) rather than a
-        passing 503 - the request only reaches the `expected_status=503`
-        assertion at all because the gateway bounds the round trip itself
-        (parameter_service_timeout_sec, default 2.0s) and returns a SOVD
-        error instead of blocking.
-
-        By the time this runs, test_01's concurrent calls have already
-        negative-cached this node (see module docstring), so this request
-        is expected to return near-instantly via that cache rather than
-        paying a fresh round trip - a fast cache hit is exactly the kind of
-        "bounded, not hanging" behavior this test is asserting, and is
-        itself proof the negative cache introduced by the #531 fix works
-        end-to-end, not just in the component test.
-        """
-        start = time.monotonic()
-        data = self.get_json(
-            f'/apps/{APP_ID}/configurations',
-            timeout=15,
-            expected_status=503,
-        )
-        elapsed = time.monotonic() - start
-        print(f'GET /apps/{APP_ID}/configurations returned 503 in {elapsed:.2f}s')
-
-        self.assertLess(
-            elapsed, 10.0,
-            'GET /configurations against an unresponsive node took '
-            f'{elapsed:.1f}s - expected a bounded failure well within the '
-            'parameter service timeout, not a near-timeout rescue by the '
-            'test client itself'
-        )
-        # x-medkit-* vendor codes are remapped to the SOVD vendor-error
-        # envelope on the wire (see write_generic_error in
-        # http/detail/primitives.cpp): error_code stays a generic SOVD code,
-        # the precise vendor code moves to vendor_code.
-        self.assertEqual(data.get('error_code'), 'vendor-error')
-        self.assertEqual(data.get('vendor_code'), 'x-medkit-ros2-node-unavailable')
-        self.assertIn('entity_id', data.get('parameters', {}))
-        self.assertEqual(data['parameters']['entity_id'], APP_ID)
 
 
 @launch_testing.post_shutdown_test()


### PR DESCRIPTION
## Summary

`Ros2ParameterTransport` made parameter service round trips (`list_parameters`, `get_parameters`, `set_parameters`, `describe_parameters`) with no timeout, so a node whose parameter service is discoverable but does not answer (mid-recovery after a discovery restart, hung, or shutting down) blocked the calling thread forever. All parameter operations share one spin lock, and a Component or Area `/configurations` request fans out one thread per backing node, so one stuck node could hold HTTP worker threads forever, exhaust the worker pool, and stop the whole REST API (including `/health`) with no recovery until the gateway was restarted.

Bounding the calls alone is not enough. `SyncParametersClient` returns the same empty result for a real timeout and for a successful-but-empty response (only `list_parameters` throws on timeout; `get_parameters` and `set_parameters` return an empty vector), so a bounded call cannot tell "the node did not answer" from "the node answered with no value". This change therefore switches the transport to `AsyncParametersClient` and spins the client node with an explicit `spin_until_future_complete`, so the outcome of every round trip is an unambiguous `FutureReturnCode`.

What the change does:

- Every parameter round trip is bounded by the configured service timeout, and its outcome is an explicit `FutureReturnCode`:
  - `TIMEOUT`: the node did not answer, so return 503 (service unavailable) and negative-cache the node so the next request to it fails fast.
  - `SUCCESS`: use the result, which may legitimately be empty (an unset or not-found parameter). An empty result is handled as a normal empty response, never as a timeout, so a healthy node is never wrongly negative-cached.
  - `INTERRUPTED`: the gateway is shutting down, so return a shutdown error without marking the node.
- Read and write paths are both covered. A timed-out read or write now returns 503 (a write timeout was previously misclassified as 500). A client sending a bad value on a set request still cannot negative-cache a healthy node, because input parsing is outside the timeout scope.
- The default-values cache is never poisoned with an empty map on a timeout, so a node that timed out once is retried after the negative-cache TTL instead of staying unavailable until restart. A genuine empty result from a responsive node is still memoized.
- The shared spin lock is held for at most one round trip per default-values pass, so a stuck node cannot make a concurrent request to a different, healthy node time out on lock acquisition.
- Removes the dead `invalidate()` transport method (an interface method that was never called).

No behavior change for a healthy node: a responsive service answers well within the existing `parameter_service_timeout_sec` gateway parameter, which is the bound used. The client swap is internal to the transport.

---

## Issue

- closes #531

---

## Type

- [x] Bug fix

---

## Testing

Component tests (`test_ros2_parameter_transport`) drive the real transport against real nodes. One node blocks `list_parameters`; another responds to `list_parameters` but blocks `get`/`set`, which exercises the read and write timeout paths that a list-only stub cannot reach. The tests assert that a timeout returns 503 and negative-caches the node, that a responsive node returning an empty result is NOT marked (the false positive this change fixes), that a marked node recovers after the TTL, and that the default-values cache is not poisoned. Assertions check the error class rather than wall-clock time, so they do not flake under the slower sanitizer runs. Each timeout path was verified to hang against the pre-fix code (the call was killed by a watchdog) and to pass after the fix.

End-to-end launch test (`test_param_service_hang`) runs the real gateway plus a demo node with an unresponsive parameter service. It asserts that a single `GET /{entity}/configurations` on that node returns a bounded 503 (it hangs against the pre-fix code) and that `/health` stays responsive under concurrent stuck requests.

Run:

```
colcon build --packages-up-to ros2_medkit_integration_tests
./scripts/test.sh test_ros2_parameter_transport
./scripts/test.sh test_param_service_hang
```

---

## Checklist

- [x] Breaking changes are clearly described (none; the bound is the existing configured service timeout, and the client swap is internal to the transport)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed (no public API change; internal transport change, with header and design-doc comments updated)
