### PR TITLE
fix(gateway): bound parameter transport per-node caches with LRU eviction

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -557,6 +557,10 @@ if(BUILD_TESTING)
   target_link_libraries(test_ros2_parameter_transport gateway_ros2)
   medkit_set_test_domain(test_ros2_parameter_transport)
 
+  # BoundedLruCache: pure-C++ header, no ROS - bounds the parameter transport's
+  # per-node caches. No test domain (creates no ROS nodes).
+  ament_add_gtest(test_bounded_lru_cache test/test_bounded_lru_cache.cpp)
+
   find_package(std_msgs REQUIRED)
 
   # Add DiscoveryManager tests

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <map>
 #include <utility>
@@ -48,10 +49,19 @@ namespace ros2_medkit_gateway {
 template <typename Key, typename Value>
 class BoundedLruCache {
  public:
+  /// Invoked with the (key, value) of an entry about to be evicted, just before
+  /// it is erased. Lets a caller observe evictions (for example to log a warning
+  /// when a cached default value is dropped). Runs while the caller's mutex is
+  /// held, so it must be cheap and must not call back into the cache.
+  using EvictCallback = std::function<void(const Key &, const Value &)>;
+
   /// @param max_size Maximum number of entries retained. Values below 1 are
   ///                 clamped to 1 (a zero-capacity LRU cache is meaningless and
   ///                 would evict the entry it just inserted).
-  explicit BoundedLruCache(std::size_t max_size) : max_size_(max_size == 0 ? 1 : max_size) {
+  /// @param on_evict Optional callback run for each least-recently-used entry
+  ///                 evicted on overflow. Empty by default (no observation).
+  explicit BoundedLruCache(std::size_t max_size, EvictCallback on_evict = {})
+    : max_size_(max_size == 0 ? 1 : max_size), on_evict_(std::move(on_evict)) {
   }
 
   /// Look up @p key, marking it most-recently-used on a hit.
@@ -118,11 +128,15 @@ class BoundedLruCache {
         victim = it;
       }
     }
+    if (on_evict_) {
+      on_evict_(victim->first, victim->second.value);
+    }
     entries_.erase(victim);
   }
 
   std::size_t max_size_;
   std::uint64_t counter_{0};
+  EvictCallback on_evict_;
   std::map<Key, Entry> entries_;
 };
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
@@ -76,17 +76,17 @@ class BoundedLruCache {
   ///
   /// The just-stored entry always carries the largest stamp, so it is never the
   /// eviction victim; erasing a different entry from the underlying std::map
-  /// does not invalidate the reference returned here.
+  /// does not invalidate the iterator (and returned reference) kept here.
+  /// insert_or_assign is used (not operator[]) so Value need not be
+  /// default-constructible.
   ///
   /// @return reference to the stored value (valid until the next mutating call).
   Value & put(const Key & key, Value value) {
-    auto & entry = entries_[key];
-    entry.value = std::move(value);
-    entry.stamp = ++counter_;
+    auto it = entries_.insert_or_assign(key, Entry{std::move(value), ++counter_}).first;
     if (entries_.size() > max_size_) {
-      evict_lru();
+      evict_lru();  // never evicts `it`: it carries the largest stamp
     }
-    return entry.value;
+    return it->second.value;
   }
 
   /// Remove all entries. The access counter is intentionally not reset - stamps

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/util/bounded_lru_cache.hpp
@@ -1,0 +1,129 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <map>
+#include <utility>
+
+namespace ros2_medkit_gateway {
+
+/// Fixed-capacity least-recently-used cache.
+///
+/// Backs per-key caches that would otherwise grow one entry per distinct key
+/// for a process lifetime - for example the parameter transport's per-node
+/// AsyncParametersClient cache and default-value cache, each of which gains one
+/// entry per node name ever queried and, unbounded, leaks memory over a long
+/// run against a churning graph. When an insert pushes the entry count past
+/// @c max_size, the least-recently-used entry is evicted.
+///
+/// Recency is tracked with a monotonic access counter, not a wall or steady
+/// clock: every find() hit and every put() stamps the entry with the next
+/// counter value, and eviction removes the entry with the smallest stamp. This
+/// gives a strict, tie-free ordering that is deterministic and test-friendly,
+/// and needs no clock. The counter is 64-bit; at one access per nanosecond it
+/// would take ~585 years to wrap, so overflow is not a practical concern.
+///
+/// NOT thread-safe. A shared instance must be guarded by the caller's own mutex
+/// on every call. Ros2ParameterTransport holds clients_mutex_ around its client
+/// cache and defaults_mutex_ around its default-value cache for exactly this
+/// reason.
+///
+/// @tparam Key   map key type (must be usable as a std::map key)
+/// @tparam Value cached value type
+template <typename Key, typename Value>
+class BoundedLruCache {
+ public:
+  /// @param max_size Maximum number of entries retained. Values below 1 are
+  ///                 clamped to 1 (a zero-capacity LRU cache is meaningless and
+  ///                 would evict the entry it just inserted).
+  explicit BoundedLruCache(std::size_t max_size) : max_size_(max_size == 0 ? 1 : max_size) {
+  }
+
+  /// Look up @p key, marking it most-recently-used on a hit.
+  /// @return pointer to the stored value, or nullptr if absent. The pointer is
+  ///         valid only until the next mutating call (put/clear) on this cache.
+  Value * find(const Key & key) {
+    auto it = entries_.find(key);
+    if (it == entries_.end()) {
+      return nullptr;
+    }
+    it->second.stamp = ++counter_;
+    return &it->second.value;
+  }
+
+  /// Report whether @p key is present WITHOUT changing its recency.
+  bool contains(const Key & key) const {
+    return entries_.find(key) != entries_.end();
+  }
+
+  /// Insert or replace the value for @p key, mark it most-recently-used, then
+  /// evict the least-recently-used entry if the cache is now over capacity.
+  ///
+  /// The just-stored entry always carries the largest stamp, so it is never the
+  /// eviction victim; erasing a different entry from the underlying std::map
+  /// does not invalidate the reference returned here.
+  ///
+  /// @return reference to the stored value (valid until the next mutating call).
+  Value & put(const Key & key, Value value) {
+    auto & entry = entries_[key];
+    entry.value = std::move(value);
+    entry.stamp = ++counter_;
+    if (entries_.size() > max_size_) {
+      evict_lru();
+    }
+    return entry.value;
+  }
+
+  /// Remove all entries. The access counter is intentionally not reset - stamps
+  /// only need to be monotonic, not dense.
+  void clear() {
+    entries_.clear();
+  }
+
+  std::size_t size() const {
+    return entries_.size();
+  }
+  std::size_t max_size() const {
+    return max_size_;
+  }
+
+ private:
+  struct Entry {
+    Value value;
+    std::uint64_t stamp{0};
+  };
+
+  /// Erase the entry with the smallest access stamp (the least-recently-used).
+  /// Only called right after an over-capacity insert, so the map holds at least
+  /// two entries and the just-inserted one (largest stamp) is never the victim.
+  void evict_lru() {
+    auto victim = entries_.begin();
+    for (auto it = std::next(entries_.begin()); it != entries_.end(); ++it) {
+      if (it->second.stamp < victim->second.stamp) {
+        victim = it;
+      }
+    }
+    entries_.erase(victim);
+  }
+
+  std::size_t max_size_;
+  std::uint64_t counter_{0};
+  std::map<Key, Entry> entries_;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -41,10 +41,16 @@ namespace ros2_medkit_gateway::ros2 {
  * parameter-client spins, and the JSON <-> rclcpp::ParameterValue conversion
  * helpers that previously lived inside ConfigurationManager.
  *
- * The client cache and the defaults cache are keyed by node name and bounded by
- * LRU eviction (BoundedLruCache, capacity kMaxParamNodeCacheSize). Both would
- * otherwise gain one permanent entry per distinct node name ever queried and
- * leak memory on a long-lived gateway facing a churning graph.
+ * The client cache and the default-value caches are keyed by node name and
+ * bounded by LRU eviction (BoundedLruCache). Each would otherwise gain one
+ * permanent entry per distinct node name ever queried and leak memory on a
+ * long-lived gateway facing a churning graph. The client cache uses a moderate
+ * cap (kMaxParamClientCacheSize) because each entry is heavy; the default-value
+ * caches use a much larger cap (kMaxDefaultsCacheSize) because their entries are
+ * light AND because evicting a default can rebase what "default" means. To keep
+ * reset-to-default correct, set_parameter records a parameter's pre-write value
+ * in pre_write_values_, which get_default / list_defaults prefer over the
+ * first-seen snapshot.
  *
  * Uses AsyncParametersClient + explicit spin_until_future_complete (not the
  * SyncParametersClient) so a service TIMEOUT is distinguished from a
@@ -66,14 +72,21 @@ class Ros2ParameterTransport : public ParameterTransport {
    * @param negative_cache_ttl_sec How long an unavailable node remains in the
    *                               negative cache before another IPC attempt.
    *                               Set to 0 to disable.
-   * @param param_node_cache_size Capacity of each per-node cache (the
-   *                              AsyncParametersClient cache and the
-   *                              default-value cache) before least-recently-used
-   *                              eviction. Defaults to kMaxParamNodeCacheSize;
-   *                              overridable mainly for tests.
+   * @param client_cache_size Capacity of the per-node AsyncParametersClient cache
+   *                          before least-recently-used eviction. Defaults to
+   *                          kMaxParamClientCacheSize; overridable mainly for
+   *                          tests.
+   * @param defaults_cache_size Capacity of each per-node default-value cache (the
+   *                            first-seen snapshot and the pre-write record) before
+   *                            least-recently-used eviction. Defaults to
+   *                            kMaxDefaultsCacheSize; larger than the client cache
+   *                            because a parameter map is far lighter than an
+   *                            AsyncParametersClient, so evicting a default (which
+   *                            can rebase "default" to a current value) stays rare.
    */
   Ros2ParameterTransport(rclcpp::Node * node, double service_timeout_sec, double negative_cache_ttl_sec,
-                         std::size_t param_node_cache_size = kMaxParamNodeCacheSize);
+                         std::size_t client_cache_size = kMaxParamClientCacheSize,
+                         std::size_t defaults_cache_size = kMaxDefaultsCacheSize);
 
   ~Ros2ParameterTransport() override;
 
@@ -104,6 +117,10 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// cache. Thread-safe. Exposed for diagnostics and to let tests assert the
   /// cache stays bounded under many distinct node names.
   std::size_t param_client_cache_size() const;
+
+  /// Number of entries currently held in the per-node first-seen default-value
+  /// cache. Thread-safe. Exposed for diagnostics and eviction tests.
+  std::size_t default_values_cache_size() const;
 
  private:
   /// Get or create a cached AsyncParametersClient for the given node.
@@ -150,6 +167,10 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Returns unique_lock on success, nullopt on timeout (result populated with error).
   std::optional<std::unique_lock<std::timed_mutex>> try_acquire_spin_lock(ParameterResult & result);
 
+  /// Throttled WARN emitted when a default-value cache evicts an entry, so the
+  /// rare case where a re-seed could rebase "default" is at least observable.
+  void warn_defaults_evicted(const std::string & node_name) const;
+
   rclcpp::Node * node_;
 
   /// Timeout for waiting for parameter services.
@@ -169,10 +190,19 @@ class Ros2ParameterTransport : public ParameterTransport {
   mutable std::shared_mutex negative_cache_mutex_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> unavailable_nodes_;
 
-  /// Cache of default parameter values per node, bounded by LRU eviction.
-  /// Key: node_name, Value: map of param_name -> Parameter.
+  /// Default-value caches, both guarded by defaults_mutex_ and bounded by LRU
+  /// eviction. Key: node_name, Value: map of param_name -> Parameter.
+  ///
+  /// default_values_ is the first-seen snapshot: the values a node reported the
+  /// first time it was queried. pre_write_values_ records the value of a
+  /// parameter as it was JUST BEFORE the gateway first overwrote it via
+  /// set_parameter. get_default / list_defaults prefer pre_write_values_ so that
+  /// "reset to default" restores what the value was before the gateway changed
+  /// it, even if the first-seen snapshot was captured after that write or was
+  /// evicted and re-seeded from the current (post-write) value.
   mutable std::mutex defaults_mutex_;
   BoundedLruCache<std::string, std::map<std::string, rclcpp::Parameter>> default_values_;
+  BoundedLruCache<std::string, std::map<std::string, rclcpp::Parameter>> pre_write_values_;
 
   /// Mutex to serialize spin operations on param_node_.
   /// spin_for() drives spin_until_future_complete on param_node_, which is NOT
@@ -191,13 +221,19 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Maximum entries in negative cache before hard eviction.
   static constexpr size_t kMaxNegativeCacheSize = 500;
 
-  /// Maximum entries in each per-node cache (the AsyncParametersClient cache and
-  /// the default-value cache) before least-recently-used eviction. A safety-net
-  /// bound against unbounded growth on a long-lived gateway facing a churning
-  /// graph. Tighter than kMaxNegativeCacheSize because each entry here is heavy
-  /// (an AsyncParametersClient owns several DDS service clients) while a
-  /// negative-cache entry is a single timestamp.
-  static constexpr std::size_t kMaxParamNodeCacheSize = 256;
+  /// Maximum entries in the per-node AsyncParametersClient cache before
+  /// least-recently-used eviction. Kept moderate because each entry is heavy: an
+  /// AsyncParametersClient owns several DDS service clients on param_node_.
+  /// Evicting one is transparent - the next query rebuilds the client.
+  static constexpr std::size_t kMaxParamClientCacheSize = 256;
+
+  /// Maximum entries in each per-node default-value cache before
+  /// least-recently-used eviction. Much larger than the client cache because a
+  /// parameter map is orders of magnitude lighter than an AsyncParametersClient,
+  /// AND because evicting a default is NOT transparent: a re-seed can rebase what
+  /// "default" means. A large cap keeps defaults eviction exceptional on any
+  /// realistic graph while still bounding memory.
+  static constexpr std::size_t kMaxDefaultsCacheSize = 8192;
 
   /// Margin added to service_timeout_sec_ for spin_mutex acquisition timeout.
   /// Must exceed service_timeout_sec_ to avoid spurious TIMEOUT errors.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -28,6 +29,7 @@
 
 #include "ros2_medkit_gateway/core/configuration/parameter_types.hpp"
 #include "ros2_medkit_gateway/core/transports/parameter_transport.hpp"
+#include "ros2_medkit_gateway/core/util/bounded_lru_cache.hpp"
 
 namespace ros2_medkit_gateway::ros2 {
 
@@ -38,6 +40,11 @@ namespace ros2_medkit_gateway::ros2 {
  * cache, the negative-cache for unreachable nodes, the spin_mutex serialising
  * parameter-client spins, and the JSON <-> rclcpp::ParameterValue conversion
  * helpers that previously lived inside ConfigurationManager.
+ *
+ * The client cache and the defaults cache are keyed by node name and bounded by
+ * LRU eviction (BoundedLruCache, capacity kMaxParamNodeCacheSize). Both would
+ * otherwise gain one permanent entry per distinct node name ever queried and
+ * leak memory on a long-lived gateway facing a churning graph.
  *
  * Uses AsyncParametersClient + explicit spin_until_future_complete (not the
  * SyncParametersClient) so a service TIMEOUT is distinguished from a
@@ -59,8 +66,14 @@ class Ros2ParameterTransport : public ParameterTransport {
    * @param negative_cache_ttl_sec How long an unavailable node remains in the
    *                               negative cache before another IPC attempt.
    *                               Set to 0 to disable.
+   * @param param_node_cache_size Capacity of each per-node cache (the
+   *                              AsyncParametersClient cache and the
+   *                              default-value cache) before least-recently-used
+   *                              eviction. Defaults to kMaxParamNodeCacheSize;
+   *                              overridable mainly for tests.
    */
-  Ros2ParameterTransport(rclcpp::Node * node, double service_timeout_sec, double negative_cache_ttl_sec);
+  Ros2ParameterTransport(rclcpp::Node * node, double service_timeout_sec, double negative_cache_ttl_sec,
+                         std::size_t param_node_cache_size = kMaxParamNodeCacheSize);
 
   ~Ros2ParameterTransport() override;
 
@@ -86,6 +99,11 @@ class Ros2ParameterTransport : public ParameterTransport {
 
   bool is_node_available(const std::string & node_name) const override;
   void shutdown() override;
+
+  /// Number of entries currently held in the per-node AsyncParametersClient
+  /// cache. Thread-safe. Exposed for diagnostics and to let tests assert the
+  /// cache stays bounded under many distinct node names.
+  std::size_t param_client_cache_size() const;
 
  private:
   /// Get or create a cached AsyncParametersClient for the given node.
@@ -151,10 +169,10 @@ class Ros2ParameterTransport : public ParameterTransport {
   mutable std::shared_mutex negative_cache_mutex_;
   std::unordered_map<std::string, std::chrono::steady_clock::time_point> unavailable_nodes_;
 
-  /// Cache of default parameter values per node.
+  /// Cache of default parameter values per node, bounded by LRU eviction.
   /// Key: node_name, Value: map of param_name -> Parameter.
   mutable std::mutex defaults_mutex_;
-  std::map<std::string, std::map<std::string, rclcpp::Parameter>> default_values_;
+  BoundedLruCache<std::string, std::map<std::string, rclcpp::Parameter>> default_values_;
 
   /// Mutex to serialize spin operations on param_node_.
   /// spin_for() drives spin_until_future_complete on param_node_, which is NOT
@@ -166,12 +184,20 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Created once in constructor - must be in DDS graph early for fast service discovery.
   std::shared_ptr<rclcpp::Node> param_node_;
 
-  /// Cached AsyncParametersClient per target node.
+  /// Cached AsyncParametersClient per target node, bounded by LRU eviction.
   mutable std::mutex clients_mutex_;
-  std::map<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;
+  BoundedLruCache<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;
 
   /// Maximum entries in negative cache before hard eviction.
   static constexpr size_t kMaxNegativeCacheSize = 500;
+
+  /// Maximum entries in each per-node cache (the AsyncParametersClient cache and
+  /// the default-value cache) before least-recently-used eviction. A safety-net
+  /// bound against unbounded growth on a long-lived gateway facing a churning
+  /// graph. Tighter than kMaxNegativeCacheSize because each entry here is heavy
+  /// (an AsyncParametersClient owns several DDS service clients) while a
+  /// negative-cache entry is a single timestamp.
+  static constexpr std::size_t kMaxParamNodeCacheSize = 256;
 
   /// Margin added to service_timeout_sec_ for spin_mutex acquisition timeout.
   /// Must exceed service_timeout_sec_ to avoid spurious TIMEOUT errors.

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -24,12 +24,20 @@ using namespace std::chrono_literals;
 namespace ros2_medkit_gateway::ros2 {
 
 Ros2ParameterTransport::Ros2ParameterTransport(rclcpp::Node * node, double service_timeout_sec,
-                                               double negative_cache_ttl_sec, std::size_t param_node_cache_size)
+                                               double negative_cache_ttl_sec, std::size_t client_cache_size,
+                                               std::size_t defaults_cache_size)
   : node_(node)
   , service_timeout_sec_(service_timeout_sec)
   , negative_cache_ttl_sec_(negative_cache_ttl_sec)
-  , default_values_(param_node_cache_size)
-  , param_clients_(param_node_cache_size) {
+  , default_values_(defaults_cache_size,
+                    [this](const std::string & node_name, const std::map<std::string, rclcpp::Parameter> &) {
+                      warn_defaults_evicted(node_name);
+                    })
+  , pre_write_values_(defaults_cache_size,
+                      [this](const std::string & node_name, const std::map<std::string, rclcpp::Parameter> &) {
+                        warn_defaults_evicted(node_name);
+                      })
+  , param_clients_(client_cache_size) {
   // Create internal node for parameter client operations early.
   // Must be in DDS graph before any parameter queries for fast service discovery.
   rclcpp::NodeOptions options;
@@ -53,14 +61,23 @@ void Ros2ParameterTransport::shutdown() {
   if (shutdown_requested_.exchange(true)) {
     return;  // Already shut down
   }
-  // Hold lock through cleanup to prevent race with in-flight requests.
+  // Destroying the cached clients and param_node_ frees rcl entities on
+  // param_node_. spin_for() reads that entity set under spin_mutex_, so the
+  // teardown must also hold spin_mutex_ or it could free an entity mid-spin
+  // (use-after-free). Each spin is bounded by the service timeout, so the lock
+  // is always released shortly. If the initial timed wait lapses we BLOCK for it
+  // rather than tear down under a live spinner: a spin cannot outlive its bounded
+  // duration, so this cannot hang in practice, and a bounded hang would be safer
+  // than freeing an entity a live spin still references.
   std::unique_lock<std::timed_mutex> spin_lock(spin_mutex_, std::defer_lock);
   if (!spin_lock.try_lock_for(kShutdownTimeout)) {
     if (node_) {
       RCLCPP_WARN(node_->get_logger(),
-                  "Ros2ParameterTransport shutdown: spin_mutex_ not released within timeout, "
-                  "proceeding with cleanup");
+                  "Ros2ParameterTransport shutdown: spin_mutex_ still held after %llds; waiting for the "
+                  "in-flight parameter operation to finish before tearing down clients",
+                  static_cast<long long>(kShutdownTimeout.count()));
     }
+    spin_lock.lock();  // block until the bounded spin releases; never tear down under a live spinner
   }
   std::lock_guard<std::mutex> lock(clients_mutex_);
   param_clients_.clear();
@@ -151,6 +168,22 @@ std::shared_ptr<rclcpp::AsyncParametersClient> Ros2ParameterTransport::get_param
 std::size_t Ros2ParameterTransport::param_client_cache_size() const {
   std::lock_guard<std::mutex> lock(clients_mutex_);
   return param_clients_.size();
+}
+
+std::size_t Ros2ParameterTransport::default_values_cache_size() const {
+  std::lock_guard<std::mutex> lock(defaults_mutex_);
+  return default_values_.size();
+}
+
+void Ros2ParameterTransport::warn_defaults_evicted(const std::string & node_name) const {
+  if (!node_) {
+    return;
+  }
+  RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), 60000,
+                       "Default-value cache over capacity; evicted cached defaults for node '%s'. A later "
+                       "reset-to-default for a parameter on this node may restore its current value instead of "
+                       "its original one. Increase the defaults cache size if this recurs.",
+                       node_name.c_str());
 }
 
 template <typename FutureT>
@@ -678,6 +711,23 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       return result;
     }
 
+    // The write succeeded. Record what the value was BEFORE this write (from the
+    // pre-read above) so reset-to-default can later restore the pre-write value -
+    // even if the first-seen default snapshot was captured after a write, or was
+    // evicted and re-seeded from the current (post-write) value. emplace records
+    // only the FIRST write per (node, param) - the original value - and only when
+    // the pre-read actually returned a value, so this reuses that read and adds no
+    // round trip.
+    if (!current_params.empty()) {
+      std::lock_guard<std::mutex> lock(defaults_mutex_);
+      auto * node_pre_write = pre_write_values_.find(node_name);
+      if (node_pre_write == nullptr) {
+        pre_write_values_.put(node_name, {{param_name, current_params[0]}});
+      } else {
+        node_pre_write->emplace(param_name, current_params[0]);  // no-op if already recorded
+      }
+    }
+
     json param_obj;
     param_obj["name"] = param_name;
     param_obj["value"] = parameter_value_to_json(param_value);
@@ -697,6 +747,24 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
 ParameterResult Ros2ParameterTransport::get_default(const std::string & node_name, const std::string & param_name) {
   if (shutdown_requested_.load()) {
     return {false, {}, "Ros2ParameterTransport is shut down", ParameterErrorCode::SHUT_DOWN};
+  }
+
+  // Prefer the pre-write record: if the gateway overwrote this parameter, the
+  // authoritative default for reset is the value it had before that write, not
+  // the first-seen snapshot (which could have been captured after the write, or
+  // evicted and re-seeded from the current value). This also short-circuits the
+  // defaults round trip below when a pre-write value is on record.
+  {
+    std::lock_guard<std::mutex> lock(defaults_mutex_);
+    if (auto * node_pre_write = pre_write_values_.find(node_name)) {
+      auto pre_it = node_pre_write->find(param_name);
+      if (pre_it != node_pre_write->end()) {
+        ParameterResult pre_result;
+        pre_result.success = true;
+        pre_result.data = parameter_value_to_json(pre_it->second.get_parameter_value());
+        return pre_result;
+      }
+    }
   }
 
   // For self-node, populate the defaults cache lazily from the live node
@@ -802,15 +870,29 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
   ParameterResult result;
   std::lock_guard<std::mutex> lock(defaults_mutex_);
   auto * node_defaults = default_values_.find(node_name);
-  if (node_defaults == nullptr) {
+  auto * node_pre_write = pre_write_values_.find(node_name);
+  if (node_defaults == nullptr && node_pre_write == nullptr) {
     result.success = false;
     result.error_message = "No default values cached for node: " + node_name;
     result.error_code = ParameterErrorCode::NO_DEFAULTS_CACHED;
     return result;
   }
 
+  // Merge the first-seen snapshot with the pre-write record, pre-write taking
+  // precedence - the same preference get_default applies - so the listing reports
+  // the same defaults reset would restore.
+  std::map<std::string, rclcpp::Parameter> merged;
+  if (node_defaults != nullptr) {
+    merged = *node_defaults;
+  }
+  if (node_pre_write != nullptr) {
+    for (const auto & [name, param] : *node_pre_write) {
+      merged[name] = param;
+    }
+  }
+
   json defaults_array = json::array();
-  for (const auto & [name, param] : *node_defaults) {
+  for (const auto & [name, param] : merged) {
     json entry;
     entry["name"] = name;
     entry["value"] = parameter_value_to_json(param.get_parameter_value());

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -24,8 +24,12 @@ using namespace std::chrono_literals;
 namespace ros2_medkit_gateway::ros2 {
 
 Ros2ParameterTransport::Ros2ParameterTransport(rclcpp::Node * node, double service_timeout_sec,
-                                               double negative_cache_ttl_sec)
-  : node_(node), service_timeout_sec_(service_timeout_sec), negative_cache_ttl_sec_(negative_cache_ttl_sec) {
+                                               double negative_cache_ttl_sec, std::size_t param_node_cache_size)
+  : node_(node)
+  , service_timeout_sec_(service_timeout_sec)
+  , negative_cache_ttl_sec_(negative_cache_ttl_sec)
+  , default_values_(param_node_cache_size)
+  , param_clients_(param_node_cache_size) {
   // Create internal node for parameter client operations early.
   // Must be in DDS graph before any parameter queries for fast service discovery.
   rclcpp::NodeOptions options;
@@ -134,16 +138,19 @@ void Ros2ParameterTransport::mark_node_unavailable(const std::string & node_name
 
 std::shared_ptr<rclcpp::AsyncParametersClient> Ros2ParameterTransport::get_param_client(const std::string & node_name) {
   std::lock_guard<std::mutex> lock(clients_mutex_);
-  auto it = param_clients_.find(node_name);
-  if (it != param_clients_.end()) {
-    return it->second;
+  if (auto * cached = param_clients_.find(node_name)) {
+    return *cached;
   }
   if (!param_node_) {
     return nullptr;
   }
   auto client = std::make_shared<rclcpp::AsyncParametersClient>(param_node_, node_name);
-  param_clients_[node_name] = client;
-  return client;
+  return param_clients_.put(node_name, client);
+}
+
+std::size_t Ros2ParameterTransport::param_client_cache_size() const {
+  std::lock_guard<std::mutex> lock(clients_mutex_);
+  return param_clients_.size();
 }
 
 template <typename FutureT>
@@ -181,12 +188,12 @@ ParameterResult Ros2ParameterTransport::list_own_parameters() {
     // Cache defaults for reset operations (same as IPC path).
     {
       std::lock_guard<std::mutex> lock(defaults_mutex_);
-      if (default_values_.find(own_node_fqn_) == default_values_.end()) {
+      if (!default_values_.contains(own_node_fqn_)) {
         std::map<std::string, rclcpp::Parameter> node_defaults;
         for (const auto & param : params) {
           node_defaults[param.get_name()] = param;
         }
-        default_values_[own_node_fqn_] = std::move(node_defaults);
+        default_values_.put(own_node_fqn_, std::move(node_defaults));
       }
     }
 
@@ -253,18 +260,25 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
   ParameterResult result;
 
   try {
-    auto client = get_param_client(node_name);
-    if (!client) {
-      result.success = false;
-      result.error_message = "Parameter client unavailable (transport shut down)";
-      result.error_code = ParameterErrorCode::SHUT_DOWN;
-      return result;
-    }
-
     std::vector<rclcpp::Parameter> parameters;
     {
       auto spin_lock = try_acquire_spin_lock(result);
       if (!spin_lock) {
+        return result;
+      }
+
+      // Get (or create) the client INSIDE the spin lock, exactly as get_parameter
+      // and set_parameter do. Creating or LRU-evicting an AsyncParametersClient
+      // mutates param_node_'s entity set, and spin_for() reads that set under
+      // spin_mutex_. Doing it outside the lock would race a concurrent spin on
+      // param_node_: an evicted client's rcl entities could be destroyed mid-spin
+      // (use-after-free), reachable once the cache is at capacity and two parameter
+      // requests run at once - the exact multi-node fan-out this transport serves.
+      auto client = get_param_client(node_name);
+      if (!client) {
+        result.success = false;
+        result.error_message = "Parameter client unavailable (transport shut down)";
+        result.error_code = ParameterErrorCode::SHUT_DOWN;
         return result;
       }
 
@@ -690,14 +704,14 @@ ParameterResult Ros2ParameterTransport::get_default(const std::string & node_nam
   // assembly side-effect) in case the manager calls reset before list.
   if (is_self_node(node_name)) {
     std::lock_guard<std::mutex> lock(defaults_mutex_);
-    if (default_values_.find(node_name) == default_values_.end()) {
+    if (!default_values_.contains(node_name)) {
       try {
         auto params = node_->get_parameters(node_->list_parameters({}, 0).names);
         std::map<std::string, rclcpp::Parameter> node_defaults;
         for (const auto & param : params) {
           node_defaults[param.get_name()] = param;
         }
-        default_values_[node_name] = std::move(node_defaults);
+        default_values_.put(node_name, std::move(node_defaults));
       } catch (const std::exception & e) {
         ParameterResult result;
         result.success = false;
@@ -709,18 +723,10 @@ ParameterResult Ros2ParameterTransport::get_default(const std::string & node_nam
   } else {
     // Non-self: ensure defaults are cached. cache_default_values requires
     // spin_mutex_ to be held.
-    {
-      std::lock_guard<std::mutex> lock(defaults_mutex_);
-      if (default_values_.find(node_name) != default_values_.end()) {
-        // already cached, no need to spin
-      } else {
-        // Drop the lock before spinning - cache_default_values reacquires it.
-      }
-    }
     bool needs_cache = false;
     {
       std::lock_guard<std::mutex> lock(defaults_mutex_);
-      needs_cache = (default_values_.find(node_name) == default_values_.end());
+      needs_cache = !default_values_.contains(node_name);
     }
     if (needs_cache) {
       ParameterResult tmp;
@@ -734,15 +740,15 @@ ParameterResult Ros2ParameterTransport::get_default(const std::string & node_nam
 
   ParameterResult result;
   std::lock_guard<std::mutex> lock(defaults_mutex_);
-  auto node_it = default_values_.find(node_name);
-  if (node_it == default_values_.end()) {
+  auto * node_defaults = default_values_.find(node_name);
+  if (node_defaults == nullptr) {
     result.success = false;
     result.error_message = "No default values cached for node: " + node_name;
     result.error_code = ParameterErrorCode::NO_DEFAULTS_CACHED;
     return result;
   }
-  auto param_it = node_it->second.find(param_name);
-  if (param_it == node_it->second.end()) {
+  auto param_it = node_defaults->find(param_name);
+  if (param_it == node_defaults->end()) {
     result.success = false;
     result.error_message = "No default value for parameter: " + param_name;
     result.error_code = ParameterErrorCode::NOT_FOUND;
@@ -761,14 +767,14 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
   // Mirror the get_default cache-population logic.
   if (is_self_node(node_name)) {
     std::lock_guard<std::mutex> lock(defaults_mutex_);
-    if (default_values_.find(node_name) == default_values_.end()) {
+    if (!default_values_.contains(node_name)) {
       try {
         auto params = node_->get_parameters(node_->list_parameters({}, 0).names);
         std::map<std::string, rclcpp::Parameter> node_defaults;
         for (const auto & param : params) {
           node_defaults[param.get_name()] = param;
         }
-        default_values_[node_name] = std::move(node_defaults);
+        default_values_.put(node_name, std::move(node_defaults));
       } catch (const std::exception & e) {
         ParameterResult result;
         result.success = false;
@@ -781,7 +787,7 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
     bool needs_cache = false;
     {
       std::lock_guard<std::mutex> lock(defaults_mutex_);
-      needs_cache = (default_values_.find(node_name) == default_values_.end());
+      needs_cache = !default_values_.contains(node_name);
     }
     if (needs_cache) {
       ParameterResult tmp;
@@ -795,8 +801,8 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
 
   ParameterResult result;
   std::lock_guard<std::mutex> lock(defaults_mutex_);
-  auto node_it = default_values_.find(node_name);
-  if (node_it == default_values_.end()) {
+  auto * node_defaults = default_values_.find(node_name);
+  if (node_defaults == nullptr) {
     result.success = false;
     result.error_message = "No default values cached for node: " + node_name;
     result.error_code = ParameterErrorCode::NO_DEFAULTS_CACHED;
@@ -804,7 +810,7 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
   }
 
   json defaults_array = json::array();
-  for (const auto & [name, param] : node_it->second) {
+  for (const auto & [name, param] : *node_defaults) {
     json entry;
     entry["name"] = name;
     entry["value"] = parameter_value_to_json(param.get_parameter_value());
@@ -974,7 +980,7 @@ rclcpp::ParameterValue Ros2ParameterTransport::json_to_parameter_value(const jso
 bool Ros2ParameterTransport::cache_default_values(const std::string & node_name) {
   {
     std::lock_guard<std::mutex> lock(defaults_mutex_);
-    if (default_values_.find(node_name) != default_values_.end()) {
+    if (default_values_.contains(node_name)) {
       return false;  // already cached from a prior successful round-trip
     }
   }
@@ -1004,9 +1010,10 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       auto rc = spin_for(list_future);
       if (rc == rclcpp::FutureReturnCode::TIMEOUT) {
         // Node did not answer: negative-cache and short-circuit. Crucially, do NOT
-        // cache anything - caching an empty map on a timeout would permanently poison
-        // default_values_ (never invalidated) so get_default/reset return NOT_FOUND
-        // forever even after the node recovers (#531).
+        // cache anything - caching an empty map on a timeout would poison
+        // default_values_ (entries are only evicted under LRU cache pressure, never
+        // invalidated on recovery) so get_default/reset return NOT_FOUND until the
+        // entry ages out even after the node recovers (#531).
         mark_node_unavailable(node_name);
         return true;
       }
@@ -1023,8 +1030,8 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       // do not re-round-trip under spin_mutex_ forever. Only a TIMEOUT must avoid caching
       // (poison-avoidance); a SUCCESS-empty is safe to cache (#531).
       std::lock_guard<std::mutex> lock(defaults_mutex_);
-      if (default_values_.find(node_name) == default_values_.end()) {
-        default_values_[node_name] = {};
+      if (!default_values_.contains(node_name)) {
+        default_values_.put(node_name, {});
       }
       return false;
     }
@@ -1054,8 +1061,8 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
 
     {
       std::lock_guard<std::mutex> lock(defaults_mutex_);
-      if (default_values_.find(node_name) == default_values_.end()) {
-        default_values_[node_name] = std::move(node_defaults);
+      if (!default_values_.contains(node_name)) {
+        default_values_.put(node_name, std::move(node_defaults));
       }
     }
   } catch (const std::exception & e) {

--- a/src/ros2_medkit_gateway/test/test_bounded_lru_cache.cpp
+++ b/src/ros2_medkit_gateway/test/test_bounded_lru_cache.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "ros2_medkit_gateway/core/util/bounded_lru_cache.hpp"
+
+namespace ros2_medkit_gateway {
+namespace {
+
+TEST(BoundedLruCacheTest, FindMissReturnsNullptr) {
+  BoundedLruCache<int, std::string> cache(4);
+  EXPECT_EQ(cache.find(42), nullptr);
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(BoundedLruCacheTest, PutThenFindReturnsStoredValue) {
+  BoundedLruCache<int, std::string> cache(4);
+  cache.put(1, "one");
+  auto * value = cache.find(1);
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, "one");
+}
+
+TEST(BoundedLruCacheTest, PutReplaceUpdatesValueWithoutGrowing) {
+  BoundedLruCache<int, std::string> cache(4);
+  cache.put(1, "one");
+  cache.put(1, "uno");
+  EXPECT_EQ(cache.size(), 1u);
+  auto * value = cache.find(1);
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, "uno");
+}
+
+TEST(BoundedLruCacheTest, PutReturnsReferenceToStoredValue) {
+  BoundedLruCache<int, int> cache(4);
+  int & ref = cache.put(7, 70);
+  EXPECT_EQ(ref, 70);
+  ref = 71;  // mutate through the returned reference
+  auto * value = cache.find(7);
+  ASSERT_NE(value, nullptr);
+  EXPECT_EQ(*value, 71);
+}
+
+TEST(BoundedLruCacheTest, SizeNeverExceedsCapacity) {
+  BoundedLruCache<int, int> cache(8);
+  for (int i = 0; i < 100; ++i) {
+    cache.put(i, i);
+    EXPECT_LE(cache.size(), 8u);
+  }
+  EXPECT_EQ(cache.size(), 8u);
+}
+
+TEST(BoundedLruCacheTest, EvictsInsertionOrderWhenNothingAccessed) {
+  BoundedLruCache<int, int> cache(2);
+  cache.put(1, 1);
+  cache.put(2, 2);
+  cache.put(3, 3);  // over cap -> evict the oldest untouched entry (key 1)
+  EXPECT_EQ(cache.find(1), nullptr);
+  EXPECT_NE(cache.find(2), nullptr);
+  EXPECT_NE(cache.find(3), nullptr);
+}
+
+TEST(BoundedLruCacheTest, FindRefreshesRecencySoHotEntrySurvives) {
+  BoundedLruCache<int, int> cache(3);
+  cache.put(1, 10);
+  cache.put(2, 20);
+  cache.put(3, 30);
+  // Touch key 1, making key 2 the least-recently-used.
+  ASSERT_NE(cache.find(1), nullptr);
+  cache.put(4, 40);  // over cap -> evict the LRU (key 2), not the touched key 1
+  EXPECT_EQ(cache.size(), 3u);
+  EXPECT_NE(cache.find(1), nullptr);  // refreshed, survives
+  EXPECT_EQ(cache.find(2), nullptr);  // least-recently-used, evicted
+  EXPECT_NE(cache.find(3), nullptr);
+  EXPECT_NE(cache.find(4), nullptr);  // just inserted, survives
+}
+
+TEST(BoundedLruCacheTest, ContainsDoesNotRefreshRecency) {
+  BoundedLruCache<int, int> cache(2);
+  cache.put(1, 1);
+  cache.put(2, 2);
+  EXPECT_TRUE(cache.contains(1));  // peek must NOT count as an access
+  cache.put(3, 3);                 // key 1 is still the LRU despite the contains() peek -> evicted
+  EXPECT_EQ(cache.find(1), nullptr);
+  EXPECT_NE(cache.find(2), nullptr);
+  EXPECT_NE(cache.find(3), nullptr);
+}
+
+TEST(BoundedLruCacheTest, ClearEmptiesCache) {
+  BoundedLruCache<int, int> cache(4);
+  cache.put(1, 1);
+  cache.put(2, 2);
+  cache.clear();
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(cache.find(1), nullptr);
+}
+
+TEST(BoundedLruCacheTest, ClearThenReusePreservesBound) {
+  BoundedLruCache<int, int> cache(2);
+  cache.put(1, 1);
+  cache.put(2, 2);
+  cache.clear();
+  for (int i = 10; i < 20; ++i) {
+    cache.put(i, i);
+  }
+  EXPECT_EQ(cache.size(), 2u);
+}
+
+TEST(BoundedLruCacheTest, ZeroCapacityClampsToOne) {
+  BoundedLruCache<int, int> cache(0);
+  EXPECT_EQ(cache.max_size(), 1u);
+  cache.put(1, 1);
+  cache.put(2, 2);  // over cap(1) -> evict key 1
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_EQ(cache.find(1), nullptr);
+  EXPECT_NE(cache.find(2), nullptr);
+}
+
+}  // namespace
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/test/test_bounded_lru_cache.cpp
+++ b/src/ros2_medkit_gateway/test/test_bounded_lru_cache.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "ros2_medkit_gateway/core/util/bounded_lru_cache.hpp"
 
@@ -128,6 +130,34 @@ TEST(BoundedLruCacheTest, ZeroCapacityClampsToOne) {
   EXPECT_EQ(cache.size(), 1u);
   EXPECT_EQ(cache.find(1), nullptr);
   EXPECT_NE(cache.find(2), nullptr);
+}
+
+TEST(BoundedLruCacheTest, PutOnExistingKeyRefreshesRecency) {
+  BoundedLruCache<int, std::string> cache(2);
+  cache.put(1, "one");
+  cache.put(2, "two");
+  cache.put(1, "updated");  // replace must re-stamp key 1 as most-recently-used
+  cache.put(3, "three");    // over cap -> evict the LRU, which is now key 2, not key 1
+  EXPECT_EQ(cache.size(), 2u);
+  auto * one = cache.find(1);
+  ASSERT_NE(one, nullptr);
+  EXPECT_EQ(*one, "updated");
+  EXPECT_EQ(cache.find(2), nullptr);  // least-recently-used after the replace, evicted
+  EXPECT_NE(cache.find(3), nullptr);
+}
+
+TEST(BoundedLruCacheTest, OnEvictCallbackFiresWithEvictedEntry) {
+  std::vector<std::pair<int, std::string>> evicted;
+  BoundedLruCache<int, std::string> cache(2, [&evicted](const int & key, const std::string & value) {
+    evicted.emplace_back(key, value);
+  });
+  cache.put(1, "one");
+  cache.put(2, "two");
+  EXPECT_TRUE(evicted.empty());  // still at capacity, nothing evicted yet
+  cache.put(3, "three");         // over cap -> evict the least-recently-used (key 1)
+  ASSERT_EQ(evicted.size(), 1u);
+  EXPECT_EQ(evicted[0].first, 1);
+  EXPECT_EQ(evicted[0].second, "one");
 }
 
 }  // namespace

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -36,6 +36,7 @@
 #include <chrono>
 #include <memory>
 #include <rclcpp/rclcpp.hpp>
+#include <string>
 #include <thread>
 
 #include "ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp"
@@ -278,6 +279,35 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, ListParametersCapHoldsWithNeg
       << "with the negative cache disabled the cache_default_values short-circuit must still fire "
          "(SERVICE_UNAVAILABLE); TIMEOUT would mean the cap was defeated and a second round-trip ran";
   EXPECT_LT(elapsed, std::chrono::seconds(5)) << "sanity: still bounded";
+}
+
+// The per-node AsyncParametersClient cache is bounded by LRU eviction, so a
+// gateway that queries an ever-growing set of distinct node names cannot leak
+// one client per node for its whole lifetime (the pre-fix behaviour). A
+// transport built with a small cache cap and pointed at many distinct,
+// nonexistent node names must keep its client cache at the cap. get_param_client
+// runs (and inserts) before the failing wait_for_service, so every distinct
+// query would add an entry without the bound. A short service timeout is used
+// because every query hits a nonexistent service; the assertion is on the cache
+// size, not on timing.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, ClientCacheStaysBoundedAcrossManyNodes) {
+  constexpr std::size_t kCacheCap = 4;
+  constexpr double kShortTimeoutSec = 0.1;
+  constexpr double kNegativeCacheDisabled = 0.0;
+  auto bounded_transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), kShortTimeoutSec,
+                                                                          kNegativeCacheDisabled, kCacheCap);
+
+  constexpr std::size_t kDistinctNodes = kCacheCap * 3;
+  for (std::size_t i = 0; i < kDistinctNodes; ++i) {
+    const std::string node_name = "/nonexistent_param_node_" + std::to_string(i);
+    auto result = bounded_transport->get_parameter(node_name, "some_param");
+    EXPECT_FALSE(result.success) << "a nonexistent node must not resolve a parameter";
+  }
+
+  EXPECT_LE(bounded_transport->param_client_cache_size(), kCacheCap)
+      << "the per-node client cache must never grow past its capacity";
+  EXPECT_EQ(bounded_transport->param_client_cache_size(), kCacheCap)
+      << "after " << kDistinctNodes << " distinct nodes the bounded cache should be full at the cap";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -47,6 +47,15 @@ namespace {
 
 constexpr const char * kUnresponsiveNodeName = "unresponsive_param_node";
 
+// A fully responsive node with one declared integer parameter, used to exercise
+// cache eviction against a node that actually answers parameter requests.
+std::shared_ptr<rclcpp::Node> make_responsive_param_node(const std::string & node_name, const std::string & param_name,
+                                                         int64_t value) {
+  auto node = std::make_shared<rclcpp::Node>(node_name);
+  node->declare_parameter(param_name, value);
+  return node;
+}
+
 }  // namespace
 
 class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
@@ -308,6 +317,106 @@ TEST_F(TestRos2ParameterTransportUnresponsiveNode, ClientCacheStaysBoundedAcross
       << "the per-node client cache must never grow past its capacity";
   EXPECT_EQ(bounded_transport->param_client_cache_size(), kCacheCap)
       << "after " << kDistinctNodes << " distinct nodes the bounded cache should be full at the cap";
+}
+
+// Evicting a live node's AsyncParametersClient must be transparent: the next
+// query rebuilds the client (on param_node_) and still succeeds. This is the
+// contract the client-cache bound must preserve - eviction destroys rcl entities
+// on param_node_, so a broken rebuild would otherwise be invisible.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, EvictedLiveClientIsTransparentlyRebuilt) {
+  auto responsive_node = make_responsive_param_node("client_evict_responsive_node", "answer", 42);
+  executor_->add_node(responsive_node);
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  const std::string responsive_fqn = responsive_node->get_fully_qualified_name();
+
+  constexpr std::size_t kClientCap = 2;
+  constexpr double kNegativeCacheDisabled = 0.0;
+  auto transport =
+      std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, kNegativeCacheDisabled, kClientCap);
+
+  auto first = transport->get_parameter(responsive_fqn, "answer");
+  ASSERT_TRUE(first.success) << first.error_message;
+  EXPECT_EQ(first.data["value"].get<int64_t>(), 42);
+
+  // Push the responsive node's client out of the LRU cache with distinct,
+  // nonexistent nodes (each inserts a client before its wait_for_service fails).
+  for (std::size_t i = 0; i <= kClientCap; ++i) {
+    transport->get_parameter("/client_evict_filler_" + std::to_string(i), "x");
+  }
+  EXPECT_LE(transport->param_client_cache_size(), kClientCap);
+
+  // Re-query the evicted live node: the client is rebuilt and the query succeeds.
+  auto again = transport->get_parameter(responsive_fqn, "answer");
+  ASSERT_TRUE(again.success) << "evicting a live node's client must be transparent; got: " << again.error_message;
+  EXPECT_EQ(again.data["value"].get<int64_t>(), 42);
+
+  executor_->remove_node(responsive_node);
+}
+
+// When a live node's cached defaults are evicted, get_default must RE-FETCH them
+// rather than report NO_DEFAULTS_CACHED. Uses a defaults cap of 1 and two
+// responsive nodes so caching the second evicts the first.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, EvictedDefaultsAreRefetchedNotReportedMissing) {
+  auto node_a = make_responsive_param_node("defaults_evict_node_a", "p", 7);
+  auto node_b = make_responsive_param_node("defaults_evict_node_b", "p", 8);
+  executor_->add_node(node_a);
+  executor_->add_node(node_b);
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  const std::string fqn_a = node_a->get_fully_qualified_name();
+  const std::string fqn_b = node_b->get_fully_qualified_name();
+
+  constexpr std::size_t kClientCap = 16;   // large: leave clients cached
+  constexpr std::size_t kDefaultsCap = 1;  // tiny: force defaults eviction
+  constexpr double kNegativeCacheDisabled = 0.0;
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, kNegativeCacheDisabled,
+                                                                  kClientCap, kDefaultsCap);
+
+  auto def_a1 = transport->get_default(fqn_a, "p");
+  ASSERT_TRUE(def_a1.success) << def_a1.error_message;
+  EXPECT_EQ(def_a1.data.get<int64_t>(), 7);
+  EXPECT_EQ(transport->default_values_cache_size(), 1u);
+
+  // Caching B's defaults evicts A's (defaults cap is 1).
+  auto def_b = transport->get_default(fqn_b, "p");
+  ASSERT_TRUE(def_b.success) << def_b.error_message;
+  EXPECT_EQ(transport->default_values_cache_size(), 1u);
+
+  // A's defaults were evicted; get_default must re-fetch, not report them missing.
+  auto def_a2 = transport->get_default(fqn_a, "p");
+  ASSERT_TRUE(def_a2.success) << "evicted defaults must be re-fetched, not NO_DEFAULTS_CACHED; got error_code "
+                              << static_cast<int>(def_a2.error_code);
+  EXPECT_EQ(def_a2.data.get<int64_t>(), 7);
+
+  executor_->remove_node(node_a);
+  executor_->remove_node(node_b);
+}
+
+// After the gateway overwrites a parameter, reset-to-default must restore the
+// PRE-write value, not the current (post-write) one - even though the default
+// caches only ever see current values. set_parameter records the pre-write value
+// (from its existing pre-read) and get_default prefers it.
+TEST_F(TestRos2ParameterTransportUnresponsiveNode, GetDefaultReturnsPreWriteValueAfterSet) {
+  auto responsive_node = make_responsive_param_node("prewrite_responsive_node", "p", 100);
+  executor_->add_node(responsive_node);
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  const std::string fqn = responsive_node->get_fully_qualified_name();
+
+  constexpr double kNegativeCacheDisabled = 0.0;
+  auto transport = std::make_shared<ros2::Ros2ParameterTransport>(client_node_.get(), 0.5, kNegativeCacheDisabled);
+
+  auto set_res = transport->set_parameter(fqn, "p", nlohmann::json(200));
+  ASSERT_TRUE(set_res.success) << set_res.error_message;
+
+  auto def = transport->get_default(fqn, "p");
+  ASSERT_TRUE(def.success) << def.error_message;
+  EXPECT_EQ(def.data.get<int64_t>(), 100) << "get_default must return the pre-write value the gateway recorded";
+
+  // Sanity: the live value really is 200 now (the write took effect).
+  auto got = transport->get_parameter(fqn, "p");
+  ASSERT_TRUE(got.success) << got.error_message;
+  EXPECT_EQ(got.data["value"].get<int64_t>(), 200);
+
+  executor_->remove_node(responsive_node);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`Ros2ParameterTransport` kept per-node caches that gained one entry per distinct node name and were never evicted at runtime: the `AsyncParametersClient` cache (only cleared at shutdown) and the default-value cache (never cleared). On a long-lived gateway facing a churning graph these grow without bound, which leaks memory. The negative cache was already bounded; this extends the same discipline to the others.

This change backs the caches with a new header-only `BoundedLruCache<Key, Value>` and adds the hardening needed to make eviction safe and correct:

- **Separate caps for separate weights.** The client cache uses a moderate cap (`kMaxParamClientCacheSize`) because each entry is heavy: an `AsyncParametersClient` owns several DDS service clients. The default-value caches use a much larger cap (`kMaxDefaultsCacheSize`) because a parameter map is light AND because evicting a default is not transparent.

- **Pre-write default preservation.** Evicting and re-seeding a node's defaults could rebase what "default" means to a current (already-overwritten) value, so reset-to-default would report success and change nothing. `set_parameter` now records a parameter's pre-write value (from the pre-read it already does, so no extra round trip) in a dedicated `pre_write_values_` cache that `get_default` and `list_defaults` prefer over the first-seen snapshot. A throttled WARN is logged when a default-value cache evicts an entry.

- **Client eviction is race-free.** Creating or evicting an `AsyncParametersClient` mutates `param_node_`'s entity set, which `spin_for()` reads under `spin_mutex_`. `get_param_client` now runs inside the spin lock in every operation (matching `get_parameter` and `set_parameter`), and `shutdown()` blocks for the in-flight spin before tearing the clients down, so an rcl entity is never freed while a spin still references it.

- `BoundedLruCache` tracks recency with a monotonic access counter (no clock, so eviction order is deterministic and tie-free) and is not internally locked: the transport holds its existing `clients_mutex_` / `defaults_mutex_` around every call.

No behavior change for a healthy gateway with a stable set of nodes: nothing is evicted until a cache passes its cap.

---

## Issue

- closes #533

---

## Type

- [x] Bug fix

---

## Testing

`BoundedLruCache` unit tests pin the eviction rules deterministically: size never passes the cap, `find()` refreshes recency (a hot entry survives) while `contains()` does not, replace on an existing key refreshes recency, insertion order breaks ties, a zero cap clamps to one, and the on-evict callback fires with the evicted entry.

Transport tests drive the real `Ros2ParameterTransport`:

- the client cache stays at its cap across many distinct node names;
- evicting a live node's client is transparent: the next query rebuilds it and still succeeds;
- an evicted live node's defaults are re-fetched, not reported missing;
- after a set, `get_default` returns the pre-write value while the live value is the new one.

Run:

```
colcon build --packages-select ros2_medkit_gateway
./scripts/test.sh test_bounded_lru_cache
./scripts/test.sh test_ros2_parameter_transport
```

---

## Checklist

- [x] Breaking changes are clearly described (none; internal caches only, no public API or wire change)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed (internal transport change; header and class doc comments updated, no public API change)
