### PR TITLE
test: isolate every integration launch test on its own DDS domain

### DIFF
--- a/src/ros2_medkit_action_status_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_action_status_bridge/CMakeLists.txt
@@ -95,7 +95,7 @@ if(BUILD_TESTING)
   ros2_medkit_clang_tidy()
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 215 END 219)
+  medkit_init_test_domains(START 116 END 119)
 
   ament_add_gtest(test_action_status_bridge test/test_action_status_bridge.cpp)
   target_link_libraries(test_action_status_bridge action_status_bridge_lib)
@@ -111,11 +111,7 @@ if(BUILD_TESTING)
   install(DIRECTORY test
     DESTINATION share/${PROJECT_NAME}
   )
-  add_launch_test(
-    test/test_integration.test.py
-    TARGET test_integration
-    TIMEOUT 120
-  )
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 120)
 
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -19,19 +19,33 @@
 # non-overlapping domain ID ranges to prevent DDS cross-contamination.
 #
 # Allocated ranges:
-#   ros2_medkit_sovd_service_iface:   1 -   9 (9 slots)
-#   ros2_medkit_fault_manager:       10 -  29 (20 slots)
-#   ros2_medkit_gateway:             30 -  89 (60 slots)
-#   ros2_medkit_diagnostic_bridge:   90 -  99 (10 slots)
-#   ros2_medkit_param_beacon:       100 - 109 (10 slots)
-#   ros2_medkit_topic_beacon:       110 - 119 (10 slots)
-#   ros2_medkit_graph_provider:     120 - 129 (10 slots)
-#   ros2_medkit_linux_introspection: 130 - 139 (10 slots)
-#   ros2_medkit_integration_tests:  140 - 209 (70 slots)
-#   ros2_medkit_log_bridge:         210 - 214 (5 slots, carved from integration_tests)
-#   ros2_medkit_action_status_bridge: 215 - 219 (5 slots, carved from integration_tests)
-#   ros2_medkit_opcua:              220 - 229 (10 slots, carved from integration_tests)
-#   multi-domain tests (secondary): 230 - 232 (3 slots, reserved for peer_aggregation etc.)
+#   ros2_medkit_sovd_service_interface: 1 -   9 (9 slots)
+#   ros2_medkit_fault_manager:         10 -  29 (20 slots)
+#   ros2_medkit_gateway:               30 -  89 (60 slots)
+#   ros2_medkit_diagnostic_bridge:     90 -  99 (10 slots)
+#   ros2_medkit_param_beacon:         100 - 104 (5 slots)
+#   ros2_medkit_topic_beacon:         105 - 109 (5 slots)
+#   ros2_medkit_fault_reporter:       110 - 112 (3 slots)
+#   ros2_medkit_log_bridge:           113 - 115 (3 slots)
+#   ros2_medkit_action_status_bridge: 116 - 119 (4 slots)
+#   ros2_medkit_graph_provider:       120 - 129 (10 slots)
+#   ros2_medkit_integration_tests:    130 - 219 (90 slots)
+#   ros2_medkit_opcua:                220 - 229 (10 slots)
+#   multi-domain tests (secondary):   230 - 232 (3 slots, reserved for peer_aggregation etc.)
+#
+# Launch_testing tests (add_launch_test) create real ROS nodes and MUST consume
+# a domain, exactly like a gtest. Two concurrently scheduled tests on the same
+# domain (the default, 0) discover each other's nodes and cross-contaminate.
+# Use medkit_add_launch_test (below), which registers the test and assigns its
+# domain in one call, so a launch test can never be added without isolation.
+#
+# ros2_medkit_linux_introspection reads /proc and cgroups only (no ROS nodes),
+# so it needs no domain isolation and reserves no range.
+#
+# integration_tests (it grows by glob) and opcua are the tightest pools. When
+# either fills, reclaim slack from the fixed 5-slot beacon pools above (each
+# uses one of five) and re-carve - the 1-232 DDS space is otherwise fully
+# allocated.
 #
 # To add a new package: pick the next free range and update this comment.
 
@@ -73,4 +87,25 @@ macro(medkit_set_test_domain TEST_NAME)
     ENVIRONMENT "ROS_DOMAIN_ID=${_MEDKIT_DOMAIN_COUNTER}"
   )
   math(EXPR _MEDKIT_DOMAIN_COUNTER "${_MEDKIT_DOMAIN_COUNTER} + 1")
+endmacro()
+
+# Register a launch_testing test AND assign it a unique DDS domain in one call.
+# This is the required way to add a launch test: it makes it impossible to add
+# one without domain isolation (see the note above about domain-0 collisions).
+# Do not call add_launch_test directly.
+#
+# The caller may still set extra properties afterwards (e.g. LABELS), since this
+# only sets the ENVIRONMENT and TIMEOUT properties.
+#
+# Usage:
+#   medkit_add_launch_test(test_integration test/test_integration.test.py)
+#   medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 90)
+macro(medkit_add_launch_test TEST_NAME TEST_FILE)
+  cmake_parse_arguments(_MALT "" "TIMEOUT" "" ${ARGN})
+  if(DEFINED _MALT_TIMEOUT)
+    add_launch_test(${TEST_FILE} TARGET ${TEST_NAME} TIMEOUT ${_MALT_TIMEOUT})
+  else()
+    add_launch_test(${TEST_FILE} TARGET ${TEST_NAME})
+  endif()
+  medkit_set_test_domain(${TEST_NAME})
 endmacro()

--- a/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
@@ -130,11 +130,7 @@ if(BUILD_TESTING)
   # post-shutdown exit-code check. Override the label to "integration" via
   # set_tests_properties (the repo convention) so it runs only in the
   # integration phase.
-  add_launch_test(
-    test/test_integration.test.py
-    TARGET test_integration
-    TIMEOUT 60
-  )
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60)
   set_tests_properties(test_integration PROPERTIES LABELS "integration")
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CMakeLists.txt
@@ -80,7 +80,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gmock REQUIRED)
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 100 END 109)
+  medkit_init_test_domains(START 100 END 104)
 
   # Include plugin source in test (plugin is MODULE/dlopen, test instantiates directly)
   # TIMEOUT 180: the 12 test cases each spin a node for ~200-400 ms. Under

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CMakeLists.txt
@@ -86,7 +86,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 110 END 119)
+  medkit_init_test_domains(START 105 END 109)
 
   # Include plugin source in test (plugin is MODULE/dlopen, test instantiates directly)
   ament_add_gtest(test_topic_beacon_plugin

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -207,32 +207,16 @@ if(BUILD_TESTING)
     DESTINATION share/${PROJECT_NAME}
   )
 
-  add_launch_test(
-    test/test_integration.test.py
-    TARGET test_integration
-    TIMEOUT 60
-  )
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60)
   set_tests_properties(test_integration PROPERTIES LABELS "integration")
 
-  add_launch_test(
-    test/test_rosbag_integration.test.py
-    TARGET test_rosbag_integration
-    TIMEOUT 90
-  )
+  medkit_add_launch_test(test_rosbag_integration test/test_rosbag_integration.test.py TIMEOUT 90)
   set_tests_properties(test_rosbag_integration PROPERTIES LABELS "integration")
 
-  add_launch_test(
-    test/test_entity_thresholds_integration.test.py
-    TARGET test_entity_thresholds_integration
-    TIMEOUT 60
-  )
+  medkit_add_launch_test(test_entity_thresholds_integration test/test_entity_thresholds_integration.test.py TIMEOUT 60)
   set_tests_properties(test_entity_thresholds_integration PROPERTIES LABELS "integration")
 
-  add_launch_test(
-    test/test_rosbag_entity_scope.test.py
-    TARGET test_rosbag_entity_scope
-    TIMEOUT 120
-  )
+  medkit_add_launch_test(test_rosbag_entity_scope test/test_rosbag_entity_scope.test.py TIMEOUT 120)
   set_tests_properties(test_rosbag_entity_scope PROPERTIES LABELS "integration")
 
   # CaptureThreadPool unit tests (no ROS node, no domain id needed)

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
@@ -106,8 +106,9 @@ def generate_test_description():
     script_file.close()
     PUBLISHER_SCRIPT_PATH = script_file.name
 
+    # Inherit the CMake-injected per-test ROS_DOMAIN_ID; ROS_LOCALHOST_ONLY
+    # keeps discovery on loopback.
     env = os.environ.copy()
-    env['ROS_DOMAIN_ID'] = '43'
     env['ROS_LOCALHOST_ONLY'] = '1'
 
     publishers = launch.actions.ExecuteProcess(
@@ -122,7 +123,7 @@ def generate_test_description():
         executable='fault_manager_node',
         name='fault_manager',
         output='screen',
-        additional_env={'ROS_DOMAIN_ID': '43', 'ROS_LOCALHOST_ONLY': '1'},
+        additional_env={'ROS_LOCALHOST_ONLY': '1'},
         parameters=[{
             'storage_type': 'memory',
             'confirmation_threshold': -1,
@@ -156,7 +157,8 @@ class TestRosbagEntityScope(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        os.environ['ROS_DOMAIN_ID'] = '43'
+        # Inherit the CMake-injected per-test ROS_DOMAIN_ID; keep discovery
+        # on loopback.
         os.environ['ROS_LOCALHOST_ONLY'] = '1'
         rclpy.init()
         cls.node = Node('test_entity_scope_client')

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
@@ -129,10 +129,11 @@ if __name__ == '__main__':
     script_file.close()
     PUBLISHER_SCRIPT_PATH = script_file.name
 
-    # Use explicit ROS settings to ensure processes can discover each other
+    # Inherit the per-test ROS_DOMAIN_ID that CMake injects via
+    # medkit_set_test_domain, so this test is isolated from other packages
+    # running in parallel. ROS_LOCALHOST_ONLY keeps discovery on loopback.
     env = os.environ.copy()
-    env['ROS_DOMAIN_ID'] = '42'
-    env['ROS_LOCALHOST_ONLY'] = '1'  # Force localhost-only discovery
+    env['ROS_LOCALHOST_ONLY'] = '1'
 
     test_publisher = launch.actions.ExecuteProcess(
         cmd=['python3', script_file.name],
@@ -142,7 +143,6 @@ if __name__ == '__main__':
     )
 
     fault_manager_env = get_coverage_env()
-    fault_manager_env['ROS_DOMAIN_ID'] = '42'
     fault_manager_env['ROS_LOCALHOST_ONLY'] = '1'
 
     fault_manager_node = launch_ros.actions.Node(
@@ -198,8 +198,8 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Initialize ROS 2 context and create service clients."""
-        # Use same ROS settings as launch processes to ensure discovery
-        os.environ['ROS_DOMAIN_ID'] = '42'
+        # Match the launch processes: inherit the CMake-injected
+        # ROS_DOMAIN_ID and keep discovery on loopback.
         os.environ['ROS_LOCALHOST_ONLY'] = '1'
         rclpy.init()
         cls.node = Node('test_rosbag_client')

--- a/src/ros2_medkit_fault_reporter/CMakeLists.txt
+++ b/src/ros2_medkit_fault_reporter/CMakeLists.txt
@@ -90,6 +90,9 @@ if(BUILD_TESTING)
 
   ros2_medkit_clang_tidy()
 
+  include(ROS2MedkitTestDomain)
+  medkit_init_test_domains(START 110 END 112)
+
   # Unit tests
   ament_add_gtest(test_local_filter test/test_local_filter.cpp)
   target_link_libraries(test_local_filter fault_reporter_lib)
@@ -105,11 +108,7 @@ if(BUILD_TESTING)
     DESTINATION share/${PROJECT_NAME}
   )
 
-  add_launch_test(
-    test/test_integration.test.py
-    TARGET test_integration
-    TIMEOUT 60
-  )
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60)
   ros2_medkit_relax_vendor_warnings()
 endif()
 

--- a/src/ros2_medkit_gateway/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_manager.cpp
@@ -44,10 +44,10 @@ using ros2_medkit_msgs::srv::GetSnapshots;
 class FaultManagerTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
-    // Isolate from other packages' tests running in parallel (e.g. ros2_medkit_fault_manager
-    // launches a real fault_manager_node with /fault_manager/get_snapshots on the default domain).
-    // Without this, our mock services collide with real ones on Humble's slower DDS cleanup.
-    setenv("ROS_DOMAIN_ID", "99", 1);
+    // ROS_DOMAIN_ID is injected per test by CMake (medkit_set_test_domain in
+    // CMakeLists.txt), which keeps this suite's mock /fault_manager services
+    // isolated from the real fault_manager_node that ros2_medkit_fault_manager
+    // launches in its own tests. Do not override the injected domain here.
     rclcpp::init(0, nullptr);
   }
 

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -120,11 +120,15 @@ if(BUILD_TESTING)
   set(_INTEG_PORT 9100)
 
   include(ROS2MedkitTestDomain)
-  # Primary per-test domain pool. Upper bound is 229: the documented
-  # integration_tests allocation is 140-229, with 230-232 reserved for the
-  # multi-gateway secondary pool (see get_test_domain_id below). One domain is
-  # consumed per feature + scenario test.
-  medkit_init_test_domains(START 140 END 229)
+  # Primary per-test domain pool 130-219, with 220-229 owned by opcua and
+  # 230-232 reserved for the multi-gateway secondary pool (see
+  # get_test_domain_id below). One domain is consumed per feature + scenario
+  # test. This pool grows by glob, so it is the first to fill; when it does,
+  # reclaim slack from the fixed beacon pools (see ROS2MedkitTestDomain.cmake).
+  # The tests below call add_launch_test directly instead of the
+  # medkit_add_launch_test wrapper because each needs a combined
+  # GATEWAY_TEST_PORT + ROS_DOMAIN_ID environment, assigned inline in the loop.
+  medkit_init_test_domains(START 130 END 219)
 
   # Feature tests (atomic, independent, 120s timeout)
   file(GLOB FEATURE_TESTS test/features/*.test.py)

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
@@ -36,7 +36,7 @@ def get_test_domain_id(offset=0):
     """Return a DDS domain ID for this test, optionally with an offset.
 
     Each integration test gets a unique ``ROS_DOMAIN_ID`` from CMake
-    (stride of 1, range 140-229). For offset 0, returns the assigned
+    (stride of 1, range 130-219). For offset 0, returns the assigned
     domain ID directly.
 
     For offset in 1..3 (multi-gateway tests needing extra DDS domains),

--- a/src/ros2_medkit_log_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_log_bridge/CMakeLists.txt
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
   ros2_medkit_clang_tidy()
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 210 END 214)
+  medkit_init_test_domains(START 113 END 115)
 
   ament_add_gtest(test_log_bridge test/test_log_bridge.cpp)
   target_link_libraries(test_log_bridge log_bridge_lib)
@@ -113,11 +113,7 @@ if(BUILD_TESTING)
   install(DIRECTORY test
     DESTINATION share/${PROJECT_NAME}
   )
-  add_launch_test(
-    test/test_integration.test.py
-    TARGET test_integration
-    TIMEOUT 90
-  )
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 90)
 
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_log_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_log_bridge/test/test_integration.test.py
@@ -87,7 +87,17 @@ class TestLogBridgeIntegration(unittest.TestCase):
         )
         assert cls.list_faults_client.wait_for_service(timeout_sec=10.0), \
             'ListFaults service not available'
-        time.sleep(1.0)  # let the bridge connect
+        # Wait for log_bridge_node to match our /rosout publisher. A fixed sleep
+        # is not enough on a slow or loaded machine: if the bridge has not
+        # discovered us yet, the first log we publish is dropped before the
+        # subscription exists and its fault never appears (the later tests still
+        # pass because discovery has completed by then). Poll the matched
+        # subscription count instead.
+        deadline = time.time() + 15.0
+        while cls.rosout_pub.get_subscription_count() < 1 and time.time() < deadline:
+            rclpy.spin_once(cls.node, timeout_sec=0.1)
+        assert cls.rosout_pub.get_subscription_count() >= 1, \
+            'log_bridge did not subscribe to /rosout within the timeout'
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
# Pull Request

## Summary

Give every `launch_testing` integration test a unique `ROS_DOMAIN_ID` so parallel ctest runs cannot cross-contaminate, and make that invariant hard to break.

Before this change, only `ros2_medkit_integration_tests` isolated its launch tests. The `add_launch_test` targets in `ros2_medkit_fault_manager`, `ros2_medkit_diagnostic_bridge`, `ros2_medkit_fault_reporter`, `ros2_medkit_action_status_bridge` and `ros2_medkit_log_bridge` set no domain, so they all ran on the default domain 0. Under parallel ctest they discovered each other's nodes. That is how `test_01_error_log_creates_attributed_fault` in `ros2_medkit_log_bridge` failed: its fault manager picked up `ACTION_TEST_ACTION_ABORTED` from the `ros2_medkit_action_status_bridge` test node.

Changes (commit 1):
- Add a `medkit_add_launch_test` wrapper that registers a launch test and assigns its domain in one call, and route every launch test through it, so a launch test can no longer be added without isolation. `fault_reporter` had no range, so it gets one.
- Reallocate the domain table so the pools are disjoint and the glob-grown `integration_tests` pool gets headroom: reclaim the slack in the fixed beacon pools (`param_beacon`, `topic_beacon` each used 1 of 10, now 5 each), move `fault_reporter`/`log_bridge`/`action_status_bridge` into 110-119, and grow `integration_tests` to 130-219 (90 slots, 74 used). `graph_provider` (120-129) and `opcua` (220-229) are unchanged.
- Drop three hardcoded `ROS_DOMAIN_ID` overrides that bypassed the table: the `fault_manager` rosbag launch tests forced 42/43 (which collided with the gateway gtests assigned 42/43), and the gateway `test_fault_manager` gtest forced 99 as a manual workaround for the launch tests running on domain 0. Each test now inherits its assigned domain.

Commit 2 fixes a separate flake in the same test that CI surfaced: the `log_bridge` integration test used a fixed 1s sleep to let the bridge connect, then published a single ERROR log. On a slow machine the bridge had not matched the `/rosout` publisher within 1s, so the first log was dropped and its fault never appeared. It now waits on the matched subscription count instead, the same pattern the other bridge tests already use.

---

## Issue

- closes #550

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Built the affected packages and confirmed each launch test's ctest `ENVIRONMENT` carries a unique `ROS_DOMAIN_ID` (fault_manager 15-18, diagnostic_bridge 91, fault_reporter 110, log_bridge 114, action_status_bridge 117, integration_tests 130-203). `medkit_add_launch_test` verified to assign the domain (fault_reporter test -> 110).

Ran the two tests that were cross-contaminating (`log_bridge` and `action_status_bridge`) at the same time; both pass together now. Ran the two rosbag tests and the gateway `test_fault_manager` on their assigned domains, concurrently with a real `fault_manager_node`, to confirm the removed hardcodes were not needed.

CMake configure passes with no domain-range exhaustion.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
