### PR TITLE
fix(gateway): route trigger subscriptions through the shared subscription executor

### DIFF
--- a/scripts/check_no_naked_subscriptions.sh
+++ b/scripts/check_no_naked_subscriptions.sh
@@ -47,7 +47,6 @@ ALLOWED_DIRS_PATTERN="(${GATEWAY_ROOT}/src/ros2_common/|${GATEWAY_ROOT}/include/
 ALLOWED_LEGACY_FILES=(
   "${GATEWAY_ROOT}/src/http/handlers/sse_fault_handler.cpp"        # faults provider follow-up
   "${GATEWAY_ROOT}/src/trigger_fault_subscriber.cpp"               # faults provider follow-up
-  "${GATEWAY_ROOT}/src/ros2/trigger_topic_subscriber.cpp"          # adapter for TopicSubscriptionTransport (rclcpp boundary)
   "${GATEWAY_ROOT}/src/ros2/transports/ros2_action_transport.cpp"  # operations provider follow-up
   "${GATEWAY_ROOT}/src/ros2/transports/ros2_log_source.cpp"        # /rosout adapter (LogSource port)
   "${FAULT_MANAGER_ROOT}/src/snapshot_capture.cpp"                 # uses LockedSubscriptionGuard (in-place serialisation)

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -621,6 +621,12 @@ if(BUILD_TESTING)
   medkit_target_dependencies(test_ros2_topic_data_provider rclcpp std_msgs)
   medkit_set_test_domain(test_ros2_topic_data_provider)
 
+  # TriggerTopicSubscriber adapter tests (rclcpp + a real subscription executor)
+  ament_add_gtest(test_trigger_topic_subscriber test/test_trigger_topic_subscriber.cpp)
+  target_link_libraries(test_trigger_topic_subscriber gateway_ros2)
+  medkit_target_dependencies(test_trigger_topic_subscriber rclcpp std_msgs)
+  medkit_set_test_domain(test_trigger_topic_subscriber)
+
   # Add Ros2LogSource tests (rclcpp required - publishes to /rosout)
   ament_add_gtest(test_ros2_log_source test/test_ros2_log_source.cpp)
   target_link_libraries(test_ros2_log_source gateway_ros2)
@@ -1100,6 +1106,7 @@ if(BUILD_TESTING)
       test_ros2_subscription_slot
       test_topic_data_provider_interface
       test_ros2_topic_data_provider
+      test_trigger_topic_subscriber
       test_ros2_log_source
       test_discovery_models
       test_host_info_provider

--- a/src/ros2_medkit_gateway/design/ros2_subscription_architecture.rst
+++ b/src/ros2_medkit_gateway/design/ros2_subscription_architecture.rst
@@ -241,9 +241,13 @@ Regression gate
 ``create_callback_group``. New production code must route through
 ``Ros2SubscriptionSlot``.
 
-Known-legacy call sites (fault subscribers, operation manager, log manager,
-trigger_topic_subscriber) are explicitly allowlisted and tracked for
-migration under Phase C of the provider architecture rollout.
+Known-legacy call sites (fault subscribers, operation manager, log manager)
+are explicitly allowlisted and tracked for migration under Phase C of the
+provider architecture rollout. The trigger topic subscriber was migrated to
+``Ros2SubscriptionSlot`` (issue #548): its per-trigger subscriptions are now
+created, destroyed, and dispatched on the executor worker, so a subscription
+callback can no longer fire on a partially destroyed subscriber during
+shutdown.
 
 Observability
 -------------

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -195,6 +195,26 @@ class GatewayNode : public rclcpp::Node {
   EntityFreezeFrameCapture * get_entity_freeze_frame_capture() const;
 
   /**
+   * @brief Route the trigger topic subscriber through the shared subscription
+   *        executor (issue #548). Its per-trigger subscriptions are then
+   *        created, destroyed, and dispatched on the executor's single worker
+   *        thread, so callbacks drain before teardown instead of racing the
+   *        main multi-threaded executor. Call once after the executor is built
+   *        (main.cpp). No-op when triggers are disabled.
+   */
+  void set_trigger_subscription_executor(ros2_common::Ros2SubscriptionExecutor & exec);
+
+  /**
+   * @brief Shut down the trigger topic subscriber, draining and destroying its
+   *        subscriptions on the executor worker. Idempotent. Must be called
+   *        BEFORE the subscription executor is destroyed (the trigger
+   *        subscriptions live on the executor's node and are torn down via its
+   *        worker). No-op when triggers are disabled. ~GatewayNode also calls
+   *        it, which becomes a no-op once this has run.
+   */
+  void shutdown_trigger_subscriber();
+
+  /**
    * @brief Get the ResourceSamplerRegistry instance
    * @return Raw pointer to ResourceSamplerRegistry (valid for lifetime of GatewayNode)
    */

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/gateway_node.hpp
@@ -215,6 +215,16 @@ class GatewayNode : public rclcpp::Node {
   void shutdown_trigger_subscriber();
 
   /**
+   * @brief Stop and join the REST server.
+   *
+   * Callable from the main teardown before the subscription executor is
+   * destroyed, so no httplib handler thread can be mid-subscribe()/unsubscribe()
+   * (which dereference the subscription executor) when it is freed. Idempotent;
+   * ~GatewayNode also calls it.
+   */
+  void stop_rest_server();
+
+  /**
    * @brief Get the ResourceSamplerRegistry instance
    * @return Raw pointer to ResourceSamplerRegistry (valid for lifetime of GatewayNode)
    */
@@ -302,7 +312,6 @@ class GatewayNode : public rclcpp::Node {
  private:
   void refresh_cache();
   void start_rest_server();
-  void stop_rest_server();
 
   /// Log a one-time discovery summary shortly after startup: discovered node /
   /// topic / entity counts, the REST URL and a sample curl. When no application

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
@@ -24,7 +24,10 @@
 #include <unordered_map>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <tl/expected.hpp>
 
+#include "ros2_medkit_gateway/ros2_common/ros2_subscription_slot.hpp"
 #include "ros2_medkit_serialization/json_serializer.hpp"
 
 namespace ros2_medkit_gateway {
@@ -34,22 +37,36 @@ namespace ros2_medkit_gateway {
  *
  * Each trigger that observes a "data" resource registers exactly one
  * subscription here, identified by a caller-provided handle key. The
- * subscriber owns the rclcpp::GenericSubscription, performs the CDR -> JSON
+ * subscriber owns a subscription slot on the shared subscription executor,
+ * performs the CDR -> JSON
  * deserialization, and delivers each sample to the handle's callback. When
  * the topic's type cannot be resolved at subscribe time (publisher not yet
  * up), the entry is queued as "pending" and retried every 5 seconds. Pending
  * entries time out after 60 seconds.
  *
  * Threading: subscribe()/unsubscribe()/shutdown() are mutex-guarded.
- * Per-handle callbacks are invoked from rclcpp executor threads. The
- * subscription-destructor pattern (callbacks cannot fire on a partially
- * destroyed subscriber) is enforced by the shutdown_flag_ guard followed by
- * subscription map clearing inside shutdown().
+ * Every subscription is created, destroyed, AND dispatched on the single
+ * worker thread of the shared Ros2SubscriptionExecutor (via
+ * Ros2SubscriptionSlot). Because create, destroy, and callback dispatch all
+ * run on the same worker, a destroy can never race an in-flight callback, and
+ * executor teardown drains any queued callback before the subscriber's state
+ * (serializer, captured strings) is torn down. This closes the shutdown data
+ * race in issue #548, where subscriptions created directly on the main node
+ * were dispatched by the multi-threaded main executor and could fire on a
+ * partially destroyed subscriber.
+ *
+ * @warning Ros2SubscriptionSlot creation and destruction post a task to the
+ * executor worker and block until it runs (run_sync). The per-handle callback
+ * acquires mutex_. Therefore slot create/destroy must NEVER happen while
+ * holding mutex_: the worker could be inside a callback blocked on mutex_ while
+ * the caller waits for that same worker, deadlocking. All map bookkeeping
+ * happens under mutex_; all slot create/destroy happens strictly outside it.
  *
  * The lifetime of an individual subscription is tied to the corresponding
  * handle key: unsubscribe(handle_key) atomically removes both the user
- * callback and the underlying rclcpp::Subscription, so any in-flight
- * dispatch sees the empty map and short-circuits.
+ * callback and the subscription slot from the map, so any in-flight dispatch
+ * sees the empty map and short-circuits; the slot is then destroyed outside
+ * the lock, draining the worker.
  *
  * The retry callback (set via set_retry_callback) is fired on every retry
  * tick. The trigger manager wires this to retry_unresolved_triggers() so
@@ -77,9 +94,23 @@ class TriggerTopicSubscriber {
   TriggerTopicSubscriber & operator=(TriggerTopicSubscriber &&) = delete;
 
   /**
+   * @brief Wire the shared subscription executor used to create, destroy, and
+   *        dispatch every per-handle subscription.
+   *
+   * Non-owning: the executor must outlive every subscription (the gateway
+   * calls shutdown() before destroying the executor). Must be set before the
+   * first subscribe() that resolves to a real topic; if it is null when a
+   * subscription would be created, subscribe() throws and retry logs+skips
+   * rather than silently falling back to a racy path.
+   *
+   * @param exec Shared subscription executor, or nullptr to detach.
+   */
+  void set_subscription_executor(ros2_common::Ros2SubscriptionExecutor * exec);
+
+  /**
    * @brief Subscribe to a topic under a unique handle key.
    *
-   * Each call yields one rclcpp::GenericSubscription dedicated to the
+   * Each call yields one subscription slot dedicated to the
    * caller's handle. If @p msg_type is empty the type is resolved from the
    * ROS graph; if no publisher is yet advertising the topic, the entry is
    * queued for retry.
@@ -97,7 +128,7 @@ class TriggerTopicSubscriber {
                  SampleCallback callback);
 
   /// Drop the subscription for @p handle_key. Both the user callback and the
-  /// rclcpp::GenericSubscription are released; in-flight dispatch is
+  /// subscription slot are released; in-flight dispatch is
   /// guaranteed not to fire after this returns.
   void unsubscribe(const std::string & handle_key);
 
@@ -110,9 +141,13 @@ class TriggerTopicSubscriber {
   void set_retry_callback(RetryCallback cb);
 
  private:
-  /// Per-handle live subscription state.
+  /// rclcpp generic-subscription callback delivering one serialized sample.
+  using MessageCallback = std::function<void(std::shared_ptr<const rclcpp::SerializedMessage>)>;
+
+  /// Per-handle live subscription state. The slot creates its subscription on
+  /// the shared executor worker and destroys it there when reset.
   struct LiveEntry {
-    rclcpp::GenericSubscription::SharedPtr subscription;
+    std::unique_ptr<ros2_common::Ros2SubscriptionSlot> slot;
     std::string topic_name;
     std::string msg_type;
     SampleCallback callback;
@@ -131,15 +166,34 @@ class TriggerTopicSubscriber {
   /// Interval between retry attempts for pending subscriptions (seconds).
   static constexpr int kRetryIntervalSec = 5;
 
-  /// Create a GenericSubscription for @p handle_key with the resolved type.
-  /// Caller must hold mutex_.
-  void create_subscription_internal(const std::string & handle_key, const std::string & topic_name,
-                                    const std::string & msg_type, SampleCallback callback);
+  /// Build the rclcpp callback that deserializes a sample and dispatches it to
+  /// the handle's user callback (looked up under mutex_). Pure builder - no
+  /// locking, safe to call outside mutex_.
+  MessageCallback make_message_callback(const std::string & handle_key, const std::string & topic_name,
+                                        const std::string & msg_type);
+
+  /// Create a subscription slot for @p handle_key on the shared executor.
+  /// MUST be called WITHOUT holding mutex_ (create_generic posts to the worker
+  /// via run_sync). Returns the slot or an error string; the caller inserts it
+  /// into live_ under the lock with a fresh world-state re-check.
+  tl::expected<std::unique_ptr<ros2_common::Ros2SubscriptionSlot>, std::string>
+  create_slot_unlocked(const std::string & handle_key, const std::string & topic_name, const std::string & msg_type);
+
+  /// Resolve a topic's message type from the ROS graph (read-only query; does
+  /// not require mutex_). Returns empty when no publisher advertises the topic.
+  std::string resolve_topic_type(const std::string & topic_name) const;
 
   /// Retry callback for pending subscriptions. Called by retry_timer_.
   void retry_pending_subscriptions();
 
   rclcpp::Node * node_;
+  // Non-owning shared subscription executor. All slot create/destroy/dispatch
+  // is serialized on its single worker thread. Must outlive every slot.
+  // Atomic because it is set once on the main thread (after construction) while
+  // the REST server - started in the GatewayNode constructor - can already be
+  // running subscribe() on an httplib thread; the reads below are deliberately
+  // outside mutex_, so acquire/release is the right tool, not the lock.
+  std::atomic<ros2_common::Ros2SubscriptionExecutor *> sub_exec_{nullptr};
   std::shared_ptr<ros2_medkit_serialization::JsonSerializer> serializer_;
   std::mutex mutex_;
   std::unordered_map<std::string, LiveEntry> live_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
@@ -147,6 +147,9 @@ class TriggerTopicSubscriber {
   void set_retry_callback(RetryCallback cb);
 
  private:
+  /// Test-only access to private state and the retry hook.
+  friend struct TriggerTopicSubscriberTestAccess;
+
   /// rclcpp generic-subscription callback delivering one serialized sample.
   using MessageCallback = std::function<void(std::shared_ptr<const rclcpp::SerializedMessage>)>;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
@@ -153,9 +153,12 @@ class TriggerTopicSubscriber {
     SampleCallback callback;
   };
 
-  /// Per-handle pending entry awaiting topic-type resolution.
+  /// Per-handle pending entry awaiting topic-type resolution or, before the
+  /// subscription executor is wired at startup, the executor itself.
   struct PendingEntry {
     std::string topic_name;
+    /// Caller-provided type, or empty to auto-resolve from the ROS graph on retry.
+    std::string msg_type;
     SampleCallback callback;
     std::chrono::steady_clock::time_point created_at;
   };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
@@ -97,13 +97,15 @@ class TriggerTopicSubscriber {
    * @brief Wire the shared subscription executor used to create, destroy, and
    *        dispatch every per-handle subscription.
    *
-   * Non-owning: the executor must outlive every subscription (the gateway
-   * calls shutdown() before destroying the executor). Must be set before the
-   * first subscribe() that resolves to a real topic; if it is null when a
-   * subscription would be created, subscribe() throws and retry logs+skips
-   * rather than silently falling back to a racy path.
+   * Non-owning: the executor must outlive every subscription (the gateway calls
+   * shutdown() before destroying it). Set once, on the main thread, after
+   * construction; the value is read on httplib threads without the lock, so it
+   * is stored atomically and is never cleared afterwards. Until it is wired,
+   * subscribe() queues the handle as pending; the retry timer, which only fires
+   * once the executor is spinning (after wiring), creates the subscription on
+   * its first tick, so no subscription is ever created on a racy path.
    *
-   * @param exec Shared subscription executor, or nullptr to detach.
+   * @param exec Shared subscription executor. Must be non-null in normal use.
    */
   void set_subscription_executor(ros2_common::Ros2SubscriptionExecutor * exec);
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp
@@ -98,14 +98,18 @@ class TriggerTopicSubscriber {
    *        dispatch every per-handle subscription.
    *
    * Non-owning: the executor must outlive every subscription (the gateway calls
-   * shutdown() before destroying it). Set once, on the main thread, after
-   * construction; the value is read on httplib threads without the lock, so it
-   * is stored atomically and is never cleared afterwards. Until it is wired,
-   * subscribe() queues the handle as pending; the retry timer, which only fires
-   * once the executor is spinning (after wiring), creates the subscription on
-   * its first tick, so no subscription is ever created on a racy path.
+   * shutdown() before destroying it). Wired exactly once, on the main thread,
+   * after construction; the value is read on httplib threads without the lock,
+   * so it is stored atomically. It is enforced set-once: a null argument, or a
+   * re-set to a different executor, is ignored with a warning (existing slots
+   * hold the wired executor and would be orphaned by a swap). Until it is
+   * wired, subscribe() queues the handle as pending; the retry timer, which
+   * only fires once the executor is spinning (after wiring), creates the
+   * subscription on its first tick, so no subscription is ever created on a
+   * racy path.
    *
-   * @param exec Shared subscription executor. Must be non-null in normal use.
+   * @param exec Shared subscription executor. Null or a later different value
+   *             is ignored.
    */
   void set_subscription_executor(ros2_common::Ros2SubscriptionExecutor * exec);
 

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1810,6 +1810,18 @@ EntityFreezeFrameCapture * GatewayNode::get_entity_freeze_frame_capture() const 
   return entity_freeze_frame_capture_.get();
 }
 
+void GatewayNode::set_trigger_subscription_executor(ros2_common::Ros2SubscriptionExecutor & exec) {
+  if (trigger_topic_subscriber_) {
+    trigger_topic_subscriber_->set_subscription_executor(&exec);
+  }
+}
+
+void GatewayNode::shutdown_trigger_subscriber() {
+  if (trigger_topic_subscriber_) {
+    trigger_topic_subscriber_->shutdown();
+  }
+}
+
 ResourceSamplerRegistry * GatewayNode::get_sampler_registry() const {
   return sampler_registry_.get();
 }

--- a/src/ros2_medkit_gateway/src/main.cpp
+++ b/src/ros2_medkit_gateway/src/main.cpp
@@ -140,6 +140,13 @@ int main(int argc, char ** argv) {
     // and so takes the executor's shutdown fast path.
     node->init_entity_freeze_frame_capture(*sub_exec);
 
+    // Route per-trigger topic subscriptions through the same serial worker
+    // (issue #548): their callbacks are then dispatched on - and drained by -
+    // the executor at teardown, so a subscription cannot fire on a partially
+    // destroyed subscriber. shutdown_trigger_subscriber() below drops those
+    // subscriptions while sub_exec is still alive.
+    node->set_trigger_subscription_executor(*sub_exec);
+
     // Spin in a try/catch so an uncaught handler exception falls through to the
     // explicit teardown block below. Without this, an escaping throw bypasses
     // the teardown ordering and triggers exactly the rclcpp abort described
@@ -161,11 +168,15 @@ int main(int argc, char ** argv) {
     //   1. detach the provider from GatewayNode so the managers stop using it
     //      before we drop it (GatewayNode otherwise holds a shared_ptr that
     //      would keep the provider alive past data_provider.reset()).
-    //   2. drop the provider (clears pool entries via the subscription worker)
-    //   3. reset sub_exec (joins worker, tears down internal subscription executor)
-    //   4. remove the gateway node from the executor and drop our ref so
+    //   2. shut down the trigger topic subscriber so its per-trigger
+    //      subscriptions are destroyed on - and drained by - the subscription
+    //      worker while sub_exec is still alive (issue #548).
+    //   3. drop the provider (clears pool entries via the subscription worker)
+    //   4. reset sub_exec (joins worker, tears down internal subscription executor)
+    //   5. remove the gateway node from the executor and drop our ref so
     //      ~GatewayNode runs with the executor still alive.
     node->set_topic_data_provider(nullptr);
+    node->shutdown_trigger_subscriber();
     data_provider.reset();
     sub_exec.reset();
     executor.remove_node(node);

--- a/src/ros2_medkit_gateway/src/main.cpp
+++ b/src/ros2_medkit_gateway/src/main.cpp
@@ -165,16 +165,22 @@ int main(int argc, char ** argv) {
     // (Lyrical; recent Jazzy patch releases) asserts 'node needs to be
     // associated with an executor' and aborts with exit -6 when the managers'
     // shutdown paths touch service clients. Explicit teardown avoids that:
-    //   1. detach the provider from GatewayNode so the managers stop using it
+    //   1. stop + join the REST server FIRST, so no httplib handler thread can
+    //      be mid-subscribe()/unsubscribe() (which dereference sub_exec through
+    //      the trigger subscriber, and the data provider likewise) when the
+    //      subscription executor is freed in step 4 (issue #548). ~GatewayNode
+    //      calls stop_rest_server() again; it is idempotent.
+    //   2. detach the provider from GatewayNode so the managers stop using it
     //      before we drop it (GatewayNode otherwise holds a shared_ptr that
     //      would keep the provider alive past data_provider.reset()).
-    //   2. shut down the trigger topic subscriber so its per-trigger
+    //   3. shut down the trigger topic subscriber so its per-trigger
     //      subscriptions are destroyed on - and drained by - the subscription
     //      worker while sub_exec is still alive (issue #548).
-    //   3. drop the provider (clears pool entries via the subscription worker)
-    //   4. reset sub_exec (joins worker, tears down internal subscription executor)
-    //   5. remove the gateway node from the executor and drop our ref so
+    //   4. drop the provider (clears pool entries via the subscription worker)
+    //   5. reset sub_exec (joins worker, tears down internal subscription executor)
+    //   6. remove the gateway node from the executor and drop our ref so
     //      ~GatewayNode runs with the executor still alive.
+    node->stop_rest_server();
     node->set_topic_data_provider(nullptr);
     node->shutdown_trigger_subscriber();
     data_provider.reset();

--- a/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
@@ -202,27 +202,33 @@ void TriggerTopicSubscriber::subscribe(const std::string & topic_name, const std
   }
   auto slot = std::move(*slot_or_err);
 
-  // Phase C (under lock): commit unless shutdown began meanwhile. A fresh
-  // handle key has no concurrent unsubscribe (the transport Handle does not
-  // exist until this returns), so shutdown_flag_ is the only world-change to
-  // guard here - the create-then-insert TOCTOU.
+  // Populate the entry BEFORE the lock (function scope). If live_'s insert then
+  // throws bad_alloc under the lock, entry - which owns the slot - is destroyed
+  // during unwind AFTER the lock_guard releases mutex_, so ~Ros2SubscriptionSlot
+  // posts its run_sync destroy off the lock, never under it (which would
+  // deadlock the worker). Same discipline as old_slot/slots_to_drop.
+  LiveEntry entry;
+  entry.slot = std::move(slot);
+  entry.topic_name = topic_name;
+  entry.msg_type = resolved_type;
+  entry.callback = std::move(callback);
+
+  // Phase C (under lock): commit unless shutdown began meanwhile. A fresh handle
+  // key has no concurrent unsubscribe (the transport Handle does not exist until
+  // this returns), so shutdown_flag_ is the only world-change to guard here.
   bool committed = false;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!shutdown_flag_.load()) {
-      LiveEntry entry;
-      entry.slot = std::move(slot);
-      entry.topic_name = topic_name;
-      entry.msg_type = resolved_type;
-      entry.callback = std::move(callback);
       live_[handle_key] = std::move(entry);
       committed = true;
     }
   }
   if (!committed) {
-    // Shutdown raced us between create and insert: drop the just-created slot
-    // OUTSIDE the lock instead of inserting it.
-    slot.reset();
+    // Shutdown raced us between create and insert. `entry` still owns the slot;
+    // it is destroyed at function return, outside the lock (run_sync destroy on
+    // the worker, which is still alive because shutdown() runs before
+    // sub_exec.reset()).
     RCLCPP_INFO(node_->get_logger(),
                 "TriggerTopicSubscriber: dropped subscription for handle '%s' (shutdown in progress)",
                 handle_key.c_str());
@@ -388,20 +394,25 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
                    r.topic_name.c_str(), r.handle_key.c_str(), slot_or_err.error().c_str());
       continue;  // leave it pending; a later tick retries until the timeout
     }
-    auto slot = std::move(*slot_or_err);
+    // Populate the entry BEFORE the lock. If live_'s insert throws bad_alloc
+    // under the lock, entry - which owns the slot - is destroyed during unwind
+    // AFTER the lock releases, so ~Ros2SubscriptionSlot posts its run_sync
+    // destroy off the lock, never under it (which would deadlock the worker).
+    LiveEntry entry;
+    entry.slot = std::move(*slot_or_err);
+    entry.topic_name = r.topic_name;
+    entry.msg_type = r.msg_type;
+    entry.callback = std::move(r.callback);
 
     bool committed = false;
     {
       std::lock_guard<std::mutex> lock(mutex_);
       auto pend_it = pending_.find(r.handle_key);
       if (!shutdown_flag_.load() && pend_it != pending_.end()) {
-        pending_.erase(pend_it);
-        LiveEntry entry;
-        entry.slot = std::move(slot);
-        entry.topic_name = r.topic_name;
-        entry.msg_type = r.msg_type;
-        entry.callback = std::move(r.callback);
+        // Insert BEFORE erasing pending_: if the insert throws, the handle
+        // stays pending and a later tick retries it, rather than being lost.
         live_[r.handle_key] = std::move(entry);
+        pending_.erase(pend_it);
         committed = true;
       }
     }
@@ -409,9 +420,9 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
       RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: resolved pending handle '%s' -> '%s' (type=%s)",
                   r.handle_key.c_str(), r.topic_name.c_str(), r.msg_type.c_str());
     } else {
-      // Unsubscribed or shutdown between snapshot and commit: drop the
-      // just-created slot OUTSIDE the lock instead of inserting it.
-      slot.reset();
+      // Unsubscribed or shutdown between snapshot and commit. `entry` still owns
+      // the slot; it is destroyed at the end of this loop iteration, outside the
+      // lock.
       RCLCPP_DEBUG(node_->get_logger(),
                    "TriggerTopicSubscriber: pending handle '%s' vanished before commit; dropped subscription",
                    r.handle_key.c_str());

--- a/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
@@ -18,7 +18,7 @@
 #include <utility>
 #include <vector>
 
-#include <rclcpp/generic_subscription.hpp>
+#include <rclcpp/qos.hpp>
 #include <rclcpp/serialized_message.hpp>
 
 #include "ros2_medkit_serialization/serialization_error.hpp"
@@ -42,54 +42,28 @@ TriggerTopicSubscriber::~TriggerTopicSubscriber() {
   shutdown();
 }
 
-void TriggerTopicSubscriber::subscribe(const std::string & topic_name, const std::string & msg_type,
-                                       const std::string & handle_key, SampleCallback callback) {
-  if (shutdown_flag_.load()) {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  // Idempotent: drop any prior registration for this handle so the new one
-  // takes over cleanly (both live and pending paths).
-  live_.erase(handle_key);
-  pending_.erase(handle_key);
-
-  std::string resolved_type = msg_type;
-  if (resolved_type.empty()) {
-    auto topic_names_and_types = node_->get_topic_names_and_types();
-    auto it = topic_names_and_types.find(topic_name);
-    if (it != topic_names_and_types.end() && !it->second.empty()) {
-      resolved_type = it->second[0];
-    }
-  }
-
-  if (resolved_type.empty()) {
-    RCLCPP_WARN(node_->get_logger(),
-                "TriggerTopicSubscriber: cannot determine type for topic '%s' "
-                "(no publishers yet), queuing handle '%s' for retry",
-                topic_name.c_str(), handle_key.c_str());
-    PendingEntry entry;
-    entry.topic_name = topic_name;
-    entry.callback = std::move(callback);
-    entry.created_at = std::chrono::steady_clock::now();
-    pending_[handle_key] = std::move(entry);
-    return;
-  }
-
-  create_subscription_internal(handle_key, topic_name, resolved_type, std::move(callback));
+void TriggerTopicSubscriber::set_subscription_executor(ros2_common::Ros2SubscriptionExecutor * exec) {
+  // Release so a subscribe() on an httplib thread that observes this executor
+  // also observes everything the setter's caller published before it.
+  sub_exec_.store(exec, std::memory_order_release);
 }
 
-void TriggerTopicSubscriber::create_subscription_internal(const std::string & handle_key,
-                                                          const std::string & topic_name, const std::string & msg_type,
-                                                          SampleCallback callback) {
-  rclcpp::QoS qos = rclcpp::SensorDataQoS();
+std::string TriggerTopicSubscriber::resolve_topic_type(const std::string & topic_name) const {
+  auto topic_names_and_types = node_->get_topic_names_and_types();
+  auto it = topic_names_and_types.find(topic_name);
+  if (it != topic_names_and_types.end() && !it->second.empty()) {
+    return it->second[0];
+  }
+  return {};
+}
 
+TriggerTopicSubscriber::MessageCallback TriggerTopicSubscriber::make_message_callback(const std::string & handle_key,
+                                                                                      const std::string & topic_name,
+                                                                                      const std::string & msg_type) {
   // Snapshot the handle key + topic + type by value so the callback never
   // dereferences any expired strings; the user callback is looked up under
-  // mutex_ to avoid firing after unsubscribe()/shutdown() returns.
-  // NOLINTNEXTLINE(performance-unnecessary-value-param) - GenericSubscription requires value type in callback
-  auto cb = [this, handle_key, topic_name, msg_type](std::shared_ptr<const rclcpp::SerializedMessage> msg) {
+  // mutex_ to avoid firing after unsubscribe()/shutdown() drops the entry.
+  return [this, handle_key, topic_name, msg_type](const std::shared_ptr<const rclcpp::SerializedMessage> & msg) {
     if (shutdown_flag_.load()) {
       return;
     }
@@ -123,50 +97,146 @@ void TriggerTopicSubscriber::create_subscription_internal(const std::string & ha
                            e.what());
     }
   };
+}
 
-  try {
-    auto subscription = node_->create_generic_subscription(topic_name, msg_type, qos, cb);
+tl::expected<std::unique_ptr<ros2_common::Ros2SubscriptionSlot>, std::string>
+TriggerTopicSubscriber::create_slot_unlocked(const std::string & handle_key, const std::string & topic_name,
+                                             const std::string & msg_type) {
+  auto * exec = sub_exec_.load(std::memory_order_acquire);
+  if (!exec) {
+    // Fail loudly instead of silently creating on the racy main node/executor
+    // path. In the wired gateway this never happens (main.cpp calls
+    // set_subscription_executor before any subscribe()).
+    return tl::unexpected(std::string{"TriggerTopicSubscriber: no subscription executor wired"});
+  }
+  const rclcpp::QoS qos = rclcpp::SensorDataQoS();
+  return ros2_common::Ros2SubscriptionSlot::create_generic(*exec, topic_name, msg_type, qos,
+                                                           make_message_callback(handle_key, topic_name, msg_type));
+}
 
-    LiveEntry entry;
-    entry.subscription = std::move(subscription);
-    entry.topic_name = topic_name;
-    entry.msg_type = msg_type;
-    entry.callback = std::move(callback);
-    live_[handle_key] = std::move(entry);
+void TriggerTopicSubscriber::subscribe(const std::string & topic_name, const std::string & msg_type,
+                                       const std::string & handle_key, SampleCallback callback) {
+  if (shutdown_flag_.load()) {
+    return;
+  }
+  if (!sub_exec_.load(std::memory_order_acquire)) {
+    // Fail loudly rather than falling back to the racy main-node path. The
+    // transport wraps subscribe() in try/catch and returns nullptr on throw,
+    // so the trigger creation is rejected instead of registering a dead handle.
+    RCLCPP_ERROR(node_->get_logger(),
+                 "TriggerTopicSubscriber: no subscription executor wired; cannot subscribe handle '%s' to '%s'",
+                 handle_key.c_str(), topic_name.c_str());
+    throw std::runtime_error("TriggerTopicSubscriber: subscription executor not wired");
+  }
 
-    RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: subscribed handle '%s' to '%s' (type=%s)",
-                handle_key.c_str(), topic_name.c_str(), msg_type.c_str());
-  } catch (const std::exception & e) {
+  // Phase A (under lock): drop any prior registration for this handle and
+  // resolve the message type. The prior slot is moved out and destroyed
+  // OUTSIDE the lock - ~Ros2SubscriptionSlot posts a run_sync destroy to the
+  // worker, which would deadlock against a callback waiting on mutex_.
+  // old_slot is declared in the function scope (before the lock_guard) so that
+  // on the early return below it is destroyed AFTER the lock_guard releases
+  // mutex_ during stack unwinding.
+  std::unique_ptr<ros2_common::Ros2SubscriptionSlot> old_slot;
+  std::string resolved_type = msg_type;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = live_.find(handle_key);
+    if (it != live_.end()) {
+      old_slot = std::move(it->second.slot);
+      live_.erase(it);
+    }
+    pending_.erase(handle_key);
+
+    if (resolved_type.empty()) {
+      resolved_type = resolve_topic_type(topic_name);
+    }
+
+    if (resolved_type.empty()) {
+      RCLCPP_WARN(node_->get_logger(),
+                  "TriggerTopicSubscriber: cannot determine type for topic '%s' "
+                  "(no publishers yet), queuing handle '%s' for retry",
+                  topic_name.c_str(), handle_key.c_str());
+      PendingEntry entry;
+      entry.topic_name = topic_name;
+      entry.callback = std::move(callback);
+      entry.created_at = std::chrono::steady_clock::now();
+      pending_[handle_key] = std::move(entry);
+      // Queued as pending; retry_pending_subscriptions() takes it from here.
+      // Returning here (not falling through) keeps the moved-from `callback`
+      // strictly on this branch, and old_slot drops after mutex_ releases.
+      return;
+    }
+  }
+  // Drop the prior slot outside the lock (run_sync destroy on the worker).
+  old_slot.reset();
+
+  // Phase B (outside lock): create the slot on the shared executor worker.
+  auto slot_or_err = create_slot_unlocked(handle_key, topic_name, resolved_type);
+  if (!slot_or_err) {
     RCLCPP_ERROR(node_->get_logger(),
                  "TriggerTopicSubscriber: failed to create subscription for '%s' (handle '%s'): %s", topic_name.c_str(),
-                 handle_key.c_str(), e.what());
-    // Propagate. The transport adapter wraps each subscribe in a try/catch
-    // and returns nullptr so the trigger manager rejects the trigger
-    // creation with a 5xx instead of returning 201 for a dead handle.
-    throw;
+                 handle_key.c_str(), slot_or_err.error().c_str());
+    // Propagate so the transport returns nullptr and the trigger is rejected.
+    throw std::runtime_error(slot_or_err.error());
   }
+  auto slot = std::move(*slot_or_err);
+
+  // Phase C (under lock): commit unless shutdown began meanwhile. A fresh
+  // handle key has no concurrent unsubscribe (the transport Handle does not
+  // exist until this returns), so shutdown_flag_ is the only world-change to
+  // guard here - the create-then-insert TOCTOU.
+  bool committed = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!shutdown_flag_.load()) {
+      LiveEntry entry;
+      entry.slot = std::move(slot);
+      entry.topic_name = topic_name;
+      entry.msg_type = resolved_type;
+      entry.callback = std::move(callback);
+      live_[handle_key] = std::move(entry);
+      committed = true;
+    }
+  }
+  if (!committed) {
+    // Shutdown raced us between create and insert: drop the just-created slot
+    // OUTSIDE the lock instead of inserting it.
+    slot.reset();
+    RCLCPP_INFO(node_->get_logger(),
+                "TriggerTopicSubscriber: dropped subscription for handle '%s' (shutdown in progress)",
+                handle_key.c_str());
+    return;
+  }
+  RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: subscribed handle '%s' to '%s' (type=%s)",
+              handle_key.c_str(), topic_name.c_str(), resolved_type.c_str());
 }
 
 void TriggerTopicSubscriber::unsubscribe(const std::string & handle_key) {
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::unique_ptr<ros2_common::Ros2SubscriptionSlot> slot_to_drop;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
 
-  if (pending_.erase(handle_key) > 0) {
-    RCLCPP_DEBUG(node_->get_logger(), "TriggerTopicSubscriber: removed pending handle '%s'", handle_key.c_str());
-    return;
+    if (pending_.erase(handle_key) > 0) {
+      RCLCPP_DEBUG(node_->get_logger(), "TriggerTopicSubscriber: removed pending handle '%s'", handle_key.c_str());
+      return;
+    }
+
+    auto it = live_.find(handle_key);
+    if (it == live_.end()) {
+      return;
+    }
+
+    // Move the slot out and erase the map entry atomically under the lock so
+    // any in-flight dispatch already sees the empty map and short-circuits.
+    slot_to_drop = std::move(it->second.slot);
+    it->second.callback = nullptr;
+    live_.erase(it);
   }
-
-  auto it = live_.find(handle_key);
-  if (it == live_.end()) {
-    return;
-  }
-
-  // Reset the subscription before erasing the map entry: rclcpp guarantees
-  // that GenericSubscription destruction waits for in-flight callbacks to
-  // drain, so the captured handle_key cannot resolve to a stale entry after
-  // this returns.
-  it->second.subscription.reset();
-  it->second.callback = nullptr;
-  live_.erase(it);
+  // Destroy the slot OUTSIDE the lock. ~Ros2SubscriptionSlot posts a destroy
+  // task to the executor worker (the same thread that dispatches callbacks),
+  // so any in-flight callback for this handle drains before the destroy runs.
+  // Doing this under mutex_ would deadlock against such a callback.
+  slot_to_drop.reset();
 
   RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: unsubscribed handle '%s'", handle_key.c_str());
 }
@@ -181,15 +251,23 @@ void TriggerTopicSubscriber::shutdown() {
     retry_timer_.reset();
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  pending_.clear();
-  // Reset every subscription explicitly so rclcpp drains in-flight callbacks
-  // before we tear down user callbacks (the subscription-destructor pattern).
-  for (auto & [_, entry] : live_) {
-    entry.subscription.reset();
-    entry.callback = nullptr;
+  // Move every live slot out under the lock, clear the maps, then destroy the
+  // slots OUTSIDE the lock. shutdown_flag_ (set above) makes new dispatches
+  // short-circuit; the slot destructors post run_sync destroys to the executor
+  // worker, draining any in-flight callback before returning. Destroying slots
+  // while holding mutex_ would deadlock against a callback blocked on mutex_.
+  std::vector<std::unique_ptr<ros2_common::Ros2SubscriptionSlot>> slots_to_drop;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    pending_.clear();
+    slots_to_drop.reserve(live_.size());
+    for (auto & [_, entry] : live_) {
+      slots_to_drop.push_back(std::move(entry.slot));
+      entry.callback = nullptr;
+    }
+    live_.clear();
   }
-  live_.clear();
+  slots_to_drop.clear();  // slot destructors run here, outside the lock
   RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: shutdown complete");
 }
 
@@ -209,39 +287,94 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
     return;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (pending_.empty()) {
-    return;
+  // One resolvable pending handle. The callback is COPIED (not moved) so
+  // pending_[handle_key] stays intact as the "still wanted" marker until the
+  // slot is committed; if unsubscribe() removes it while we create the slot
+  // (outside the lock), the commit is skipped and the slot dropped.
+  struct Resolvable {
+    std::string handle_key;
+    std::string topic_name;
+    std::string msg_type;
+    SampleCallback callback;
+  };
+
+  // Phase A (under lock): snapshot resolvable handles and expire stale ones.
+  // Subscription creation does NOT happen here - it goes through run_sync,
+  // which must never run while holding mutex_.
+  std::vector<Resolvable> resolvable;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (pending_.empty()) {
+      return;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    auto topic_names_and_types = node_->get_topic_names_and_types();
+    std::vector<std::string> expired_keys;
+
+    for (auto & [handle_key, entry] : pending_) {
+      if (now - entry.created_at > std::chrono::seconds(kPendingTimeoutSec)) {
+        RCLCPP_ERROR(node_->get_logger(),
+                     "TriggerTopicSubscriber: handle '%s' (topic '%s') type not available after %ds, giving up",
+                     handle_key.c_str(), entry.topic_name.c_str(), kPendingTimeoutSec);
+        expired_keys.push_back(handle_key);
+        continue;
+      }
+
+      auto type_it = topic_names_and_types.find(entry.topic_name);
+      if (type_it != topic_names_and_types.end() && !type_it->second.empty()) {
+        resolvable.push_back(Resolvable{handle_key, entry.topic_name, type_it->second[0], entry.callback});
+      }
+    }
+
+    for (const auto & key : expired_keys) {
+      pending_.erase(key);
+    }
   }
 
-  auto now = std::chrono::steady_clock::now();
-  std::vector<std::string> resolved_keys;
-  std::vector<std::string> expired_keys;
+  // Phase B/C (per handle, outside lock): create the slot, then commit it into
+  // live_ iff the handle is still pending (not unsubscribed meanwhile) and
+  // shutdown has not begun. pending_[key] is the "still wanted" marker.
+  for (auto & r : resolvable) {
+    if (shutdown_flag_.load()) {
+      break;
+    }
 
-  auto topic_names_and_types = node_->get_topic_names_and_types();
-
-  for (auto & [handle_key, entry] : pending_) {
-    if (now - entry.created_at > std::chrono::seconds(kPendingTimeoutSec)) {
+    auto slot_or_err = create_slot_unlocked(r.handle_key, r.topic_name, r.msg_type);
+    if (!slot_or_err) {
       RCLCPP_ERROR(node_->get_logger(),
-                   "TriggerTopicSubscriber: handle '%s' (topic '%s') type not available after %ds, giving up",
-                   handle_key.c_str(), entry.topic_name.c_str(), kPendingTimeoutSec);
-      expired_keys.push_back(handle_key);
-      continue;
+                   "TriggerTopicSubscriber: retry failed to create subscription for '%s' (handle '%s'): %s",
+                   r.topic_name.c_str(), r.handle_key.c_str(), slot_or_err.error().c_str());
+      continue;  // leave it pending; a later tick retries until the timeout
     }
+    auto slot = std::move(*slot_or_err);
 
-    auto type_it = topic_names_and_types.find(entry.topic_name);
-    if (type_it != topic_names_and_types.end() && !type_it->second.empty()) {
-      create_subscription_internal(handle_key, entry.topic_name, type_it->second[0], std::move(entry.callback));
-      resolved_keys.push_back(handle_key);
+    bool committed = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      auto pend_it = pending_.find(r.handle_key);
+      if (!shutdown_flag_.load() && pend_it != pending_.end()) {
+        pending_.erase(pend_it);
+        LiveEntry entry;
+        entry.slot = std::move(slot);
+        entry.topic_name = r.topic_name;
+        entry.msg_type = r.msg_type;
+        entry.callback = std::move(r.callback);
+        live_[r.handle_key] = std::move(entry);
+        committed = true;
+      }
     }
-  }
-
-  for (const auto & key : resolved_keys) {
-    RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: resolved pending handle '%s'", key.c_str());
-    pending_.erase(key);
-  }
-  for (const auto & key : expired_keys) {
-    pending_.erase(key);
+    if (committed) {
+      RCLCPP_INFO(node_->get_logger(), "TriggerTopicSubscriber: resolved pending handle '%s' -> '%s' (type=%s)",
+                  r.handle_key.c_str(), r.topic_name.c_str(), r.msg_type.c_str());
+    } else {
+      // Unsubscribed or shutdown between snapshot and commit: drop the
+      // just-created slot OUTSIDE the lock instead of inserting it.
+      slot.reset();
+      RCLCPP_DEBUG(node_->get_logger(),
+                   "TriggerTopicSubscriber: pending handle '%s' vanished before commit; dropped subscription",
+                   r.handle_key.c_str());
+    }
   }
 }
 

--- a/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
@@ -104,9 +104,10 @@ TriggerTopicSubscriber::create_slot_unlocked(const std::string & handle_key, con
                                              const std::string & msg_type) {
   auto * exec = sub_exec_.load(std::memory_order_acquire);
   if (!exec) {
-    // Fail loudly instead of silently creating on the racy main node/executor
-    // path. In the wired gateway this never happens (main.cpp calls
-    // set_subscription_executor before any subscribe()).
+    // Defensive: the callers only reach here once the executor is wired -
+    // subscribe() defers to pending while it is unwired, and retry runs off the
+    // timer, which fires only after spin (i.e. after wiring). Never create on
+    // the racy main-node path; report so the caller leaves the handle pending.
     return tl::unexpected(std::string{"TriggerTopicSubscriber: no subscription executor wired"});
   }
   const rclcpp::QoS qos = rclcpp::SensorDataQoS();
@@ -119,25 +120,39 @@ void TriggerTopicSubscriber::subscribe(const std::string & topic_name, const std
   if (shutdown_flag_.load()) {
     return;
   }
-  if (!sub_exec_.load(std::memory_order_acquire)) {
-    // Fail loudly rather than falling back to the racy main-node path. The
-    // transport wraps subscribe() in try/catch and returns nullptr on throw,
-    // so the trigger creation is rejected instead of registering a dead handle.
-    RCLCPP_ERROR(node_->get_logger(),
-                 "TriggerTopicSubscriber: no subscription executor wired; cannot subscribe handle '%s' to '%s'",
-                 handle_key.c_str(), topic_name.c_str());
-    throw std::runtime_error("TriggerTopicSubscriber: subscription executor not wired");
-  }
 
-  // Phase A (under lock): drop any prior registration for this handle and
-  // resolve the message type. The prior slot is moved out and destroyed
-  // OUTSIDE the lock - ~Ros2SubscriptionSlot posts a run_sync destroy to the
-  // worker, which would deadlock against a callback waiting on mutex_.
-  // old_slot is declared in the function scope (before the lock_guard) so that
-  // on the early return below it is destroyed AFTER the lock_guard releases
-  // mutex_ during stack unwinding.
-  std::unique_ptr<ros2_common::Ros2SubscriptionSlot> old_slot;
+  // If the subscription executor is not wired yet, defer to pending instead of
+  // failing. This window is real: persistent triggers are restored in the
+  // GatewayNode constructor, and the REST server (also started there) can take a
+  // POST /triggers, both before main.cpp wires the executor. The retry timer
+  // only fires once the executor is spinning (after wiring), so a deferred
+  // handle resolves on its first tick - no error log, no 5xx for a valid
+  // request. sub_exec_ is set once and never cleared, so a value seen here stays
+  // valid through Phase B below.
+  const bool executor_ready = sub_exec_.load(std::memory_order_acquire) != nullptr;
+
+  // Resolve the message type OUTSIDE mutex_. get_topic_names_and_types() takes
+  // the rmw graph locks and building the full map is not cheap; holding mutex_
+  // across it would stall every sample dispatch on the worker (each takes
+  // mutex_) for the query's duration. Phase C re-checks the world under the
+  // lock, so a race between this resolve and the commit is harmless. Skip it
+  // when the executor is unwired - we would defer to pending regardless, and
+  // retry re-resolves then.
   std::string resolved_type = msg_type;
+  if (executor_ready && resolved_type.empty()) {
+    resolved_type = resolve_topic_type(topic_name);
+  }
+  // A single const decision, used for both the queue-under-lock branch and the
+  // early return below, so `callback` is moved on exactly one of the two
+  // mutually exclusive paths (queue vs create).
+  const bool should_defer = !executor_ready || resolved_type.empty();
+
+  // Phase A (under lock): drop any prior registration for this handle. The prior
+  // slot is moved out and destroyed OUTSIDE the lock - ~Ros2SubscriptionSlot
+  // posts a run_sync destroy to the worker, which would deadlock against a
+  // callback waiting on mutex_. old_slot is declared in the function scope so it
+  // is destroyed only after the lock_guard releases mutex_.
+  std::unique_ptr<ros2_common::Ros2SubscriptionSlot> old_slot;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     auto it = live_.find(handle_key);
@@ -146,29 +161,35 @@ void TriggerTopicSubscriber::subscribe(const std::string & topic_name, const std
       live_.erase(it);
     }
     pending_.erase(handle_key);
+  }
+  // Drop the prior slot outside the lock (run_sync destroy on the worker).
+  old_slot.reset();
 
-    if (resolved_type.empty()) {
-      resolved_type = resolve_topic_type(topic_name);
+  if (should_defer) {
+    // Queue for retry, which creates the slot once the type resolves and the
+    // executor is wired. `callback` is consumed on this branch only; the create
+    // path below (reached only when !should_defer) never touches it.
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      PendingEntry entry;
+      entry.topic_name = topic_name;
+      entry.msg_type = msg_type;  // caller's original; retry re-resolves when empty
+      entry.callback = std::move(callback);
+      entry.created_at = std::chrono::steady_clock::now();
+      pending_[handle_key] = std::move(entry);
     }
-
-    if (resolved_type.empty()) {
+    if (!executor_ready) {
+      RCLCPP_DEBUG(node_->get_logger(),
+                   "TriggerTopicSubscriber: subscription executor not wired yet, queuing handle '%s' ('%s') for retry",
+                   handle_key.c_str(), topic_name.c_str());
+    } else {
       RCLCPP_WARN(node_->get_logger(),
                   "TriggerTopicSubscriber: cannot determine type for topic '%s' "
                   "(no publishers yet), queuing handle '%s' for retry",
                   topic_name.c_str(), handle_key.c_str());
-      PendingEntry entry;
-      entry.topic_name = topic_name;
-      entry.callback = std::move(callback);
-      entry.created_at = std::chrono::steady_clock::now();
-      pending_[handle_key] = std::move(entry);
-      // Queued as pending; retry_pending_subscriptions() takes it from here.
-      // Returning here (not falling through) keeps the moved-from `callback`
-      // strictly on this branch, and old_slot drops after mutex_ releases.
-      return;
     }
+    return;
   }
-  // Drop the prior slot outside the lock (run_sync destroy on the worker).
-  old_slot.reset();
 
   // Phase B (outside lock): create the slot on the shared executor worker.
   auto slot_or_err = create_slot_unlocked(handle_key, topic_name, resolved_type);
@@ -287,10 +308,10 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
     return;
   }
 
-  // One resolvable pending handle. The callback is COPIED (not moved) so
-  // pending_[handle_key] stays intact as the "still wanted" marker until the
-  // slot is committed; if unsubscribe() removes it while we create the slot
-  // (outside the lock), the commit is skipped and the slot dropped.
+  // The callback is COPIED (not moved) out of pending_ so pending_[handle_key]
+  // stays intact as the "still wanted" marker until the slot is committed; if
+  // unsubscribe() removes it while we create the slot (outside the lock), the
+  // commit is skipped and the slot dropped.
   struct Resolvable {
     std::string handle_key;
     std::string topic_name;
@@ -298,10 +319,17 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
     SampleCallback callback;
   };
 
-  // Phase A (under lock): snapshot resolvable handles and expire stale ones.
-  // Subscription creation does NOT happen here - it goes through run_sync,
-  // which must never run while holding mutex_.
-  std::vector<Resolvable> resolvable;
+  // Phase A (under lock): expire stale handles and snapshot the rest. NO graph
+  // query here - get_topic_names_and_types() takes the rmw graph locks and is
+  // not cheap, and holding mutex_ across it would stall every sample dispatch on
+  // the worker (each takes mutex_) for the query's duration.
+  struct Candidate {
+    std::string handle_key;
+    std::string topic_name;
+    std::string msg_type;  // caller's requested type, empty = auto-resolve
+    SampleCallback callback;
+  };
+  std::vector<Candidate> candidates;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (pending_.empty()) {
@@ -309,7 +337,6 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
     }
 
     const auto now = std::chrono::steady_clock::now();
-    auto topic_names_and_types = node_->get_topic_names_and_types();
     std::vector<std::string> expired_keys;
 
     for (auto & [handle_key, entry] : pending_) {
@@ -320,15 +347,29 @@ void TriggerTopicSubscriber::retry_pending_subscriptions() {
         expired_keys.push_back(handle_key);
         continue;
       }
-
-      auto type_it = topic_names_and_types.find(entry.topic_name);
-      if (type_it != topic_names_and_types.end() && !type_it->second.empty()) {
-        resolvable.push_back(Resolvable{handle_key, entry.topic_name, type_it->second[0], entry.callback});
-      }
+      candidates.push_back(Candidate{handle_key, entry.topic_name, entry.msg_type, entry.callback});
     }
 
     for (const auto & key : expired_keys) {
       pending_.erase(key);
+    }
+  }
+
+  // Resolve types OUTSIDE the lock: use the caller's explicit type when given,
+  // otherwise the current ROS graph. A handle unsubscribed between here and the
+  // commit is caught by the Phase C re-check, so racing this query is harmless.
+  const auto topic_names_and_types = node_->get_topic_names_and_types();
+  std::vector<Resolvable> resolvable;
+  for (auto & c : candidates) {
+    std::string type = c.msg_type;
+    if (type.empty()) {
+      auto type_it = topic_names_and_types.find(c.topic_name);
+      if (type_it != topic_names_and_types.end() && !type_it->second.empty()) {
+        type = type_it->second[0];
+      }
+    }
+    if (!type.empty()) {
+      resolvable.push_back(Resolvable{c.handle_key, c.topic_name, std::move(type), std::move(c.callback)});
     }
   }
 

--- a/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/trigger_topic_subscriber.cpp
@@ -43,9 +43,20 @@ TriggerTopicSubscriber::~TriggerTopicSubscriber() {
 }
 
 void TriggerTopicSubscriber::set_subscription_executor(ros2_common::Ros2SubscriptionExecutor * exec) {
-  // Release so a subscribe() on an httplib thread that observes this executor
-  // also observes everything the setter's caller published before it.
-  sub_exec_.store(exec, std::memory_order_release);
+  if (exec == nullptr) {
+    RCLCPP_WARN(node_->get_logger(), "TriggerTopicSubscriber: ignoring null subscription executor");
+    return;
+  }
+  // Wire exactly once. Existing slots hold this executor (they tear down through
+  // it), so a later re-set to a different one would orphan them; reject it with
+  // compare_exchange and warn. Release so a subscribe() on an httplib thread
+  // that observes the executor also observes everything published before it.
+  ros2_common::Ros2SubscriptionExecutor * expected = nullptr;
+  if (!sub_exec_.compare_exchange_strong(expected, exec, std::memory_order_release, std::memory_order_acquire) &&
+      expected != exec) {
+    RCLCPP_WARN(node_->get_logger(),
+                "TriggerTopicSubscriber: subscription executor already wired; ignoring re-set to a different one");
+  }
 }
 
 std::string TriggerTopicSubscriber::resolve_topic_type(const std::string & topic_name) const {

--- a/src/ros2_medkit_gateway/test/test_trigger_topic_subscriber.cpp
+++ b/src/ros2_medkit_gateway/test/test_trigger_topic_subscriber.cpp
@@ -1,0 +1,184 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
+
+#include "ros2_medkit_gateway/ros2/trigger_topic_subscriber.hpp"
+#include "ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp"
+
+using namespace std::chrono_literals;
+using ros2_medkit_gateway::TriggerTopicSubscriber;
+using ros2_medkit_gateway::ros2_common::Ros2SubscriptionExecutor;
+
+namespace ros2_medkit_gateway {
+
+// Friend shim: reach the private retry hook and the pending_/live_ maps so a
+// test can drive the retry path deterministically (the retry timer would take
+// kRetryIntervalSec seconds) and assert the pending -> live transition.
+struct TriggerTopicSubscriberTestAccess {
+  static void run_retry(TriggerTopicSubscriber & s) {
+    s.retry_pending_subscriptions();
+  }
+
+  static std::size_t pending_count(TriggerTopicSubscriber & s) {
+    std::lock_guard<std::mutex> lock(s.mutex_);
+    return s.pending_.size();
+  }
+  static std::size_t live_count(TriggerTopicSubscriber & s) {
+    std::lock_guard<std::mutex> lock(s.mutex_);
+    return s.live_.size();
+  }
+  static Ros2SubscriptionExecutor * executor(TriggerTopicSubscriber & s) {
+    return s.sub_exec_.load(std::memory_order_acquire);
+  }
+};
+
+}  // namespace ros2_medkit_gateway
+
+using ros2_medkit_gateway::TriggerTopicSubscriberTestAccess;
+
+class TriggerTopicSubscriberTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+  static void TearDownTestSuite() {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override {
+    node_ = std::make_shared<rclcpp::Node>("trigger_sub_test_gateway");
+    // Publishers live on a separate node kept OFF the executor (same reason as
+    // the data-provider test: a publisher-owning node iterated by a spinning
+    // MultiThreadedExecutor races its internal hash map under TSan).
+    publisher_node_ = std::make_shared<rclcpp::Node>("trigger_sub_test_publisher");
+    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(node_);
+    spin_thread_ = std::thread([this] {
+      executor_->spin();
+    });
+    sub_exec_ = std::make_shared<Ros2SubscriptionExecutor>(node_);
+    subscriber_ = std::make_unique<TriggerTopicSubscriber>(node_.get());
+  }
+
+  void TearDown() override {
+    // Drain the subscriber's slots on the still-live subscription worker before
+    // the executor is destroyed (same order the gateway uses), then stop the
+    // main executor and join, then tear down.
+    subscriber_->shutdown();
+    executor_->cancel();
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    subscriber_.reset();
+    sub_exec_.reset();
+    executor_.reset();
+    publisher_node_.reset();
+    node_.reset();
+  }
+
+  // Wait until node_ has discovered a publisher for `topic` (so the retry path
+  // can resolve its type from the graph). Returns false on timeout.
+  bool wait_for_topic_discovered(const std::string & topic) {
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (std::chrono::steady_clock::now() < deadline) {
+      auto names = node_->get_topic_names_and_types();
+      if (names.count(topic) != 0) {
+        return true;
+      }
+      std::this_thread::sleep_for(20ms);
+    }
+    return false;
+  }
+
+  std::shared_ptr<rclcpp::Node> node_;
+  std::shared_ptr<rclcpp::Node> publisher_node_;
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+  std::shared_ptr<Ros2SubscriptionExecutor> sub_exec_;
+  std::unique_ptr<TriggerTopicSubscriber> subscriber_;
+};
+
+// A subscribe() that arrives before the subscription executor is wired (the
+// startup window: persistent restore in the ctor, or an early POST) must NOT
+// throw. It is queued as pending, and once the executor is wired the retry
+// path creates the real slot, which then delivers samples.
+TEST_F(TriggerTopicSubscriberTest, DefersBeforeWiringThenResolvesAfterRetry) {
+  const std::string topic = "/trigger_sub_test_topic";
+  auto pub = publisher_node_->create_publisher<std_msgs::msg::Int32>(topic, 10);
+  ASSERT_TRUE(wait_for_topic_discovered(topic));
+
+  std::atomic<int> hits{0};
+  auto cb = [&hits](const nlohmann::json & /*sample*/) {
+    hits.fetch_add(1, std::memory_order_relaxed);
+  };
+
+  // Subscribe with the executor still unwired: must not throw, and the handle
+  // is parked in pending_ (no live slot yet).
+  ASSERT_NO_THROW(subscriber_->subscribe(topic, /*msg_type=*/"", "handle_1", cb));
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::pending_count(*subscriber_), 1u);
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::live_count(*subscriber_), 0u);
+
+  // Wire the executor and run one retry tick: the pending handle resolves its
+  // type from the graph and becomes a live slot.
+  subscriber_->set_subscription_executor(sub_exec_.get());
+  TriggerTopicSubscriberTestAccess::run_retry(*subscriber_);
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::pending_count(*subscriber_), 0u);
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::live_count(*subscriber_), 1u);
+
+  // The live slot delivers: publish until the callback fires (bounded).
+  std_msgs::msg::Int32 msg;
+  msg.data = 42;
+  for (int i = 0; i < 60 && hits.load(std::memory_order_relaxed) == 0; ++i) {
+    pub->publish(msg);
+    std::this_thread::sleep_for(50ms);
+  }
+  EXPECT_GT(hits.load(std::memory_order_relaxed), 0);
+}
+
+// The executor is wired exactly once. A null argument is ignored, and a later
+// re-set to a different executor is ignored (existing slots hold the first one
+// and would be orphaned by a swap).
+TEST_F(TriggerTopicSubscriberTest, SetSubscriptionExecutorIsSetOnceAndIgnoresNull) {
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::executor(*subscriber_), nullptr);
+
+  subscriber_->set_subscription_executor(nullptr);
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::executor(*subscriber_), nullptr);
+
+  subscriber_->set_subscription_executor(sub_exec_.get());
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::executor(*subscriber_), sub_exec_.get());
+
+  // A second, different executor is rejected; the first stays wired. Built on
+  // publisher_node_ so its internal subscription node does not collide with the
+  // one sub_exec_ created on node_.
+  auto other = std::make_shared<Ros2SubscriptionExecutor>(publisher_node_);
+  subscriber_->set_subscription_executor(other.get());
+  EXPECT_EQ(TriggerTopicSubscriberTestAccess::executor(*subscriber_), sub_exec_.get());
+}

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
@@ -70,6 +70,16 @@ GATEWAY_STARTUP_INTERVAL = 0.5
 DISCOVERY_TIMEOUT = 60.0
 DISCOVERY_INTERVAL = 0.5  # seconds between discovery polls
 
+# Parameter service readiness
+# A node's ROS 2 parameter service can lag its graph discovery, and the
+# configurations endpoint returns 503 until it responds. This lag is small
+# without instrumentation but grows under the TSan job, where the service was
+# still 503 more than 15s after discovery finished. Generous on purpose: a
+# larger timeout costs nothing on the passing path (the poll returns the moment
+# the endpoint answers 200) and only bounds how long a genuinely dead service
+# waits before failing, well inside the sanitizer jobs' 360s ctest budget.
+PARAM_SERVICE_TIMEOUT = 90.0
+
 # Operations
 ACTION_TIMEOUT = 30.0
 

--- a/src/ros2_medkit_integration_tests/test/features/test_configuration_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_configuration_api.test.py
@@ -47,20 +47,39 @@ class TestConfigurationApi(GatewayTestCase):
     MIN_EXPECTED_APPS = 1
     REQUIRED_APPS = {'temp_sensor'}
 
+    # Monotonic param-service readiness, cached across this class's tests.
+    _param_service_ready = False
+    _param_service_dead = False
+
     def setUp(self):
         """Wait for the node's parameter service before each test.
 
         The configurations endpoints read the ROS 2 parameter service on the
         temp_sensor node, which can be briefly unavailable just after discovery
         (the endpoint returns 503 until it is ready) - more likely under the
-        slowdown of the sanitizer jobs. Gate every test on it being ready so the
-        per-test requests are not racing param-service startup.
+        slowdown of the sanitizer jobs. Gate every test on it being ready.
+
+        Readiness is monotonic, so cache it on the class: only the first test
+        polls (up to PARAM_SERVICE_TIMEOUT); the rest return immediately. On a
+        genuinely dead service the first poll times out and marks the class dead
+        so the remaining tests fail fast, instead of each paying the full
+        timeout (which would blow the ctest job budget).
         """
         super().setUp()
-        self.poll_endpoint_until(
-            '/apps/temp_sensor/configurations',
-            timeout=PARAM_SERVICE_TIMEOUT,
-        )
+        cls = type(self)
+        if cls._param_service_ready:
+            return
+        if cls._param_service_dead:
+            self.fail('parameter service was not ready (cached from an earlier test)')
+        try:
+            self.poll_endpoint_until(
+                '/apps/temp_sensor/configurations',
+                timeout=PARAM_SERVICE_TIMEOUT,
+            )
+        except AssertionError:
+            cls._param_service_dead = True
+            raise
+        cls._param_service_ready = True
 
     def test_01_list_configurations(self):
         """GET /apps/{app_id}/configurations lists all parameters.

--- a/src/ros2_medkit_integration_tests/test/features/test_configuration_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_configuration_api.test.py
@@ -26,7 +26,10 @@ import launch_testing
 import launch_testing.actions
 import requests
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    PARAM_SERVICE_TIMEOUT,
+)
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
@@ -43,6 +46,21 @@ class TestConfigurationApi(GatewayTestCase):
 
     MIN_EXPECTED_APPS = 1
     REQUIRED_APPS = {'temp_sensor'}
+
+    def setUp(self):
+        """Wait for the node's parameter service before each test.
+
+        The configurations endpoints read the ROS 2 parameter service on the
+        temp_sensor node, which can be briefly unavailable just after discovery
+        (the endpoint returns 503 until it is ready) - more likely under the
+        slowdown of the sanitizer jobs. Gate every test on it being ready so the
+        per-test requests are not racing param-service startup.
+        """
+        super().setUp()
+        self.poll_endpoint_until(
+            '/apps/temp_sensor/configurations',
+            timeout=PARAM_SERVICE_TIMEOUT,
+        )
 
     def test_01_list_configurations(self):
         """GET /apps/{app_id}/configurations lists all parameters.

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_response_drift.test.py
@@ -60,7 +60,10 @@ try:
 except ImportError:
     from jsonschema.validators import Draft7Validator as _Validator
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    PARAM_SERVICE_TIMEOUT,
+)
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
@@ -380,11 +383,13 @@ class TestOpenApiResponseDrift(GatewayTestCase):
 
         @verifies REQ_INTEROP_002
         """
-        resp = requests.get(
-            f'{self.BASE_URL}/apps/temp_sensor/configurations', timeout=10
+        # The configurations endpoint reads the node's parameter service, which
+        # returns 503 until it is ready just after discovery. Poll for it rather
+        # than asserting 200 on a single early GET.
+        body = self.poll_endpoint_until(
+            '/apps/temp_sensor/configurations',
+            timeout=PARAM_SERVICE_TIMEOUT,
         )
-        self.assertEqual(resp.status_code, 200)
-        body = resp.json()
 
         items = body.get('items', [])
         self.assertGreater(

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_config_management.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_config_management.test.py
@@ -60,20 +60,39 @@ class TestScenarioConfigManagement(GatewayTestCase):
     APP_ID = 'temp_sensor'
     ENTITY_ENDPOINT = '/apps/temp_sensor'
 
+    # Monotonic param-service readiness, cached across this class's tests.
+    _param_service_ready = False
+    _param_service_dead = False
+
     def setUp(self):
         """Wait for the node's parameter service before each test.
 
         The configurations endpoints read the ROS 2 parameter service on the
         temp_sensor node, which can be briefly unavailable just after discovery
         (the endpoint returns 503 until it is ready) - more likely under the
-        slowdown of the sanitizer jobs. Gate every test on it being ready so the
-        per-test GETs are not racing param-service startup.
+        slowdown of the sanitizer jobs. Gate every test on it being ready.
+
+        Readiness is monotonic, so cache it on the class: only the first test
+        polls (up to PARAM_SERVICE_TIMEOUT); the rest return immediately. On a
+        genuinely dead service the first poll times out and marks the class dead
+        so the remaining tests fail fast, instead of each paying the full
+        timeout (which would blow the ctest job budget).
         """
         super().setUp()
-        self.poll_endpoint_until(
-            f'{self.ENTITY_ENDPOINT}/configurations',
-            timeout=PARAM_SERVICE_TIMEOUT,
-        )
+        cls = type(self)
+        if cls._param_service_ready:
+            return
+        if cls._param_service_dead:
+            self.fail('parameter service was not ready (cached from an earlier test)')
+        try:
+            self.poll_endpoint_until(
+                f'{self.ENTITY_ENDPOINT}/configurations',
+                timeout=PARAM_SERVICE_TIMEOUT,
+            )
+        except AssertionError:
+            cls._param_service_dead = True
+            raise
+        cls._param_service_ready = True
 
     # ------------------------------------------------------------------
     # Tests

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_config_management.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_config_management.test.py
@@ -25,7 +25,10 @@ import launch_testing
 import launch_testing.actions
 import requests
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    PARAM_SERVICE_TIMEOUT,
+)
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
@@ -56,6 +59,21 @@ class TestScenarioConfigManagement(GatewayTestCase):
 
     APP_ID = 'temp_sensor'
     ENTITY_ENDPOINT = '/apps/temp_sensor'
+
+    def setUp(self):
+        """Wait for the node's parameter service before each test.
+
+        The configurations endpoints read the ROS 2 parameter service on the
+        temp_sensor node, which can be briefly unavailable just after discovery
+        (the endpoint returns 503 until it is ready) - more likely under the
+        slowdown of the sanitizer jobs. Gate every test on it being ready so the
+        per-test GETs are not racing param-service startup.
+        """
+        super().setUp()
+        self.poll_endpoint_until(
+            f'{self.ENTITY_ENDPOINT}/configurations',
+            timeout=PARAM_SERVICE_TIMEOUT,
+        )
 
     # ------------------------------------------------------------------
     # Tests

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_discovery_manifest.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_discovery_manifest.test.py
@@ -283,11 +283,17 @@ class TestScenarioDiscoveryManifest(GatewayTestCase):
         """GET /apps/{id}/configurations returns parameters when node is running.
 
         App is defined in manifest with bound_fqn. Configurations are retrieved
-        from the ROS 2 parameter service on the node.
+        from the ROS 2 parameter service on the node, which may not be ready the
+        instant the app is discovered - the endpoint returns 503 until it is.
+        Poll until it responds rather than asserting on a single early GET.
 
         @verifies REQ_INTEROP_003
         """
-        data = self.get_json('/apps/lidar-sensor/configurations')
+        data = self.poll_endpoint_until(
+            '/apps/lidar-sensor/configurations',
+            lambda d: d if 'items' in d else None,
+            timeout=15.0,
+        )
         self.assertIn('items', data)
         self.assertIn('x-medkit', data)
 

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_discovery_manifest.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_discovery_manifest.test.py
@@ -41,7 +41,10 @@ import launch_testing
 import launch_testing.actions
 import requests
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    PARAM_SERVICE_TIMEOUT,
+)
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_demo_nodes, create_gateway_node
 
@@ -292,7 +295,7 @@ class TestScenarioDiscoveryManifest(GatewayTestCase):
         data = self.poll_endpoint_until(
             '/apps/lidar-sensor/configurations',
             lambda d: d if 'items' in d else None,
-            timeout=15.0,
+            timeout=PARAM_SERVICE_TIMEOUT,
         )
         self.assertIn('items', data)
         self.assertIn('x-medkit', data)


### PR DESCRIPTION
## Summary

`TriggerTopicSubscriber` created its per-trigger subscriptions on the shared main
executor and destroyed them believing that `rclcpp::GenericSubscription`
destruction drains in-flight callbacks. rclcpp gives no such guarantee, so at
gateway shutdown a subscription callback could still be running (deserializing a
sample) while the subscription, its captured strings, and the subscriber's
serializer were being destroyed on the main thread. TSan flags this as a data
race and the gateway child exits 66. It is nondeterministic and pre-existing
(also on `main`).

This routes trigger subscriptions through the shared `Ros2SubscriptionExecutor`
(the same isolated single-worker path `/data` already uses), via
`Ros2SubscriptionSlot`. Their callbacks now dispatch on - and are drained by -
that one worker thread before teardown, so a callback can no longer fire on a
partially destroyed subscriber.

Key points:
- Every slot create/destroy posts a `run_sync` task to that worker, and all of
  them happen strictly outside the subscriber mutex, so a create/destroy can
  never deadlock against a callback that takes the same mutex.
- `main.cpp` shuts the trigger subscriber down (destroying its slots on the
  drained worker) before `sub_exec.reset()`.
- The executor pointer is set once after construction and read on HTTP threads,
  so it is `std::atomic` (acquire/release).
- Behavior note: a persistent "data" trigger whose topic type is already
  resolvable during `GatewayNode` construction (before the executor is wired)
  now subscribes within one retry tick instead of immediately. No crash, no lost
  trigger.

## Issue

- closes #548

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

## Testing

- `test_triggers_data` passes repeatedly under the default RMW with a clean
  gateway shutdown (no hang = no deadlock, exit 0 = no crash); the trigger unit
  tests pass; clang-tidy is clean.
- The race fix itself is confirmed by the TSan sanitizer job in CI. TSan cannot
  run in the local sandbox (it aborts on an "unexpected memory mapping" because
  ASLR cannot be disabled there), so a local fastrtps run only proves the absence
  of deadlock/crash, not race-freedom.

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
