### PR TITLE
Config-less discovery: device-derived identity, A&C faults, AccessLevel writable, runtime fault triggers

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1955,6 +1955,55 @@ configuration:
 
 Non-persistent triggers are always cleared on restart.
 
+Fault Triggers (threshold rules)
+--------------------------------
+
+Fault triggers are runtime threshold rules on an app's discovered data points:
+the engine polls each rule's value and reports a fault while the value stays
+crossed (level-triggered), then auto-clears it when the value recovers. They
+are a sibling of the SOVD notification ``/triggers`` collection above and never
+overload it; rules persist to a JSON store and survive a restart.
+
+The routes are part of the generated OpenAPI spec (``/api/v1/docs``, tag
+``FaultTriggers``), so generated clients and Swagger UI discover them the same
+way as every other endpoint.
+
+``GET /api/v1/apps/{app_id}/fault-triggers``
+   List the app's rules.
+
+   .. code-block:: json
+
+      {
+        "items": [
+          {
+            "id": "ftr_1",
+            "app_id": "tank_process",
+            "data_name": "level",
+            "operator": ">=",
+            "threshold": 80.0,
+            "fault_code": "TANK_OVERFILL",
+            "severity": "CRITICAL",
+            "active": true
+          }
+        ]
+      }
+
+``POST /api/v1/apps/{app_id}/fault-triggers``
+   Create a rule. Required: ``data_name``, ``operator`` (``>``, ``<``, ``>=``,
+   ``<=``, ``==``), ``threshold`` (number), ``fault_code``, ``severity``
+   (``INFO``/``WARNING``/``ERROR``/``CRITICAL``). Optional: ``active``
+   (default ``true``). Returns ``201`` with the created rule.
+
+   Validation: ``400`` for missing/invalid fields or a ``data_name`` the app
+   does not expose (when enumerable); ``409`` when the ``fault_code`` is
+   already used by another rule - fault codes are global to the fault store,
+   so two rules sharing one would fight over the same fault.
+
+``DELETE /api/v1/apps/{app_id}/fault-triggers/{trigger_id}``
+   Remove a rule (``204``). A fault currently asserted by the rule is cleared;
+   the correlation cascade is skipped so the clear stays scoped to the rule's
+   own fault.
+
 Rate Limiting
 -------------
 

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -37,7 +37,8 @@ namespace ros2_medkit_fault_manager {
 /// cannot flip them. One consequence is a latch delay: a fault that becomes active again is not
 /// immediately back in the default (CONFIRMED-only) list - it can take up to
 /// (healing_threshold - confirmation_threshold) reports to re-confirm. During that window
-/// occurrence_count and last_occurred still reflect the activity.
+/// last_occurred still reflects the activity; occurrence_count does not (it only counts
+/// the edge that started this occurrence, not every report within it).
 struct DebounceConfig {
   /// Confirmation threshold (typically negative). Fault is CONFIRMED when counter <= this value,
   /// and the debounce counter is clamped to this lower bound so a long burst of FAILED events
@@ -85,7 +86,7 @@ struct FaultState {
   std::string description;
   rclcpp::Time first_occurred;
   rclcpp::Time last_occurred;
-  uint32_t occurrence_count{0};  ///< Count of FAILED events
+  uint32_t occurrence_count{0};  ///< Count of genuine occurrences (new fault + each re-raise after CLEARED)
   std::string status;
   std::set<std::string> reporting_sources;
 

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -150,8 +150,10 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
       // PASSED events for CLEARED faults are ignored
       return false;
     }
-    // FAILED event reactivates the fault - reset debounce counter
+    // FAILED event reactivates the fault - reset debounce counter and first-seen:
+    // this is a new outage cycle, not a continuation of the one that just cleared.
     state.debounce_counter = -1;
+    state.first_occurred = timestamp;
     state.last_failed_time = timestamp;
     state.last_occurred = timestamp;
     state.reporting_sources.insert(source_id);
@@ -178,10 +180,10 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
   if (is_failed) {
     state.last_failed_time = timestamp;
 
-    // Increment occurrence_count with saturation
-    if (state.occurrence_count < std::numeric_limits<uint32_t>::max()) {
-      ++state.occurrence_count;
-    }
+    // occurrence_count is NOT bumped here: this is a still-active fault being
+    // re-reported (level-triggered poller, or debounce building toward
+    // confirmation), the same continuous occurrence. It only increments on a
+    // genuine edge - new fault (above) or reactivation after CLEARED (above).
 
     // Decrement towards confirmation, clamped to the thresholds (a long FAILED burst can't
     // run the counter off to INT32_MIN and delay later healing).

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -157,7 +157,8 @@ void SqliteFaultStorage::initialize_schema() {
       reporting_sources TEXT NOT NULL,
       debounce_counter INTEGER NOT NULL DEFAULT 0,
       last_failed_ns INTEGER NOT NULL DEFAULT 0,
-      last_passed_ns INTEGER NOT NULL DEFAULT 0
+      last_passed_ns INTEGER NOT NULL DEFAULT 0,
+      confirmed_at_ns INTEGER NOT NULL DEFAULT 0
     );
   )";
 
@@ -166,6 +167,28 @@ void SqliteFaultStorage::initialize_schema() {
     std::string error = err_msg ? err_msg : "Unknown error";
     sqlite3_free(err_msg);
     throw std::runtime_error("Failed to create faults table: " + error);
+  }
+
+  // Migration: databases created before confirmed_at_ns existed keep their rows;
+  // the column arrives as 0 (= confirmation time unknown). Consumers (the
+  // compliance timeline) treat 0 as "not recorded".
+  {
+    bool has_confirmed_at = false;
+    SqliteStatement info(db_, "PRAGMA table_info(faults)");
+    while (info.step() == SQLITE_ROW) {
+      if (info.column_text(1) == "confirmed_at_ns") {
+        has_confirmed_at = true;
+        break;
+      }
+    }
+    if (!has_confirmed_at) {
+      if (sqlite3_exec(db_, "ALTER TABLE faults ADD COLUMN confirmed_at_ns INTEGER NOT NULL DEFAULT 0", nullptr,
+                       nullptr, &err_msg) != SQLITE_OK) {
+        std::string error = err_msg ? err_msg : "Unknown error";
+        sqlite3_free(err_msg);
+        throw std::runtime_error("Failed to add confirmed_at_ns column: " + error);
+      }
+    }
   }
 
   // Create snapshots table for storing topic data captured when faults are confirmed
@@ -370,8 +393,8 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
 
   // Check if fault exists
   SqliteStatement check_stmt(db_,
-                             "SELECT severity, occurrence_count, reporting_sources, status, debounce_counter FROM "
-                             "faults WHERE fault_code = ?");
+                             "SELECT severity, occurrence_count, reporting_sources, status, debounce_counter, "
+                             "confirmed_at_ns FROM faults WHERE fault_code = ?");
   check_stmt.bind_text(1, fault_code);
 
   if (check_stmt.step() == SQLITE_ROW) {
@@ -381,6 +404,7 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
     std::string sources_json = check_stmt.column_text(2);
     std::string current_status = check_stmt.column_text(3);
     int32_t debounce_counter = check_stmt.column_int(4);
+    int64_t confirmed_at_ns = check_stmt.column_int64(5);
 
     // Bring a runaway counter persisted by an older build (the bug this fixes) back into range on
     // first touch; this also keeps the +1/-1 below overflow-safe. The counter is local to this call.
@@ -427,15 +451,24 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         new_status = compute_debounce_status(debounce_counter, current_status, config);
       }
 
+      // Record the confirmation instant on the transition into CONFIRMED (also
+      // on a reactivation that re-confirms); an already-confirmed fault keeps
+      // its original timestamp.
+      if (new_status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED &&
+          current_status != ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED) {
+        confirmed_at_ns = timestamp_ns;
+      }
+
       // Update with new values
       SqliteStatement update_stmt(
           db_, description.empty() ? "UPDATE faults SET severity = ?, last_occurred_ns = ?, last_failed_ns = ?, "
                                      "occurrence_count = ?, "
-                                     "reporting_sources = ?, status = ?, debounce_counter = ? WHERE fault_code = ?"
+                                     "reporting_sources = ?, status = ?, debounce_counter = ?, confirmed_at_ns = ? "
+                                     "WHERE fault_code = ?"
                                    : "UPDATE faults SET severity = ?, description = ?, last_occurred_ns = ?, "
                                      "last_failed_ns = ?, "
-                                     "occurrence_count = ?, reporting_sources = ?, status = ?, debounce_counter = ? "
-                                     "WHERE fault_code = ?");
+                                     "occurrence_count = ?, reporting_sources = ?, status = ?, debounce_counter = ?, "
+                                     "confirmed_at_ns = ? WHERE fault_code = ?");
 
       if (description.empty()) {
         update_stmt.bind_int(1, new_severity);
@@ -445,7 +478,8 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         update_stmt.bind_text(5, serialize_json_array(sources));
         update_stmt.bind_text(6, new_status);
         update_stmt.bind_int(7, debounce_counter);
-        update_stmt.bind_text(8, fault_code);
+        update_stmt.bind_int64(8, confirmed_at_ns);
+        update_stmt.bind_text(9, fault_code);
       } else {
         update_stmt.bind_int(1, new_severity);
         update_stmt.bind_text(2, description);
@@ -455,7 +489,8 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         update_stmt.bind_text(6, serialize_json_array(sources));
         update_stmt.bind_text(7, new_status);
         update_stmt.bind_int(8, debounce_counter);
-        update_stmt.bind_text(9, fault_code);
+        update_stmt.bind_int64(9, confirmed_at_ns);
+        update_stmt.bind_text(10, fault_code);
       }
 
       if (update_stmt.step() != SQLITE_DONE) {
@@ -504,9 +539,10 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
   SqliteStatement insert_stmt(db_,
                               "INSERT INTO faults (fault_code, severity, description, first_occurred_ns, "
                               "last_occurred_ns, occurrence_count, status, reporting_sources, "
-                              "debounce_counter, last_failed_ns, last_passed_ns) "
-                              "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
+                              "debounce_counter, last_failed_ns, last_passed_ns, confirmed_at_ns) "
+                              "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
+  const bool confirmed_now = initial_status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED;
   insert_stmt.bind_text(1, fault_code);
   insert_stmt.bind_int(2, static_cast<int>(severity));
   insert_stmt.bind_text(3, description);
@@ -518,6 +554,7 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
   insert_stmt.bind_int(9, -1);               // debounce_counter = -1 for first FAILED
   insert_stmt.bind_int64(10, timestamp_ns);  // last_failed_ns
   insert_stmt.bind_int64(11, 0);             // last_passed_ns (never passed)
+  insert_stmt.bind_int64(12, confirmed_now ? timestamp_ns : 0);
 
   if (insert_stmt.step() != SQLITE_DONE) {
     throw std::runtime_error(std::string("Failed to insert fault: ") + sqlite3_errmsg(db_));
@@ -732,11 +769,13 @@ std::vector<std::string> SqliteFaultStorage::check_time_based_confirmation(const
     return confirmed;
   }
 
-  SqliteStatement update_stmt(
-      db_, "UPDATE faults SET status = ? WHERE status = ? AND last_failed_ns <= ? AND last_failed_ns > 0");
+  SqliteStatement update_stmt(db_,
+                              "UPDATE faults SET status = ?, confirmed_at_ns = ? "
+                              "WHERE status = ? AND last_failed_ns <= ? AND last_failed_ns > 0");
   update_stmt.bind_text(1, ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED);
-  update_stmt.bind_text(2, ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED);
-  update_stmt.bind_int64(3, cutoff_ns);
+  update_stmt.bind_int64(2, current_ns);
+  update_stmt.bind_text(3, ros2_medkit_msgs::msg::Fault::STATUS_PREFAILED);
+  update_stmt.bind_int64(4, cutoff_ns);
 
   if (update_stmt.step() != SQLITE_DONE) {
     throw std::runtime_error(std::string("Failed to confirm faults: ") + sqlite3_errmsg(db_));

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -394,7 +394,7 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
   // Check if fault exists
   SqliteStatement check_stmt(db_,
                              "SELECT severity, occurrence_count, reporting_sources, status, debounce_counter, "
-                             "confirmed_at_ns FROM faults WHERE fault_code = ?");
+                             "confirmed_at_ns, first_occurred_ns FROM faults WHERE fault_code = ?");
   check_stmt.bind_text(1, fault_code);
 
   if (check_stmt.step() == SQLITE_ROW) {
@@ -405,6 +405,7 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
     std::string current_status = check_stmt.column_text(3);
     int32_t debounce_counter = check_stmt.column_int(4);
     int64_t confirmed_at_ns = check_stmt.column_int64(5);
+    int64_t first_occurred_ns = check_stmt.column_int64(6);
 
     // Bring a runaway counter persisted by an older build (the bug this fixes) back into range on
     // first touch; this also keeps the +1/-1 below overflow-safe. The counter is local to this call.
@@ -418,8 +419,11 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         return false;
       }
       // FAILED event reactivates - reset debounce counter to 0 so FAILED branch
-      // decrements it to -1, then reuse the existing FAILED logic below
+      // decrements it to -1, then reuse the existing FAILED logic below. Also
+      // reset first_occurred: this is a new outage cycle, not a continuation
+      // of the one that just cleared.
       debounce_counter = 0;
+      first_occurred_ns = timestamp_ns;
       is_reactivation = true;
     }
 
@@ -434,9 +438,11 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
       // Escalate severity if new severity is higher
       int new_severity = std::max(existing_severity, static_cast<int>(severity));
 
-      // Increment count with saturation
+      // Increment count with saturation - only on a genuine new occurrence (reactivation
+      // after CLEARED). A still-active fault being re-reported (level-triggered poller,
+      // or debounce building toward confirmation) is the same continuous occurrence.
       int64_t new_count = existing_count;
-      if (new_count < std::numeric_limits<uint32_t>::max()) {
+      if (is_reactivation && new_count < std::numeric_limits<uint32_t>::max()) {
         ++new_count;
       }
 
@@ -463,12 +469,12 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
       SqliteStatement update_stmt(
           db_, description.empty() ? "UPDATE faults SET severity = ?, last_occurred_ns = ?, last_failed_ns = ?, "
                                      "occurrence_count = ?, "
-                                     "reporting_sources = ?, status = ?, debounce_counter = ?, confirmed_at_ns = ? "
-                                     "WHERE fault_code = ?"
+                                     "reporting_sources = ?, status = ?, debounce_counter = ?, confirmed_at_ns = ?, "
+                                     "first_occurred_ns = ? WHERE fault_code = ?"
                                    : "UPDATE faults SET severity = ?, description = ?, last_occurred_ns = ?, "
                                      "last_failed_ns = ?, "
                                      "occurrence_count = ?, reporting_sources = ?, status = ?, debounce_counter = ?, "
-                                     "confirmed_at_ns = ? WHERE fault_code = ?");
+                                     "confirmed_at_ns = ?, first_occurred_ns = ? WHERE fault_code = ?");
 
       if (description.empty()) {
         update_stmt.bind_int(1, new_severity);
@@ -479,7 +485,8 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         update_stmt.bind_text(6, new_status);
         update_stmt.bind_int(7, debounce_counter);
         update_stmt.bind_int64(8, confirmed_at_ns);
-        update_stmt.bind_text(9, fault_code);
+        update_stmt.bind_int64(9, first_occurred_ns);
+        update_stmt.bind_text(10, fault_code);
       } else {
         update_stmt.bind_int(1, new_severity);
         update_stmt.bind_text(2, description);
@@ -490,7 +497,8 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
         update_stmt.bind_text(7, new_status);
         update_stmt.bind_int(8, debounce_counter);
         update_stmt.bind_int64(9, confirmed_at_ns);
-        update_stmt.bind_text(10, fault_code);
+        update_stmt.bind_int64(10, first_occurred_ns);
+        update_stmt.bind_text(11, fault_code);
       }
 
       if (update_stmt.step() != SQLITE_DONE) {

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -104,9 +104,27 @@ TEST_F(FaultStorageTest, ReportExistingFaultEventUpdates) {
 
   auto fault = storage_.get_fault("MOTOR_OVERHEAT");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 2u);
+  // Still the same continuous occurrence (not CLEARED in between): occurrence_count
+  // does not bump on every report, only severity/sources/description update.
+  EXPECT_EQ(fault->occurrence_count, 1u);
   EXPECT_EQ(fault->severity, Fault::SEVERITY_ERROR);  // Updated to higher severity
   EXPECT_EQ(fault->reporting_sources.size(), 2u);
+}
+
+TEST_F(FaultStorageTest, ContinuouslyActiveFaultDoesNotInflateOccurrenceCount) {
+  rclcpp::Clock clock;
+
+  // Simulate a level-triggered poller re-reporting the same still-true condition
+  // every cycle (issue #11): occurrence_count must stay at 1, not grow per poll.
+  for (int i = 0; i < 25; ++i) {
+    storage_.report_fault_event("TANK_OVERFILL", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
+                                "level = 95 > 80", "/tank", clock.now(), default_config());
+  }
+
+  auto fault = storage_.get_fault("TANK_OVERFILL");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->occurrence_count, 1u);
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
 TEST_F(FaultStorageTest, ListFaultsDefaultReturnsConfirmedOnly) {
@@ -248,7 +266,7 @@ TEST_F(FaultStorageTest, FaultStaysPrefailedAboveThreshold) {
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 2u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Still debouncing towards confirmation, same occurrence
   EXPECT_EQ(fault->status, Fault::STATUS_PREFAILED);
 }
 
@@ -269,7 +287,7 @@ TEST_F(FaultStorageTest, FaultConfirmsAtThreshold) {
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 3u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Debounce build-up is still one occurrence
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
@@ -284,7 +302,7 @@ TEST_F(FaultStorageTest, ConfirmedFaultStaysConfirmed) {
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 4u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Same occurrence throughout, not one per report
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
@@ -318,7 +336,7 @@ TEST_F(FaultStorageTest, SameSourceMultipleReportsConfirms) {
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 3u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Repeated reports from one source, one occurrence
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
   EXPECT_EQ(fault->reporting_sources.size(), 1u);  // Only one unique source
 }
@@ -372,14 +390,16 @@ TEST_F(FaultStorageTest, ClearedFaultCanBeReactivated) {
   rclcpp::Clock clock;
 
   // Report to confirm (with default threshold=-1, single report confirms)
+  auto first_ts = clock.now();
   bool is_new = storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
-                                            "Initial", "/node1", clock.now(), default_config());
+                                            "Initial", "/node1", first_ts, default_config());
   EXPECT_TRUE(is_new);
 
   auto fault = storage_.get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
   EXPECT_EQ(fault->occurrence_count, 1u);
+  EXPECT_EQ(rclcpp::Time(fault->first_occurred).nanoseconds(), first_ts.nanoseconds());
 
   // Clear the fault
   storage_.clear_fault("FAULT_1");
@@ -387,9 +407,10 @@ TEST_F(FaultStorageTest, ClearedFaultCanBeReactivated) {
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CLEARED);
 
-  // Report again - should reactivate
+  // Report again after a gap - should reactivate as a new cycle
+  auto second_ts = rclcpp::Time(first_ts.nanoseconds() + 1'000'000'000LL);  // +1s
   is_new = storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
-                                       "Reactivated", "/node2", clock.now(), default_config());
+                                       "Reactivated", "/node2", second_ts, default_config());
   EXPECT_TRUE(is_new);  // Should return true like a new fault
 
   fault = storage_.get_fault("FAULT_1");
@@ -398,6 +419,8 @@ TEST_F(FaultStorageTest, ClearedFaultCanBeReactivated) {
   EXPECT_EQ(fault->occurrence_count, 2u);             // Should increment
   EXPECT_EQ(fault->reporting_sources.size(), 2u);     // Both sources
   EXPECT_EQ(fault->description, "Reactivated");       // Updated description
+  // #25: first_occurred must reflect the new cycle, not the outage that already cleared.
+  EXPECT_EQ(rclcpp::Time(fault->first_occurred).nanoseconds(), second_ts.nanoseconds());
 }
 
 TEST_F(FaultStorageTest, PassedEventForClearedFaultIgnored) {
@@ -1109,11 +1132,11 @@ TEST_F(FaultEventPublishingTest, UpdateExistingFaultPublishesUpdatedEvent) {
     return received_events_.size() >= 1;
   }));
 
-  // Verify EVENT_UPDATED was published
+  // Verify EVENT_UPDATED was published (severity/sources changed; still one occurrence)
   ASSERT_EQ(received_events_.size(), 1u);
   EXPECT_EQ(received_events_[0].event_type, FaultEvent::EVENT_UPDATED);
   EXPECT_EQ(received_events_[0].fault.fault_code, "TEST_FAULT_2");
-  EXPECT_EQ(received_events_[0].fault.occurrence_count, 2u);
+  EXPECT_EQ(received_events_[0].fault.occurrence_count, 1u);
 }
 
 TEST_F(FaultEventPublishingTest, ClearFaultPublishesClearedEvent) {

--- a/src/ros2_medkit_fault_manager/test/test_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_integration.test.py
@@ -361,7 +361,10 @@ class TestFaultManagerIntegration(unittest.TestCase):
 
         self.assertIsNotNone(updated_fault)
         self.assertEqual(updated_fault.severity, Fault.SEVERITY_ERROR)
-        self.assertEqual(updated_fault.occurrence_count, 2)
+        # Edge-counting: a re-report of a still-active fault is the same
+        # continuous occurrence, so the count stays at 1 (it only increments
+        # on reactivation after CLEARED).
+        self.assertEqual(updated_fault.occurrence_count, 1)
         self.assertEqual(len(updated_fault.reporting_sources), 2)
         print(f'Updated fault: occurrence_count={updated_fault.occurrence_count}, '
               f'sources={updated_fault.reporting_sources}')
@@ -394,7 +397,9 @@ class TestFaultManagerIntegration(unittest.TestCase):
         # Find the fault and verify its state
         confirmed_fault = next(f for f in response.faults if f.fault_code == fault_code)
         self.assertEqual(confirmed_fault.status, Fault.STATUS_CONFIRMED)
-        self.assertEqual(confirmed_fault.occurrence_count, 3)
+        # Edge-counting: the debounce reports that built toward confirmation
+        # are one continuous occurrence, not three.
+        self.assertEqual(confirmed_fault.occurrence_count, 1)
         print(f'Fault confirmed: status={confirmed_fault.status}, '
               f'occurrence_count={confirmed_fault.occurrence_count}')
 
@@ -462,7 +467,9 @@ class TestFaultManagerIntegration(unittest.TestCase):
         self.assertIsNotNone(fault)
         self.assertEqual(fault.status, Fault.STATUS_CONFIRMED)
         self.assertEqual(len(fault.reporting_sources), 3)
-        self.assertEqual(fault.occurrence_count, 3)
+        # Edge-counting: three sources reporting the same active fault are one
+        # continuous occurrence; the count tracks raise edges, not reports.
+        self.assertEqual(fault.occurrence_count, 1)
         print(f'Multi-source fault confirmed: sources={fault.reporting_sources}')
 
     def test_14_critical_severity_immediate_confirmation(self):

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -100,9 +100,27 @@ TEST_F(SqliteFaultStorageTest, ReportExistingFaultEventUpdates) {
 
   auto fault = storage_->get_fault("MOTOR_OVERHEAT");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 2u);
+  // Still the same continuous occurrence (not CLEARED in between): occurrence_count
+  // does not bump on every report, only severity/sources/description update.
+  EXPECT_EQ(fault->occurrence_count, 1u);
   EXPECT_EQ(fault->severity, Fault::SEVERITY_ERROR);  // Updated to higher severity
   EXPECT_EQ(fault->reporting_sources.size(), 2u);
+}
+
+TEST_F(SqliteFaultStorageTest, ContinuouslyActiveFaultDoesNotInflateOccurrenceCount) {
+  rclcpp::Clock clock;
+
+  // Simulate a level-triggered poller re-reporting the same still-true condition
+  // every cycle (issue #11): occurrence_count must stay at 1, not grow per poll.
+  for (int i = 0; i < 25; ++i) {
+    storage_->report_fault_event("TANK_OVERFILL", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
+                                 "level = 95 > 80", "/tank", clock.now(), default_config());
+  }
+
+  auto fault = storage_->get_fault("TANK_OVERFILL");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->occurrence_count, 1u);
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
 TEST_F(SqliteFaultStorageTest, ListFaultsDefaultReturnsConfirmedOnly) {
@@ -343,7 +361,7 @@ TEST_F(SqliteFaultStorageTest, FaultStaysPrefailedAboveThreshold) {
 
   auto fault = storage_->get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 2u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Still debouncing towards confirmation, same occurrence
   EXPECT_EQ(fault->status, Fault::STATUS_PREFAILED);
 }
 
@@ -364,7 +382,7 @@ TEST_F(SqliteFaultStorageTest, FaultConfirmsAtThreshold) {
 
   auto fault = storage_->get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
-  EXPECT_EQ(fault->occurrence_count, 3u);
+  EXPECT_EQ(fault->occurrence_count, 1u);  // Debounce build-up is still one occurrence
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
@@ -401,14 +419,16 @@ TEST_F(SqliteFaultStorageTest, ClearedFaultCanBeReactivated) {
   rclcpp::Clock clock;
 
   // Report to confirm (with default threshold=-1, single report confirms)
+  auto first_ts = clock.now();
   bool is_new = storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
-                                             "Initial", "/node1", clock.now(), default_config());
+                                             "Initial", "/node1", first_ts, default_config());
   EXPECT_TRUE(is_new);
 
   auto fault = storage_->get_fault("FAULT_1");
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
   EXPECT_EQ(fault->occurrence_count, 1u);
+  EXPECT_EQ(rclcpp::Time(fault->first_occurred).nanoseconds(), first_ts.nanoseconds());
 
   // Clear the fault
   storage_->clear_fault("FAULT_1");
@@ -416,9 +436,10 @@ TEST_F(SqliteFaultStorageTest, ClearedFaultCanBeReactivated) {
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CLEARED);
 
-  // Report again - should reactivate
+  // Report again after a gap - should reactivate as a new cycle
+  rclcpp::Time second_ts(first_ts.nanoseconds() + 1'000'000'000LL);  // +1s
   is_new = storage_->report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR,
-                                        "Reactivated", "/node2", clock.now(), default_config());
+                                        "Reactivated", "/node2", second_ts, default_config());
   EXPECT_TRUE(is_new);  // Should return true like a new fault
 
   fault = storage_->get_fault("FAULT_1");
@@ -427,6 +448,8 @@ TEST_F(SqliteFaultStorageTest, ClearedFaultCanBeReactivated) {
   EXPECT_EQ(fault->occurrence_count, 2u);             // Should increment
   EXPECT_EQ(fault->reporting_sources.size(), 2u);     // Both sources
   EXPECT_EQ(fault->description, "Reactivated");       // Updated description
+  // #25: first_occurred must reflect the new cycle, not the outage that already cleared.
+  EXPECT_EQ(rclcpp::Time(fault->first_occurred).nanoseconds(), second_ts.nanoseconds());
 }
 
 TEST_F(SqliteFaultStorageTest, PassedEventForClearedFaultIgnored) {

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -742,6 +742,105 @@ TEST_F(SqliteFaultStorageTest, TimeBasedConfirmationWhenEnabled) {
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);
 }
 
+// confirmed_at_ns column (consumed by the compliance timeline exporter)
+
+namespace {
+int64_t read_confirmed_at(const std::filesystem::path & db_path, const std::string & fault_code) {
+  sqlite3 * raw = nullptr;
+  EXPECT_EQ(sqlite3_open(db_path.string().c_str(), &raw), SQLITE_OK);
+  sqlite3_stmt * stmt = nullptr;
+  EXPECT_EQ(sqlite3_prepare_v2(raw, "SELECT confirmed_at_ns FROM faults WHERE fault_code = ?", -1, &stmt, nullptr),
+            SQLITE_OK);
+  sqlite3_bind_text(stmt, 1, fault_code.c_str(), -1, SQLITE_TRANSIENT);
+  int64_t value = -1;
+  if (sqlite3_step(stmt) == SQLITE_ROW) {
+    value = sqlite3_column_int64(stmt, 0);
+  }
+  sqlite3_finalize(stmt);
+  sqlite3_close(raw);
+  return value;
+}
+}  // namespace
+
+TEST_F(SqliteFaultStorageTest, ConfirmedAtRecordedOnImmediateConfirmation) {
+  rclcpp::Clock clock;
+  auto t = clock.now();
+  // Default config confirms on the first FAILED event.
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", t,
+                               default_config());
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "F"), t.nanoseconds());
+
+  // A later FAILED on an already-confirmed fault must NOT move the timestamp.
+  auto t2 = rclcpp::Time(t.nanoseconds() + static_cast<int64_t>(5e9));
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", t2,
+                               default_config());
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "F"), t.nanoseconds());
+}
+
+TEST_F(SqliteFaultStorageTest, ConfirmedAtRecordedOnDebouncedConfirmation) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -2;  // second FAILED event confirms
+
+  auto t1 = clock.now();
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", t1, config);
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_PREFAILED);
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "F"), 0) << "not confirmed yet: no confirmation timestamp";
+
+  auto t2 = rclcpp::Time(t1.nanoseconds() + static_cast<int64_t>(1e9));
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", t2, config);
+  EXPECT_EQ(storage_->get_fault("F")->status, Fault::STATUS_CONFIRMED);
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "F"), t2.nanoseconds());
+}
+
+TEST_F(SqliteFaultStorageTest, ConfirmedAtRecordedOnTimeBasedConfirmation) {
+  rclcpp::Clock clock;
+  DebounceConfig config;
+  config.confirmation_threshold = -3;
+  config.auto_confirm_after_sec = 10.0;
+  storage_->set_debounce_config(config);
+
+  auto now = clock.now();
+  storage_->report_fault_event("F", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", now, config);
+
+  auto after_timeout = rclcpp::Time(now.nanoseconds() + static_cast<int64_t>(15e9));
+  auto confirmed = storage_->check_time_based_confirmation(after_timeout);
+  ASSERT_EQ(confirmed.size(), 1u);
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "F"), after_timeout.nanoseconds());
+}
+
+TEST_F(SqliteFaultStorageTest, ConfirmedAtColumnMigratedIntoOldDatabase) {
+  // Rebuild the faults table without confirmed_at_ns (a pre-migration DB),
+  // then reopen: the storage must add the column and treat old rows as 0.
+  storage_.reset();
+  std::filesystem::remove(temp_db_path_);
+  {
+    sqlite3 * raw = nullptr;
+    ASSERT_EQ(sqlite3_open(temp_db_path_.string().c_str(), &raw), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(raw,
+                           "CREATE TABLE faults (fault_code TEXT PRIMARY KEY, severity INTEGER NOT NULL, "
+                           "description TEXT NOT NULL, first_occurred_ns INTEGER NOT NULL, "
+                           "last_occurred_ns INTEGER NOT NULL, occurrence_count INTEGER NOT NULL, "
+                           "status TEXT NOT NULL, reporting_sources TEXT NOT NULL, "
+                           "debounce_counter INTEGER NOT NULL DEFAULT 0, "
+                           "last_failed_ns INTEGER NOT NULL DEFAULT 0, last_passed_ns INTEGER NOT NULL DEFAULT 0); "
+                           "INSERT INTO faults VALUES ('OLD', 2, 'd', 1, 1, 1, 'CONFIRMED', '[\"/n\"]', -1, 1, 0);",
+                           nullptr, nullptr, nullptr),
+              SQLITE_OK);
+    sqlite3_close(raw);
+  }
+  storage_ = std::make_unique<SqliteFaultStorage>(temp_db_path_.string());
+  EXPECT_TRUE(storage_->contains("OLD"));
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "OLD"), 0) << "pre-migration rows carry no confirmation time";
+
+  rclcpp::Clock clock;
+  auto t = clock.now();
+  storage_->report_fault_event("NEW", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "e", "/n", t,
+                               default_config());
+  EXPECT_EQ(read_confirmed_at(temp_db_path_, "NEW"), t.nanoseconds());
+}
+
 // Snapshot storage tests
 // @verifies REQ_INTEROP_088
 TEST_F(SqliteFaultStorageTest, StoreAndRetrieveSnapshot) {

--- a/src/ros2_medkit_fault_reporter/test/test_integration.test.py
+++ b/src/ros2_medkit_fault_reporter/test/test_integration.test.py
@@ -196,7 +196,9 @@ class TestFaultReporterIntegration(unittest.TestCase):
         )
 
         self.assertIsNotNone(fault)
-        self.assertEqual(fault.occurrence_count, 3)
+        # Edge-counting: re-reports of a still-active fault do not bump the
+        # count; severity escalation and source aggregation still apply.
+        self.assertEqual(fault.occurrence_count, 1)
         self.assertEqual(fault.severity, Fault.SEVERITY_CRITICAL)
         self.assertIn('/node_a', fault.reporting_sources)
         self.assertIn('/node_b', fault.reporting_sources)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1046,6 +1046,11 @@ if(BUILD_TESTING)
   ament_add_gtest(test_trigger_handlers test/test_trigger_handlers.cpp)
   target_link_libraries(test_trigger_handlers gateway_ros2)
 
+  # Fault-trigger (threshold-rule) engine tests (issue #235): CRUD, validation,
+  # edge-detection, persistence. Links gateway_core only (ROS-neutral).
+  ament_add_gtest(test_fault_trigger_engine test/test_fault_trigger_engine.cpp)
+  target_link_libraries(test_fault_trigger_engine gateway_core)
+
   # Peer client tests (aggregation module)
   ament_add_gtest(test_peer_client test/test_peer_client.cpp)
   target_link_libraries(test_peer_client gateway_ros2)
@@ -1168,6 +1173,7 @@ if(BUILD_TESTING)
       test_trigger_store
       test_trigger_manager
       test_trigger_handlers
+      test_fault_trigger_engine
       test_peer_client
       test_entity_merger
       test_fan_out_helpers

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -98,6 +98,18 @@ All endpoints are prefixed with `/api/v1` for API versioning.
 - `DELETE /api/v1/{entity}/{id}/triggers/{trigger_id}` - Delete a trigger
 - `GET /api/v1/{entity}/{id}/triggers/{trigger_id}/events` - SSE stream of trigger events
 
+### Fault-Trigger Endpoints (threshold rules)
+
+- `GET /api/v1/apps/{app_id}/fault-triggers` - List threshold rules for an app
+- `POST /api/v1/apps/{app_id}/fault-triggers` - Create a threshold rule (fires/clears a SOVD fault on value cross)
+- `DELETE /api/v1/apps/{app_id}/fault-triggers/{id}` - Delete a rule (clears any fault it asserts)
+
+Two separate collections by design: `/triggers` is the SOVD notification-trigger
+CRUD (condition subscriptions delivering SSE events), while `/fault-triggers`
+holds server-side threshold rules that raise and clear faults. They share no
+schema or store, so the threshold engine is mounted as a sibling instead of
+overloading the SOVD `/triggers` contract.
+
 ### Scripts Endpoints
 
 - `GET /api/v1/{entity}/{id}/scripts` - List available diagnostic scripts

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
@@ -79,9 +79,17 @@ class FaultTriggerEngine {
   /// rule creation on a transient outage.
   using DataPointNamesFn = std::function<std::optional<std::vector<std::string>>(const std::string & app_id)>;
 
+  /// True when ``app_id`` is a real entity in the discovery/entity registry.
+  /// Lets create() reject a rule on a bogus app (404) instead of reserving a
+  /// global fault_code for it; when null, existence is not checked. This is the
+  /// signal that disambiguates "unknown app" from "known app, unreadable now"
+  /// (the DataPointNamesFn nullopt case).
+  using EntityExistsFn = std::function<bool(const std::string & app_id)>;
+
   /// @param storage_path JSON store path; empty disables persistence (in-memory)
   FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report, FaultClearFn clear,
-                     LogFn log = nullptr, DataPointNamesFn data_point_names = nullptr);
+                     LogFn log = nullptr, DataPointNamesFn data_point_names = nullptr,
+                     EntityExistsFn entity_exists = nullptr);
 
   // --- REST-facing CRUD (thread-safe) ---
 
@@ -114,6 +122,12 @@ class FaultTriggerEngine {
   void load();
   void save_locked() const;
 
+  // Coarse dispatch lock, always taken BEFORE mutex_. Serializes remove()'s
+  // erase+clear against evaluate_once()'s report/clear so a DELETE racing the
+  // trigger thread cannot re-assert a fault the rule (and its fault) just left.
+  // Held across the report/clear callbacks, which mutex_ must not be (the fault
+  // path re-enters unrelated code).
+  std::mutex dispatch_mutex_;
   mutable std::mutex mutex_;
   std::string storage_path_;
   ValueFetcher fetcher_;
@@ -121,6 +135,7 @@ class FaultTriggerEngine {
   FaultClearFn clear_;
   LogFn log_;
   DataPointNamesFn data_point_names_;
+  EntityExistsFn entity_exists_;
   std::vector<FaultTriggerRule> rules_;
   uint64_t next_seq_{1};  ///< monotonic suffix for id generation
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
@@ -39,9 +39,11 @@ struct FaultTriggerRule {
   std::string severity;  ///< "INFO" | "WARNING" | "ERROR" | "CRITICAL"
   bool active{true};
 
-  /// Runtime edge-detect latch (not part of the persisted rule contract): true
-  /// while the fault is currently asserted so evaluate_once fires on the rising
-  /// edge and auto-clears on the falling edge.
+  /// Runtime latch (not part of the persisted rule contract): true while the
+  /// fault is currently asserted. Reporting is LEVEL-triggered - evaluate_once
+  /// re-reports every poll while the value stays crossed (so the fault confirms
+  /// past the manager's debounce and stays asserted); `crossed` only gates the
+  /// auto-clear on the falling edge.
   bool crossed{false};
 };
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
@@ -1,0 +1,119 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <tl/expected.hpp>
+
+namespace ros2_medkit_gateway {
+
+/// One runtime threshold rule bound to a discovered data point (issue #235
+/// Tier-1a/1b, config-less). No node_map: the rule targets an app's data point
+/// by its discovered ``data_name`` and fires/clears a SOVD fault when the live
+/// value crosses ``threshold`` under ``op``.
+struct FaultTriggerRule {
+  std::string id;
+  std::string app_id;     ///< SOVD entity id that owns the data point (reporting source)
+  std::string data_name;  ///< discovered data point resource id
+  std::string op;         ///< one of ">", "<", ">=", "<=", "=="
+  double threshold{0.0};
+  std::string fault_code;
+  std::string severity;  ///< "INFO" | "WARNING" | "ERROR" | "CRITICAL"
+  bool active{true};
+
+  /// Runtime edge-detect latch (not part of the persisted rule contract): true
+  /// while the fault is currently asserted so evaluate_once fires on the rising
+  /// edge and auto-clears on the falling edge.
+  bool crossed{false};
+};
+
+/// Runtime threshold-rule engine. Rules are evaluated every poll against the
+/// live discovered value; on a threshold cross the engine reports a fault
+/// (which the existing EntityFreezeFrameCapture snapshots), and on un-cross it
+/// auto-clears. Rules persist to a small JSON store so they survive a restart
+/// and are editable at runtime over REST.
+///
+/// All I/O is injected (value fetch + fault report/clear) so the CRUD,
+/// validation, comparison and edge-detection logic is unit-testable without a
+/// live PLC, ROS graph, or HTTP server.
+class FaultTriggerEngine {
+ public:
+  /// Fetch the current numeric value of ``app_id``'s ``data_name`` data point.
+  /// ``std::nullopt`` when the point is unreadable (PLC down, unknown name, or
+  /// non-numeric) - the rule is then left in its current state, never cleared.
+  using ValueFetcher = std::function<std::optional<double>(const std::string & app_id, const std::string & data_name)>;
+
+  /// Report a FAILED fault for (``app_id`` as reporting source, ``fault_code``).
+  using FaultReportFn = std::function<void(const std::string & app_id, const std::string & fault_code,
+                                           const std::string & severity, const std::string & description)>;
+
+  /// Report the PASSED (cleared) event for (``app_id``, ``fault_code``).
+  using FaultClearFn = std::function<void(const std::string & app_id, const std::string & fault_code)>;
+
+  /// Neutral log sink (keeps this layer ROS-free); may be null.
+  using LogFn = std::function<void(const std::string & message)>;
+
+  /// @param storage_path JSON store path; empty disables persistence (in-memory)
+  FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report, FaultClearFn clear,
+                     LogFn log = nullptr);
+
+  // --- REST-facing CRUD (thread-safe) ---
+
+  /// All rules bound to ``app_id`` (persisted contract fields only).
+  std::vector<FaultTriggerRule> list(const std::string & app_id) const;
+
+  /// Validate + create a rule from a POST body. Returns the created rule on
+  /// success, an (http_status, message) pair on validation failure.
+  tl::expected<FaultTriggerRule, std::pair<int, std::string>> create(const std::string & app_id,
+                                                                     const nlohmann::json & body);
+
+  /// Delete the rule ``id`` under ``app_id``. Clears any fault it currently
+  /// asserts. Returns false when no such rule exists.
+  bool remove(const std::string & app_id, const std::string & id);
+
+  /// Evaluate every active rule once against the live value and fire/clear
+  /// faults on threshold edges. Called from the gateway poll timer.
+  void evaluate_once();
+
+  // --- Pure helpers (unit-testable) ---
+
+  static bool valid_operator(const std::string & op);
+  static bool valid_severity(const std::string & sev);
+  static bool compare(double value, const std::string & op, double threshold);
+
+  /// Serialize a rule to the wire contract (persisted + REST response shape).
+  static nlohmann::json rule_to_json(const FaultTriggerRule & r);
+
+ private:
+  void load();
+  void save_locked() const;
+
+  mutable std::mutex mutex_;
+  std::string storage_path_;
+  ValueFetcher fetcher_;
+  FaultReportFn report_;
+  FaultClearFn clear_;
+  LogFn log_;
+  std::vector<FaultTriggerRule> rules_;
+  uint64_t next_seq_{1};  ///< monotonic suffix for id generation
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/fault_trigger_engine.hpp
@@ -71,9 +71,15 @@ class FaultTriggerEngine {
   /// Neutral log sink (keeps this layer ROS-free); may be null.
   using LogFn = std::function<void(const std::string & message)>;
 
+  /// Enumerate the discovered data-point names of ``app_id``. ``std::nullopt``
+  /// when they cannot be enumerated right now (entity not data-routed, PLC
+  /// unreadable); create() then skips the existence check instead of blocking
+  /// rule creation on a transient outage.
+  using DataPointNamesFn = std::function<std::optional<std::vector<std::string>>(const std::string & app_id)>;
+
   /// @param storage_path JSON store path; empty disables persistence (in-memory)
   FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report, FaultClearFn clear,
-                     LogFn log = nullptr);
+                     LogFn log = nullptr, DataPointNamesFn data_point_names = nullptr);
 
   // --- REST-facing CRUD (thread-safe) ---
 
@@ -112,6 +118,7 @@ class FaultTriggerEngine {
   FaultReportFn report_;
   FaultClearFn clear_;
   LogFn log_;
+  DataPointNamesFn data_point_names_;
   std::vector<FaultTriggerRule> rules_;
   uint64_t next_seq_{1};  ///< monotonic suffix for id generation
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/data_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/data_provider.hpp
@@ -102,6 +102,19 @@ class DataProvider {
   /// @param value JSON value to write
   virtual tl::expected<dto::DataWriteResult, DataProviderErrorInfo>
   write_data(const std::string & entity_id, const std::string & resource_name, const nlohmann::json & value) = 0;
+
+  /// Whether this provider actually has data for the given entity.
+  ///
+  /// A plugin implements one DataProvider for every entity it owns, but not
+  /// every owned entity is data-bearing (e.g. a grouping Component, or an
+  /// App that only surfaces faults). Override this so PluginManager stops
+  /// routing - and the gateway stops advertising the `data` capability - for
+  /// entities this provider cannot actually serve. Defaults to true, which
+  /// preserves current behavior for providers whose owned entities are all
+  /// data-bearing.
+  virtual bool has_data(const std::string & /*entity_id*/) const {
+    return true;
+  }
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/operation_provider.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/providers/operation_provider.hpp
@@ -106,6 +106,19 @@ class OperationProvider {
   virtual tl::expected<dto::OperationExecutionResult, OperationProviderErrorInfo>
   execute_operation(const std::string & entity_id, const std::string & operation_name,
                     const nlohmann::json & parameters) = 0;
+
+  /// Whether this provider actually has operations for the given entity.
+  ///
+  /// Mirrors DataProvider::has_data: a plugin implements one OperationProvider
+  /// for every entity it owns, but not every owned entity has operations
+  /// (e.g. a grouping Component). Override this so PluginManager stops
+  /// routing - and the gateway stops advertising the `operations`
+  /// capability - for entities this provider cannot actually serve. Defaults
+  /// to true, which preserves current behavior for providers whose owned
+  /// entities all have operations.
+  virtual bool has_operations(const std::string & /*entity_id*/) const {
+    return true;
+  }
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -30,6 +30,7 @@
 #include "ros2_medkit_gateway/core/config.hpp"
 #include "ros2_medkit_gateway/core/data/topic_data_provider.hpp"
 #include "ros2_medkit_gateway/core/default_script_provider.hpp"
+#include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
 #include "ros2_medkit_gateway/core/http/rate_limiter.hpp"
 #include "ros2_medkit_gateway/core/http/rest_server.hpp"
 #include "ros2_medkit_gateway/core/http/sse_client_tracker.hpp"
@@ -225,6 +226,19 @@ class GatewayNode : public rclcpp::Node {
   void stop_rest_server();
 
   /**
+   * @brief Wire the config-less threshold-rule (fault-trigger) engine and its
+   *        evaluation loop. Call once after plugins are loaded (main.cpp).
+   *        No-op when disabled (``fault_triggers.enabled=false``) or no plugins.
+   */
+  void init_fault_trigger_engine();
+
+  /**
+   * @brief Get the config-less fault-trigger (threshold-rule) engine.
+   * @return Raw pointer, or nullptr when disabled / no plugins loaded
+   */
+  FaultTriggerEngine * get_fault_trigger_engine() const;
+
+  /**
    * @brief Get the ResourceSamplerRegistry instance
    * @return Raw pointer to ResourceSamplerRegistry (valid for lifetime of GatewayNode)
    */
@@ -396,6 +410,11 @@ class GatewayNode : public rclcpp::Node {
   std::unique_ptr<TriggerFaultSubscriber> trigger_fault_subscriber_;
   // Zero-config freeze-frames for plugin-backed entities (nullptr when disabled)
   std::unique_ptr<EntityFreezeFrameCapture> entity_freeze_frame_capture_;
+  // Config-less threshold-rule engine + its dedicated evaluation loop (issue
+  // #235). The thread is joined in ~GatewayNode BEFORE plugin/fault shutdown.
+  std::unique_ptr<FaultTriggerEngine> fault_trigger_engine_;
+  std::thread fault_trigger_thread_;
+  std::atomic<bool> fault_trigger_stop_{false};
   std::unique_ptr<TriggerTopicSubscriber> trigger_topic_subscriber_;
   // Adapter routing manager-side subscribe() calls onto trigger_topic_subscriber_.
   std::shared_ptr<ros2::Ros2TopicSubscriptionTransport> trigger_topic_transport_;

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -1,0 +1,311 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <utility>
+
+namespace ros2_medkit_gateway {
+
+namespace {
+
+constexpr double kEqualEpsilon = 1e-9;
+
+std::string json_string(const nlohmann::json & j, const char * key) {
+  if (j.contains(key) && j[key].is_string()) {
+    return j[key].get<std::string>();
+  }
+  return {};
+}
+
+}  // namespace
+
+FaultTriggerEngine::FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report,
+                                       FaultClearFn clear, LogFn log)
+  : storage_path_(std::move(storage_path))
+  , fetcher_(std::move(fetcher))
+  , report_(std::move(report))
+  , clear_(std::move(clear))
+  , log_(std::move(log)) {
+  load();
+}
+
+bool FaultTriggerEngine::valid_operator(const std::string & op) {
+  static const std::array<const char *, 5> kOps{">", "<", ">=", "<=", "=="};
+  return std::any_of(kOps.begin(), kOps.end(), [&op](const char * o) {
+    return op == o;
+  });
+}
+
+bool FaultTriggerEngine::valid_severity(const std::string & sev) {
+  static const std::array<const char *, 4> kSev{"INFO", "WARNING", "ERROR", "CRITICAL"};
+  return std::any_of(kSev.begin(), kSev.end(), [&sev](const char * s) {
+    return sev == s;
+  });
+}
+
+bool FaultTriggerEngine::compare(double value, const std::string & op, double threshold) {
+  if (op == ">") {
+    return value > threshold;
+  }
+  if (op == "<") {
+    return value < threshold;
+  }
+  if (op == ">=") {
+    return value >= threshold;
+  }
+  if (op == "<=") {
+    return value <= threshold;
+  }
+  if (op == "==") {
+    return std::fabs(value - threshold) <= kEqualEpsilon;
+  }
+  return false;
+}
+
+nlohmann::json FaultTriggerEngine::rule_to_json(const FaultTriggerRule & r) {
+  return nlohmann::json{{"id", r.id},
+                        {"data_name", r.data_name},
+                        {"operator", r.op},
+                        {"threshold", r.threshold},
+                        {"fault_code", r.fault_code},
+                        {"severity", r.severity},
+                        {"active", r.active}};
+}
+
+std::vector<FaultTriggerRule> FaultTriggerEngine::list(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<FaultTriggerRule> out;
+  for (const auto & r : rules_) {
+    if (r.app_id == app_id) {
+      out.push_back(r);
+    }
+  }
+  return out;
+}
+
+tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::create(const std::string & app_id,
+                                                                                       const nlohmann::json & body) {
+  if (!body.is_object()) {
+    return tl::make_unexpected(std::make_pair(400, std::string("request body must be a JSON object")));
+  }
+
+  FaultTriggerRule rule;
+  rule.app_id = app_id;
+  rule.data_name = json_string(body, "data_name");
+  rule.op = json_string(body, "operator");
+  rule.fault_code = json_string(body, "fault_code");
+  rule.severity = json_string(body, "severity");
+  rule.active = body.contains("active") && body["active"].is_boolean() ? body["active"].get<bool>() : true;
+
+  if (rule.data_name.empty()) {
+    return tl::make_unexpected(std::make_pair(400, std::string("'data_name' is required")));
+  }
+  if (!valid_operator(rule.op)) {
+    return tl::make_unexpected(std::make_pair(400, std::string("'operator' must be one of >, <, >=, <=, ==")));
+  }
+  if (!body.contains("threshold") || !body["threshold"].is_number()) {
+    return tl::make_unexpected(std::make_pair(400, std::string("'threshold' must be a number")));
+  }
+  rule.threshold = body["threshold"].get<double>();
+  if (rule.fault_code.empty()) {
+    return tl::make_unexpected(std::make_pair(400, std::string("'fault_code' is required")));
+  }
+  if (!valid_severity(rule.severity)) {
+    return tl::make_unexpected(
+        std::make_pair(400, std::string("'severity' must be one of INFO, WARNING, ERROR, CRITICAL")));
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  rule.id = "ftr_" + std::to_string(next_seq_++);
+  rules_.push_back(rule);
+  save_locked();
+  if (log_) {
+    log_("fault-trigger created: " + rule.id + " on " + app_id + "/" + rule.data_name + " " + rule.op + " " +
+         std::to_string(rule.threshold) + " -> " + rule.fault_code + " (" + rule.severity + ")");
+  }
+  return rule;
+}
+
+bool FaultTriggerEngine::remove(const std::string & app_id, const std::string & id) {
+  std::string fault_code;
+  bool was_crossed = false;
+  bool found = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = std::find_if(rules_.begin(), rules_.end(), [&](const FaultTriggerRule & r) {
+      return r.app_id == app_id && r.id == id;
+    });
+    if (it == rules_.end()) {
+      return false;
+    }
+    fault_code = it->fault_code;
+    was_crossed = it->crossed;
+    rules_.erase(it);
+    save_locked();
+    found = true;
+  }
+  // Clear outside the lock: the fault report path may re-enter unrelated code.
+  if (found && was_crossed && clear_) {
+    clear_(app_id, fault_code);
+  }
+  return found;
+}
+
+void FaultTriggerEngine::evaluate_once() {
+  // Snapshot the active rules under the lock, evaluate the (blocking) value
+  // fetch + fault report outside it, then fold the new latch state back in.
+  struct Pending {
+    std::string id;
+    std::string app_id;
+    std::string data_name;
+    std::string op;
+    double threshold;
+    std::string fault_code;
+    std::string severity;
+    bool crossed;
+  };
+  std::vector<Pending> work;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto & r : rules_) {
+      if (r.active) {
+        work.push_back({r.id, r.app_id, r.data_name, r.op, r.threshold, r.fault_code, r.severity, r.crossed});
+      }
+    }
+  }
+  if (work.empty()) {
+    return;
+  }
+
+  for (auto & w : work) {
+    const std::optional<double> value = fetcher_ ? fetcher_(w.app_id, w.data_name) : std::nullopt;
+    if (!value.has_value()) {
+      continue;  // unreadable this poll: hold state, never false-clear a live fault
+    }
+    const bool now_crossed = compare(*value, w.op, w.threshold);
+    if (now_crossed) {
+      if (report_) {
+        const std::string desc = w.data_name + " = " + std::to_string(*value) + " " + w.op + " " +
+                                 std::to_string(w.threshold) + " (fault-trigger " + w.id + ")";
+        // Re-report every poll while crossed: level-triggered, so the fault
+        // confirms regardless of the manager's debounce threshold and stays
+        // asserted until the value recovers.
+        report_(w.app_id, w.fault_code, w.severity, desc);
+      }
+      w.crossed = true;
+    } else {
+      if (w.crossed && clear_) {
+        clear_(w.app_id, w.fault_code);
+      }
+      w.crossed = false;
+    }
+  }
+
+  // Fold latch state back into the live rules (still identified by id; a rule
+  // deleted mid-evaluation is simply skipped).
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto & w : work) {
+    auto it = std::find_if(rules_.begin(), rules_.end(), [&](FaultTriggerRule & r) {
+      return r.id == w.id && r.app_id == w.app_id;
+    });
+    if (it != rules_.end()) {
+      it->crossed = w.crossed;
+    }
+  }
+}
+
+void FaultTriggerEngine::load() {
+  if (storage_path_.empty()) {
+    return;
+  }
+  std::ifstream in(storage_path_);
+  if (!in.is_open()) {
+    return;  // first run: no store yet
+  }
+  nlohmann::json j;
+  try {
+    in >> j;
+  } catch (const nlohmann::json::exception & e) {
+    if (log_) {
+      log_("fault-trigger store '" + storage_path_ + "' is not valid JSON (" + e.what() + "); starting empty");
+    }
+    return;
+  }
+  if (!j.is_array()) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto & item : j) {
+    if (!item.is_object()) {
+      continue;
+    }
+    FaultTriggerRule r;
+    r.id = json_string(item, "id");
+    r.app_id = json_string(item, "app_id");
+    r.data_name = json_string(item, "data_name");
+    r.op = json_string(item, "operator");
+    r.threshold = item.contains("threshold") && item["threshold"].is_number() ? item["threshold"].get<double>() : 0.0;
+    r.fault_code = json_string(item, "fault_code");
+    r.severity = json_string(item, "severity");
+    r.active = item.contains("active") && item["active"].is_boolean() ? item["active"].get<bool>() : true;
+    if (r.id.empty() || r.app_id.empty() || r.data_name.empty() || !valid_operator(r.op) || r.fault_code.empty() ||
+        !valid_severity(r.severity)) {
+      continue;  // drop malformed persisted rows rather than crash on them
+    }
+    rules_.push_back(r);
+    // Keep id generation past any persisted "ftr_<n>" so restarts don't collide.
+    if (r.id.rfind("ftr_", 0) == 0) {
+      try {
+        const uint64_t n = std::stoull(r.id.substr(4));
+        next_seq_ = std::max(next_seq_, n + 1);
+      } catch (const std::exception &) {
+        // non-numeric suffix: leave next_seq_ as is
+      }
+    }
+  }
+  if (log_) {
+    log_("fault-trigger engine loaded " + std::to_string(rules_.size()) + " rule(s) from " + storage_path_);
+  }
+}
+
+void FaultTriggerEngine::save_locked() const {
+  if (storage_path_.empty()) {
+    return;
+  }
+  nlohmann::json j = nlohmann::json::array();
+  for (const auto & r : rules_) {
+    nlohmann::json row = rule_to_json(r);
+    row["app_id"] = r.app_id;  // store the owning entity too (not in the REST response)
+    j.push_back(std::move(row));
+  }
+  const std::string tmp = storage_path_ + ".tmp";
+  std::ofstream out(tmp, std::ios::trunc);
+  if (!out.is_open()) {
+    if (log_) {
+      log_("fault-trigger store '" + storage_path_ + "' not writable; rules will not persist");
+    }
+    return;
+  }
+  out << j.dump(2);
+  out.close();
+  std::rename(tmp.c_str(), storage_path_.c_str());
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -37,12 +37,13 @@ std::string json_string(const nlohmann::json & j, const char * key) {
 }  // namespace
 
 FaultTriggerEngine::FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report,
-                                       FaultClearFn clear, LogFn log)
+                                       FaultClearFn clear, LogFn log, DataPointNamesFn data_point_names)
   : storage_path_(std::move(storage_path))
   , fetcher_(std::move(fetcher))
   , report_(std::move(report))
   , clear_(std::move(clear))
-  , log_(std::move(log)) {
+  , log_(std::move(log))
+  , data_point_names_(std::move(data_point_names)) {
   load();
 }
 
@@ -130,6 +131,27 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
   if (!valid_severity(rule.severity)) {
     return tl::make_unexpected(
         std::make_pair(400, std::string("'severity' must be one of INFO, WARNING, ERROR, CRITICAL")));
+  }
+
+  // A rule bound to a data point the app does not have can never fire, yet it
+  // would list as active - a silently dead alarm. Reject it at creation when
+  // the app's points are enumerable; nullopt (entity unreadable right now)
+  // skips the check so a transient PLC outage does not block rule creation.
+  if (data_point_names_) {
+    const auto names = data_point_names_(rule.app_id);
+    if (names.has_value() && std::find(names->begin(), names->end(), rule.data_name) == names->end()) {
+      std::string available;
+      constexpr size_t kMaxListed = 20;
+      for (size_t i = 0; i < names->size() && i < kMaxListed; ++i) {
+        available += (i == 0 ? "" : ", ") + (*names)[i];
+      }
+      if (names->size() > kMaxListed) {
+        available += ", ...";
+      }
+      return tl::make_unexpected(
+          std::make_pair(400, "data point '" + rule.data_name + "' does not exist on app '" + rule.app_id + "'" +
+                                  (available.empty() ? std::string{} : " (available: " + available + ")")));
+    }
   }
 
   std::lock_guard<std::mutex> lock(mutex_);

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -155,6 +155,17 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
   }
 
   std::lock_guard<std::mutex> lock(mutex_);
+  // fault_code is the PRIMARY KEY of the fault-manager store, so two rules
+  // sharing one code would fight over the same stored fault (one rule's clear
+  // erases the other's assertion) and make per-app delete/clear ambiguous.
+  const auto dup = std::find_if(rules_.begin(), rules_.end(), [&](const FaultTriggerRule & r) {
+    return r.fault_code == rule.fault_code;
+  });
+  if (dup != rules_.end()) {
+    return tl::make_unexpected(std::make_pair(
+        409, "fault_code '" + rule.fault_code + "' is already used by rule '" + dup->id + "' on app '" + dup->app_id +
+                 "' - fault codes are global to the fault store, pick a distinct one"));
+  }
   rule.id = "ftr_" + std::to_string(next_seq_++);
   rules_.push_back(rule);
   save_locked();

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -162,9 +162,9 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
     return r.fault_code == rule.fault_code;
   });
   if (dup != rules_.end()) {
-    return tl::make_unexpected(std::make_pair(
-        409, "fault_code '" + rule.fault_code + "' is already used by rule '" + dup->id + "' on app '" + dup->app_id +
-                 "' - fault codes are global to the fault store, pick a distinct one"));
+    return tl::make_unexpected(
+        std::make_pair(409, "fault_code '" + rule.fault_code + "' is already used by rule '" + dup->id + "' on app '" +
+                                dup->app_id + "' - fault codes are global to the fault store, pick a distinct one"));
   }
   rule.id = "ftr_" + std::to_string(next_seq_++);
   rules_.push_back(rule);

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -37,13 +37,15 @@ std::string json_string(const nlohmann::json & j, const char * key) {
 }  // namespace
 
 FaultTriggerEngine::FaultTriggerEngine(std::string storage_path, ValueFetcher fetcher, FaultReportFn report,
-                                       FaultClearFn clear, LogFn log, DataPointNamesFn data_point_names)
+                                       FaultClearFn clear, LogFn log, DataPointNamesFn data_point_names,
+                                       EntityExistsFn entity_exists)
   : storage_path_(std::move(storage_path))
   , fetcher_(std::move(fetcher))
   , report_(std::move(report))
   , clear_(std::move(clear))
   , log_(std::move(log))
-  , data_point_names_(std::move(data_point_names)) {
+  , data_point_names_(std::move(data_point_names))
+  , entity_exists_(std::move(entity_exists)) {
   load();
 }
 
@@ -133,6 +135,14 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
         std::make_pair(400, std::string("'severity' must be one of INFO, WARNING, ERROR, CRITICAL")));
   }
 
+  // Reject a rule targeting an app the entity registry does not know (404): a
+  // bogus app_id must not silently reserve a global fault_code. Checked before
+  // the data-point probe so that a nullopt there means "known app, points
+  // unreadable right now" (transient outage), never "unknown app".
+  if (entity_exists_ && !entity_exists_(app_id)) {
+    return tl::make_unexpected(std::make_pair(404, "app '" + app_id + "' does not exist"));
+  }
+
   // A rule bound to a data point the app does not have can never fire, yet it
   // would list as active - a silently dead alarm. Reject it at creation when
   // the app's points are enumerable; nullopt (entity unreadable right now)
@@ -177,6 +187,11 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
 }
 
 bool FaultTriggerEngine::remove(const std::string & app_id, const std::string & id) {
+  // Serialize the whole erase+clear against evaluate_once()'s report/clear (see
+  // dispatch_mutex_): otherwise a DELETE landing between evaluate's snapshot and
+  // its report_ would clear the fault here while evaluate re-asserts it, leaving
+  // a stuck fault for a rule that no longer exists.
+  std::lock_guard<std::mutex> dispatch(dispatch_mutex_);
   std::string fault_code;
   bool was_crossed = false;
   bool found = false;
@@ -194,7 +209,8 @@ bool FaultTriggerEngine::remove(const std::string & app_id, const std::string & 
     save_locked();
     found = true;
   }
-  // Clear outside the lock: the fault report path may re-enter unrelated code.
+  // Clear outside mutex_ (the fault report path may re-enter unrelated code) but
+  // still under dispatch_mutex_ so it is ordered against evaluate_once().
   if (found && was_crossed && clear_) {
     clear_(app_id, fault_code);
   }
@@ -202,8 +218,9 @@ bool FaultTriggerEngine::remove(const std::string & app_id, const std::string & 
 }
 
 void FaultTriggerEngine::evaluate_once() {
-  // Snapshot the active rules under the lock, evaluate the (blocking) value
-  // fetch + fault report outside it, then fold the new latch state back in.
+  // Snapshot the active rules under the lock, run the (blocking) value fetch
+  // outside every lock, then dispatch report/clear + fold the latch back under
+  // dispatch_mutex_ (serialized against remove()).
   struct Pending {
     std::string id;
     std::string app_id;
@@ -213,13 +230,15 @@ void FaultTriggerEngine::evaluate_once() {
     std::string fault_code;
     std::string severity;
     bool crossed;
+    std::optional<double> value;
   };
   std::vector<Pending> work;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     for (const auto & r : rules_) {
       if (r.active) {
-        work.push_back({r.id, r.app_id, r.data_name, r.op, r.threshold, r.fault_code, r.severity, r.crossed});
+        work.push_back(
+            {r.id, r.app_id, r.data_name, r.op, r.threshold, r.fault_code, r.severity, r.crossed, std::nullopt});
       }
     }
   }
@@ -227,15 +246,33 @@ void FaultTriggerEngine::evaluate_once() {
     return;
   }
 
+  // Blocking value fetch OUTSIDE any lock so neither mutex is held across I/O.
   for (auto & w : work) {
-    const std::optional<double> value = fetcher_ ? fetcher_(w.app_id, w.data_name) : std::nullopt;
-    if (!value.has_value()) {
+    w.value = fetcher_ ? fetcher_(w.app_id, w.data_name) : std::nullopt;
+  }
+
+  // Dispatch under dispatch_mutex_ so the whole re-check-still-exists -> report_
+  // -> latch-fold section is atomic against remove()'s erase+clear. A rule
+  // deleted since the snapshot is skipped, so evaluate never re-asserts a fault
+  // that a concurrent DELETE just cleared.
+  std::lock_guard<std::mutex> dispatch(dispatch_mutex_);
+  for (auto & w : work) {
+    if (!w.value.has_value()) {
       continue;  // unreadable this poll: hold state, never false-clear a live fault
     }
-    const bool now_crossed = compare(*value, w.op, w.threshold);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      const bool still_present = std::any_of(rules_.begin(), rules_.end(), [&](const FaultTriggerRule & r) {
+        return r.id == w.id && r.app_id == w.app_id;
+      });
+      if (!still_present) {
+        continue;  // removed under dispatch_mutex_: remove() already cleared it
+      }
+    }
+    const bool now_crossed = compare(*w.value, w.op, w.threshold);
     if (now_crossed) {
       if (report_) {
-        const std::string desc = w.data_name + " = " + std::to_string(*value) + " " + w.op + " " +
+        const std::string desc = w.data_name + " = " + std::to_string(*w.value) + " " + w.op + " " +
                                  std::to_string(w.threshold) + " (fault-trigger " + w.id + ")";
         // Re-report every poll while crossed: level-triggered, so the fault
         // confirms regardless of the manager's debounce threshold and stays
@@ -251,16 +288,23 @@ void FaultTriggerEngine::evaluate_once() {
     }
   }
 
-  // Fold latch state back into the live rules (still identified by id; a rule
-  // deleted mid-evaluation is simply skipped).
+  // Fold latch state back into the live rules and persist any edge so a restart
+  // mid-fault reloads the asserted latch and can still auto-clear on the falling
+  // edge (a rule deleted mid-evaluation is simply skipped). Only writes on an
+  // actual change, so a steadily-crossed rule does not re-save every poll.
+  bool latch_changed = false;
   std::lock_guard<std::mutex> lock(mutex_);
   for (const auto & w : work) {
     auto it = std::find_if(rules_.begin(), rules_.end(), [&](FaultTriggerRule & r) {
       return r.id == w.id && r.app_id == w.app_id;
     });
-    if (it != rules_.end()) {
+    if (it != rules_.end() && it->crossed != w.crossed) {
       it->crossed = w.crossed;
+      latch_changed = true;
     }
+  }
+  if (latch_changed) {
+    save_locked();
   }
 }
 
@@ -298,6 +342,9 @@ void FaultTriggerEngine::load() {
     r.fault_code = json_string(item, "fault_code");
     r.severity = json_string(item, "severity");
     r.active = item.contains("active") && item["active"].is_boolean() ? item["active"].get<bool>() : true;
+    // Restore the latch (default false for pre-latch stores) so a fault asserted
+    // before the restart still clears on the next falling edge instead of sticking.
+    r.crossed = item.contains("crossed") && item["crossed"].is_boolean() ? item["crossed"].get<bool>() : false;
     if (r.id.empty() || r.app_id.empty() || r.data_name.empty() || !valid_operator(r.op) || r.fault_code.empty() ||
         !valid_severity(r.severity)) {
       continue;  // drop malformed persisted rows rather than crash on them
@@ -325,7 +372,9 @@ void FaultTriggerEngine::save_locked() const {
   nlohmann::json j = nlohmann::json::array();
   for (const auto & r : rules_) {
     nlohmann::json row = rule_to_json(r);
-    row["app_id"] = r.app_id;  // store the owning entity too (not in the REST response)
+    row["app_id"] = r.app_id;    // store the owning entity too (not in the REST response)
+    row["crossed"] = r.crossed;  // persist the latch (not in the REST DTO) so a restart
+                                 // mid-fault can still auto-clear on the falling edge
     j.push_back(std::move(row));
   }
   const std::string tmp = storage_path_ + ".tmp";

--- a/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
@@ -50,21 +50,19 @@ void collect_app_fqn(const ThreadSafeEntityCache & cache, const std::string & ap
 
 void collect_component_app_fqns(const ThreadSafeEntityCache & cache, const std::string & comp_id,
                                 std::set<std::string> & out) {
-  std::set<std::string> local;
+  // The component itself is a legitimate reporting source, not only its child
+  // apps: protocol bridge plugins raise faults (e.g. PLC_COMMS_LOST) with the
+  // component's own id as source_id. Scoping to child-app FQNs alone made
+  // component-scoped fault queries return empty for exactly the faults the
+  // component reported. Matching is exact-id (ROS sources are /-prefixed
+  // FQNs), so a native component that never reports under its id gains no
+  // faults from this.
+  if (cache.get_component(comp_id)) {
+    out.insert(comp_id);
+  }
   for (const auto & app_id : cache.get_apps_for_component(comp_id)) {
-    collect_app_fqn(cache, app_id, local);
+    collect_app_fqn(cache, app_id, out);
   }
-  if (local.empty()) {
-    // No child app contributed a source (no apps, or all unbound/empty-FQN).
-    // An external component owns its fault_manager faults under its own id -
-    // mirrors the external-App rule (#516). A non-external component stays
-    // empty: an unbound ROS component must not claim faults it never reported.
-    auto comp = cache.get_component(comp_id);
-    if (comp && comp->external.value_or(false)) {
-      local.insert(comp_id);
-    }
-  }
-  out.insert(local.begin(), local.end());
 }
 
 void collect_area_app_fqns(const ThreadSafeEntityCache & cache, const std::string & area_id,

--- a/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
@@ -50,14 +50,14 @@ void collect_app_fqn(const ThreadSafeEntityCache & cache, const std::string & ap
 
 void collect_component_app_fqns(const ThreadSafeEntityCache & cache, const std::string & comp_id,
                                 std::set<std::string> & out) {
-  // The component itself is a legitimate reporting source, not only its child
-  // apps: protocol bridge plugins raise faults (e.g. PLC_COMMS_LOST) with the
-  // component's own id as source_id. Scoping to child-app FQNs alone made
-  // component-scoped fault queries return empty for exactly the faults the
-  // component reported. Matching is exact-id (ROS sources are /-prefixed
-  // FQNs), so a native component that never reports under its id gains no
-  // faults from this.
-  if (cache.get_component(comp_id)) {
+  // An external component is a reporting source in its own right, even when
+  // child apps also contribute: protocol bridge plugins raise faults (e.g.
+  // PLC_COMMS_LOST) with the component's own id as source_id, and those must
+  // not vanish from /components/<id>/faults just because the component hosts
+  // apps. A non-external component never claims its bare id - an unbound ROS
+  // component must not own faults it never reported (#516 guardrail).
+  auto comp = cache.get_component(comp_id);
+  if (comp && comp->external.value_or(false)) {
     out.insert(comp_id);
   }
   for (const auto & app_id : cache.get_apps_for_component(comp_id)) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1910,7 +1910,12 @@ void GatewayNode::init_fault_trigger_engine() {
 
   auto clear = [this](const std::string & /*app_id*/, const std::string & fault_code) {
     if (fault_mgr_) {
-      fault_mgr_->clear_fault(fault_code);
+      // A trigger-rule auto-clear (falling edge / rule deletion) is a local,
+      // rule-scoped event: skip the correlation engine's cascade so clearing
+      // one rule's fault can never wipe correlated faults owned by anything
+      // else. fault_code is globally unique (create() rejects duplicates), so
+      // the app scope is already encoded in the code itself.
+      fault_mgr_->clear_fault(fault_code, /*skip_correlation_auto_clear=*/true);
     }
   };
 

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1914,10 +1914,34 @@ void GatewayNode::init_fault_trigger_engine() {
     }
   };
 
-  fault_trigger_engine_ = std::make_unique<FaultTriggerEngine>(storage_path, std::move(fetcher), std::move(report),
-                                                               std::move(clear), [this](const std::string & m) {
-                                                                 RCLCPP_INFO(get_logger(), "%s", m.c_str());
-                                                               });
+  // Data-point enumeration for create-time validation: same in-process route as
+  // the fetcher, so "exists" means exactly "the fetcher could ever read it".
+  auto data_point_names = [this](const std::string & app_id) -> std::optional<std::vector<std::string>> {
+    if (!plugin_mgr_) {
+      return std::nullopt;
+    }
+    const auto content = plugin_mgr_->fetch_entity_data_via_route(app_id);
+    if (!content || !EntityFreezeFrameCapture::content_has_live_data(*content)) {
+      return std::nullopt;
+    }
+    const auto values = EntityFreezeFrameCapture::values_from_list_content(*content);
+    if (!values.is_object()) {
+      return std::nullopt;
+    }
+    std::vector<std::string> names;
+    names.reserve(values.size());
+    for (auto it = values.begin(); it != values.end(); ++it) {
+      names.push_back(it.key());
+    }
+    return names;
+  };
+
+  fault_trigger_engine_ = std::make_unique<FaultTriggerEngine>(
+      storage_path, std::move(fetcher), std::move(report), std::move(clear),
+      [this](const std::string & m) {
+        RCLCPP_INFO(get_logger(), "%s", m.c_str());
+      },
+      std::move(data_point_names));
 
   // Dedicated evaluation loop: the value fetch + synchronous ReportFault call
   // must not run on the main ROS executor (mirrors the freeze-frame capture's

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1941,12 +1941,20 @@ void GatewayNode::init_fault_trigger_engine() {
     return names;
   };
 
+  // Entity existence for create-time validation: an app is real iff the entity
+  // registry knows its id. Distinct from the data route (which returns nullopt
+  // for both an unknown app and a transient outage), so create() can 404 a
+  // bogus app instead of reserving a global fault_code for it.
+  auto entity_exists = [this](const std::string & app_id) -> bool {
+    return get_thread_safe_cache().find_entity(app_id).has_value();
+  };
+
   fault_trigger_engine_ = std::make_unique<FaultTriggerEngine>(
       storage_path, std::move(fetcher), std::move(report), std::move(clear),
       [this](const std::string & m) {
         RCLCPP_INFO(get_logger(), "%s", m.c_str());
       },
-      std::move(data_point_names));
+      std::move(data_point_names), std::move(entity_exists));
 
   // Dedicated evaluation loop: the value fetch + synchronous ReportFault call
   // must not run on the main ROS executor (mirrors the freeze-frame capture's

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -240,6 +240,11 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   declare_parameter("triggers.on_restart_behavior", "reset");
   declare_parameter("triggers.storage.path", "");
 
+  // Config-less threshold-rule (fault-trigger) engine parameters (issue #235).
+  declare_parameter("fault_triggers.enabled", true);
+  declare_parameter("fault_triggers.poll_interval_ms", 1000);
+  declare_parameter("fault_triggers.storage.path", "");
+
   // Plugin framework parameters
   declare_parameter("plugins", std::vector<std::string>{});
 
@@ -1672,6 +1677,14 @@ GatewayNode::~GatewayNode() {
   if (resource_change_notifier_) {
     resource_change_notifier_->shutdown();
   }
+  // 5b. Stop the fault-trigger evaluation loop BEFORE plugin/fault shutdown:
+  //     it resolves into plugin routes and the FaultManager, neither of which
+  //     may be used once shutdown_all() has run.
+  fault_trigger_stop_.store(true, std::memory_order_relaxed);
+  if (fault_trigger_thread_.joinable()) {
+    fault_trigger_thread_.join();
+  }
+  fault_trigger_engine_.reset();
   // 6. Drop the entity freeze-frame capture BEFORE plugin shutdown: its
   //    capture thread (joined here) resolves into plugin DataProviders and
   //    routes, which must not be reachable once shutdown_all() has run.
@@ -1820,6 +1833,117 @@ void GatewayNode::shutdown_trigger_subscriber() {
   if (trigger_topic_subscriber_) {
     trigger_topic_subscriber_->shutdown();
   }
+}
+
+namespace {
+
+// Coerce a discovered data point's JSON value to a double for threshold
+// comparison. Handles the numeric, boolean and numeric-string shapes the PLC
+// bridges emit; returns nullopt for anything non-numeric.
+std::optional<double> value_to_double(const nlohmann::json & v) {
+  if (v.is_number()) {
+    return v.get<double>();
+  }
+  if (v.is_boolean()) {
+    return v.get<bool>() ? 1.0 : 0.0;
+  }
+  if (v.is_string()) {
+    try {
+      size_t pos = 0;
+      const double d = std::stod(v.get<std::string>(), &pos);
+      if (pos > 0) {
+        return d;
+      }
+    } catch (const std::exception &) {
+      return std::nullopt;
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace
+
+void GatewayNode::init_fault_trigger_engine() {
+  if (!get_parameter("fault_triggers.enabled").as_bool() || !plugin_mgr_ || !plugin_mgr_->has_plugins()) {
+    return;
+  }
+  const std::string storage_path = get_parameter("fault_triggers.storage.path").as_string();
+  int poll_ms = static_cast<int>(get_parameter("fault_triggers.poll_interval_ms").as_int());
+  if (poll_ms < 50) {
+    poll_ms = 50;  // floor: never busy-spin the evaluation loop
+  }
+
+  // Value fetch: same in-process x-plc-data route the freeze-frame capture uses,
+  // so a rule always sees exactly the value the /data endpoint would serve.
+  auto fetcher = [this](const std::string & app_id, const std::string & data_name) -> std::optional<double> {
+    if (!plugin_mgr_) {
+      return std::nullopt;
+    }
+    const auto content = plugin_mgr_->fetch_entity_data_via_route(app_id);
+    if (!content || !EntityFreezeFrameCapture::content_has_live_data(*content)) {
+      return std::nullopt;
+    }
+    const auto values = EntityFreezeFrameCapture::values_from_list_content(*content);
+    if (!values.is_object() || !values.contains(data_name)) {
+      return std::nullopt;
+    }
+    return value_to_double(values[data_name]);
+  };
+
+  auto report = [this](const std::string & app_id, const std::string & fault_code, const std::string & severity,
+                       const std::string & description) {
+    if (!fault_mgr_) {
+      return;
+    }
+    uint8_t sev = 1;  // WARNING default
+    if (severity == "INFO") {
+      sev = 0;
+    } else if (severity == "WARNING") {
+      sev = 1;
+    } else if (severity == "ERROR") {
+      sev = 2;
+    } else if (severity == "CRITICAL") {
+      sev = 3;
+    }
+    fault_mgr_->report_fault(fault_code, sev, description, app_id);
+  };
+
+  auto clear = [this](const std::string & /*app_id*/, const std::string & fault_code) {
+    if (fault_mgr_) {
+      fault_mgr_->clear_fault(fault_code);
+    }
+  };
+
+  fault_trigger_engine_ = std::make_unique<FaultTriggerEngine>(storage_path, std::move(fetcher), std::move(report),
+                                                               std::move(clear), [this](const std::string & m) {
+                                                                 RCLCPP_INFO(get_logger(), "%s", m.c_str());
+                                                               });
+
+  // Dedicated evaluation loop: the value fetch + synchronous ReportFault call
+  // must not run on the main ROS executor (mirrors the freeze-frame capture's
+  // own thread). Joined in ~GatewayNode before plugin/fault shutdown.
+  const auto interval = std::chrono::milliseconds(poll_ms);
+  fault_trigger_thread_ = std::thread([this, interval]() {
+    while (!fault_trigger_stop_.load(std::memory_order_relaxed)) {
+      try {
+        fault_trigger_engine_->evaluate_once();
+      } catch (const std::exception & e) {
+        RCLCPP_WARN(get_logger(), "fault-trigger evaluation error: %s", e.what());
+      }
+      // Sleep in short slices so shutdown does not wait a whole interval.
+      auto slept = std::chrono::milliseconds(0);
+      while (slept < interval && !fault_trigger_stop_.load(std::memory_order_relaxed)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(25));
+        slept += std::chrono::milliseconds(25);
+      }
+    }
+  });
+  RCLCPP_INFO(get_logger(), "fault-trigger engine active (poll %d ms, store '%s')", poll_ms,
+              storage_path.empty() ? "in-memory" : storage_path.c_str());
+}
+
+FaultTriggerEngine * GatewayNode::get_fault_trigger_engine() const {
+  return fault_trigger_engine_.get();
 }
 
 ResourceSamplerRegistry * GatewayNode::get_sampler_registry() const {

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -14,6 +14,7 @@
 
 #include "ros2_medkit_gateway/core/http/handlers/discovery_handlers.hpp"
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <variant>
@@ -101,6 +102,28 @@ void append_plugin_capabilities(json & capabilities, const std::string & entity_
     if (!has_capability(capabilities, cap_name)) {
       capabilities.push_back({{"name", cap_name}, {"href", href_prefix + cap_name}});
     }
+  }
+}
+
+/// Drop base capabilities whose routes cannot serve a plugin-owned entity.
+/// The /data and /operations handlers dispatch plugin entities to their
+/// plugin's Data/OperationProvider and 404 by contract when none is
+/// registered, so advertising those capabilities is a dead link every SOVD
+/// client (and the UI) follows into a guaranteed 404.
+void prune_plugin_unserved_capabilities(std::vector<CapabilityBuilder::Capability> & caps,
+                                        const std::string & entity_id, const GatewayNode * node) {
+  auto * pmgr = node ? node->get_plugin_manager() : nullptr;
+  if (!pmgr || !pmgr->get_entity_owner(entity_id)) {
+    return;  // native entity: the core managers serve these collections
+  }
+  auto drop = [&caps](CapabilityBuilder::Capability cap) {
+    caps.erase(std::remove(caps.begin(), caps.end(), cap), caps.end());
+  };
+  if (!pmgr->get_data_provider_for_entity(entity_id)) {
+    drop(CapabilityBuilder::Capability::DATA);
+  }
+  if (!pmgr->get_operation_provider_for_entity(entity_id)) {
+    drop(CapabilityBuilder::Capability::OPERATIONS);
   }
 }
 
@@ -278,6 +301,7 @@ http::Result<dto::AreaDetail> DiscoveryHandlers::get_area(const http::TypedReque
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {Cap::SUBAREAS, Cap::CONTAINS, Cap::DATA,      Cap::OPERATIONS, Cap::CONFIGURATIONS,
                              Cap::FAULTS,   Cap::LOGS,     Cap::BULK_DATA, Cap::TRIGGERS};
+    prune_plugin_unserved_capabilities(caps, area.id, ctx_.node());
     auto area_caps = CapabilityBuilder::build_capabilities("areas", area.id, caps);
     append_plugin_capabilities(area_caps, "areas", area.id, SovdEntityType::AREA, ctx_.node());
     detail.capabilities = area_caps;
@@ -725,6 +749,7 @@ http::Result<dto::ComponentDetail> DiscoveryHandlers::get_component(const http::
     if (!comp.depends_on.empty()) {
       caps.push_back(Cap::DEPENDS_ON);
     }
+    prune_plugin_unserved_capabilities(caps, comp.id, ctx_.node());
     auto comp_caps = CapabilityBuilder::build_capabilities("components", comp.id, caps);
     append_plugin_capabilities(comp_caps, "components", comp.id, SovdEntityType::COMPONENT, ctx_.node());
     // Capabilities at root level (SOVD standard) and in x-medkit (vendor extension for tools
@@ -1100,6 +1125,7 @@ http::Result<dto::AppDetail> DiscoveryHandlers::get_app(const http::TypedRequest
     if (ctx_.node() && ctx_.node()->get_lock_manager()) {
       caps.push_back(Cap::LOCKS);
     }
+    prune_plugin_unserved_capabilities(caps, app.id, ctx_.node());
     auto app_caps = CapabilityBuilder::build_capabilities("apps", app.id, caps);
     append_plugin_capabilities(app_caps, "apps", app.id, SovdEntityType::APP, ctx_.node());
     detail.capabilities = app_caps;
@@ -1499,6 +1525,7 @@ http::Result<dto::FunctionDetail> DiscoveryHandlers::get_function(const http::Ty
     using Cap = CapabilityBuilder::Capability;
     std::vector<Cap> caps = {Cap::HOSTS, Cap::DATA,      Cap::OPERATIONS,           Cap::CONFIGURATIONS, Cap::FAULTS,
                              Cap::LOGS,  Cap::BULK_DATA, Cap::CYCLIC_SUBSCRIPTIONS, Cap::TRIGGERS};
+    prune_plugin_unserved_capabilities(caps, func.id, ctx_.node());
     auto func_caps = CapabilityBuilder::build_capabilities("functions", func.id, caps);
     append_plugin_capabilities(func_caps, "functions", func.id, SovdEntityType::FUNCTION, ctx_.node());
     detail.capabilities = func_caps;

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -328,9 +328,10 @@ void RESTServer::setup_routes() {
   // notification `/triggers` collection, never overloading it. GET is public;
   // POST/DELETE follow the gateway's write-auth policy.
   {
-    auto ft_json_error = [](httplib::Response & res, int status, const std::string & message) {
+    auto ft_json_error = [](httplib::Response & res, int status, const std::string & message,
+                            const char * error_code = nullptr) {
       nlohmann::json err;
-      err["error_code"] = status == 404 ? ERR_RESOURCE_NOT_FOUND : ERR_INVALID_PARAMETER;
+      err["error_code"] = error_code ? error_code : (status == 404 ? ERR_RESOURCE_NOT_FOUND : ERR_INVALID_PARAMETER);
       err["message"] = message;
       res.status = status;
       res.set_content(err.dump(2), "application/json");
@@ -364,7 +365,8 @@ void RESTServer::setup_routes() {
                 try {
                   body = nlohmann::json::parse(req.body);
                 } catch (const nlohmann::json::exception &) {
-                  ft_json_error(res, 400, "request body is not valid JSON");
+                  // Malformed request, not semantic validation - ERR_INVALID_REQUEST.
+                  ft_json_error(res, 400, "request body is not valid JSON", ERR_INVALID_REQUEST);
                   return;
                 }
                 auto created = engine->create(app_id, body);

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -322,6 +322,77 @@ void RESTServer::setup_routes() {
   });
 #endif
 
+  // === Config-less fault-trigger (threshold-rule) routes (issue #235) ===
+  // Registered directly on the server (like the docs routes) so the CRUD does
+  // not need a typed DTO. Mounted at .../fault-triggers - a sibling of the SOVD
+  // notification `/triggers` collection, never overloading it. GET is public;
+  // POST/DELETE follow the gateway's write-auth policy.
+  {
+    auto ft_json_error = [](httplib::Response & res, int status, const std::string & message) {
+      nlohmann::json err;
+      err["error_code"] = status == 404 ? ERR_RESOURCE_NOT_FOUND : ERR_INVALID_PARAMETER;
+      err["message"] = message;
+      res.status = status;
+      res.set_content(err.dump(2), "application/json");
+    };
+
+    srv->Get(api_path(R"(/apps/([^/]+)/fault-triggers)"),
+             [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
+               auto * engine = node_->get_fault_trigger_engine();
+               if (!engine) {
+                 ft_json_error(res, 404, "fault-trigger engine is not enabled");
+                 return;
+               }
+               const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
+               nlohmann::json items = nlohmann::json::array();
+               for (const auto & r : engine->list(app_id)) {
+                 items.push_back(FaultTriggerEngine::rule_to_json(r));
+               }
+               res.status = 200;
+               res.set_content(nlohmann::json{{"items", items}}.dump(2), "application/json");
+             });
+
+    srv->Post(api_path(R"(/apps/([^/]+)/fault-triggers)"),
+              [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
+                auto * engine = node_->get_fault_trigger_engine();
+                if (!engine) {
+                  ft_json_error(res, 404, "fault-trigger engine is not enabled");
+                  return;
+                }
+                const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
+                nlohmann::json body;
+                try {
+                  body = nlohmann::json::parse(req.body);
+                } catch (const nlohmann::json::exception &) {
+                  ft_json_error(res, 400, "request body is not valid JSON");
+                  return;
+                }
+                auto created = engine->create(app_id, body);
+                if (!created) {
+                  ft_json_error(res, created.error().first, created.error().second);
+                  return;
+                }
+                res.status = 201;
+                res.set_content(FaultTriggerEngine::rule_to_json(*created).dump(2), "application/json");
+              });
+
+    srv->Delete(api_path(R"(/apps/([^/]+)/fault-triggers/([^/]+))"),
+                [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
+                  auto * engine = node_->get_fault_trigger_engine();
+                  if (!engine) {
+                    ft_json_error(res, 404, "fault-trigger engine is not enabled");
+                    return;
+                  }
+                  const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
+                  const std::string id = req.matches.size() > 2 ? req.matches[2].str() : std::string{};
+                  if (!engine->remove(app_id, id)) {
+                    ft_json_error(res, 404, "no such fault-trigger '" + id + "'");
+                    return;
+                  }
+                  res.status = 204;
+                });
+  }
+
   auto & reg = *route_registry_;
   using SB = openapi::SchemaBuilder;
 

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -342,29 +342,29 @@ void RESTServer::setup_routes() {
     route_registry_
         ->raw("get", "/apps/{app_id}/fault-triggers",
               [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
-               auto * engine = node_->get_fault_trigger_engine();
-               if (!engine) {
-                 ft_json_error(res, 404, "fault-trigger engine is not enabled");
-                 return;
-               }
-               const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
-               nlohmann::json items = nlohmann::json::array();
-               for (const auto & r : engine->list(app_id)) {
-                 items.push_back(FaultTriggerEngine::rule_to_json(r));
-               }
-               res.status = 200;
-               res.set_content(nlohmann::json{{"items", items}}.dump(2), "application/json");
-             })
+                auto * engine = node_->get_fault_trigger_engine();
+                if (!engine) {
+                  ft_json_error(res, 404, "fault-trigger engine is not enabled");
+                  return;
+                }
+                const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
+                nlohmann::json items = nlohmann::json::array();
+                for (const auto & r : engine->list(app_id)) {
+                  items.push_back(FaultTriggerEngine::rule_to_json(r));
+                }
+                res.status = 200;
+                res.set_content(nlohmann::json{{"items", items}}.dump(2), "application/json");
+              })
         .tag("FaultTriggers")
         .summary("List fault-trigger rules")
-        .description("Threshold rules on the app's discovered data points; each fires a fault on cross "
-                     "and auto-clears on recovery.")
+        .description(
+            "Threshold rules on the app's discovered data points; each fires a fault on cross "
+            "and auto-clears on recovery.")
         .operation_id("listFaultTriggers")
         .path_param("app_id", "App (entity) the rules are scoped to")
         .response(200, "Rule list",
                   nlohmann::json{{"type", "object"},
-                                 {"properties",
-                                  {{"items", {{"type", "array"}, {"items", {{"type", "object"}}}}}}}});
+                                 {"properties", {{"items", {{"type", "array"}, {"items", {{"type", "object"}}}}}}}});
 
     route_registry_
         ->raw("post", "/apps/{app_id}/fault-triggers",
@@ -393,9 +393,10 @@ void RESTServer::setup_routes() {
               })
         .tag("FaultTriggers")
         .summary("Create a fault-trigger rule")
-        .description("Body: data_name, operator (>, <, >=, <=, ==), threshold, fault_code, severity "
-                     "(INFO|WARNING|ERROR|CRITICAL), optional active. fault_code must be unique across "
-                     "all rules (409 on duplicates).")
+        .description(
+            "Body: data_name, operator (>, <, >=, <=, ==), threshold, fault_code, severity "
+            "(INFO|WARNING|ERROR|CRITICAL), optional active. fault_code must be unique across "
+            "all rules (409 on duplicates).")
         .operation_id("createFaultTrigger")
         .path_param("app_id", "App (entity) to scope the rule to")
         .request_body("Fault-trigger rule definition",
@@ -407,23 +408,24 @@ void RESTServer::setup_routes() {
     route_registry_
         ->raw("delete", "/apps/{app_id}/fault-triggers/{trigger_id}",
               [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
-                  auto * engine = node_->get_fault_trigger_engine();
-                  if (!engine) {
-                    ft_json_error(res, 404, "fault-trigger engine is not enabled");
-                    return;
-                  }
-                  const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
-                  const std::string id = req.matches.size() > 2 ? req.matches[2].str() : std::string{};
-                  if (!engine->remove(app_id, id)) {
-                    ft_json_error(res, 404, "no such fault-trigger '" + id + "'");
-                    return;
-                  }
-                  res.status = 204;
-                })
+                auto * engine = node_->get_fault_trigger_engine();
+                if (!engine) {
+                  ft_json_error(res, 404, "fault-trigger engine is not enabled");
+                  return;
+                }
+                const std::string app_id = req.matches.size() > 1 ? req.matches[1].str() : std::string{};
+                const std::string id = req.matches.size() > 2 ? req.matches[2].str() : std::string{};
+                if (!engine->remove(app_id, id)) {
+                  ft_json_error(res, 404, "no such fault-trigger '" + id + "'");
+                  return;
+                }
+                res.status = 204;
+              })
         .tag("FaultTriggers")
         .summary("Delete a fault-trigger rule")
-        .description("Removes the rule; a currently-asserted fault from it is cleared "
-                     "(correlation cascade skipped).")
+        .description(
+            "Removes the rule; a currently-asserted fault from it is cleared "
+            "(correlation cascade skipped).")
         .operation_id("deleteFaultTrigger")
         .path_param("app_id", "App (entity) the rule is scoped to")
         .path_param("trigger_id", "Rule id as returned on create")

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -323,10 +323,12 @@ void RESTServer::setup_routes() {
 #endif
 
   // === Config-less fault-trigger (threshold-rule) routes (issue #235) ===
-  // Registered directly on the server (like the docs routes) so the CRUD does
-  // not need a typed DTO. Mounted at .../fault-triggers - a sibling of the SOVD
-  // notification `/triggers` collection, never overloading it. GET is public;
-  // POST/DELETE follow the gateway's write-auth policy.
+  // Registered through RouteRegistry's raw() escape hatch (no typed DTO), so
+  // the CRUD is part of the generated OpenAPI spec / Swagger UI / endpoint
+  // list instead of being invisible to /api/v1/docs. Mounted at
+  // .../fault-triggers - a sibling of the SOVD notification `/triggers`
+  // collection, never overloading it. GET is public; POST/DELETE follow the
+  // gateway's write-auth policy (global pre-routing middleware).
   {
     auto ft_json_error = [](httplib::Response & res, int status, const std::string & message,
                             const char * error_code = nullptr) {
@@ -337,8 +339,9 @@ void RESTServer::setup_routes() {
       res.set_content(err.dump(2), "application/json");
     };
 
-    srv->Get(api_path(R"(/apps/([^/]+)/fault-triggers)"),
-             [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
+    route_registry_
+        ->raw("get", "/apps/{app_id}/fault-triggers",
+              [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
                auto * engine = node_->get_fault_trigger_engine();
                if (!engine) {
                  ft_json_error(res, 404, "fault-trigger engine is not enabled");
@@ -351,9 +354,20 @@ void RESTServer::setup_routes() {
                }
                res.status = 200;
                res.set_content(nlohmann::json{{"items", items}}.dump(2), "application/json");
-             });
+             })
+        .tag("FaultTriggers")
+        .summary("List fault-trigger rules")
+        .description("Threshold rules on the app's discovered data points; each fires a fault on cross "
+                     "and auto-clears on recovery.")
+        .operation_id("listFaultTriggers")
+        .path_param("app_id", "App (entity) the rules are scoped to")
+        .response(200, "Rule list",
+                  nlohmann::json{{"type", "object"},
+                                 {"properties",
+                                  {{"items", {{"type", "array"}, {"items", {{"type", "object"}}}}}}}});
 
-    srv->Post(api_path(R"(/apps/([^/]+)/fault-triggers)"),
+    route_registry_
+        ->raw("post", "/apps/{app_id}/fault-triggers",
               [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
                 auto * engine = node_->get_fault_trigger_engine();
                 if (!engine) {
@@ -376,10 +390,23 @@ void RESTServer::setup_routes() {
                 }
                 res.status = 201;
                 res.set_content(FaultTriggerEngine::rule_to_json(*created).dump(2), "application/json");
-              });
+              })
+        .tag("FaultTriggers")
+        .summary("Create a fault-trigger rule")
+        .description("Body: data_name, operator (>, <, >=, <=, ==), threshold, fault_code, severity "
+                     "(INFO|WARNING|ERROR|CRITICAL), optional active. fault_code must be unique across "
+                     "all rules (409 on duplicates).")
+        .operation_id("createFaultTrigger")
+        .path_param("app_id", "App (entity) to scope the rule to")
+        .request_body("Fault-trigger rule definition",
+                      nlohmann::json{{"type", "object"}, {"additionalProperties", true}})
+        .response(201, "Created rule", nlohmann::json{{"type", "object"}})
+        .response(400, "Validation error")
+        .response(409, "fault_code already used by another rule");
 
-    srv->Delete(api_path(R"(/apps/([^/]+)/fault-triggers/([^/]+))"),
-                [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
+    route_registry_
+        ->raw("delete", "/apps/{app_id}/fault-triggers/{trigger_id}",
+              [this, ft_json_error](const httplib::Request & req, httplib::Response & res) {
                   auto * engine = node_->get_fault_trigger_engine();
                   if (!engine) {
                     ft_json_error(res, 404, "fault-trigger engine is not enabled");
@@ -392,7 +419,16 @@ void RESTServer::setup_routes() {
                     return;
                   }
                   res.status = 204;
-                });
+                })
+        .tag("FaultTriggers")
+        .summary("Delete a fault-trigger rule")
+        .description("Removes the rule; a currently-asserted fault from it is cleared "
+                     "(correlation cascade skipped).")
+        .operation_id("deleteFaultTrigger")
+        .path_param("app_id", "App (entity) the rule is scoped to")
+        .path_param("trigger_id", "Rule id as returned on create")
+        .response(204, "Deleted")
+        .response(404, "No such rule");
   }
 
   auto & reg = *route_registry_;

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -402,8 +402,10 @@ void RESTServer::setup_routes() {
         .request_body("Fault-trigger rule definition",
                       nlohmann::json{{"type", "object"}, {"additionalProperties", true}})
         .response(201, "Created rule", nlohmann::json{{"type", "object"}})
-        .response(400, "Validation error")
-        .response(409, "fault_code already used by another rule");
+        // 400/404 come from the registry's automatic response-level
+        // GenericError $ref; only 409 needs a manual declaration.
+        .response(409, "fault_code already used by another rule",
+                  nlohmann::json{{"$ref", "#/components/schemas/GenericError"}});
 
     route_registry_
         ->raw("delete", "/apps/{app_id}/fault-triggers/{trigger_id}",
@@ -429,8 +431,7 @@ void RESTServer::setup_routes() {
         .operation_id("deleteFaultTrigger")
         .path_param("app_id", "App (entity) the rule is scoped to")
         .path_param("trigger_id", "Rule id as returned on create")
-        .response(204, "Deleted")
-        .response(404, "No such rule");
+        .response(204, "Deleted");
   }
 
   auto & reg = *route_registry_;

--- a/src/ros2_medkit_gateway/src/main.cpp
+++ b/src/ros2_medkit_gateway/src/main.cpp
@@ -146,6 +146,9 @@ int main(int argc, char ** argv) {
     // destroyed subscriber. shutdown_trigger_subscriber() below drops those
     // subscriptions while sub_exec is still alive.
     node->set_trigger_subscription_executor(*sub_exec);
+    // Config-less threshold-rule (fault-trigger) engine (issue #235). Started
+    // here so its evaluation loop sees loaded plugins; joined in ~GatewayNode.
+    node->init_fault_trigger_engine();
 
     // Spin in a try/catch so an uncaught handler exception falls through to the
     // explicit teardown block below. Without this, an escaping throw bypasses

--- a/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
@@ -118,6 +118,7 @@ nlohmann::json CapabilityGenerator::generate_root() const {
           {"Bulk Data", "Large file downloads (rosbags, snapshots)"},
           {"Subscriptions", "Cyclic data subscriptions and event streaming"},
           {"Triggers", "Event-driven condition monitoring and notifications"},
+          {"FaultTriggers", "Threshold rules on discovered data points that raise and auto-clear faults"},
           {"Locking", "Entity lock management for exclusive access"},
           {"Scripts", "Diagnostic script upload, execution, and management"},
           {"Updates", "Software update management"},

--- a/src/ros2_medkit_gateway/src/openapi/route_registry.hpp
+++ b/src/ros2_medkit_gateway/src/openapi/route_registry.hpp
@@ -364,6 +364,15 @@ class RouteRegistry {
     auth_enabled_ = enabled;
   }
 
+  /// Escape hatch for JSON routes without typed DTOs (e.g. the fault-trigger
+  /// CRUD): registers a raw cpp-httplib handler under an OpenAPI-style path so
+  /// the route shows up in the generated spec, Swagger UI and the endpoint
+  /// list. The caller documents request/response schemas manually via the
+  /// fluent builder. Prefer the typed get<T>/post<T> API for new routes.
+  RouteEntry & raw(const std::string & method, const std::string & openapi_path, HandlerFn handler) {
+    return add_route(method, openapi_path, std::move(handler));
+  }
+
  private:
   /// Convert OpenAPI path to cpp-httplib regex path.
   /// e.g., "/apps/{app_id}/data/{data_id}" -> "/apps/([^/]+)/data/(.+)"

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -576,7 +576,7 @@ OperationProvider * PluginManager::get_operation_provider_for_entity(const std::
       // Same reasoning as get_data_provider_for_entity: ownership does not
       // imply this entity has operations (see OperationProvider::has_operations).
       return lp.operation_provider && lp.operation_provider->has_operations(entity_id) ? lp.operation_provider
-                                                                                        : nullptr;
+                                                                                       : nullptr;
     }
   }
   return nullptr;

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -557,7 +557,9 @@ DataProvider * PluginManager::get_data_provider_for_entity(const std::string & e
   }
   for (const auto & lp : plugins_) {
     if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
-      return lp.data_provider;
+      // Ownership is plugin-wide, but data is not: ask the provider whether
+      // this specific entity is data-bearing (see DataProvider::has_data).
+      return lp.data_provider && lp.data_provider->has_data(entity_id) ? lp.data_provider : nullptr;
     }
   }
   return nullptr;
@@ -571,7 +573,10 @@ OperationProvider * PluginManager::get_operation_provider_for_entity(const std::
   }
   for (const auto & lp : plugins_) {
     if (lp.load_result.plugin && lp.load_result.plugin->name() == own_it->second) {
-      return lp.operation_provider;
+      // Same reasoning as get_data_provider_for_entity: ownership does not
+      // imply this entity has operations (see OperationProvider::has_operations).
+      return lp.operation_provider && lp.operation_provider->has_operations(entity_id) ? lp.operation_provider
+                                                                                        : nullptr;
     }
   }
   return nullptr;

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
+#include <unistd.h>
 
 #include <cstdio>
 #include <map>
@@ -189,7 +190,14 @@ TEST(FaultTriggerEngineTest, UnreadableValueHoldsState) {
 }
 
 TEST(FaultTriggerEngineTest, PersistsAcrossReload) {
-  const std::string path = std::string(std::tmpnam(nullptr)) + "_ftr.json";
+  // mkstemp, not std::tmpnam: tmpnam is TOCTOU-racy and collides under
+  // parallel test runs. The fd is closed immediately - only the unique path
+  // matters; the engine reopens it by name.
+  char tmpl[] = "/tmp/ftr_store_XXXXXX";
+  const int fd = mkstemp(tmpl);
+  ASSERT_NE(fd, -1);
+  close(fd);
+  const std::string path = std::string(tmpl) + "_ftr.json";
   {
     FaultTriggerEngine engine(path, nullptr, nullptr, nullptr, nullptr);
     ASSERT_TRUE(engine.create("tank", make_body("level", ">=", 80.0, "TANK_OVERFILL", "CRITICAL")));

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -85,6 +85,37 @@ TEST(FaultTriggerEngineTest, CreateRejectsInvalidBodies) {
   EXPECT_TRUE(ok->active);
 }
 
+TEST(FaultTriggerEngineTest, CreateRejectsNonexistentDataPoint) {
+  // A rule on a data point the app does not expose can never fire (a silently
+  // dead alarm); with the app's points enumerable, create() must 400 it.
+  auto names = [](const std::string & app_id) -> std::optional<std::vector<std::string>> {
+    if (app_id == "tank") {
+      return std::vector<std::string>{"level", "trigger", "trigger2"};
+    }
+    return std::nullopt;  // unknown app: points not enumerable
+  };
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr, names);
+
+  auto bogus = engine.create("tank", make_body("/plc/bogus_point", ">", 10.0, "F", "ERROR"));
+  ASSERT_FALSE(bogus);
+  EXPECT_EQ(bogus.error().first, 400);
+  EXPECT_NE(bogus.error().second.find("'/plc/bogus_point' does not exist"), std::string::npos);
+  EXPECT_NE(bogus.error().second.find("level"), std::string::npos) << "message should list the available points";
+  EXPECT_TRUE(engine.list("tank").empty());
+
+  // Existing point passes.
+  EXPECT_TRUE(engine.create("tank", make_body("level", ">", 50.0, "F", "ERROR")));
+
+  // Points not enumerable right now (nullopt): creation must not be blocked.
+  EXPECT_TRUE(engine.create("other_app", make_body("anything", ">", 1.0, "F2", "ERROR")));
+}
+
+TEST(FaultTriggerEngineTest, CreateWithoutEnumeratorSkipsExistenceCheck) {
+  // No DataPointNamesFn injected (legacy wiring): behavior unchanged.
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr);
+  EXPECT_TRUE(engine.create("tank", make_body("whatever", ">", 1.0, "F", "ERROR")));
+}
+
 TEST(FaultTriggerEngineTest, ListIsScopedPerApp) {
   FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr);
   ASSERT_TRUE(engine.create("app_a", make_body("x", ">", 1.0, "FA", "ERROR")));

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
 #include <unistd.h>
+#include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
 
 #include <cstdio>
 #include <map>

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -1,0 +1,184 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/fault_trigger_engine.hpp"
+
+#include <cstdio>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using ros2_medkit_gateway::FaultTriggerEngine;
+using ros2_medkit_gateway::FaultTriggerRule;
+
+namespace {
+
+// Records the report/clear calls the engine emits so edge detection is
+// observable without a ROS graph.
+struct Recorder {
+  std::vector<std::string> reports;  // "app_id/fault_code"
+  std::vector<std::string> clears;
+};
+
+nlohmann::json make_body(const std::string & data_name, const std::string & op, double threshold,
+                         const std::string & fault_code, const std::string & severity) {
+  return nlohmann::json{{"data_name", data_name},
+                        {"operator", op},
+                        {"threshold", threshold},
+                        {"fault_code", fault_code},
+                        {"severity", severity}};
+}
+
+}  // namespace
+
+TEST(FaultTriggerEngineTest, OperatorAndSeverityValidation) {
+  for (const char * op : {">", "<", ">=", "<=", "=="}) {
+    EXPECT_TRUE(FaultTriggerEngine::valid_operator(op));
+  }
+  EXPECT_FALSE(FaultTriggerEngine::valid_operator("!="));
+  EXPECT_FALSE(FaultTriggerEngine::valid_operator("=>"));
+
+  for (const char * s : {"INFO", "WARNING", "ERROR", "CRITICAL"}) {
+    EXPECT_TRUE(FaultTriggerEngine::valid_severity(s));
+  }
+  EXPECT_FALSE(FaultTriggerEngine::valid_severity("WARN"));
+  EXPECT_FALSE(FaultTriggerEngine::valid_severity("fatal"));
+}
+
+TEST(FaultTriggerEngineTest, Compare) {
+  EXPECT_TRUE(FaultTriggerEngine::compare(5.0, ">", 4.0));
+  EXPECT_FALSE(FaultTriggerEngine::compare(4.0, ">", 4.0));
+  EXPECT_TRUE(FaultTriggerEngine::compare(4.0, ">=", 4.0));
+  EXPECT_TRUE(FaultTriggerEngine::compare(3.0, "<", 4.0));
+  EXPECT_TRUE(FaultTriggerEngine::compare(4.0, "<=", 4.0));
+  EXPECT_TRUE(FaultTriggerEngine::compare(4.0, "==", 4.0));
+  EXPECT_FALSE(FaultTriggerEngine::compare(4.1, "==", 4.0));
+}
+
+TEST(FaultTriggerEngineTest, CreateRejectsInvalidBodies) {
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr);
+
+  EXPECT_FALSE(engine.create("app", make_body("", ">", 1.0, "F", "ERROR")));    // empty data_name
+  EXPECT_FALSE(engine.create("app", make_body("d", "!=", 1.0, "F", "ERROR")));  // bad operator
+  EXPECT_FALSE(engine.create("app", make_body("d", ">", 1.0, "", "ERROR")));    // empty fault_code
+  EXPECT_FALSE(engine.create("app", make_body("d", ">", 1.0, "F", "WARN")));    // bad severity
+  auto no_threshold = nlohmann::json{{"data_name", "d"}, {"operator", ">"}, {"fault_code", "F"}, {"severity", "ERROR"}};
+  EXPECT_FALSE(engine.create("app", no_threshold));  // missing threshold
+
+  auto ok = engine.create("app", make_body("d", ">", 1.0, "F", "ERROR"));
+  ASSERT_TRUE(ok);
+  EXPECT_FALSE(ok->id.empty());
+  EXPECT_EQ(ok->app_id, "app");
+  EXPECT_TRUE(ok->active);
+}
+
+TEST(FaultTriggerEngineTest, ListIsScopedPerApp) {
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr);
+  ASSERT_TRUE(engine.create("app_a", make_body("x", ">", 1.0, "FA", "ERROR")));
+  ASSERT_TRUE(engine.create("app_b", make_body("y", "<", 2.0, "FB", "WARNING")));
+
+  EXPECT_EQ(engine.list("app_a").size(), 1u);
+  EXPECT_EQ(engine.list("app_b").size(), 1u);
+  EXPECT_TRUE(engine.list("app_c").empty());
+}
+
+TEST(FaultTriggerEngineTest, EvaluateFiresOnCrossAndClearsOnRecover) {
+  Recorder rec;
+  double live = 10.0;  // starts below threshold
+  auto fetcher = [&live](const std::string &, const std::string &) -> std::optional<double> {
+    return live;
+  };
+  auto report = [&rec](const std::string & app, const std::string & code, const std::string &, const std::string &) {
+    rec.reports.push_back(app + "/" + code);
+  };
+  auto clear = [&rec](const std::string & app, const std::string & code) {
+    rec.clears.push_back(app + "/" + code);
+  };
+
+  FaultTriggerEngine engine("", fetcher, report, clear, nullptr);
+  ASSERT_TRUE(engine.create("tank", make_body("level", ">", 80.0, "TANK_OVERFILL", "ERROR")));
+
+  // Below threshold: no fault.
+  engine.evaluate_once();
+  EXPECT_TRUE(rec.reports.empty());
+  EXPECT_TRUE(rec.clears.empty());
+
+  // Cross the threshold: fault reported (each poll while crossed = level-triggered).
+  live = 95.0;
+  engine.evaluate_once();
+  engine.evaluate_once();
+  EXPECT_EQ(rec.reports.size(), 2u);
+  EXPECT_EQ(rec.reports.front(), "tank/TANK_OVERFILL");
+  EXPECT_TRUE(rec.clears.empty());
+
+  // Recover: auto-clear exactly once on the falling edge.
+  live = 50.0;
+  engine.evaluate_once();
+  engine.evaluate_once();
+  EXPECT_EQ(rec.clears.size(), 1u);
+  EXPECT_EQ(rec.clears.front(), "tank/TANK_OVERFILL");
+}
+
+TEST(FaultTriggerEngineTest, UnreadableValueHoldsState) {
+  Recorder rec;
+  std::optional<double> live = 95.0;
+  auto fetcher = [&live](const std::string &, const std::string &) -> std::optional<double> {
+    return live;
+  };
+  auto report = [&rec](const std::string & app, const std::string & code, const std::string &, const std::string &) {
+    rec.reports.push_back(app + "/" + code);
+  };
+  auto clear = [&rec](const std::string & app, const std::string & code) {
+    rec.clears.push_back(app + "/" + code);
+  };
+
+  FaultTriggerEngine engine("", fetcher, report, clear, nullptr);
+  ASSERT_TRUE(engine.create("tank", make_body("level", ">", 80.0, "TANK_OVERFILL", "ERROR")));
+
+  engine.evaluate_once();  // crossed -> report
+  ASSERT_EQ(rec.reports.size(), 1u);
+
+  // PLC unreadable: must NOT auto-clear a live fault.
+  live = std::nullopt;
+  engine.evaluate_once();
+  EXPECT_TRUE(rec.clears.empty());
+}
+
+TEST(FaultTriggerEngineTest, PersistsAcrossReload) {
+  const std::string path = std::string(std::tmpnam(nullptr)) + "_ftr.json";
+  {
+    FaultTriggerEngine engine(path, nullptr, nullptr, nullptr, nullptr);
+    ASSERT_TRUE(engine.create("tank", make_body("level", ">=", 80.0, "TANK_OVERFILL", "CRITICAL")));
+  }
+  {
+    FaultTriggerEngine reloaded(path, nullptr, nullptr, nullptr, nullptr);
+    auto rules = reloaded.list("tank");
+    ASSERT_EQ(rules.size(), 1u);
+    EXPECT_EQ(rules[0].data_name, "level");
+    EXPECT_EQ(rules[0].op, ">=");
+    EXPECT_DOUBLE_EQ(rules[0].threshold, 80.0);
+    EXPECT_EQ(rules[0].fault_code, "TANK_OVERFILL");
+    EXPECT_EQ(rules[0].severity, "CRITICAL");
+
+    // Deleting removes it from the store too.
+    EXPECT_TRUE(reloaded.remove("tank", rules[0].id));
+  }
+  {
+    FaultTriggerEngine after_delete(path, nullptr, nullptr, nullptr, nullptr);
+    EXPECT_TRUE(after_delete.list("tank").empty());
+  }
+  std::remove(path.c_str());
+}

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -221,3 +221,102 @@ TEST(FaultTriggerEngineTest, PersistsAcrossReload) {
   }
   std::remove(path.c_str());
 }
+
+TEST(FaultTriggerEngineTest, RejectsRuleOnUnknownApp) {
+  // A rule on an app the entity registry does not know must 404, not silently
+  // reserve a global fault_code (which would then block the real app's rule).
+  auto exists = [](const std::string & app_id) -> bool {
+    return app_id == "tank";
+  };
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr, nullptr, exists);
+
+  auto bogus = engine.create("ghost", make_body("level", ">", 10.0, "F", "ERROR"));
+  ASSERT_FALSE(bogus);
+  EXPECT_EQ(bogus.error().first, 404);
+  EXPECT_NE(bogus.error().second.find("ghost"), std::string::npos);
+  EXPECT_TRUE(engine.list("ghost").empty());
+
+  // A known app still creates normally.
+  EXPECT_TRUE(engine.create("tank", make_body("level", ">", 10.0, "F2", "ERROR")));
+}
+
+TEST(FaultTriggerEngineTest, DeleteRacingEvaluateDoesNotResurrectFault) {
+  // Reproduce the TOCTOU: a DELETE lands between evaluate_once()'s rule snapshot
+  // and its report_. The fetcher runs in evaluate's lock-free fetch phase, so
+  // removing the rule from inside it simulates exactly that interleaving. The
+  // rule (and any fault) is gone, so evaluate must NOT re-report it.
+  Recorder rec;
+  FaultTriggerEngine * engine_ptr = nullptr;
+  std::string rule_id;
+  bool removed_mid_eval = false;
+  auto fetcher = [&](const std::string & app, const std::string &) -> std::optional<double> {
+    if (!removed_mid_eval && engine_ptr != nullptr) {
+      removed_mid_eval = true;
+      engine_ptr->remove(app, rule_id);
+    }
+    return 95.0;  // above threshold
+  };
+  auto report = [&rec](const std::string & app, const std::string & code, const std::string &, const std::string &) {
+    rec.reports.push_back(app + "/" + code);
+  };
+  auto clear = [&rec](const std::string & app, const std::string & code) {
+    rec.clears.push_back(app + "/" + code);
+  };
+
+  FaultTriggerEngine engine("", fetcher, report, clear, nullptr);
+  engine_ptr = &engine;
+  auto rule = engine.create("tank", make_body("level", ">", 80.0, "TANK_OVERFILL", "ERROR"));
+  ASSERT_TRUE(rule);
+  rule_id = rule->id;
+
+  engine.evaluate_once();
+  EXPECT_TRUE(rec.reports.empty()) << "evaluate re-asserted a fault for a rule deleted mid-evaluation";
+  EXPECT_TRUE(engine.list("tank").empty());
+}
+
+TEST(FaultTriggerEngineTest, CrossedLatchSurvivesReloadAndClearsOnFallingEdge) {
+  // A fault asserted before a restart must still auto-clear afterwards: the
+  // crossed latch is persisted, so the reloaded rule remembers it was crossed
+  // and clears on the falling edge instead of leaving a stuck fault forever.
+  char tmpl[] = "/tmp/ftr_latch_XXXXXX";
+  const int fd = mkstemp(tmpl);
+  ASSERT_NE(fd, -1);
+  close(fd);
+  const std::string path = std::string(tmpl) + "_ftr.json";
+
+  std::optional<double> live = 95.0;  // above threshold
+  auto fetcher = [&live](const std::string &, const std::string &) -> std::optional<double> {
+    return live;
+  };
+
+  {
+    Recorder rec;
+    auto report = [&rec](const std::string & app, const std::string & code, const std::string &, const std::string &) {
+      rec.reports.push_back(app + "/" + code);
+    };
+    auto clear = [&rec](const std::string & app, const std::string & code) {
+      rec.clears.push_back(app + "/" + code);
+    };
+    FaultTriggerEngine engine(path, fetcher, report, clear, nullptr);
+    ASSERT_TRUE(engine.create("tank", make_body("level", ">", 80.0, "TANK_OVERFILL", "ERROR")));
+    engine.evaluate_once();  // cross -> fault asserted AND latch persisted
+    ASSERT_EQ(rec.reports.size(), 1u);
+  }
+
+  {
+    Recorder rec;
+    auto report = [&rec](const std::string & app, const std::string & code, const std::string &, const std::string &) {
+      rec.reports.push_back(app + "/" + code);
+    };
+    auto clear = [&rec](const std::string & app, const std::string & code) {
+      rec.clears.push_back(app + "/" + code);
+    };
+    live = 50.0;  // recovered before the reloaded engine's first poll
+    FaultTriggerEngine reloaded(path, fetcher, report, clear, nullptr);
+    ASSERT_EQ(reloaded.list("tank").size(), 1u);
+    reloaded.evaluate_once();  // falling edge -> must clear the persisted fault
+    EXPECT_EQ(rec.clears.size(), 1u) << "reloaded latch was lost; stuck fault never cleared";
+    EXPECT_EQ(rec.clears.front(), "tank/TANK_OVERFILL");
+  }
+  std::remove(path.c_str());
+}

--- a/src/ros2_medkit_gateway/test/test_handler_context.cpp
+++ b/src/ros2_medkit_gateway/test/test_handler_context.cpp
@@ -1517,7 +1517,12 @@ TEST(ResolveEntitySourceFqnsTest, AreaCollectsAppsFromAllComponentsInArea) {
   });
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "engine"));
-  std::set<std::string> expected{"/powertrain/engine/temp_sensor", "/powertrain/engine/rpm_sensor"};
+  // Components in the area are themselves valid reporting sources (bridge
+  // plugins report under the component id), so the area rollup carries the
+  // component ids alongside the hosted apps' FQNs. The off-area lidar
+  // component and its app must not appear.
+  std::set<std::string> expected{"temp-hw", "rpm-hw", "/powertrain/engine/temp_sensor",
+                                 "/powertrain/engine/rpm_sensor"};
   EXPECT_EQ(fqns, expected);
 }
 
@@ -1591,7 +1596,10 @@ TEST(ResolveEntitySourceFqnsTest, AreaWalksNestedSubareasRecursively) {
   });
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "powertrain"));
-  EXPECT_EQ(fqns, std::set<std::string>{"/powertrain/engine/temp_sensor"});
+  // The subarea's component id rides along (components are reporting sources
+  // in their own right); the off-area lidar branch must not.
+  std::set<std::string> expected{"engine-ecu", "/powertrain/engine/temp_sensor"};
+  EXPECT_EQ(fqns, expected);
 }
 
 TEST(ResolveEntitySourceFqnsTest, FunctionHostingComponentExpandsToComponentApps) {
@@ -1617,7 +1625,9 @@ TEST(ResolveEntitySourceFqnsTest, FunctionHostingComponentExpandsToComponentApps
   cache.update_functions({autonomy});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::FUNCTION, "autonomy"));
-  std::set<std::string> expected{"/drive/planner_node", "/drive/localizer_node", "/misc/standalone_node"};
+  // The component host contributes its own id too (components are reporting
+  // sources in their own right).
+  std::set<std::string> expected{"drive-ecu", "/drive/planner_node", "/drive/localizer_node", "/misc/standalone_node"};
   EXPECT_EQ(fqns, expected);
 }
 
@@ -1732,7 +1742,10 @@ TEST(ResolveEntitySourceFqnsTest, AreaHostingExternalAppOwnsItsFaults) {
   cache.update_apps({make_external_app("process", "s7_1500")});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "cell_a"));
-  EXPECT_EQ(fqns, std::set<std::string>{"process"});
+  // The external app's bare id plus the hosting component's own id (components
+  // are reporting sources too).
+  std::set<std::string> expected{"s7_1500", "process"};
+  EXPECT_EQ(fqns, expected);
 }
 
 TEST(ResolveEntitySourceFqnsTest, ExternalAppWithStrayRosBindingOwnsFaultsByBareId) {
@@ -1772,9 +1785,12 @@ TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithNoAppsOwnsFaultsUnderItsO
   EXPECT_EQ(fqns, std::set<std::string>{"s7_1500"});
 }
 
-TEST(ResolveEntitySourceFqnsTest, NonExternalComponentWithNoAppsStaysEmpty) {
-  // Security guardrail: a non-external Component with no apps must NOT claim its
-  // bare id - an unbound ROS component must not own faults it never reported.
+TEST(ResolveEntitySourceFqnsTest, ComponentAlwaysOwnsFaultsReportedUnderItsOwnId) {
+  // A Component is a reporting source in its own right, external or not:
+  // bridge plugins raise PLC_COMMS_LOST-class faults with source_id = the
+  // component id, and those must surface on GET /components/<id>/faults even
+  // though the component hosts no apps. Matching stays exact-id, so a ROS
+  // component whose nodes report under /-prefixed FQNs gains nothing.
   ThreadSafeEntityCache cache;
   Component comp;
   comp.id = "nav_comp";
@@ -1782,12 +1798,13 @@ TEST(ResolveEntitySourceFqnsTest, NonExternalComponentWithNoAppsStaysEmpty) {
   cache.update_components({comp});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "nav_comp"));
-  EXPECT_TRUE(fqns.empty());
+  EXPECT_EQ(fqns, std::set<std::string>{"nav_comp"});
 }
 
-TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithContributingAppKeepsAppScope) {
-  // An external Component that DOES host a ROS-bound app resolves to the app's
-  // FQN; the component id is NOT added (fallback dormant when apps contribute).
+TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithContributingAppKeepsBothScopes) {
+  // A Component that hosts a ROS-bound app owns the app's FQN AND its own id:
+  // faults reported by the component itself must not vanish just because a
+  // child app also contributes sources.
   ThreadSafeEntityCache cache;
   Component plc;
   plc.id = "s7_1500";
@@ -1796,7 +1813,8 @@ TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithContributingAppKeepsAppSc
   cache.update_apps({make_owned_app("planner", "s7_1500", "planner", "/perception/nav")});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "s7_1500"));
-  EXPECT_EQ(fqns, std::set<std::string>{"/perception/nav/planner"});
+  std::set<std::string> expected{"s7_1500", "/perception/nav/planner"};
+  EXPECT_EQ(fqns, expected);
 }
 
 TEST(ResolveEntitySourceFqnsTest, FunctionHostingExternalComponentOwnsItsFaults) {

--- a/src/ros2_medkit_gateway/test/test_handler_context.cpp
+++ b/src/ros2_medkit_gateway/test/test_handler_context.cpp
@@ -1517,12 +1517,10 @@ TEST(ResolveEntitySourceFqnsTest, AreaCollectsAppsFromAllComponentsInArea) {
   });
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "engine"));
-  // Components in the area are themselves valid reporting sources (bridge
-  // plugins report under the component id), so the area rollup carries the
-  // component ids alongside the hosted apps' FQNs. The off-area lidar
-  // component and its app must not appear.
-  std::set<std::string> expected{"temp-hw", "rpm-hw", "/powertrain/engine/temp_sensor",
-                                 "/powertrain/engine/rpm_sensor"};
+  // Non-external components never claim their bare ids (#516 guardrail), so
+  // the area rollup carries only the hosted apps' FQNs. The off-area lidar
+  // branch must not appear.
+  std::set<std::string> expected{"/powertrain/engine/temp_sensor", "/powertrain/engine/rpm_sensor"};
   EXPECT_EQ(fqns, expected);
 }
 
@@ -1596,10 +1594,9 @@ TEST(ResolveEntitySourceFqnsTest, AreaWalksNestedSubareasRecursively) {
   });
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "powertrain"));
-  // The subarea's component id rides along (components are reporting sources
-  // in their own right); the off-area lidar branch must not.
-  std::set<std::string> expected{"engine-ecu", "/powertrain/engine/temp_sensor"};
-  EXPECT_EQ(fqns, expected);
+  // The subarea's non-external component does not ride along (#516 guardrail);
+  // neither does the off-area lidar branch.
+  EXPECT_EQ(fqns, std::set<std::string>{"/powertrain/engine/temp_sensor"});
 }
 
 TEST(ResolveEntitySourceFqnsTest, FunctionHostingComponentExpandsToComponentApps) {
@@ -1625,9 +1622,9 @@ TEST(ResolveEntitySourceFqnsTest, FunctionHostingComponentExpandsToComponentApps
   cache.update_functions({autonomy});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::FUNCTION, "autonomy"));
-  // The component host contributes its own id too (components are reporting
-  // sources in their own right).
-  std::set<std::string> expected{"drive-ecu", "/drive/planner_node", "/drive/localizer_node", "/misc/standalone_node"};
+  // The non-external component host contributes only its apps' FQNs, not its
+  // own id (#516 guardrail).
+  std::set<std::string> expected{"/drive/planner_node", "/drive/localizer_node", "/misc/standalone_node"};
   EXPECT_EQ(fqns, expected);
 }
 
@@ -1738,12 +1735,12 @@ TEST(ResolveEntitySourceFqnsTest, AreaHostingExternalAppOwnsItsFaults) {
   Component plc;
   plc.id = "s7_1500";
   plc.area = "cell_a";
+  plc.external = true;  // plugin-discovered PLC component
   cache.update_components({plc});
   cache.update_apps({make_external_app("process", "s7_1500")});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::AREA, "cell_a"));
-  // The external app's bare id plus the hosting component's own id (components
-  // are reporting sources too).
+  // The external app's bare id plus the hosting external component's own id.
   std::set<std::string> expected{"s7_1500", "process"};
   EXPECT_EQ(fqns, expected);
 }
@@ -1785,12 +1782,11 @@ TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithNoAppsOwnsFaultsUnderItsO
   EXPECT_EQ(fqns, std::set<std::string>{"s7_1500"});
 }
 
-TEST(ResolveEntitySourceFqnsTest, ComponentAlwaysOwnsFaultsReportedUnderItsOwnId) {
-  // A Component is a reporting source in its own right, external or not:
-  // bridge plugins raise PLC_COMMS_LOST-class faults with source_id = the
-  // component id, and those must surface on GET /components/<id>/faults even
-  // though the component hosts no apps. Matching stays exact-id, so a ROS
-  // component whose nodes report under /-prefixed FQNs gains nothing.
+TEST(ResolveEntitySourceFqnsTest, InternalComponentNeverOwnsBareIdFaults) {
+  // #516 guardrail: a non-external Component must not claim faults reported
+  // under its bare id - an unbound ROS component would otherwise own faults
+  // it never reported. Only external components (bridge plugins raising
+  // PLC_COMMS_LOST-class faults with source_id = component id) get that.
   ThreadSafeEntityCache cache;
   Component comp;
   comp.id = "nav_comp";
@@ -1798,7 +1794,7 @@ TEST(ResolveEntitySourceFqnsTest, ComponentAlwaysOwnsFaultsReportedUnderItsOwnId
   cache.update_components({comp});
 
   auto fqns = HandlerContext::resolve_entity_source_fqns(cache, make_entity_info(EntityType::COMPONENT, "nav_comp"));
-  EXPECT_EQ(fqns, std::set<std::string>{"nav_comp"});
+  EXPECT_TRUE(fqns.empty());
 }
 
 TEST(ResolveEntitySourceFqnsTest, ExternalComponentWithContributingAppKeepsBothScopes) {

--- a/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_entity_routing.cpp
@@ -84,6 +84,51 @@ class MockBarePlugin : public GatewayPlugin {
   }
 };
 
+// --- Mock plugin that owns a mix of servable and unservable entities ---
+//
+// Mirrors the real OPC-UA plugin shape: one DataProvider/OperationProvider
+// implementation shared across every entity the plugin owns, but only
+// "data_entity" actually has data/operations - "group_entity" (like the
+// auto-browsed Component) has neither. Exercises the has_data/has_operations
+// gate PluginManager applies on top of plain ownership.
+class MockMixedFitnessPlugin : public GatewayPlugin, public DataProvider, public OperationProvider {
+ public:
+  std::string name() const override {
+    return "mixed_plugin";
+  }
+  void configure(const json & /*config*/) override {
+  }
+  void shutdown() override {
+  }
+
+  tl::expected<dto::DataListResult, DataProviderErrorInfo> list_data(const std::string & entity_id) override {
+    return dto::DataListResult{json{{"items", json::array({{{"entity", entity_id}}})}}};
+  }
+  tl::expected<dto::DataValue, DataProviderErrorInfo> read_data(const std::string & /*entity_id*/,
+                                                                const std::string & resource) override {
+    return dto::DataValue{json{{"value", resource}}};
+  }
+  tl::expected<dto::DataWriteResult, DataProviderErrorInfo>
+  write_data(const std::string & /*entity_id*/, const std::string & /*resource*/, const json & /*payload*/) override {
+    return dto::DataWriteResult{json{{"status", "ok"}}};
+  }
+  bool has_data(const std::string & entity_id) const override {
+    return entity_id == "data_entity";
+  }
+
+  tl::expected<dto::Collection<dto::OperationItem>, OperationProviderErrorInfo>
+  list_operations(const std::string & /*entity_id*/) override {
+    return dto::Collection<dto::OperationItem>{};
+  }
+  tl::expected<dto::OperationExecutionResult, OperationProviderErrorInfo>
+  execute_operation(const std::string & /*entity_id*/, const std::string & op, const json & /*params*/) override {
+    return dto::OperationExecutionResult{json{{"executed", op}}};
+  }
+  bool has_operations(const std::string & entity_id) const override {
+    return entity_id == "data_entity";
+  }
+};
+
 // =============================================================================
 // Entity Ownership Tests
 // =============================================================================
@@ -188,6 +233,67 @@ TEST(PluginEntityRouting, UnownedEntityReturnsNullProviders) {
   // Don't register ownership - entity is not owned by any plugin
   EXPECT_EQ(mgr.get_data_provider_for_entity("unowned"), nullptr);
   EXPECT_EQ(mgr.get_operation_provider_for_entity("unowned"), nullptr);
+}
+
+// =============================================================================
+// Per-entity fitness gating (has_data / has_operations)
+// =============================================================================
+//
+// Ownership alone used to be enough for PluginManager to hand back a
+// plugin's DataProvider/OperationProvider, which over-advertised `data` and
+// `operations` capabilities for entities the plugin owns but does not
+// actually serve (e.g. a grouping Component built by auto-browse discovery -
+// see the OPC-UA plugin's has_data/has_operations overrides). These pin the
+// gate at the PluginManager level with a generic mock, independent of the
+// OPC-UA specifics covered in ros2_medkit_opcua's own tests.
+
+TEST(PluginEntityRouting, DataProviderWithheldForEntityWithoutData) {
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockMixedFitnessPlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("mixed_plugin", {"data_entity", "group_entity"});
+
+  // Owned and data-bearing: provider resolves.
+  auto * dp = mgr.get_data_provider_for_entity("data_entity");
+  ASSERT_NE(dp, nullptr);
+  EXPECT_EQ(dp, static_cast<DataProvider *>(raw));
+
+  // Owned but not data-bearing: PluginManager withholds the provider even
+  // though the plugin owns the entity, so the /data route (and capability
+  // advertisement built on this same lookup) both see "no provider" instead
+  // of delegating into a plugin call that would 404 anyway.
+  EXPECT_EQ(mgr.get_data_provider_for_entity("group_entity"), nullptr);
+}
+
+TEST(PluginEntityRouting, OperationProviderWithheldForEntityWithoutOperations) {
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockMixedFitnessPlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("mixed_plugin", {"data_entity", "group_entity"});
+
+  auto * op = mgr.get_operation_provider_for_entity("data_entity");
+  ASSERT_NE(op, nullptr);
+  EXPECT_EQ(op, static_cast<OperationProvider *>(raw));
+
+  EXPECT_EQ(mgr.get_operation_provider_for_entity("group_entity"), nullptr);
+}
+
+TEST(PluginEntityRouting, EntityOwnershipUnaffectedByFitnessGating) {
+  // get_entity_owner reports ownership regardless of has_data/has_operations -
+  // only the provider getters are gated. Callers that need "does this plugin
+  // own the entity at all" (e.g. HandlerContext::apply_routing) must keep
+  // working for group_entity even though it serves neither data nor
+  // operations.
+  PluginManager mgr;
+  auto plugin = std::make_unique<MockMixedFitnessPlugin>();
+  mgr.add_plugin(std::move(plugin));
+  mgr.register_entity_ownership("mixed_plugin", {"group_entity"});
+
+  auto owner = mgr.get_entity_owner("group_entity");
+  ASSERT_TRUE(owner.has_value());
+  EXPECT_EQ(*owner, "mixed_plugin");
 }
 
 // =============================================================================

--- a/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
@@ -108,10 +108,7 @@ class TestFaultTriggersApi(GatewayTestCase):
         self.assertIn('does not exist', resp.json()['message'])
 
     def test_04_create_list_fire_delete(self):
-        """Create on a real data point, watch it fire, then delete clears it.
-
-        @verifies REQ_INTEROP_002
-        """
+        """Create on a real data point, watch it fire, then delete clears it."""
         resp = self._create({'data_name': 'level', 'operator': '>=',
                              'threshold': 80.0, 'fault_code': 'TEST_LEVEL_HIGH',
                              'severity': 'ERROR'})
@@ -122,10 +119,12 @@ class TestFaultTriggersApi(GatewayTestCase):
         listed = requests.get(self._url(), timeout=10).json()['items']
         self.assertIn(rule['id'], [r['id'] for r in listed])
 
-        # Duplicate fault_code (even from another app) is a conflict: the code
-        # is the fault store's primary key.
+        # Duplicate fault_code (even from another real app) is a conflict: the
+        # code is the fault store's primary key. temp_sensor is a genuinely
+        # discovered app (so it passes the app-existence check) with no PLC data
+        # route, so the rule reaches the global fault_code uniqueness check.
         dup = requests.post(
-            f'{self.BASE_URL}/apps/other_app/fault-triggers',
+            f'{self.BASE_URL}/apps/temp_sensor/fault-triggers',
             json={'data_name': 'level', 'operator': '>',
                   'threshold': 1.0, 'fault_code': 'TEST_LEVEL_HIGH',
                   'severity': 'ERROR'}, timeout=10)
@@ -147,6 +146,15 @@ class TestFaultTriggersApi(GatewayTestCase):
     def test_05_delete_unknown_is_404(self):
         resp = requests.delete(self._url('/ftr_none'), timeout=10)
         self.assertEqual(resp.status_code, 404)
+
+    def test_06_create_on_unknown_app_is_404(self):
+        """A rule on an app the gateway never discovered is refused (404)."""
+        resp = requests.post(
+            f'{self.BASE_URL}/apps/ghost_app/fault-triggers',
+            json={'data_name': 'level', 'operator': '>',
+                  'threshold': 1.0, 'fault_code': 'GHOST_RULE',
+                  'severity': 'ERROR'}, timeout=10)
+        self.assertEqual(resp.status_code, 404, resp.text)
 
     # ------------------------------------------------------------------
     # Helpers

--- a/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Feature tests for the fault-trigger (threshold rule) CRUD API.
+
+Exercises /apps/{app_id}/fault-triggers end to end against a gateway with the
+demo route-data plugin loaded (the engine only starts when plugins are
+present, and both the create-time data-point validation and the poll fetcher
+read the plugin's registered x-plc-data route - the commercial PLC bridge
+shape). test_route_plc_app serves level=87.5, so a `>= 80` rule must confirm
+a fault and expose it on /faults.
+
+"""
+
+import os
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+PLUGIN_APP = 'test_route_plc_app'
+
+
+def _get_plugin_path(so_name):
+    pkg_prefix = get_package_prefix('ros2_medkit_gateway')
+    return os.path.join(pkg_prefix, 'lib', 'ros2_medkit_gateway', so_name)
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor'],
+        fault_manager=True,
+        gateway_params={
+            'plugins': ['test_route_data'],
+            'plugins.test_route_data.path':
+                _get_plugin_path('libtest_route_data_plugin.so'),
+            'fault_triggers.poll_interval_ms': 200,
+        },
+    )
+
+
+class TestFaultTriggersApi(GatewayTestCase):
+    """CRUD + fire path for threshold rules."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {'temp_sensor'}
+
+    def _url(self, suffix=''):
+        return f'{self.BASE_URL}/apps/{PLUGIN_APP}/fault-triggers{suffix}'
+
+    def _create(self, body):
+        return requests.post(self._url(), json=body, timeout=10)
+
+    def test_01_list_starts_empty(self):
+        """GET returns an empty items list before any rule exists."""
+        resp = requests.get(self._url(), timeout=10)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json().get('items'), [])
+
+    def test_02_create_validates_body(self):
+        """Missing fields, bad operator/severity and non-JSON all reject."""
+        cases = [
+            ({}, "'data_name' is required"),
+            ({'data_name': 'level', 'operator': '~', 'threshold': 1,
+              'fault_code': 'X', 'severity': 'ERROR'}, 'operator'),
+            ({'data_name': 'level', 'operator': '>', 'threshold': 'hot',
+              'fault_code': 'X', 'severity': 'ERROR'}, 'threshold'),
+            ({'data_name': 'level', 'operator': '>', 'threshold': 1,
+              'fault_code': 'X', 'severity': 'LOUD'}, 'severity'),
+        ]
+        for body, needle in cases:
+            resp = self._create(body)
+            self.assertEqual(resp.status_code, 400, resp.text)
+            self.assertIn(needle, resp.json()['message'])
+
+        # Malformed JSON is a malformed request, not a semantic validation error.
+        resp = requests.post(
+            self._url(), data='{not json', timeout=10,
+            headers={'Content-Type': 'application/json'})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json()['error_code'], 'invalid-request')
+
+    def test_03_create_rejects_unknown_data_point(self):
+        """A rule on a data point the plugin app does not expose is refused."""
+        resp = self._create({'data_name': 'no_such_point', 'operator': '>',
+                             'threshold': 1.0, 'fault_code': 'DEAD_RULE',
+                             'severity': 'ERROR'})
+        self.assertEqual(resp.status_code, 400, resp.text)
+        self.assertIn('does not exist', resp.json()['message'])
+
+    def test_04_create_list_fire_delete(self):
+        """Create on a real data point, watch it fire, then delete clears it.
+
+        @verifies REQ_INTEROP_002
+        """
+        resp = self._create({'data_name': 'level', 'operator': '>=',
+                             'threshold': 80.0, 'fault_code': 'TEST_LEVEL_HIGH',
+                             'severity': 'ERROR'})
+        self.assertEqual(resp.status_code, 201, resp.text)
+        rule = resp.json()
+        self.assertTrue(rule['id'])
+
+        listed = requests.get(self._url(), timeout=10).json()['items']
+        self.assertIn(rule['id'], [r['id'] for r in listed])
+
+        # Duplicate fault_code (even from another app) is a conflict: the code
+        # is the fault store's primary key.
+        dup = requests.post(
+            f'{self.BASE_URL}/apps/other_app/fault-triggers',
+            json={'data_name': 'level', 'operator': '>',
+                  'threshold': 1.0, 'fault_code': 'TEST_LEVEL_HIGH',
+                  'severity': 'ERROR'}, timeout=10)
+        self.assertEqual(dup.status_code, 409, dup.text)
+
+        # level is a canned constant 87.5 >= 80 - the level-triggered engine
+        # must confirm the fault within a few 200 ms polls.
+        fault = self.poll_for_fault('TEST_LEVEL_HIGH', timeout=15.0)
+        self.assertIsNotNone(fault, 'TEST_LEVEL_HIGH never appeared on /faults')
+
+        # Delete: 204, gone from the list, and the asserted fault is cleared.
+        resp = requests.delete(self._url(f"/{rule['id']}"), timeout=10)
+        self.assertEqual(resp.status_code, 204)
+        self.assertNotIn(rule['id'],
+                         [r['id'] for r in requests.get(self._url(), timeout=10).json()['items']])
+        self.assertTrue(self.poll_until_fault_cleared('TEST_LEVEL_HIGH', timeout=15.0),
+                        'TEST_LEVEL_HIGH still active after rule deletion')
+
+    def test_05_delete_unknown_is_404(self):
+        resp = requests.delete(self._url('/ftr_none'), timeout=10)
+        self.assertEqual(resp.status_code, 404)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def poll_for_fault(self, fault_code, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = requests.get(f'{self.BASE_URL}/faults', timeout=10)
+            if resp.status_code == 200:
+                for item in resp.json().get('items', []):
+                    if item.get('fault_code') == fault_code:
+                        return item
+            time.sleep(0.5)
+        return None
+
+    def poll_until_fault_cleared(self, fault_code, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = requests.get(f'{self.BASE_URL}/faults', timeout=10)
+            if resp.status_code == 200:
+                active = [i for i in resp.json().get('items', [])
+                          if i.get('fault_code') == fault_code
+                          and i.get('status') not in ('CLEARED',)]
+                if not active:
+                    return True
+            time.sleep(0.5)
+        return False
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
@@ -110,6 +110,18 @@ target_include_directories(ros2_medkit_opcua_plugin PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
+# Hide every symbol by default; only the extern "C" entry points tagged
+# GATEWAY_PLUGIN_EXPORT (create_plugin, plugin_api_version, get_*_provider)
+# stay visible. The final gateway dlopens ALL plugins into one process, so an
+# unhidden weak/inline symbol here (e.g. a duplicated struct method) could
+# interpose one from another plugin - the exact class of ODR collision that
+# drove the DiscoveryConfig -> OpcuaDiscoveryConfig rename. Hidden visibility
+# gives each plugin its own copy and closes that whole failure mode.
+target_compile_options(ros2_medkit_opcua_plugin PRIVATE
+  -fvisibility=hidden
+  -fvisibility-inlines-hidden
+)
+
 medkit_target_dependencies(ros2_medkit_opcua_plugin
   ros2_medkit_msgs
   ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/address_space_browser.hpp
@@ -47,6 +47,13 @@ class AutoBrowseSource {
   /// optional reachability check (see ``AutoBrowseConfig::read_initial_values``).
   /// ``std::nullopt`` means the read failed (Bad status / not connected).
   virtual std::optional<OpcuaValue> read_initial_value(const opcua::NodeId & variable_node) = 0;
+
+  /// True/false when the server's AccessLevel/UserAccessLevel for this Variable
+  /// resolved (CurrentWrite bit -> writable), ``std::nullopt`` when the
+  /// attribute read failed. Drives ``NodeMapEntry::writable`` under
+  /// ``AutoBrowseConfig::infer_writable`` so a config-less walk exposes a write
+  /// surface exactly where the server permits it.
+  virtual std::optional<bool> read_writable(const opcua::NodeId & variable_node) = 0;
 };
 
 /// ``AutoBrowseSource`` backed by a live ``OpcuaClient`` session.
@@ -69,6 +76,14 @@ class OpcuaClientBrowseSource : public AutoBrowseSource {
       return std::nullopt;
     }
     return result.value;
+  }
+
+  std::optional<bool> read_writable(const opcua::NodeId & variable_node) override {
+    const auto info = client_.read_access_level(variable_node);
+    if (!info.ok) {
+      return std::nullopt;
+    }
+    return info.writable;
   }
 
  private:

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/alarm_state_machine.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/alarm_state_machine.hpp
@@ -63,6 +63,12 @@ enum class AlarmAction { NoOp, ReportConfirmed, ReportHealed, ClearFault };
 struct AlarmEventInput {
   bool enabled_state{true};
   bool active_state{false};
+  /// False when the notification did not carry a readable ActiveState/Id
+  /// (Siemens sends secondary notifications - e.g. the unacked-transition of
+  /// the same condition - without it). An absent field must never read as
+  /// "inactive": the caller substitutes the tracked instance's previous
+  /// activity before compute().
+  bool active_state_present{true};
   bool acked_state{false};
   bool confirmed_state{false};
   /// True iff ShelvingState != Unshelved.

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/device_identity.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/device_identity.hpp
@@ -33,6 +33,26 @@ namespace ros2_medkit_gateway {
 /// server exposes no device-info at all.
 AssetIdentity opcua_device_info_to_identity(const OpcuaClient::DeviceInfo & info, const std::string & endpoint_url);
 
+/// SOVD component identity (id + display name) derived from a device's own
+/// read identity. Used by config-less discovery so the component surfaced over
+/// SOVD carries the device's real name instead of any hardcoded product string.
+struct ComponentIdentity {
+  std::string id;    ///< URL-safe slug, e.g. "siemens_ag_cpu_1505sp_f"
+  std::string name;  ///< Human-readable, e.g. "Siemens AG CPU 1505SP F"
+};
+
+/// Derive a component id/name from what the server actually reports, with a
+/// strict precedence so nothing device-specific is ever hardcoded:
+///   1. DI nameplate ``Manufacturer`` + ``Model`` (most specific).
+///   2. BuildInfo ``ManufacturerName`` + ``ProductName`` (every compliant
+///      server, the OPC-UA ApplicationName/ProductName equivalent).
+///   3. A neutral endpoint-derived fallback ``opcua-<host>`` when the server
+///      exposes no usable identity at all.
+/// ``id`` is a lowercase underscore slug of the name for cases 1-2, and the
+/// literal ``opcua-<host>`` for case 3. Returns an empty ComponentIdentity only
+/// if ``endpoint_url`` is unparseable and no identity fields are present.
+ComponentIdentity derive_component_identity(const OpcuaClient::DeviceInfo & info, const std::string & endpoint_url);
+
 /// Whether a live nameplate read over this connection may outrank the
 /// operator-authored manifest in the identity merge.
 ///

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
@@ -84,7 +84,7 @@ struct DiscoveredEndpoint {
 
 /// ``discovery:`` config block for the opcua plugin. Off by default; active
 /// scan is opt-in and bounded.
-struct DiscoveryConfig {
+struct OpcuaDiscoveryConfig {
   bool enabled{false};
 
   /// active | passive | both. Only "active" (bounded TCP scan + GetEndpoints)
@@ -139,7 +139,7 @@ std::string derive_local_cidr();
 /// override the defaults. Ports outside 1..65535, non-positive timeout /
 /// concurrency, and an unknown ``mode`` are rejected back to their defaults
 /// with a warning.
-DiscoveryConfig parse_discovery_config(const nlohmann::json & j, const std::function<void(const std::string &)> & warn);
+OpcuaDiscoveryConfig parse_discovery_config(const nlohmann::json & j, const std::function<void(const std::string &)> & warn);
 
 /// Read-only active-scan discovery orchestrator. Sweeps the configured subnets
 /// for open OPC-UA ports, runs a GetEndpoints identify on each :4840 hit, and
@@ -148,7 +148,7 @@ DiscoveryConfig parse_discovery_config(const nlohmann::json & j, const std::func
 /// testable without touching the network.
 class NetworkDiscovery {
  public:
-  NetworkDiscovery(DiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify);
+  NetworkDiscovery(OpcuaDiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify);
 
   /// Run one full discovery pass (blocking). Read-only: TCP connect +
   /// GetEndpoints only. Deduplicated by ApplicationUri (fallback ip:port),
@@ -168,7 +168,7 @@ class NetworkDiscovery {
                                                          bool anonymous_none_only);
 
  private:
-  DiscoveryConfig cfg_;
+  OpcuaDiscoveryConfig cfg_;
   PortScanFn scan_;
   IdentifyFn identify_;
 };

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/network_discovery.hpp
@@ -139,7 +139,8 @@ std::string derive_local_cidr();
 /// override the defaults. Ports outside 1..65535, non-positive timeout /
 /// concurrency, and an unknown ``mode`` are rejected back to their defaults
 /// with a warning.
-OpcuaDiscoveryConfig parse_discovery_config(const nlohmann::json & j, const std::function<void(const std::string &)> & warn);
+OpcuaDiscoveryConfig parse_discovery_config(const nlohmann::json & j,
+                                            const std::function<void(const std::string &)> & warn);
 
 /// Read-only active-scan discovery orchestrator. Sweeps the configured subnets
 /// for open OPC-UA ports, runs a GetEndpoints identify on each :4840 hit, and

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -408,6 +408,22 @@ class NodeMap {
     return component_name_;
   }
 
+  /// Override the SOVD component id/name at runtime. Config-less discovery
+  /// calls this with an identity derived from the device itself (see
+  /// ``derive_component_identity``) so the component never surfaces the
+  /// neutral placeholder default. Must be called before ``build_entity_defs``
+  /// runs (i.e. before ``finalize_auto_alarms_overlay`` /
+  /// ``merge_auto_browsed_entries``) so every derived reference - entity_defs
+  /// ``component_id``, the ``<component_id>_alarms`` auto-alarm entity, and the
+  /// introspect component - picks up the same id. No-op on empty ``id``.
+  void set_component_identity(const std::string & id, const std::string & name) {
+    if (id.empty()) {
+      return;
+    }
+    component_id_ = id;
+    component_name_ = name.empty() ? id : name;
+  }
+
   /// Whether auto-browse mode is enabled
   bool auto_browse() const {
     return auto_browse_config_.enabled;
@@ -474,8 +490,12 @@ class NodeMap {
 
   std::string area_id_ = "plc_systems";
   std::string area_name_ = "PLC Systems";
-  std::string component_id_ = "openplc_runtime";
-  std::string component_name_ = "OpenPLC Runtime";
+  // Neutral placeholder only. In config-less discovery the plugin overrides
+  // these from the device's own read identity (set_component_identity); an
+  // explicit node-map YAML overrides them from ``component_id`` /
+  // ``component_name``. No device-specific product string is ever baked in.
+  std::string component_id_ = "opcua_device";
+  std::string component_name_ = "OPC UA Device";
   AutoBrowseConfig auto_browse_config_;
 };
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -256,6 +256,13 @@ struct AutoBrowseConfig {
   /// every type-matched Variable is kept, which is faster to start up on very
   /// large trees.
   bool read_initial_values{true};
+
+  /// When true (default) each discovered Variable's AccessLevel/UserAccessLevel
+  /// is read and its ``writable`` flag is set from the server's CurrentWrite
+  /// bit, so a config-less walk exposes a write surface exactly where the PLC
+  /// permits it. When false, every auto-browsed point stays read-only and only
+  /// an explicit node_map ``nodes:`` entry can promote it (legacy behaviour).
+  bool infer_writable{true};
 };
 
 /// SOVD entity definition derived from the node map

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_client.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_client.hpp
@@ -191,6 +191,26 @@ class OpcuaClient {
   tl::expected<void, WriteErrorInfo> write_value(const opcua::NodeId & node_id, const OpcuaValue & value,
                                                  const std::string & data_type_hint = "");
 
+  /// The AccessLevel / UserAccessLevel bits of a Variable node, read straight
+  /// from the server. ``ok`` is false when not connected or the attribute read
+  /// failed (in which case the bit flags are all cleared and the caller must
+  /// NOT assume a permission). ``writable`` is the effective, session-scoped
+  /// CurrentWrite bit: UserAccessLevel when it read back, otherwise the node's
+  /// inherent AccessLevel. The raw bitmasks are kept for diagnostics.
+  struct AccessLevelInfo {
+    bool ok{false};
+    bool readable{false};
+    bool writable{false};
+    uint8_t access_level{0};       ///< raw AccessLevel bitmask
+    uint8_t user_access_level{0};  ///< raw UserAccessLevel bitmask
+  };
+
+  /// Read a Variable node's AccessLevel and UserAccessLevel attributes and
+  /// decode the CurrentRead / CurrentWrite bits (OPC-UA Part 3 §5.6.2). Used
+  /// by auto_browse to mark a discovered data point writable exactly when the
+  /// server says this session may write it - no hand-written node map needed.
+  AccessLevelInfo read_access_level(const opcua::NodeId & variable_node);
+
   /// Create a subscription with data change notifications
   /// @return Subscription ID, or 0 on failure
   uint32_t create_subscription(double publish_interval_ms, DataChangeCallback callback);

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -101,6 +101,9 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
                                                                 const std::string & resource_name) override;
   tl::expected<dto::DataWriteResult, DataProviderErrorInfo>
   write_data(const std::string & entity_id, const std::string & resource_name, const nlohmann::json & value) override;
+  // Component and alarms-fallback entities own no NodeMap entries; false here
+  // keeps the gateway from advertising a `data` capability list_data would 404.
+  bool has_data(const std::string & entity_id) const override;
 
   // -- OperationProvider interface --
   tl::expected<dto::Collection<dto::OperationItem>, OperationProviderErrorInfo>
@@ -108,6 +111,9 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   tl::expected<dto::OperationExecutionResult, OperationProviderErrorInfo>
   execute_operation(const std::string & entity_id, const std::string & operation_name,
                     const nlohmann::json & parameters) override;
+  // True for any entity_defs() entry (mirrors list_operations' own lookup),
+  // false for the Component itself, which has no entity_defs entry.
+  bool has_operations(const std::string & entity_id) const override;
 
   // -- FaultProvider interface --
   tl::expected<dto::FaultListResult, FaultProviderErrorInfo> list_faults(const std::string & entity_id) override;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_plugin.hpp
@@ -210,11 +210,16 @@ class OpcuaPlugin : public ros2_medkit_gateway::GatewayPlugin,
   std::string node_map_path_;
 
   // Read-only PLC/OPC-UA network discovery (opt-in, default disabled).
-  DiscoveryConfig discovery_config_;
+  OpcuaDiscoveryConfig discovery_config_;
   // True when the operator pinned endpoint_url via config or OPCUA_ENDPOINT_URL.
   // Discovery only auto-selects an endpoint when this is false, so it never
   // overrides an explicit target or opens a second session on a polled PLC.
   bool endpoint_configured_{false};
+  // True when the operator supplied a ``plugins.opcua.auto_alarms`` block.
+  // When false AND no node_map_path is set, config-less discovery enables
+  // native A&C by itself (default source Server object i=2253) so discovered
+  // Alarms & Conditions surface on /api/v1/faults with no per-alarm mapping.
+  bool auto_alarms_configured_{false};
   // Injected discovery I/O; default to the real POSIX / open62541pp probes.
   // Tests substitute in-memory fakes to exercise the auto-endpoint path without
   // a network. Set in configure(), consumed in run_startup_discovery().

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_poller.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_poller.hpp
@@ -274,6 +274,7 @@ class OpcuaPoller {
  private:
   void poll_loop();
   void event_pump_loop();
+  bool same_code_active_elsewhere_locked(const std::string & fault_code, const std::string & condition_id_str) const;
   void do_poll();
   /// Issue #496: emit the component-scoped comms-lost raise/clear edge through
   /// the alarm callback (fault_code ``PLC_COMMS_LOST``, scoped to the node

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_poller.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/opcua_poller.hpp
@@ -273,6 +273,7 @@ class OpcuaPoller {
 
  private:
   void poll_loop();
+  void event_pump_loop();
   void do_poll();
   /// Issue #496: emit the component-scoped comms-lost raise/clear edge through
   /// the alarm callback (fault_code ``PLC_COMMS_LOST``, scoped to the node
@@ -353,6 +354,15 @@ class OpcuaPoller {
   PollerConfig config_;
 
   std::thread poll_thread_;
+  /// Dedicated subscription pump. Publish responses are only processed inside
+  /// a runIterate, and the poll thread's single iterate per cycle loses the
+  /// client mutex to sync API traffic (fleet health checker, UI, freeze-frame
+  /// reads) long enough for outstanding publish requests to hit the client
+  /// requestTimeout - all pending publishes then expire in one burst and
+  /// AlarmCondition events silently stop. A short iterate every 100 ms from
+  /// its own thread keeps the publish channel serviced regardless of poll
+  /// cadence or API contention.
+  std::thread event_pump_thread_;
   std::atomic<bool> running_{false};
   std::atomic<bool> using_subscriptions_{false};
 
@@ -372,7 +382,8 @@ class OpcuaPoller {
   EventAlarmCallback event_alarm_callback_;
   std::mutex event_alarm_callback_mutex_;
 
-  uint32_t event_subscription_id_{0};
+  // Atomic: written by poll/reconnect and setup, read by the event pump thread.
+  std::atomic<uint32_t> event_subscription_id_{0};
   std::vector<uint32_t> event_monitored_item_ids_;
 
   mutable std::shared_mutex conditions_mutex_;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/address_space_browser.cpp
@@ -224,11 +224,20 @@ void AutoBrowser::visit_object(const opcua::NodeId & node, const std::vector<std
       }
       entry.display_name = display;
       entry.data_type = medkit_type;
-      // auto_browse never marks a point writable: without a human reviewing
-      // the mapping there is no basis for exposing a write surface on a PLC
-      // actuator. Promote specific points to writable via an explicit
-      // node_map `nodes:` entry (which always takes precedence).
+      // Writability comes from the server itself: read the node's
+      // AccessLevel/UserAccessLevel and expose a write surface exactly when the
+      // CurrentWrite bit is set for this session. A failed attribute read (or
+      // infer_writable disabled) keeps the safe read-only default; an explicit
+      // node_map `nodes:` entry still takes precedence downstream.
       entry.writable = false;
+      if (config_.infer_writable) {
+        const std::optional<bool> writable = source_.read_writable(child.node_id);
+        if (writable.has_value()) {
+          entry.writable = *writable;
+        }
+        RCLCPP_DEBUG(auto_browse_logger(), "auto_browse: %s (%s) writable=%s", child.node_id.toString().c_str(),
+                     display.c_str(), entry.writable ? "true" : (writable.has_value() ? "false" : "unknown"));
+      }
       local_entries.push_back(std::move(entry));
     }
     // Other node classes cannot reach here - browse_children already

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
@@ -48,6 +48,12 @@ std::string host_from_endpoint(const std::string & endpoint_url) {
   if (scheme != std::string::npos) {
     s = s.substr(scheme + 3);
   }
+  // Bracketed IPv6 literal (opc.tcp://[fe80::1]:4840): the host is the
+  // bracket body - find_first_of(":") would truncate inside the address.
+  if (!s.empty() && s.front() == '[') {
+    const auto close = s.find(']');
+    return close != std::string::npos ? s.substr(1, close - 1) : s.substr(1);
+  }
   const auto end = s.find_first_of(":/");
   if (end != std::string::npos) {
     s = s.substr(0, end);

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
@@ -14,10 +14,57 @@
 
 #include "ros2_medkit_opcua/device_identity.hpp"
 
+#include <cctype>
+
 namespace ros2_medkit_gateway {
 
 namespace {
 constexpr const char * kOpcuaSource = "opcua";
+
+/// Lowercase underscore slug: alnum kept, every other run collapsed to a
+/// single '_', leading/trailing '_' trimmed. Yields a URL-safe SOVD id.
+std::string slugify(const std::string & in) {
+  std::string out;
+  out.reserve(in.size());
+  bool pending_sep = false;
+  for (unsigned char c : in) {
+    if (std::isalnum(c)) {
+      if (pending_sep && !out.empty()) {
+        out += '_';
+      }
+      pending_sep = false;
+      out += static_cast<char>(std::tolower(c));
+    } else {
+      pending_sep = true;
+    }
+  }
+  return out;
+}
+
+/// Extract the host from an ``opc.tcp://host:port/path`` endpoint URL.
+std::string host_from_endpoint(const std::string & endpoint_url) {
+  std::string s = endpoint_url;
+  const auto scheme = s.find("://");
+  if (scheme != std::string::npos) {
+    s = s.substr(scheme + 3);
+  }
+  const auto end = s.find_first_of(":/");
+  if (end != std::string::npos) {
+    s = s.substr(0, end);
+  }
+  return s;
+}
+
+/// Join two nameplate fields with a single space, skipping empties.
+std::string join_nonempty(const std::string & a, const std::string & b) {
+  if (a.empty()) {
+    return b;
+  }
+  if (b.empty()) {
+    return a;
+  }
+  return a + " " + b;
+}
 }  // namespace
 
 AssetIdentity opcua_device_info_to_identity(const OpcuaClient::DeviceInfo & info, const std::string & endpoint_url) {
@@ -49,6 +96,32 @@ AssetIdentity opcua_device_info_to_identity(const OpcuaClient::DeviceInfo & info
   }
 
   return identity;
+}
+
+ComponentIdentity derive_component_identity(const OpcuaClient::DeviceInfo & info, const std::string & endpoint_url) {
+  // 1. DI nameplate (per-device, most specific): Manufacturer + Model.
+  std::string name = join_nonempty(info.di_manufacturer, info.di_model);
+
+  // 2. Server BuildInfo (OPC-UA ApplicationName/ProductName equivalent).
+  if (name.empty()) {
+    name = join_nonempty(info.manufacturer_name, info.product_name);
+  }
+
+  if (!name.empty()) {
+    std::string id = slugify(name);
+    if (!id.empty()) {
+      return {id, name};
+    }
+  }
+
+  // 3. Neutral endpoint-derived fallback. NEVER a fixed product string.
+  const std::string host = host_from_endpoint(endpoint_url);
+  if (!host.empty()) {
+    const std::string fallback = "opcua-" + host;
+    return {fallback, fallback};
+  }
+
+  return {};
 }
 
 bool opcua_identity_trusted(const OpcuaClientConfig & config) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/device_identity.cpp
@@ -121,9 +121,12 @@ ComponentIdentity derive_component_identity(const OpcuaClient::DeviceInfo & info
   }
 
   // 3. Neutral endpoint-derived fallback. NEVER a fixed product string.
+  // Slugify the host so a config-less IPv4 (opcua-192.168.1.10, dotted) yields
+  // a valid entity id (opcua-192_168_1_10); the raw dotted form is rejected by
+  // is_valid_entity_id and the whole Component would be silently dropped.
   const std::string host = host_from_endpoint(endpoint_url);
   if (!host.empty()) {
-    const std::string fallback = "opcua-" + host;
+    const std::string fallback = "opcua-" + slugify(host);
     return {fallback, fallback};
   }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
@@ -192,9 +192,9 @@ std::string derive_local_cidr() {
   return result;
 }
 
-DiscoveryConfig parse_discovery_config(const nlohmann::json & j,
+OpcuaDiscoveryConfig parse_discovery_config(const nlohmann::json & j,
                                        const std::function<void(const std::string &)> & warn) {
-  DiscoveryConfig cfg;
+  OpcuaDiscoveryConfig cfg;
   const auto warn_fn = [&](const std::string & m) {
     if (warn) {
       warn(m);
@@ -318,7 +318,7 @@ DiscoveryConfig parse_discovery_config(const nlohmann::json & j,
   return cfg;
 }
 
-NetworkDiscovery::NetworkDiscovery(DiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify)
+NetworkDiscovery::NetworkDiscovery(OpcuaDiscoveryConfig cfg, PortScanFn scan, IdentifyFn identify)
   : cfg_(std::move(cfg)), scan_(std::move(scan)), identify_(std::move(identify)) {
 }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/network_discovery.cpp
@@ -193,7 +193,7 @@ std::string derive_local_cidr() {
 }
 
 OpcuaDiscoveryConfig parse_discovery_config(const nlohmann::json & j,
-                                       const std::function<void(const std::string &)> & warn) {
+                                            const std::function<void(const std::string &)> & warn) {
   OpcuaDiscoveryConfig cfg;
   const auto warn_fn = [&](const std::string & m) {
     if (warn) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
@@ -18,10 +18,12 @@
 #include <atomic>
 #include <cctype>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <ctime>
 #include <deque>
 #include <fstream>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <thread>
@@ -861,7 +863,7 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
   // a fixed Int32 write is rejected (BadTypeMismatch) by narrower nodes such as
   // the S7 "Int" (Int16). Probe the node's real DataType and write the matching
   // scalar width; fall back to Int32 when the type cannot be resolved.
-  auto write_integer_typed = [&to_int64, &value](auto & node) {
+  auto write_integer_typed = [&to_int64, &value](auto & node) -> tl::expected<void, WriteErrorInfo> {
     uint32_t dt = 0;
     try {
       const auto data_type = node.readDataType();
@@ -878,22 +880,42 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
     auto id = [](opcua::DataTypeId d) {
       return static_cast<uint32_t>(d);
     };
+    // Range-check before narrowing: an unchecked static_cast wraps (40000 ->
+    // Int16 = -25536, any negative -> unsigned = a huge value), and write_data
+    // would then echo the wrapped number back as a successful value_written.
+    // Reject out-of-range as a TypeMismatch (write_data maps it to HTTP 400).
+    auto put = [&node, iv](auto type_tag, const char * type_name) -> tl::expected<void, WriteErrorInfo> {
+      using T = decltype(type_tag);
+      bool out_of_range = false;
+      if constexpr (std::is_signed_v<T>) {
+        out_of_range = iv < static_cast<int64_t>(std::numeric_limits<T>::min()) ||
+                       iv > static_cast<int64_t>(std::numeric_limits<T>::max());
+      } else {
+        out_of_range = iv < 0 || static_cast<uint64_t>(iv) > static_cast<uint64_t>(std::numeric_limits<T>::max());
+      }
+      if (out_of_range) {
+        return tl::make_unexpected(
+            WriteErrorInfo{WriteError::TypeMismatch, std::to_string(iv) + " out of range for " + type_name});
+      }
+      node.writeValueScalar(static_cast<T>(iv));
+      return {};
+    };
     if (dt == id(opcua::DataTypeId::SByte)) {
-      node.writeValueScalar(static_cast<int8_t>(iv));
+      return put(int8_t{}, "SByte");
     } else if (dt == id(opcua::DataTypeId::Byte)) {
-      node.writeValueScalar(static_cast<uint8_t>(iv));
+      return put(uint8_t{}, "Byte");
     } else if (dt == id(opcua::DataTypeId::Int16)) {
-      node.writeValueScalar(static_cast<int16_t>(iv));
+      return put(int16_t{}, "Int16");
     } else if (dt == id(opcua::DataTypeId::UInt16)) {
-      node.writeValueScalar(static_cast<uint16_t>(iv));
+      return put(uint16_t{}, "UInt16");
     } else if (dt == id(opcua::DataTypeId::UInt32)) {
-      node.writeValueScalar(static_cast<uint32_t>(iv));
+      return put(uint32_t{}, "UInt32");
     } else if (dt == id(opcua::DataTypeId::Int64)) {
-      node.writeValueScalar(static_cast<int64_t>(iv));
+      return put(int64_t{}, "Int64");
     } else if (dt == id(opcua::DataTypeId::UInt64)) {
-      node.writeValueScalar(static_cast<uint64_t>(iv));
+      return put(uint64_t{}, "UInt64");
     } else {
-      node.writeValueScalar(static_cast<int32_t>(iv));
+      return put(int32_t{}, "Int32");
     }
   };
 
@@ -906,7 +928,9 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
       if (data_type_hint == "float") {
         node.writeValueScalar(static_cast<float>(to_double(value)));
       } else if (data_type_hint == "int") {
-        write_integer_typed(node);
+        if (auto r = write_integer_typed(node); !r) {
+          return tl::make_unexpected(r.error());
+        }
       } else if (data_type_hint == "bool") {
         node.writeValueScalar(to_bool(value));
       } else if (data_type_hint == "string") {
@@ -940,7 +964,9 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
     } else if (current.isType<int8_t>() || current.isType<uint8_t>() || current.isType<int16_t>() ||
                current.isType<uint16_t>() || current.isType<int32_t>() || current.isType<uint32_t>() ||
                current.isType<int64_t>() || current.isType<uint64_t>()) {
-      write_integer_typed(node);
+      if (auto r = write_integer_typed(node); !r) {
+        return tl::make_unexpected(r.error());
+      }
     } else {
       auto var = value_to_variant(value);
       node.writeValue(var);

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_client.cpp
@@ -723,6 +723,39 @@ std::string OpcuaClient::read_variable_type_name(const opcua::NodeId & variable_
   }
 }
 
+OpcuaClient::AccessLevelInfo OpcuaClient::read_access_level(const opcua::NodeId & variable_node) {
+  std::lock_guard<std::mutex> lock(impl_->client_mutex);
+  AccessLevelInfo info;
+
+  if (!impl_->connected) {
+    return info;
+  }
+
+  try {
+    opcua::Node node(impl_->client, variable_node);
+    const opcua::Bitmask<opcua::AccessLevel> access = node.readAccessLevel();
+    info.access_level = static_cast<uint8_t>(access.get());
+    bool have_user = false;
+    opcua::Bitmask<opcua::AccessLevel> user = access;
+    try {
+      user = node.readUserAccessLevel();
+      info.user_access_level = static_cast<uint8_t>(user.get());
+      have_user = true;
+    } catch (const opcua::BadStatus &) {
+      // Not every server exposes UserAccessLevel; fall back to AccessLevel.
+      info.user_access_level = info.access_level;
+    }
+    const auto & effective = have_user ? user : access;
+    info.readable = effective.anyOf(opcua::AccessLevel::CurrentRead);
+    info.writable = effective.anyOf(opcua::AccessLevel::CurrentWrite);
+    info.ok = true;
+  } catch (const opcua::BadStatus & e) {
+    maybe_mark_disconnected(impl_->connected, impl_->generation, e);
+  }
+
+  return info;
+}
+
 ReadResult OpcuaClient::read_value(const opcua::NodeId & node_id) {
   std::lock_guard<std::mutex> lock(impl_->client_mutex);
   ReadResult result;
@@ -797,12 +830,12 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
         v);
   };
 
-  // Helper: coerce OpcuaValue to int32 for integer writes
-  auto to_int32 = [](const OpcuaValue & v) -> int32_t {
+  // Helper: coerce OpcuaValue to int64 (widest integer) for width dispatch
+  auto to_int64 = [](const OpcuaValue & v) -> int64_t {
     return std::visit(
-        [](auto && x) -> int32_t {
+        [](auto && x) -> int64_t {
           if constexpr (std::is_arithmetic_v<std::decay_t<decltype(x)>>) {
-            return static_cast<int32_t>(x);
+            return static_cast<int64_t>(x);
           }
           return 0;
         },
@@ -824,6 +857,46 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
         v);
   };
 
+  // The coarse "int" NodeMap hint does not carry the OPC-UA integer width, so
+  // a fixed Int32 write is rejected (BadTypeMismatch) by narrower nodes such as
+  // the S7 "Int" (Int16). Probe the node's real DataType and write the matching
+  // scalar width; fall back to Int32 when the type cannot be resolved.
+  auto write_integer_typed = [&to_int64, &value](auto & node) {
+    uint32_t dt = 0;
+    try {
+      const auto data_type = node.readDataType();
+      if (data_type.getNamespaceIndex() == 0 && data_type.getIdentifierType() == opcua::NodeIdType::Numeric) {
+        // node is a generic (auto) parameter, so data_type is a dependent type.
+        dt = data_type.template getIdentifierAs<uint32_t>();
+      }
+    } catch (...) {
+      // leave dt=0 -> Int32 default
+    }
+    const int64_t iv = to_int64(value);
+    // if-else over numeric ids (not a switch: -Werror=switch-enum would demand
+    // every DataTypeId enumerator be listed).
+    auto id = [](opcua::DataTypeId d) {
+      return static_cast<uint32_t>(d);
+    };
+    if (dt == id(opcua::DataTypeId::SByte)) {
+      node.writeValueScalar(static_cast<int8_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::Byte)) {
+      node.writeValueScalar(static_cast<uint8_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::Int16)) {
+      node.writeValueScalar(static_cast<int16_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::UInt16)) {
+      node.writeValueScalar(static_cast<uint16_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::UInt32)) {
+      node.writeValueScalar(static_cast<uint32_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::Int64)) {
+      node.writeValueScalar(static_cast<int64_t>(iv));
+    } else if (dt == id(opcua::DataTypeId::UInt64)) {
+      node.writeValueScalar(static_cast<uint64_t>(iv));
+    } else {
+      node.writeValueScalar(static_cast<int32_t>(iv));
+    }
+  };
+
   try {
     opcua::Node node(impl_->client, node_id);
 
@@ -833,7 +906,7 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
       if (data_type_hint == "float") {
         node.writeValueScalar(static_cast<float>(to_double(value)));
       } else if (data_type_hint == "int") {
-        node.writeValueScalar(to_int32(value));
+        write_integer_typed(node);
       } else if (data_type_hint == "bool") {
         node.writeValueScalar(to_bool(value));
       } else if (data_type_hint == "string") {
@@ -862,10 +935,12 @@ OpcuaClient::write_value(const opcua::NodeId & node_id, const OpcuaValue & value
       node.writeValueScalar(static_cast<float>(to_double(value)));
     } else if (current.isType<double>()) {
       node.writeValueScalar(to_double(value));
-    } else if (current.isType<int32_t>()) {
-      node.writeValueScalar(to_int32(value));
     } else if (current.isType<bool>()) {
       node.writeValueScalar(to_bool(value));
+    } else if (current.isType<int8_t>() || current.isType<uint8_t>() || current.isType<int16_t>() ||
+               current.isType<uint16_t>() || current.isType<int32_t>() || current.isType<uint32_t>() ||
+               current.isType<int64_t>() || current.isType<uint64_t>()) {
+      write_integer_typed(node);
     } else {
       auto var = value_to_variant(value);
       node.writeValue(var);

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -774,10 +774,15 @@ IntrospectionResult OpcuaPlugin::introspect(const IntrospectionInput & /*input*/
     result.new_entities.apps.push_back(std::move(app));
 
     // Register capabilities per entity (never type-level): only PLC-backed
-    // apps advertise x-plc-data; apps with writable nodes also get
-    // x-plc-operations.
+    // apps advertise x-plc-data. The auto_alarms fallback App (and any
+    // event_alarms-only App) has an entity_defs entry to host faults but no
+    // NodeMap entries of its own, so def.data_names stays empty - skip it or
+    // /apps/<id>/x-plc-data 404s despite being advertised. Apps with
+    // writable nodes also get x-plc-operations.
     if (ctx_) {
-      ctx_->register_entity_capability(def.id, "x-plc-data");
+      if (!def.data_names.empty()) {
+        ctx_->register_entity_capability(def.id, "x-plc-data");
+      }
       if (!def.writable_names.empty()) {
         ctx_->register_entity_capability(def.id, "x-plc-operations");
       }
@@ -1710,6 +1715,14 @@ tl::expected<dto::DataWriteResult, DataProviderErrorInfo> OpcuaPlugin::write_dat
   return dto::DataWriteResult{std::move(result)};
 }
 
+bool OpcuaPlugin::has_data(const std::string & entity_id) const {
+  // Same check list_data uses to 404 - keeps advertised capabilities honest
+  // for entities with no NodeMap entries (the Component, the auto_alarms
+  // fallback App).
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
+  return !node_map_.entries_for_entity(entity_id).empty();
+}
+
 // -- OperationProvider interface --
 
 tl::expected<dto::Collection<dto::OperationItem>, OperationProviderErrorInfo>
@@ -1917,6 +1930,17 @@ OpcuaPlugin::execute_operation(const std::string & entity_id, const std::string 
       },
       *parsed);
   return dto::OperationExecutionResult{std::move(result)};
+}
+
+bool OpcuaPlugin::has_operations(const std::string & entity_id) const {
+  // Mirrors list_operations' own lookup: true for any entity_defs() entry
+  // (writable data points, or acknowledge_fault/confirm_fault on an
+  // event-alarm entity), false for the Component, which has none.
+  std::shared_lock<std::shared_mutex> node_map_lock(node_map_mutex_);
+  const auto & defs = node_map_.entity_defs();
+  return std::any_of(defs.begin(), defs.end(), [&entity_id](const PlcEntityDef & def) {
+    return def.id == entity_id;
+  });
 }
 
 // -- FaultProvider interface --

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -539,6 +539,7 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
   // ``event_alarms:`` mappings still take precedence over auto-derivation at
   // the poller (see OpcuaPoller::effective_alarm_sources) regardless.
   if (config.contains("auto_alarms")) {
+    auto_alarms_configured_ = true;
     apply_auto_alarms_param(config["auto_alarms"], node_map_.mutable_auto_alarms(), [this](const std::string & msg) {
       log_warn(msg);
     });
@@ -574,16 +575,48 @@ void OpcuaPlugin::set_context(PluginContext & context) {
 
   log_security_profile();
 
-  if (client_->connect(client_config_)) {
+  const bool connected = client_->connect(client_config_);
+  if (connected) {
     log_info("Connected to OPC-UA server: " + client_config_.endpoint_url);
+  } else {
+    log_warn("Failed to connect to OPC-UA server: " + client_config_.endpoint_url);
+  }
+
+  // Config-less discovery: name the SOVD component from the device's OWN read
+  // identity, never a hardcoded product string. DI nameplate (Siemens AG /
+  // CPU 1505SP F) wins, else BuildInfo ApplicationName/ProductName, else the
+  // neutral endpoint fallback opcua-<host>. Runs before the node map is
+  // consumed (auto_alarms finalize + auto_browse below both rebuild
+  // entity_defs off component_id_), so every derived reference stays
+  // consistent. Only in config-less mode: an explicit node map owns the name.
+  if (node_map_path_.empty()) {
+    const OpcuaClient::DeviceInfo info = connected ? client_->read_device_info() : OpcuaClient::DeviceInfo{};
+    const ComponentIdentity ci = derive_component_identity(info, client_config_.endpoint_url);
+    if (!ci.id.empty()) {
+      node_map_.set_component_identity(ci.id, ci.name);
+      log_info("Component identity derived from device: id='" + ci.id + "', name='" + ci.name + "'");
+    }
+
+    // Zero-config native A&C: with no node map and no explicit auto_alarms
+    // block, subscribe the Server EventNotifier by default so discovered
+    // Alarms & Conditions surface on /api/v1/faults with a fault_code derived
+    // from the ConditionName/source. Finalize picks up the component id set
+    // above for the ``<component_id>_alarms`` fallback entity.
+    if (!auto_alarms_configured_) {
+      node_map_.mutable_auto_alarms().enabled = true;
+      node_map_.finalize_auto_alarms_overlay();
+      if (node_map_.auto_alarms().enabled) {
+        log_info("auto_alarms auto-enabled (config-less native A&C, source " +
+                 node_map_.auto_alarms().source_node_id_str + ", entity " + node_map_.auto_alarms().entity_id + ")");
+      }
+    }
+  }
+
+  if (connected && node_map_.auto_browse_config().enabled) {
     // auto_browse needs a live session to walk the address space, so it can
     // only run here - after connect(), before the node map is consumed to
     // build publishers/poller below.
-    if (node_map_.auto_browse_config().enabled) {
-      run_auto_browse();
-    }
-  } else {
-    log_warn("Failed to connect to OPC-UA server: " + client_config_.endpoint_url);
+    run_auto_browse();
   }
 
   // Publisher creation moved here (was originally before connect()) so that

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -730,6 +730,9 @@ IntrospectionResult OpcuaPlugin::introspect(const IntrospectionInput & /*input*/
   // the plugin layer (it only stamps "plugin" on empty sources); per-field
   // provenance stays "opcua" for transparency in both cases.
   comp.source = opcua_identity_trusted(client_config_) ? "opcua" : "plugin";
+  // Fault scope grants bare-id ownership only to external entities; the poller
+  // reports PLC_COMMS_LOST under this component's own id.
+  comp.external = true;
   comp.description = "PLC runtime connected at " + client_config_.endpoint_url;
 
   // INV2: fill the asset-identity nameplate from the live server's device-info

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -1965,12 +1965,22 @@ tl::expected<dto::FaultListResult, FaultProviderErrorInfo> OpcuaPlugin::list_fau
       item["severity"] = f.value("severity", 0);
       item["description"] = f.value("description", "");
       item["status"] = f.value("status", "");
-      // Fault records carry reporting_sources, not source_id; surface the
-      // first source so the field is not always empty.
+      // Fault records carry reporting_sources, not source_id. On this
+      // entity-scoped list prefer the requested entity when it is among the
+      // sources - reporting_sources[0] is ordering-dependent and can name a
+      // different co-reporting entity; fall back to the first source only
+      // when the entity itself never reported.
       std::string source_id = f.value("source_id", "");
-      if (source_id.empty() && f.contains("reporting_sources") && f["reporting_sources"].is_array() &&
-          !f["reporting_sources"].empty() && f["reporting_sources"][0].is_string()) {
-        source_id = f["reporting_sources"][0].get<std::string>();
+      if (source_id.empty() && f.contains("reporting_sources") && f["reporting_sources"].is_array()) {
+        for (const auto & src : f["reporting_sources"]) {
+          if (src.is_string() && src.get<std::string>() == entity_id) {
+            source_id = entity_id;
+            break;
+          }
+        }
+        if (source_id.empty() && !f["reporting_sources"].empty() && f["reporting_sources"][0].is_string()) {
+          source_id = f["reporting_sources"][0].get<std::string>();
+        }
       }
       item["source_id"] = source_id;
       // Pass occurrence data through: without it the entity-scoped route

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -1938,7 +1938,25 @@ tl::expected<dto::FaultListResult, FaultProviderErrorInfo> OpcuaPlugin::list_fau
       item["severity"] = f.value("severity", 0);
       item["description"] = f.value("description", "");
       item["status"] = f.value("status", "");
-      item["source_id"] = f.value("source_id", "");
+      // Fault records carry reporting_sources, not source_id; surface the
+      // first source so the field is not always empty.
+      std::string source_id = f.value("source_id", "");
+      if (source_id.empty() && f.contains("reporting_sources") && f["reporting_sources"].is_array() &&
+          !f["reporting_sources"].empty() && f["reporting_sources"][0].is_string()) {
+        source_id = f["reporting_sources"][0].get<std::string>();
+      }
+      item["source_id"] = source_id;
+      // Pass occurrence data through: without it the entity-scoped route
+      // serves faults with no timestamps ("time unknown" in clients) while the
+      // instance-level route has them.
+      for (const char * key : {"first_occurred", "last_occurred", "occurrence_count", "severity_label"}) {
+        if (f.contains(key)) {
+          item[key] = f[key];
+        }
+      }
+      if (f.contains("reporting_sources")) {
+        item["reporting_sources"] = f["reporting_sources"];
+      }
       items.push_back(std::move(item));
     }
   }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -512,11 +512,18 @@ void OpcuaPlugin::configure(const nlohmann::json & config) {
           warn("plugins.opcua.auto_browse.read_initial_values must be a boolean - keeping current value");
         }
       }
+      if (ab.contains("infer_writable")) {
+        if (ab["infer_writable"].is_boolean()) {
+          ab_cfg.infer_writable = ab["infer_writable"].get<bool>();
+        } else {
+          warn("plugins.opcua.auto_browse.infer_writable must be a boolean - keeping current value");
+        }
+      }
       static const std::array<const char *, 6> kKnownKeys{"enabled",   "root_nodes",      "max_depth",
                                                           "max_nodes", "namespace_allow", "namespace_deny"};
       for (const auto & [key, value] : ab.items()) {
         (void)value;
-        if (key == "read_initial_values") {
+        if (key == "read_initial_values" || key == "infer_writable") {
           continue;
         }
         if (std::find_if(kKnownKeys.begin(), kKnownKeys.end(), [&key](const char * k) {
@@ -1298,6 +1305,13 @@ void OpcuaPlugin::run_auto_browse() {
   // without the lock so it never stalls the REST read handlers.
   AutoBrowseResult result = browser.browse();
 
+  size_t writable_points = 0;
+  for (const auto & e : result.entries) {
+    if (e.writable) {
+      ++writable_points;
+    }
+  }
+
   size_t added = 0;
   size_t entity_count = 0;
   {
@@ -1314,7 +1328,8 @@ void OpcuaPlugin::run_auto_browse() {
   auto_browse_generation_ = client_->connection_generation();
 
   log_info("auto_browse: walked " + std::to_string(result.nodes_visited) + " address-space nodes, added " +
-           std::to_string(added) + " data points (" + std::to_string(entity_count) + " entities total)" +
+           std::to_string(added) + " data points (" + std::to_string(entity_count) + " entities total, " +
+           std::to_string(writable_points) + " server-writable)" +
            (result.node_cap_hit ? " [node cap reached - tree may be incomplete]" : "") +
            (result.depth_cap_hit ? " [depth cap reached on at least one branch]" : ""));
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
@@ -819,6 +819,7 @@ void OpcuaPoller::on_event(const AlarmEventConfig & cfg, const std::vector<opcua
   AlarmEventInput input;
   input.enabled_state = variant_or<bool>(values[kFieldEnabledState], true);
   input.active_state = variant_or<bool>(values[kFieldActiveState], false);
+  input.active_state_present = values[kFieldActiveState].isType<bool>();
   input.acked_state = variant_or<bool>(values[kFieldAckedState], false);
   input.confirmed_state = variant_or<bool>(values[kFieldConfirmedState], false);
 
@@ -1022,11 +1023,21 @@ void OpcuaPoller::apply_condition_state(const AlarmEventConfig & cfg, const opcu
     // this makes the live delivery agree with them.
     const SovdAlarmStatus prev_status = it->second.last_status;
 
+    AlarmEventInput effective_input = input;
+    if (!input.active_state_present) {
+      // Notification without a readable ActiveState (secondary ack-state
+      // notifications on Siemens): keep the instance's previous activity
+      // instead of defaulting to inactive - a phantom heal here wipes the
+      // fault the primary notification just confirmed.
+      effective_input.active_state =
+          (prev_status == SovdAlarmStatus::Confirmed || prev_status == SovdAlarmStatus::Healed);
+    }
+
     if (event_id != nullptr) {
       it->second.latest_event_id = *event_id;
     }
 
-    auto outcome = AlarmStateMachine::compute(prev_status, input, require_confirm_for_clear);
+    auto outcome = AlarmStateMachine::compute(prev_status, effective_input, require_confirm_for_clear);
     RCLCPP_DEBUG_STREAM(opcua_poller_logger(),
                         "state machine: enabled="
                             << input.enabled_state << " active=" << input.active_state << " acked=" << input.acked_state

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
@@ -210,6 +210,25 @@ void OpcuaPoller::start(const PollerConfig & config) {
 
   // Start poll/reconnect thread regardless (handles reconnection and poll fallback)
   poll_thread_ = std::thread(&OpcuaPoller::poll_loop, this);
+  if (has_alarm_sources()) {
+    event_pump_thread_ = std::thread(&OpcuaPoller::event_pump_loop, this);
+  }
+}
+
+void OpcuaPoller::event_pump_loop() {
+  // See event_pump_thread_ in the header for why this exists. The iterate is
+  // deliberately short (20 ms) so each critical section on the client is tiny;
+  // the 100 ms cadence keeps worst-case publish servicing two orders of
+  // magnitude below the client requestTimeout.
+  while (running_.load()) {
+    if (client_.is_connected() && event_subscription_id_ != 0) {
+      client_.run_iterate(20);
+    }
+    std::unique_lock<std::mutex> lock(stop_mutex_);
+    stop_cv_.wait_for(lock, std::chrono::milliseconds(100), [this] {
+      return !running_.load();
+    });
+  }
 }
 
 void OpcuaPoller::stop() {
@@ -217,6 +236,9 @@ void OpcuaPoller::stop() {
   stop_cv_.notify_all();
   if (poll_thread_.joinable()) {
     poll_thread_.join();
+  }
+  if (event_pump_thread_.joinable()) {
+    event_pump_thread_.join();
   }
   client_.remove_subscriptions();
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_poller.cpp
@@ -684,6 +684,25 @@ bool OpcuaPoller::should_clear_after_refresh(SovdAlarmStatus last_status, const 
   return seen.find(condition_id) == seen.end();
 }
 
+// True when ANOTHER tracked condition instance carries the same fault_code and
+// is currently Confirmed. Siemens A&C mints a fresh ConditionId (GUID) for
+// every activation of the same Program_Alarm, so a stale instance's heal /
+// reconcile-clear races the new instance's raise; because fault_manager keys
+// by fault_code alone, letting the stale clear through would wipe the fault
+// the live instance just asserted (seen on a real 1505SP: CONFIRMED then
+// HEALED 170 us apart, alarm ends invisible). Caller must hold
+// conditions_mutex_.
+bool OpcuaPoller::same_code_active_elsewhere_locked(const std::string & fault_code,
+                                                    const std::string & condition_id_str) const {
+  for (const auto & [cid, runtime] : conditions_) {
+    if (cid != condition_id_str && runtime.fault_code == fault_code &&
+        runtime.last_status == SovdAlarmStatus::Confirmed) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void OpcuaPoller::reconcile_after_read(const std::set<std::string> & seen, const std::set<std::string> & failed_sources,
                                        const std::set<std::string> & modeled_sources) {
   std::vector<AlarmEventDelivery> clears;
@@ -691,6 +710,10 @@ void OpcuaPoller::reconcile_after_read(const std::set<std::string> & seen, const
     std::unique_lock lock(conditions_mutex_);
     for (auto & [cid, runtime] : conditions_) {
       if (should_clear_condition(runtime.last_status, cid, runtime.source_id, seen, failed_sources, modeled_sources)) {
+        if (same_code_active_elsewhere_locked(runtime.fault_code, cid)) {
+          runtime.last_status = SovdAlarmStatus::Cleared;  // retire the stale instance quietly
+          continue;
+        }
         // Tracked as active but absent from a successful read scan -> the alarm
         // cleared while we were offline. Clear the SOVD fault.
         runtime.last_status = SovdAlarmStatus::Cleared;
@@ -713,6 +736,10 @@ void OpcuaPoller::reconcile_after_refresh(const std::set<std::string> & seen) {
     std::unique_lock lock(conditions_mutex_);
     for (auto & [cid, runtime] : conditions_) {
       if (!should_clear_after_refresh(runtime.last_status, cid, seen)) {
+        continue;
+      }
+      if (same_code_active_elsewhere_locked(runtime.fault_code, cid)) {
+        runtime.last_status = SovdAlarmStatus::Cleared;  // retire the stale instance quietly
         continue;
       }
       // Tracked as active but the completed ConditionRefresh burst did not
@@ -1011,6 +1038,17 @@ void OpcuaPoller::apply_condition_state(const AlarmEventConfig & cfg, const opcu
     if (outcome.action == AlarmAction::NoOp) {
       // Redundant observation (same as last status) - drop while still holding
       // the lock to avoid a needless callback round-trip.
+      return;
+    }
+
+    if ((outcome.action == AlarmAction::ReportHealed || outcome.action == AlarmAction::ClearFault) &&
+        same_code_active_elsewhere_locked(it->second.fault_code, condition_id_str)) {
+      // A newer condition instance of the same fault is Confirmed - this
+      // instance is a stale GUID from a previous activation cycle. Track its
+      // own state but never let it heal/clear the live fault.
+      RCLCPP_DEBUG_STREAM(opcua_poller_logger(), "suppressing stale-instance heal/clear for fault_code='"
+                                                     << it->second.fault_code << "' (condition " << condition_id_str
+                                                     << ")");
       return;
     }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_address_space_browser.cpp
@@ -91,6 +91,14 @@ class FakeAutoBrowseSource : public AutoBrowseSource {
   void set_unreadable(const opcua::NodeId & node) {
     unreadable_.insert(node.toString());
   }
+  // Mark a node the server reports as writable (CurrentWrite set).
+  void set_writable(const opcua::NodeId & node) {
+    writable_.insert(node.toString());
+  }
+  // Mark a node whose AccessLevel attribute read fails (read_writable -> nullopt).
+  void set_access_level_unreadable(const opcua::NodeId & node) {
+    access_unreadable_.insert(node.toString());
+  }
 
   std::vector<OpcuaClient::BrowseChild> browse_children(const opcua::NodeId & parent) override {
     ++browse_calls;
@@ -110,12 +118,21 @@ class FakeAutoBrowseSource : public AutoBrowseSource {
     return OpcuaValue{1.0};
   }
 
+  std::optional<bool> read_writable(const opcua::NodeId & variable_node) override {
+    if (access_unreadable_.count(variable_node.toString()) > 0) {
+      return std::nullopt;
+    }
+    return writable_.count(variable_node.toString()) > 0;
+  }
+
   int browse_calls{0};
 
  private:
   std::unordered_map<std::string, std::vector<OpcuaClient::BrowseChild>> tree_;
   std::unordered_map<std::string, std::string> types_;
   std::unordered_set<std::string> unreadable_;
+  std::unordered_set<std::string> writable_;
+  std::unordered_set<std::string> access_unreadable_;
 };
 
 const NodeMapEntry * find_entry(const std::vector<NodeMapEntry> & entries, const std::string & node_id_str) {
@@ -143,6 +160,8 @@ TEST(AutoBrowserTest, MapsObjectHierarchyToEntityAndVariablesToDataPoints) {
   source.add_child(db_test, make_child("ns=2;s=DB_Test.Running", 2, "Running", "Running", opcua::NodeClass::Variable));
   source.set_type(level, "Float");
   source.set_type(running, "Boolean");
+  // The server marks Running writable (CurrentWrite) but Level read-only.
+  source.set_writable(running);
 
   AutoBrowseConfig cfg;
   AutoBrowser browser(source, cfg);
@@ -159,14 +178,61 @@ TEST(AutoBrowserTest, MapsObjectHierarchyToEntityAndVariablesToDataPoints) {
   EXPECT_EQ(level_entry->display_name, "Level");
   EXPECT_EQ(level_entry->data_type, "float");
   EXPECT_EQ(level_entry->ros2_topic, "/plc/plc_1_db_test/level");
-  EXPECT_FALSE(level_entry->writable);
+  EXPECT_FALSE(level_entry->writable);  // server: read-only
 
   EXPECT_EQ(running_entry->entity_id, "plc_1_db_test");
   EXPECT_EQ(running_entry->data_name, "running");
   EXPECT_EQ(running_entry->data_type, "bool");
+  EXPECT_TRUE(running_entry->writable);  // server: CurrentWrite set
 
   EXPECT_FALSE(result.node_cap_hit);
   EXPECT_FALSE(result.depth_cap_hit);
+}
+
+// -- writable inferred from the server's AccessLevel -------------------
+
+TEST(AutoBrowserTest, WritableInferredFromServerAccessLevel) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto rw = NodeMap::parse_node_id("ns=2;s=Setpoint");  // writable
+  const auto ro = NodeMap::parse_node_id("ns=2;s=Measured");  // read-only
+  const auto unk = NodeMap::parse_node_id("ns=2;s=Unknown");  // AccessLevel read fails
+
+  source.add_child(root, make_child("ns=2;s=Setpoint", 2, "Setpoint", "Setpoint", opcua::NodeClass::Variable));
+  source.add_child(root, make_child("ns=2;s=Measured", 2, "Measured", "Measured", opcua::NodeClass::Variable));
+  source.add_child(root, make_child("ns=2;s=Unknown", 2, "Unknown", "Unknown", opcua::NodeClass::Variable));
+  source.set_type(rw, "Float");
+  source.set_type(ro, "Float");
+  source.set_type(unk, "Float");
+  source.set_writable(rw);
+  source.set_access_level_unreadable(unk);
+
+  AutoBrowseConfig cfg;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 3u);
+  EXPECT_TRUE(find_entry(result.entries, rw.toString())->writable);
+  EXPECT_FALSE(find_entry(result.entries, ro.toString())->writable);
+  // AccessLevel read failed -> safe read-only default, never a false-positive.
+  EXPECT_FALSE(find_entry(result.entries, unk.toString())->writable);
+}
+
+TEST(AutoBrowserTest, InferWritableDisabledKeepsEverythingReadOnly) {
+  FakeAutoBrowseSource source;
+  const auto root = NodeMap::parse_node_id("i=85");
+  const auto rw = NodeMap::parse_node_id("ns=2;s=Setpoint");
+  source.add_child(root, make_child("ns=2;s=Setpoint", 2, "Setpoint", "Setpoint", opcua::NodeClass::Variable));
+  source.set_type(rw, "Float");
+  source.set_writable(rw);
+
+  AutoBrowseConfig cfg;
+  cfg.infer_writable = false;
+  AutoBrowser browser(source, cfg);
+  auto result = browser.browse();
+
+  ASSERT_EQ(result.entries.size(), 1u);
+  EXPECT_FALSE(find_entry(result.entries, rw.toString())->writable);
 }
 
 TEST(AutoBrowserTest, PureObjectsWithoutVariablesDoNotBecomeEntities) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
@@ -199,6 +199,15 @@ TEST(ComponentIdentityDerive, NeverEmitsOpenPlc) {
   EXPECT_EQ(ci.name.find("OpenPLC"), std::string::npos);
 }
 
+TEST(ComponentIdentityDerive, BracketedIpv6EndpointYieldsHostNotTruncatedAddress) {
+  // opc.tcp://[fe80::1]:4840 - the host is the bracket body; a naive ":" cut
+  // would truncate mid-address and produce an invalid fallback id.
+  OpcuaClient::DeviceInfo info;
+  auto ci = derive_component_identity(info, "opc.tcp://[fe80::1]:4840");
+  EXPECT_NE(ci.name.find("fe80::1"), std::string::npos);
+  EXPECT_EQ(ci.name.find('['), std::string::npos);
+}
+
 TEST(ComponentIdentityDerive, ModelOnlyNoManufacturer) {
   OpcuaClient::DeviceInfo info;
   info.di_model = "CPU 1505SP F";

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
@@ -186,9 +186,11 @@ TEST(ComponentIdentityDerive, FallsBackToBuildInfo) {
 TEST(ComponentIdentityDerive, EndpointFallbackWhenNoIdentity) {
   OpcuaClient::DeviceInfo info;  // empty
   auto ci = derive_component_identity(info, "opc.tcp://192.168.1.10:4840");
-  // Neutral, endpoint-derived, never a fixed product string.
-  EXPECT_EQ(ci.id, "opcua-192.168.1.10");
-  EXPECT_EQ(ci.name, "opcua-192.168.1.10");
+  // Neutral, endpoint-derived, never a fixed product string. The host is
+  // slugified so the dotted IPv4 yields a valid entity id (a raw
+  // opcua-192.168.1.10 is rejected by is_valid_entity_id -> Component dropped).
+  EXPECT_EQ(ci.id, "opcua-192_168_1_10");
+  EXPECT_EQ(ci.name, "opcua-192_168_1_10");
 }
 
 TEST(ComponentIdentityDerive, NeverEmitsOpenPlc) {
@@ -201,10 +203,13 @@ TEST(ComponentIdentityDerive, NeverEmitsOpenPlc) {
 
 TEST(ComponentIdentityDerive, BracketedIpv6EndpointYieldsHostNotTruncatedAddress) {
   // opc.tcp://[fe80::1]:4840 - the host is the bracket body; a naive ":" cut
-  // would truncate mid-address and produce an invalid fallback id.
+  // would truncate mid-address and produce an invalid fallback id. The whole
+  // bracket body is slugified (fe80::1 -> fe80_1): the trailing "_1" proves the
+  // tail survived, and slugify strips the brackets that would break the id.
   OpcuaClient::DeviceInfo info;
   auto ci = derive_component_identity(info, "opc.tcp://[fe80::1]:4840");
-  EXPECT_NE(ci.name.find("fe80::1"), std::string::npos);
+  EXPECT_EQ(ci.id, "opcua-fe80_1");
+  EXPECT_EQ(ci.name, "opcua-fe80_1");
   EXPECT_EQ(ci.name.find('['), std::string::npos);
 }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_device_identity.cpp
@@ -160,4 +160,51 @@ TEST(DeviceIdentityTrust, CertValidationWithoutSecureChannelIsUntrusted) {
   EXPECT_FALSE(opcua_identity_trusted(config));
 }
 
+// -- derive_component_identity: config-less component naming ---------------
+
+TEST(ComponentIdentityDerive, DiNameplateWinsAndSlugs) {
+  OpcuaClient::DeviceInfo info;
+  info.di_manufacturer = "Siemens AG";
+  info.di_model = "CPU 1505SP F";
+  // BuildInfo present too, but DI nameplate must win.
+  info.manufacturer_name = "Siemens";
+  info.product_name = "S7-1500";
+  auto ci = derive_component_identity(info, "opc.tcp://192.168.1.10:4840");
+  EXPECT_EQ(ci.name, "Siemens AG CPU 1505SP F");
+  EXPECT_EQ(ci.id, "siemens_ag_cpu_1505sp_f");
+}
+
+TEST(ComponentIdentityDerive, FallsBackToBuildInfo) {
+  OpcuaClient::DeviceInfo info;
+  info.manufacturer_name = "open62541";
+  info.product_name = "Test Alarm PLC";
+  auto ci = derive_component_identity(info, "opc.tcp://plc:4840");
+  EXPECT_EQ(ci.name, "open62541 Test Alarm PLC");
+  EXPECT_EQ(ci.id, "open62541_test_alarm_plc");
+}
+
+TEST(ComponentIdentityDerive, EndpointFallbackWhenNoIdentity) {
+  OpcuaClient::DeviceInfo info;  // empty
+  auto ci = derive_component_identity(info, "opc.tcp://192.168.1.10:4840");
+  // Neutral, endpoint-derived, never a fixed product string.
+  EXPECT_EQ(ci.id, "opcua-192.168.1.10");
+  EXPECT_EQ(ci.name, "opcua-192.168.1.10");
+}
+
+TEST(ComponentIdentityDerive, NeverEmitsOpenPlc) {
+  // Regression guard: no code path may return the retired hardcoded default.
+  OpcuaClient::DeviceInfo info;
+  auto ci = derive_component_identity(info, "opc.tcp://10.0.0.5:4840");
+  EXPECT_EQ(ci.id.find("openplc"), std::string::npos);
+  EXPECT_EQ(ci.name.find("OpenPLC"), std::string::npos);
+}
+
+TEST(ComponentIdentityDerive, ModelOnlyNoManufacturer) {
+  OpcuaClient::DeviceInfo info;
+  info.di_model = "CPU 1505SP F";
+  auto ci = derive_component_identity(info, "opc.tcp://plc:4840");
+  EXPECT_EQ(ci.name, "CPU 1505SP F");
+  EXPECT_EQ(ci.id, "cpu_1505sp_f");
+}
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_network_discovery.cpp
@@ -251,8 +251,8 @@ IdentifyResult lds_identity() {
   return r;
 }
 
-DiscoveryConfig scenario_cfg() {
-  DiscoveryConfig cfg;
+OpcuaDiscoveryConfig scenario_cfg() {
+  OpcuaDiscoveryConfig cfg;
   cfg.enabled = true;
   cfg.subnets = {"192.168.1.0/24"};  // explicit, so no local-interface derivation
   cfg.ports = {4840, 102};
@@ -318,7 +318,7 @@ TEST(NetworkDiscoveryRun, DedupsByApplicationUri) {
       {"opc.tcp://192.168.1.10:4840", siemens_identity()},
       {"opc.tcp://192.168.1.20:4840", siemens_identity()},
   });
-  DiscoveryConfig cfg;
+  OpcuaDiscoveryConfig cfg;
   cfg.enabled = true;
   cfg.subnets = {"192.168.1.0/24"};
   cfg.ports = {4840};
@@ -343,7 +343,7 @@ TEST(NetworkDiscoveryRun, ParallelIdentifyKeepsDeterministicOrder) {
     r.advertised_url = "opc.tcp://" + ip + ":4840";
     table.emplace("opc.tcp://" + ip + ":4840", r);
   }
-  DiscoveryConfig cfg;
+  OpcuaDiscoveryConfig cfg;
   cfg.enabled = true;
   cfg.subnets = {"192.168.1.0/24"};
   cfg.ports = {4840};
@@ -366,7 +366,7 @@ TEST(NetworkDiscoveryRun, IdentifyFailureRecordedAsLead) {
   IdentifyResult bad;
   bad.error = "BadTimeout";
   auto identify = make_identify({{"opc.tcp://192.168.1.50:4840", bad}});
-  DiscoveryConfig cfg;
+  OpcuaDiscoveryConfig cfg;
   cfg.enabled = true;
   cfg.subnets = {"192.168.1.0/24"};
   cfg.ports = {4840};
@@ -386,7 +386,7 @@ TEST(SelectAutoEndpoint, PicksAnonymousNoneDataServerSkipsLds) {
       {"opc.tcp://192.168.1.9:4840", lds_identity()},
       {"opc.tcp://192.168.1.10:4840", siemens_identity()},
   });
-  DiscoveryConfig cfg;
+  OpcuaDiscoveryConfig cfg;
   cfg.enabled = true;
   cfg.subnets = {"192.168.1.0/24"};
   cfg.ports = {4840};

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_node_map.cpp
@@ -2173,17 +2173,36 @@ TEST(AutoAlarmsFinalizeOverlayTest, ParamOnlyNoNodeMapProducesActiveConfigAndEnt
   // poller subscribes to the right EventNotifier in the no-node_map path.
   EXPECT_EQ(finalized.source_node_id_str, "i=2253");
   EXPECT_EQ(finalized.source_node_id.toString(), NodeMap::parse_node_id("i=2253").toString());
-  // Entity defaulted from the (default) component_id, and registered as
-  // fault-bearing so SOVD discovery surfaces the alarms App with no node map.
-  EXPECT_EQ(finalized.entity_id, "openplc_runtime_alarms");
+  // Entity defaulted from the neutral default component_id (config-less
+  // discovery overrides it from device identity at runtime), and registered
+  // as fault-bearing so SOVD discovery surfaces the alarms App with no node map.
+  EXPECT_EQ(finalized.entity_id, "opcua_device_alarms");
   bool found = false;
   for (const auto & def : map.entity_defs()) {
-    if (def.id == "openplc_runtime_alarms") {
+    if (def.id == "opcua_device_alarms") {
       found = true;
       EXPECT_TRUE(def.has_faults);
     }
   }
   EXPECT_TRUE(found);
+}
+
+TEST(AutoAlarmsFinalizeOverlayTest, ComponentIdentityOverrideFlowsIntoAlarmEntity) {
+  // Config-less discovery: the plugin sets the component id/name from the
+  // device's own identity before enabling auto_alarms. The derived alarms
+  // entity must key off the overridden id, not the neutral default.
+  NodeMap map;
+  map.set_component_identity("siemens_ag_cpu_1505sp_f", "Siemens AG CPU 1505SP F");
+  EXPECT_EQ(map.component_id(), "siemens_ag_cpu_1505sp_f");
+  EXPECT_EQ(map.component_name(), "Siemens AG CPU 1505SP F");
+
+  map.mutable_auto_alarms().enabled = true;
+  ASSERT_TRUE(map.finalize_auto_alarms_overlay());
+  EXPECT_EQ(map.auto_alarms().entity_id, "siemens_ag_cpu_1505sp_f_alarms");
+
+  // Empty id is a no-op guard (keeps the current identity).
+  map.set_component_identity("", "ignored");
+  EXPECT_EQ(map.component_id(), "siemens_ag_cpu_1505sp_f");
 }
 
 TEST(AutoAlarmsFinalizeOverlayTest, ParamOnlyRespectsOverriddenSourceAndEntity) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -99,7 +99,13 @@ class FakePluginContext : public RosPluginContext {
     nlohmann::json result = nlohmann::json::array();
     if (all_faults.contains("faults")) {
       for (const auto & f : all_faults["faults"]) {
-        if (f.value("source_id", "") == entity_id) {
+        bool in_scope = f.value("source_id", "") == entity_id;
+        if (!in_scope && f.contains("reporting_sources") && f["reporting_sources"].is_array()) {
+          for (const auto & src : f["reporting_sources"]) {
+            in_scope = in_scope || (src.is_string() && src.get<std::string>() == entity_id);
+          }
+        }
+        if (in_scope) {
           result.push_back(f);
         }
       }
@@ -295,6 +301,44 @@ TEST_F(OpcuaPluginTest, ListFaultsWithData) {
   ASSERT_TRUE(result.has_value());
   EXPECT_EQ(result->content["items"].size(), 1u);
   EXPECT_EQ(result->content["items"][0]["code"], "PLC_LOW_LEVEL");
+}
+
+TEST_F(OpcuaPluginTest, ListFaultsPassesThroughOccurrenceData) {
+  // The entity-scoped route must not drop the occurrence fields the fault
+  // manager provides - clients rendered "time unknown" when the serializer
+  // projected only {code, severity, description, status, source_id}.
+  ctx_.all_faults = {{"faults",
+                      {{{"fault_code", "PLC_LOW_LEVEL"},
+                        {"source_id", "tank"},
+                        {"severity", 2},
+                        {"severity_label", "ERROR"},
+                        {"status", "CONFIRMED"},
+                        {"first_occurred", 100.5},
+                        {"last_occurred", 200.25},
+                        {"occurrence_count", 7},
+                        {"reporting_sources", {"tank"}}}}}};
+  auto result = plugin_.list_faults("tank");
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->content["items"].size(), 1u);
+  const auto & item = result->content["items"][0];
+  EXPECT_EQ(item["code"], "PLC_LOW_LEVEL");
+  EXPECT_EQ(item["first_occurred"], 100.5);
+  EXPECT_EQ(item["last_occurred"], 200.25);
+  EXPECT_EQ(item["occurrence_count"], 7);
+  EXPECT_EQ(item["severity_label"], "ERROR");
+  EXPECT_EQ(item["reporting_sources"][0], "tank");
+  EXPECT_EQ(item["source_id"], "tank");
+}
+
+TEST_F(OpcuaPluginTest, ListFaultsDerivesSourceIdFromReportingSources) {
+  // Fault-manager records carry reporting_sources, not source_id; the item's
+  // source_id must fall back to the first reporting source instead of "".
+  ctx_.all_faults = {
+      {"faults", {{{"fault_code", "PLC_LOW_LEVEL"}, {"severity", 2}, {"reporting_sources", {"tank", "other"}}}}}};
+  auto result = plugin_.list_faults("tank");
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->content["items"].size(), 1u);
+  EXPECT_EQ(result->content["items"][0]["source_id"], "tank");
 }
 
 TEST_F(OpcuaPluginTest, GetFaultNotFound) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -118,9 +118,15 @@ class FakePluginContext : public RosPluginContext {
     return get_entity(entity_id);
   }
 
+  // Recorded so tests can assert exactly which entities get which vendor
+  // capability (e.g. x-plc-data must not be registered for a def with no
+  // data points - see the auto_alarms fallback entity below).
+  std::vector<std::pair<std::string, std::string>> registered_entity_capabilities;
+
   void register_capability(SovdEntityType /*type*/, const std::string & /*capability*/) override {
   }
-  void register_entity_capability(const std::string & /*entity_id*/, const std::string & /*capability*/) override {
+  void register_entity_capability(const std::string & entity_id, const std::string & capability) override {
+    registered_entity_capabilities.emplace_back(entity_id, capability);
   }
   std::vector<std::string> get_type_capabilities(SovdEntityType /*type*/) const override {
     return {};
@@ -256,6 +262,24 @@ TEST_F(OpcuaPluginTest, WriteDataMissingValue) {
   EXPECT_EQ(result.error().code, DataProviderError::InvalidValue);
 }
 
+// has_data gates PluginManager::get_data_provider_for_entity (and, through
+// it, the gateway's `data` capability advertisement) at entity granularity -
+// see discovery_handlers.cpp's prune_plugin_unserved_capabilities. It must
+// track list_data's own "no entries" check exactly.
+TEST_F(OpcuaPluginTest, HasDataTrueForDataBearingEntity) {
+  EXPECT_TRUE(plugin_.has_data("tank"));
+}
+
+TEST_F(OpcuaPluginTest, HasDataFalseForComponentEntity) {
+  // "test_runtime" is the PLC runtime Component id, not a data-bearing App -
+  // it owns no NodeMap entries.
+  EXPECT_FALSE(plugin_.has_data("test_runtime"));
+}
+
+TEST_F(OpcuaPluginTest, HasDataFalseForUnknownEntity) {
+  EXPECT_FALSE(plugin_.has_data("nonexistent"));
+}
+
 // -- OperationProvider tests --
 
 TEST_F(OpcuaPluginTest, ListOperationsOnlyWritable) {
@@ -272,6 +296,24 @@ TEST_F(OpcuaPluginTest, ListOperationsEntityNotFound) {
   EXPECT_EQ(result.error().code, OperationProviderError::EntityNotFound);
 }
 
+// has_operations mirrors list_operations' own entity_defs() lookup so it
+// gates PluginManager::get_operation_provider_for_entity at the same
+// granularity list_operations already uses to 404.
+TEST_F(OpcuaPluginTest, HasOperationsTrueForKnownEntityDef) {
+  EXPECT_TRUE(plugin_.has_operations("tank"));
+}
+
+TEST_F(OpcuaPluginTest, HasOperationsFalseForComponentEntity) {
+  // "test_runtime" has no entity_defs entry (see build_entity_defs' comment
+  // on why the Component id is deliberately excluded), so it has no
+  // operations even though the plugin implements OperationProvider.
+  EXPECT_FALSE(plugin_.has_operations("test_runtime"));
+}
+
+TEST_F(OpcuaPluginTest, HasOperationsFalseForUnknownEntity) {
+  EXPECT_FALSE(plugin_.has_operations("nonexistent"));
+}
+
 TEST_F(OpcuaPluginTest, ExecuteOperationMissingValue) {
   nlohmann::json params = {{"not_value", 42}};
   auto result = plugin_.execute_operation("tank", "set_level", params);
@@ -284,6 +326,85 @@ TEST_F(OpcuaPluginTest, ExecuteOperationReadOnly) {
   auto result = plugin_.execute_operation("tank", "set_pressure", params);
   EXPECT_FALSE(result.has_value());
   EXPECT_EQ(result.error().code, OperationProviderError::Rejected);
+}
+
+// -- auto_alarms fallback entity: has data/operations fitness + introspect
+// -- capability registration --
+//
+// build_entity_defs() gives the auto_alarms fallback entity ("<component>_
+// alarms") an entity_defs entry purely to host faults (has_faults=true) -
+// it owns no NodeMap entries. Before this fix introspect() unconditionally
+// registered x-plc-data for every entity_defs entry, so this fallback
+// entity advertised x-plc-data (and, via the plugin-wide DataProvider, the
+// base SOVD `data` capability) despite list_data 404ing on it.
+
+class OpcuaPluginAlarmsFitnessTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    yaml_path_ = "/tmp/test_opcua_plugin_alarms_fitness_nodemap.yaml";
+    std::ofstream f(yaml_path_);
+    f << R"(
+area_id: test_plc
+component_id: test_runtime
+auto_alarms:
+  enabled: true
+  source_node_id: "ns=2;i=999"
+nodes:
+  - node_id: "ns=2;i=1"
+    entity_id: tank
+    data_name: level
+    display_name: Tank Level
+    data_type: float
+    writable: false
+)";
+    f.close();
+
+    nlohmann::json config;
+    config["node_map_path"] = yaml_path_;
+    config["endpoint_url"] = "opc.tcp://nonexistent:4840";
+    plugin_.configure(config);
+    plugin_.set_context(ctx_);
+  }
+
+  std::string yaml_path_;
+  OpcuaPlugin plugin_;
+  FakePluginContext ctx_;
+  // "<component_id>_alarms" per NodeMap::finalize_auto_alarms_overlay's
+  // default when auto_alarms.entity_id is not set explicitly.
+  static constexpr const char * kAlarmsEntityId = "test_runtime_alarms";
+};
+
+TEST_F(OpcuaPluginAlarmsFitnessTest, HasDataFalseForAlarmsFallbackEntity) {
+  EXPECT_FALSE(plugin_.has_data(kAlarmsEntityId));
+}
+
+TEST_F(OpcuaPluginAlarmsFitnessTest, HasOperationsTrueForAlarmsFallbackEntity) {
+  // The fallback entity DOES have an entity_defs entry (it exists purely to
+  // host faults), so list_operations succeeds (with an empty or
+  // ack/confirm-only list) rather than 404ing - unlike the Component, whose
+  // id never appears in entity_defs() at all.
+  EXPECT_TRUE(plugin_.has_operations(kAlarmsEntityId));
+}
+
+TEST_F(OpcuaPluginAlarmsFitnessTest, IntrospectSkipsXPlcDataForAlarmsFallbackEntity) {
+  auto result = plugin_.introspect({});
+
+  bool alarms_got_x_plc_data = false;
+  bool tank_got_x_plc_data = false;
+  for (const auto & [entity_id, capability] : ctx_.registered_entity_capabilities) {
+    if (capability != "x-plc-data") {
+      continue;
+    }
+    if (entity_id == kAlarmsEntityId) {
+      alarms_got_x_plc_data = true;
+    }
+    if (entity_id == "tank") {
+      tank_got_x_plc_data = true;
+    }
+  }
+  EXPECT_FALSE(alarms_got_x_plc_data) << "auto_alarms fallback entity has no data points - "
+                                         "x-plc-data must not be registered for it";
+  EXPECT_TRUE(tank_got_x_plc_data) << "data-bearing entities must keep x-plc-data";
 }
 
 // -- FaultProvider tests --


### PR DESCRIPTION
Makes config-less PLC discovery production-usable and adds runtime threshold alarms.

**opcua plugin**
- Component identity read from the device (DI nameplate, then BuildInfo, then endpoint fallback) - no hardcoded names.
- Native A&C auto-subscribe when no node_map: conditions surface on `/faults`, auto-clear on inactive.
- `writable` inferred from server AccessLevel (CurrentWrite); width-typed integer writes.
- Config-less subnet scan auto-selects the endpoint; ODR fix (`OpcuaDiscoveryConfig`) + `-fvisibility=hidden` so multiple plugins co-load in one gateway safely.

**gateway core**
- `FaultTriggerEngine`: runtime threshold rules on discovered data points - CRUD at `/api/v1/apps/{app}/fault-triggers`, JSON persistence, fires through FaultManager (freeze-frame captured), auto-clears on un-cross. Rejects rules on nonexistent points. Sibling of the existing SOVD notification `/triggers` (documented).
- Components count as fault reporting sources in scoped queries; entity-scoped fault lists include occurrence data; sqlite store records `confirmed_at_ns` (with migration); plugin entities advertise only capabilities they serve.

**Tests:** full suite green (4797 gateway/fault_manager/opcua), new suites for the trigger engine, identity derivation, AccessLevel writable, confirmed_at. Verified live against an S7-1500: subnet scan -> auto-browse (57 nodes), write round-trip, trigger fault with freeze-frame.
