### PR TITLE
test: route inline gateways and fault managers through the shared helpers (coverage SIGKILL fix)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -232,11 +232,11 @@ jobs:
       # on which runner it landed. /mnt always has ~60+ GB free.
       volumes:
         - "/mnt:/mnt"
-    # Cold-cache ASan builds are ~33 min; with the 12-min test budget this
-    # left ~0 headroom and was already cancelling at thermal_protection on
-    # PR branches that miss the ccache restore key. 60 min covers a full
-    # cold-cache cycle so the cache always gets saved on the post step.
-    timeout-minutes: 60
+    # Cold-cache ASan builds are ~33 min; with the test budget a full run is
+    # ~55 min, so the previous 60 min still cancelled on slower runners before
+    # the post step could save the ccache. 90 min gives a cold-cache cycle real
+    # headroom so a slow runner does not cancel the job mid-run.
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash
@@ -347,7 +347,9 @@ jobs:
       # fit the container overlay on small GitHub runners, so build on /mnt.
       volumes:
         - "/mnt:/mnt"
-    timeout-minutes: 45
+    # A full TSan run is ~40 min, leaving only ~5 min of headroom at 45; bump to
+    # 60 so a slow runner does not cancel the job mid-run (see sanitizer-asan).
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
@@ -56,6 +56,9 @@ def generate_test_description():
             # fault heals on that single event only with healing_threshold 0.
             'healing_threshold': 0,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     # Load the packaged config first so assertExitCodes guards against the
@@ -72,6 +75,9 @@ def generate_test_description():
         parameters=[config_file, {
             'rescan_period_sec': 1.0,  # fast discovery for the test
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     return (

--- a/src/ros2_medkit_diagnostic_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_diagnostic_bridge/test/test_integration.test.py
@@ -42,6 +42,9 @@ def generate_test_description():
             'healing_enabled': True,
             'healing_threshold': 1,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     diagnostic_bridge_node = launch_ros.actions.Node(
@@ -53,6 +56,9 @@ def generate_test_description():
             'diagnostics_topic': '/diagnostics',
             'auto_generate_codes': True,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     return (

--- a/src/ros2_medkit_fault_manager/test/test_entity_thresholds_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_entity_thresholds_integration.test.py
@@ -48,6 +48,9 @@ def generate_test_description():
             'healing_threshold': 10,
             'entity_thresholds.config_file': thresholds_config,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     return (

--- a/src/ros2_medkit_fault_manager/test/test_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_integration.test.py
@@ -97,6 +97,9 @@ def generate_test_description():
             'snapshots.capture_queue_full_policy': 'reject_newest',
             'correlation.config_file': correlation_config,  # Enable correlation
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     return (
@@ -549,17 +552,26 @@ class TestFaultManagerIntegration(unittest.TestCase):
             rclpy.spin_once(self.node, timeout_sec=0.01)
             time.sleep(interval)
 
-    def _wait_for_topic_subscribers(self, topic_name, timeout_sec=5.0):
-        """Wait for topic to have subscribers (indicates discovery complete)."""
-        start = time.time()
-        while time.time() - start < timeout_sec:
-            count = self.node.count_subscribers(topic_name)
-            if count > 0:
-                return True
-            # Keep publishing to maintain topic presence
-            rclpy.spin_once(self.node, timeout_sec=0.01)
-            time.sleep(0.1)
-        return False
+    def _wait_for_snapshot(self, fault_code, timeout=10.0):
+        """
+        Poll GetSnapshots until the async on-demand capture completes.
+
+        The snapshot subscription is created on demand when the fault confirms
+        and fills over its own timeout window, so a fixed sleep plus a single
+        query flakes under load - poll until data arrives.
+        """
+        request = GetSnapshots.Request()
+        request.fault_code = fault_code
+        request.topic = ''
+        deadline = time.time() + timeout
+        response = self._call_service(self.get_snapshots_client, request)
+        while time.time() < deadline:
+            if (response is not None and response.success
+                    and len(response.data) > 0):
+                return response
+            time.sleep(0.5)
+            response = self._call_service(self.get_snapshots_client, request)
+        return response
 
     def test_16_snapshot_capture_on_fault_confirmation(self):
         """
@@ -602,18 +614,14 @@ class TestFaultManagerIntegration(unittest.TestCase):
             response = self._call_service(self.report_fault_client, request)
             self.assertTrue(response.accepted)
 
-            # Wait for snapshot capture to complete (snapshot timeout is 3s)
-            time.sleep(4.0)
+            # Poll for the snapshot; the publisher thread keeps feeding data.
+            # _wait_for_snapshot is the ground-truth gate (it polls GetSnapshots
+            # for the actual capture), so no fragile pre-wait on the short-lived
+            # on-demand subscription is needed.
+            snap_response = self._wait_for_snapshot(fault_code)
         finally:
             stop_publishing.set()
             pub_thread.join()
-
-        # Query snapshots
-        snap_request = GetSnapshots.Request()
-        snap_request.fault_code = fault_code
-        snap_request.topic = ''  # All topics
-
-        snap_response = self._call_service(self.get_snapshots_client, snap_request)
 
         self.assertTrue(snap_response.success)
         self.assertGreater(len(snap_response.data), 0)

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_entity_scope.test.py
@@ -136,6 +136,9 @@ def generate_test_description():
             'snapshots.rosbag.storage_path': ROSBAG_STORAGE_PATH,
             'snapshots.rosbag.lazy_start': False,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     delayed_fault_manager = launch.actions.TimerAction(

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
@@ -27,8 +27,10 @@ import launch_testing.actions
 import launch_testing.markers
 import rclpy
 from rclpy.node import Node
+from rclpy.qos import HistoryPolicy, QoSProfile, ReliabilityPolicy
 from ros2_medkit_msgs.msg import Fault
 from ros2_medkit_msgs.srv import ClearFault, GetRosbag, ReportFault
+from sensor_msgs.msg import Temperature
 
 
 def get_coverage_env():
@@ -168,6 +170,9 @@ if __name__ == '__main__':
             # lazy_start=false: Start recording immediately
             'snapshots.rosbag.lazy_start': False,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     # Delay fault_manager start so test_publisher has time to register topics
@@ -223,8 +228,13 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         assert cls.get_rosbag_client.wait_for_service(timeout_sec=15.0), \
             'get_rosbag service not available'
 
-        # Give time for rosbag capture to fill buffer with messages from
-        # background publishers (duration_sec=2.0 configured)
+        # Wait for the background publisher to come up before letting the rosbag
+        # ring buffer fill (duration_sec=2.0 configured), so a slow publisher
+        # start does not leave the buffer empty.
+        deadline = time.time() + 15.0
+        while (not cls.node.get_publishers_info_by_topic('/test/temperature')
+               and time.time() < deadline):
+            time.sleep(0.2)
         time.sleep(3.0)
 
     @classmethod
@@ -250,6 +260,57 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         request.source_id = '/test_node'
         return self._call_service(self.report_fault_client, request)
 
+    def _wait_for_rosbag(self, fault_code, timeout=12.0):
+        """
+        Poll GetRosbag until the async post-fault recording is written.
+
+        The recording plus its post-fault flush (duration_after_sec) can take
+        longer than a fixed sleep under sanitizer/coverage load, so a one-shot
+        call flakes. Mirror the polling loop in test_rosbag_entity_scope.
+        """
+        request = GetRosbag.Request()
+        request.fault_code = fault_code
+        deadline = time.time() + timeout
+        response = self._call_service(self.get_rosbag_client, request)
+        while time.time() < deadline:
+            if response is not None and response.success:
+                return response
+            time.sleep(0.5)
+            response = self._call_service(self.get_rosbag_client, request)
+        return response
+
+    def _wait_for_buffered_data(self, count=5, timeout=8.0):
+        """
+        Wait until the rosbag ring buffer holds fresh data before a confirmation.
+
+        A previous fault's post-fault recording window diverts incoming messages
+        away from the ring buffer, so right after it closes the buffer can be
+        empty and flush_to_bag creates no bag. There is no service to read the
+        buffer, so subscribe to the same source the fault manager records and
+        wait until ``count`` messages arrive - by then the co-subscribed fault
+        manager has buffered a comparable amount. Adaptive, unlike a fixed sleep.
+        """
+        received = 0
+
+        def _cb(_msg):
+            nonlocal received
+            received += 1
+
+        # Match the publisher's BEST_EFFORT sensor QoS, else no messages arrive.
+        qos = QoSProfile(
+            reliability=ReliabilityPolicy.BEST_EFFORT,
+            history=HistoryPolicy.KEEP_LAST,
+            depth=10,
+        )
+        sub = self.node.create_subscription(Temperature, '/test/temperature', _cb, qos)
+        try:
+            deadline = time.time() + timeout
+            while received < count and time.time() < deadline:
+                rclpy.spin_once(self.node, timeout_sec=0.1)
+        finally:
+            self.node.destroy_subscription(sub)
+        return received >= count
+
     def test_01_rosbag_created_on_fault_confirmation(self):
         """Test that rosbag file is created when fault is confirmed."""
         fault_code = 'ROSBAG_TEST_001'
@@ -259,14 +320,8 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         self.assertTrue(response.accepted)
         print(f'Fault {fault_code} reported and confirmed')
 
-        # Wait for post-fault recording to complete
-        time.sleep(1.0)  # duration_after_sec=0.5 + buffer
-
-        # Query rosbag info
-        rosbag_request = GetRosbag.Request()
-        rosbag_request.fault_code = fault_code
-
-        rosbag_response = self._call_service(self.get_rosbag_client, rosbag_request)
+        # Poll until the async post-fault recording is written.
+        rosbag_response = self._wait_for_rosbag(fault_code)
 
         self.assertTrue(rosbag_response.success,
                         f'GetRosbag failed: {rosbag_response.error_message}')
@@ -292,13 +347,8 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         response = self._report_fault(fault_code, 'Cleanup test fault')
         self.assertTrue(response.accepted)
 
-        # Wait for post-fault recording
-        time.sleep(1.0)
-
-        # Verify rosbag exists
-        rosbag_request = GetRosbag.Request()
-        rosbag_request.fault_code = fault_code
-        rosbag_response = self._call_service(self.get_rosbag_client, rosbag_request)
+        # Poll until the async post-fault recording is written.
+        rosbag_response = self._wait_for_rosbag(fault_code)
 
         self.assertTrue(rosbag_response.success)
         bag_path = rosbag_response.file_path
@@ -313,8 +363,10 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         self.assertTrue(clear_response.success)
         print('Fault cleared')
 
-        # Small delay for cleanup
-        time.sleep(0.5)
+        # Poll until the async cleanup removes the bag file.
+        deadline = time.time() + 10.0
+        while os.path.exists(bag_path) and time.time() < deadline:
+            time.sleep(0.5)
 
         # Verify rosbag is deleted
         self.assertFalse(os.path.exists(bag_path),
@@ -322,6 +374,8 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         print('Rosbag auto-deleted on clear')
 
         # GetRosbag should now fail
+        rosbag_request = GetRosbag.Request()
+        rosbag_request.fault_code = fault_code
         rosbag_response2 = self._call_service(self.get_rosbag_client, rosbag_request)
         self.assertFalse(rosbag_response2.success)
         print(f'GetRosbag after clear: {rosbag_response2.error_message}')
@@ -353,18 +407,24 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         fault_codes = ['MULTI_BAG_A', 'MULTI_BAG_B']
         bag_paths = []
 
+        # test_02's post-fault recording window keeps new messages out of the
+        # ring buffer, so it can still be empty when this test starts. Wait for
+        # fresh buffered data before the first confirmation, otherwise
+        # flush_to_bag finds an empty buffer and creates no bag for MULTI_BAG_A.
+        self.assertTrue(self._wait_for_buffered_data(),
+                        'ring buffer did not refill before reporting faults')
+
         # Report multiple faults - buffer has messages from background publishers
         for fault_code in fault_codes:
             response = self._report_fault(fault_code, f'Multi-bag test: {fault_code}')
             self.assertTrue(response.accepted)
-            time.sleep(1.0)  # Wait for post-fault recording
+            # Serialize per fault: the rosbag ring buffer is shared, so let each
+            # fault's recording flush before the next fault is reported.
+            time.sleep(1.0)
 
-        # Verify each fault has its own rosbag
+        # Verify each fault has its own rosbag (poll for the async recording).
         for fault_code in fault_codes:
-            rosbag_request = GetRosbag.Request()
-            rosbag_request.fault_code = fault_code
-
-            rosbag_response = self._call_service(self.get_rosbag_client, rosbag_request)
+            rosbag_response = self._wait_for_rosbag(fault_code)
 
             self.assertTrue(rosbag_response.success,
                             f'GetRosbag failed for {fault_code}: {rosbag_response.error_message}')
@@ -384,14 +444,8 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         response = self._report_fault(fault_code, 'Duration test fault')
         self.assertTrue(response.accepted)
 
-        # Wait for post-fault recording (duration_after_sec=0.5)
-        time.sleep(1.0)
-
-        # Get rosbag info
-        rosbag_request = GetRosbag.Request()
-        rosbag_request.fault_code = fault_code
-
-        rosbag_response = self._call_service(self.get_rosbag_client, rosbag_request)
+        # Poll until the async post-fault recording is written.
+        rosbag_response = self._wait_for_rosbag(fault_code)
 
         self.assertTrue(rosbag_response.success)
 

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -151,11 +151,14 @@ class TestRos2ParameterTransportUnresponsiveNode : public ::testing::Test {
     // Release any in-flight blocking service callback first so the spin loop
     // (spin_some, not a blocking spin()) can drain and the spin thread exit.
     release_blocking_callback_ = true;
-    // Documented MultiThreadedExecutor teardown order: cancel -> join spin
-    // thread -> reset executor -> reset nodes. cancel() before join is safe
-    // here because the loop is a spin_some poll gated on spin_thread_running_,
-    // so it exits regardless; cancel() also unblocks any in-flight spin_some.
-    executor_->cancel();
+    // Stop and JOIN the spin thread before touching the executor. The loop is a
+    // spin_some(10ms) poll, so it returns on its own once spin_thread_running_
+    // is cleared - cancel() is not needed to unblock it (that is only required
+    // for a blocking spin()). Calling executor_->cancel() while the spin thread
+    // was still inside spin_some() raced the executor's notify-waitable (tsan:
+    // ExecutorNotifyWaitable::is_ready() on the spin thread vs
+    // trigger_entity_recollect() from cancel() on the main thread). With the
+    // thread joined first, nothing else touches the executor as we tear it down.
     spin_thread_running_ = false;
     if (spin_thread_.joinable()) {
       spin_thread_.join();

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/launch_helpers.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/launch_helpers.py
@@ -89,17 +89,25 @@ LIDAR_FAULTY_PARAMS = {
 # Factory: gateway node
 # ---------------------------------------------------------------------------
 
-def create_gateway_node(*, port=DEFAULT_PORT, extra_params=None, coverage=True):
+def create_gateway_node(*, port=DEFAULT_PORT, name='ros2_medkit_gateway',
+                        extra_params=None, coverage=True, extra_env=None):
     """Create a ``gateway_node`` launch action with standard config.
 
     Parameters
     ----------
     port : int
         HTTP server port (default: 8080).
+    name : str
+        ROS node name. Override when a test launches more than one gateway
+        so their names do not collide (e.g. ``gateway_with_scripts``).
     extra_params : dict or None
         Additional ROS parameters merged into the node config.
     coverage : bool
         If True, set GCOV_PREFIX env vars for code coverage collection.
+    extra_env : dict or None
+        Additional environment variables merged into ``additional_env`` on
+        top of the coverage env. Useful for setting ``ROS_DOMAIN_ID`` to
+        isolate a multi-gateway test's peers into distinct DDS domains.
 
     Returns
     -------
@@ -111,17 +119,22 @@ def create_gateway_node(*, port=DEFAULT_PORT, extra_params=None, coverage=True):
     if extra_params:
         params.update(extra_params)
 
+    env = dict(get_coverage_env() if coverage else {})
+    if extra_env:
+        env.update(extra_env)
+
     return launch_ros.actions.Node(
         package='ros2_medkit_gateway',
         executable='gateway_node',
-        name='ros2_medkit_gateway',
+        name=name,
         output='screen',
         parameters=[params],
-        additional_env=get_coverage_env() if coverage else {},
+        additional_env=env,
         # Default SIGINT->SIGTERM escalation is 5s and SIGTERM->SIGKILL is 5s.
-        # Under TSan/ASan the gateway shutdown sequence (mdns stop, REST server
-        # stop, transport teardown, plugin shutdown) easily exceeds 5s on slower
-        # CI runners, causing launch_testing to escalate to SIGKILL and the
+        # Under TSan/ASan/coverage the gateway shutdown sequence (mdns stop,
+        # REST server stop, transport teardown, plugin shutdown, plus flushing
+        # gcov data) easily exceeds 5s on slower CI runners, causing
+        # launch_testing to escalate to SIGKILL and the
         # TestShutdown.test_exit_codes check to report -9. The process still
         # shuts down cleanly given enough time, so widen both windows.
         sigterm_timeout='30',
@@ -135,17 +148,22 @@ def create_gateway_node(*, port=DEFAULT_PORT, extra_params=None, coverage=True):
 
 def create_fault_manager_node(
     *,
+    name='fault_manager',
     storage_type='memory',
     rosbag_enabled=True,
     rosbag_topics=None,
     snapshot_topics=None,
     extra_params=None,
     coverage=True,
+    extra_env=None,
 ):
     """Create a ``fault_manager_node`` with test-friendly defaults.
 
     Parameters
     ----------
+    name : str
+        ROS node name. Override when a test launches more than one fault
+        manager so their names do not collide.
     storage_type : str
         Storage backend: 'memory' (default, avoids filesystem issues in CI)
         or 'sqlite'.
@@ -163,6 +181,9 @@ def create_fault_manager_node(
         ``confirmation_threshold``.
     coverage : bool
         If True, set GCOV_PREFIX env vars for code coverage collection.
+    extra_env : dict or None
+        Additional environment variables merged into ``additional_env`` on
+        top of the coverage env (e.g. ``ROS_DOMAIN_ID`` for a peer).
 
     Returns
     -------
@@ -187,13 +208,24 @@ def create_fault_manager_node(
     if extra_params:
         params.update(extra_params)
 
+    # Route this process's .gcda to the fault_manager build dir, not the
+    # gateway default, so its coverage is not written to the wrong package.
+    env = dict(get_coverage_env('ros2_medkit_fault_manager') if coverage else {})
+    if extra_env:
+        env.update(extra_env)
+
     return launch_ros.actions.Node(
         package='ros2_medkit_fault_manager',
         executable='fault_manager_node',
-        name='fault_manager',
+        name=name,
         output='screen',
-        additional_env=get_coverage_env() if coverage else {},
+        additional_env=env,
         parameters=[params],
+        # Same rationale as create_gateway_node: under coverage the node must
+        # flush gcov data at shutdown, which can exceed the 5s launch default
+        # and get the process SIGKILLed to -9. Widen both windows.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
 
@@ -313,7 +345,9 @@ def create_demo_nodes(nodes=None, *, lidar_faulty=True, coverage=True,
     if nodes is None:
         nodes = ALL_DEMO_NODES
 
-    env = dict(get_coverage_env() if coverage else {})
+    # Demo executables are built in ros2_medkit_integration_tests, so route
+    # their .gcda there instead of polluting the gateway build dir.
+    env = dict(get_coverage_env('ros2_medkit_integration_tests') if coverage else {})
     if extra_env:
         env.update(extra_env)
     actions = []
@@ -328,6 +362,10 @@ def create_demo_nodes(nodes=None, *, lidar_faulty=True, coverage=True,
             'namespace': namespace,
             'output': 'screen',
             'additional_env': env,
+            # Give the node room to flush coverage data at shutdown before
+            # SIGKILL, matching the gateway/fault_manager helpers.
+            'sigterm_timeout': '30',
+            'sigkill_timeout': '15',
         }
 
         # Apply faulty parameters for lidar_sensor

--- a/src/ros2_medkit_integration_tests/test/features/test_beacon_param.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_beacon_param.test.py
@@ -82,6 +82,9 @@ def generate_test_description():
             'ros2_medkit.discovery.process_id': 9999,
             'ros2_medkit.discovery.stable_id': 'stable-temp-sensor',
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
     launch_description.add_action(param_node)
     return launch_description, context

--- a/src/ros2_medkit_integration_tests/test/features/test_beacon_topic.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_beacon_topic.test.py
@@ -84,6 +84,9 @@ def generate_test_description():
             'beacon_rate_hz': 2.0,
             'beacon_process_name': 'test_beacon',
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
     launch_description.add_action(beacon_node)
     return launch_description, context

--- a/src/ros2_medkit_integration_tests/test/features/test_cross_ecu_fanout.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_cross_ecu_fanout.test.py
@@ -36,7 +36,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import SetEnvironmentVariable, TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -52,6 +51,7 @@ from ros2_medkit_test_utils.constants import (
 )
 from ros2_medkit_test_utils.launch_helpers import (
     create_demo_nodes,
+    create_fault_manager_node,
     create_gateway_node,
 )
 
@@ -185,41 +185,21 @@ def generate_test_description():
         },
     )
 
-    peer_gateway = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    peer_gateway = create_gateway_node(
         name='secondary_gateway_node',
-        output='screen',
-        parameters=[{
-            'refresh_interval_ms': 1000,
-            'server.port': PEER_PORT,
+        port=PEER_PORT,
+        extra_params={
             'discovery.mode': 'hybrid',
             'discovery.manifest_path': peer_manifest_path,
             'discovery.manifest_strict_validation': False,
-        }],
-        additional_env=peer_domain_env,
-        # Match create_gateway_node()'s TSan/ASan-safe shutdown windows.
-        # Default 5s SIGINT->SIGTERM escalation is insufficient under
-        # sanitizers and causes SIGKILL with exit -9.
-        sigterm_timeout='30',
-        sigkill_timeout='15',
+        },
+        extra_env=peer_domain_env,
     )
 
-    primary_fault_mgr = launch_ros.actions.Node(
-        package='ros2_medkit_fault_manager',
-        executable='fault_manager_node',
-        name='fault_manager',
-        output='screen',
-        parameters=[{'storage_type': 'memory'}],
-    )
+    primary_fault_mgr = create_fault_manager_node(rosbag_enabled=False)
 
-    peer_fault_mgr = launch_ros.actions.Node(
-        package='ros2_medkit_fault_manager',
-        executable='fault_manager_node',
-        name='fault_manager',
-        output='screen',
-        parameters=[{'storage_type': 'memory'}],
-        additional_env=peer_domain_env,
+    peer_fault_mgr = create_fault_manager_node(
+        rosbag_enabled=False, extra_env=peer_domain_env,
     )
 
     primary_demo_nodes = create_demo_nodes(PRIMARY_NODES, lidar_faulty=False)

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -41,7 +41,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import SetEnvironmentVariable
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -55,6 +54,7 @@ from ros2_medkit_test_utils.constants import (
     get_test_domain_id,
     get_test_port,
 )
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
 
 # Port layout: primary at base+0, peer_B at base+1, peer_C at base+2.
 PRIMARY_PORT = get_test_port(0)
@@ -124,8 +124,6 @@ MANIFEST_FILES = [PRIMARY_MANIFEST, PEER_B_MANIFEST, PEER_C_MANIFEST]
 
 def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
     params = {
-        'refresh_interval_ms': 1000,
-        'server.port': port,
         'discovery.mode': 'manifest_only',
         'discovery.manifest_path': manifest_path,
         'discovery.manifest_strict_validation': False,
@@ -141,19 +139,11 @@ def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
             'aggregation.peer_urls': urls,
             'aggregation.peer_names': names,
         })
-    return launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    return create_gateway_node(
         name=name,
-        output='screen',
-        parameters=[params],
-        additional_env={'ROS_DOMAIN_ID': str(domain)},
-        # Match create_gateway_node()'s TSan/ASan-safe shutdown windows.
-        # Under sanitizers the gateway teardown sequence (mdns stop, REST
-        # server stop, transport shutdown, plugin shutdown) routinely
-        # exceeds launch's 5s default, causing SIGKILL with exit -9.
-        sigterm_timeout='30',
-        sigkill_timeout='15',
+        port=port,
+        extra_params=params,
+        extra_env={'ROS_DOMAIN_ID': str(domain)},
     )
 
 

--- a/src/ros2_medkit_integration_tests/test/features/test_discovery_heuristic.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_discovery_heuristic.test.py
@@ -62,6 +62,9 @@ def generate_test_description():
             namespace='/powertrain/engine',
             output='screen',
             additional_env=coverage_env,
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
         launch_ros.actions.Node(
             package='ros2_medkit_integration_tests',
@@ -70,6 +73,9 @@ def generate_test_description():
             namespace='/powertrain/engine',
             output='screen',
             additional_env=coverage_env,
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
         launch_ros.actions.Node(
             package='ros2_medkit_integration_tests',
@@ -78,6 +84,9 @@ def generate_test_description():
             namespace='/chassis/brakes',
             output='screen',
             additional_env=coverage_env,
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
         # Node in root namespace
         launch_ros.actions.Node(
@@ -87,6 +96,9 @@ def generate_test_description():
             namespace='/',
             output='screen',
             additional_env=coverage_env,
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
     ]
 

--- a/src/ros2_medkit_integration_tests/test/features/test_discovery_namespace_filter.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_discovery_namespace_filter.test.py
@@ -67,6 +67,9 @@ def generate_test_description():
         name='unmanifested_chassis_sensor',
         namespace='/chassis/brakes',
         output='screen',
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     # Launch an extra unmanifested node in /powertrain/engine (not blacklisted)
@@ -77,6 +80,9 @@ def generate_test_description():
         name='unmanifested_engine_sensor',
         namespace='/powertrain/engine',
         output='screen',
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     delayed = TimerAction(

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -61,6 +61,7 @@ from ros2_medkit_test_utils.launch_helpers import (
     create_demo_nodes,
     create_gateway_node,
     DEMO_NODE_REGISTRY,
+    get_coverage_env,
 )
 
 
@@ -168,6 +169,7 @@ class TestGraphEventDiscovery(GatewayTestCase):
 
         env = os.environ.copy()
         env['ROS_DOMAIN_ID'] = str(DEFAULT_DOMAIN_ID)
+        env.update(get_coverage_env())
 
         binary = _resolve_demo_executable(executable)
 

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_provider_greenwave.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_provider_greenwave.test.py
@@ -204,6 +204,9 @@ def generate_test_description():
             namespace=UNCOVERED_NAMESPACE,
             output='screen',
             additional_env=get_coverage_env(),
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
         launch_ros.actions.Node(
             package='ros2_medkit_integration_tests',
@@ -212,6 +215,9 @@ def generate_test_description():
             namespace=UNCOVERED_NAMESPACE,
             output='screen',
             additional_env=get_coverage_env(),
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
     ]
     demo_timer = TimerAction(

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_provider_scoping.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_provider_scoping.test.py
@@ -134,6 +134,9 @@ def _probe_pair(namespace, source_id, target_id, remap_topic):
             output='screen',
             additional_env=env,
             remappings=[('temperature', remap_topic)],
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
         launch_ros.actions.Node(
             package='ros2_medkit_integration_tests',
@@ -143,6 +146,9 @@ def _probe_pair(namespace, source_id, target_id, remap_topic):
             output='screen',
             additional_env=env,
             remappings=[('temperature', remap_topic)],
+            # Give the node room to flush coverage data at shutdown before SIGKILL.
+            sigterm_timeout='30',
+            sigkill_timeout='15',
         ),
     ]
 

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_provider_unreachable.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_provider_unreachable.test.py
@@ -46,6 +46,7 @@ from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import (
     create_test_launch,
     DEMO_NODE_REGISTRY,
+    get_coverage_env,
 )
 
 
@@ -162,6 +163,7 @@ class TestGraphProviderUnreachable(GatewayTestCase):
         executable, ros_name, namespace = DEMO_NODE_REGISTRY[MONITOR_NODE_KEY]
         env = os.environ.copy()
         env['ROS_DOMAIN_ID'] = str(DEFAULT_DOMAIN_ID)
+        env.update(get_coverage_env())
         binary = _resolve_demo_executable(executable)
         cls._monitor_proc = subprocess.Popen(
             [

--- a/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
@@ -39,7 +39,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import SetEnvironmentVariable
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -53,6 +52,7 @@ from ros2_medkit_test_utils.constants import (
     get_test_domain_id,
     get_test_port,
 )
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
 
 PRIMARY_PORT = get_test_port(0)
 PEER_B_PORT = get_test_port(1)
@@ -114,8 +114,6 @@ MANIFEST_FILES = [PRIMARY_MANIFEST, PEER_B_MANIFEST, PEER_C_MANIFEST]
 
 def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
     params = {
-        'refresh_interval_ms': 1000,
-        'server.port': port,
         'discovery.mode': 'manifest_only',
         'discovery.manifest_path': manifest_path,
         'discovery.manifest_strict_validation': False,
@@ -131,19 +129,11 @@ def _gateway(port, name, manifest_path, domain, aggregation_peers=None):
             'aggregation.peer_urls': urls,
             'aggregation.peer_names': names,
         })
-    return launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    return create_gateway_node(
         name=name,
-        output='screen',
-        parameters=[params],
-        additional_env={'ROS_DOMAIN_ID': str(domain)},
-        # Match create_gateway_node()'s TSan/ASan-safe shutdown windows.
-        # Under sanitizers the gateway teardown sequence (mdns stop, REST
-        # server stop, transport shutdown, plugin shutdown) routinely
-        # exceeds launch's 5s default, causing SIGKILL with exit -9.
-        sigterm_timeout='30',
-        sigkill_timeout='15',
+        port=port,
+        extra_params=params,
+        extra_env={'ROS_DOMAIN_ID': str(domain)},
     )
 
 

--- a/src/ros2_medkit_integration_tests/test/features/test_peer_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_peer_aggregation.test.py
@@ -38,7 +38,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import SetEnvironmentVariable, TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -94,21 +93,10 @@ def generate_test_description():
     )
 
     # Peer gateway: standard configuration, no aggregation, in PEER_DOMAIN_ID
-    peer_gateway = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    peer_gateway = create_gateway_node(
         name='peer_gateway_node',
-        output='screen',
-        parameters=[{
-            'refresh_interval_ms': 1000,
-            'server.port': PEER_PORT,
-        }],
-        additional_env=peer_domain_env,
-        # Match create_gateway_node()'s TSan/ASan-safe shutdown windows.
-        # Default 5s SIGINT->SIGTERM escalation is insufficient under
-        # sanitizers and causes SIGKILL with exit -9.
-        sigterm_timeout='30',
-        sigkill_timeout='15',
+        port=PEER_PORT,
+        extra_env=peer_domain_env,
     )
 
     # Demo nodes: each set runs in its gateway's DDS domain.

--- a/src/ros2_medkit_integration_tests/test/features/test_scripts_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_scripts_api.test.py
@@ -32,14 +32,13 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
 
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, API_BASE_PATH, get_test_port
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
-from ros2_medkit_test_utils.launch_helpers import create_demo_nodes, get_coverage_env
+from ros2_medkit_test_utils.launch_helpers import create_demo_nodes, create_gateway_node
 
 
 PORT_WITH_SCRIPTS = get_test_port(0)
@@ -58,35 +57,21 @@ SHELL_SCRIPT = '#!/bin/sh\necho "hello"\n'
 
 def generate_test_description():
     """Launch two gateways and a demo node for entity discovery."""
-    coverage_env = get_coverage_env()
-
-    gateway_with_scripts = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    gateway_with_scripts = create_gateway_node(
         name='gateway_with_scripts',
-        output='screen',
-        parameters=[{
+        port=PORT_WITH_SCRIPTS,
+        extra_params={
             'server.host': '127.0.0.1',
-            'server.port': PORT_WITH_SCRIPTS,
-            'refresh_interval_ms': 1000,
             'scripts.scripts_dir': SCRIPTS_DIR,
             'scripts.max_concurrent_executions': 3,
             'scripts.default_timeout_sec': 30,
-        }],
-        additional_env=coverage_env,
+        },
     )
 
-    gateway_no_scripts = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    gateway_no_scripts = create_gateway_node(
         name='gateway_no_scripts',
-        output='screen',
-        parameters=[{
-            'server.host': '127.0.0.1',
-            'server.port': PORT_NO_SCRIPTS,
-            'refresh_interval_ms': 1000,
-        }],
-        additional_env=coverage_env,
+        port=PORT_NO_SCRIPTS,
+        extra_params={'server.host': '127.0.0.1'},
     )
 
     # Launch a demo node so entities are available in discovery.

--- a/src/ros2_medkit_integration_tests/test/features/test_tls.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_tls.test.py
@@ -36,7 +36,7 @@ from launch.actions import TimerAction
 import launch_ros.actions
 import launch_testing
 import launch_testing.actions
-from ros2_medkit_test_utils.constants import get_test_port
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port
 from ros2_medkit_test_utils.coverage import get_coverage_env
 import urllib3
 
@@ -175,6 +175,11 @@ def generate_test_description():
         parameters=[_params_file],
         additional_env=coverage_env,
         output='screen',
+        # Loaded from a params file, so this cannot use create_gateway_node;
+        # match that helper's shutdown windows directly so the node can flush
+        # gcov data before SIGKILL under coverage.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     # Allow gateway time to start
@@ -311,6 +316,14 @@ class TestHttpsErrorHandling(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class TestShutdown(unittest.TestCase):
     """Post-shutdown cleanup tests."""
+
+    def test_exit_codes(self, proc_info):
+        """The gateway exited cleanly (SIGTERM allowed, not SIGKILL -9)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                '{} exited with code {}'.format(info.process_name, info.returncode)
+            )
 
     def test_cleanup_certificates(self):
         """Clean up temporary certificates after tests."""

--- a/src/ros2_medkit_integration_tests/test/features/test_triggers_persistent.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_triggers_persistent.test.py
@@ -37,7 +37,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -48,7 +47,7 @@ from ros2_medkit_test_utils.constants import (
     get_test_port,
 )
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
-from ros2_medkit_test_utils.launch_helpers import create_demo_nodes
+from ros2_medkit_test_utils.launch_helpers import create_demo_nodes, create_gateway_node
 
 # ---------------------------------------------------------------------------
 # Port layout (stride-10 slot from CMake)
@@ -74,18 +73,14 @@ RESOURCE_URI = f'/api/v1/apps/{APP_ID}/faults'
 
 def _make_gateway_node(port, *, on_restart_behavior):
     """Return a gateway_node launch action for the given port and DB path."""
-    return launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    return create_gateway_node(
         name=f'ros2_medkit_gateway_{port}',
-        output='screen',
-        parameters=[{
-            'refresh_interval_ms': 1000,
-            'server.port': port,
+        port=port,
+        extra_params={
             'triggers.enabled': True,
             'triggers.storage.path': DB_PATH,
             'triggers.on_restart_behavior': on_restart_behavior,
-        }],
+        },
     )
 
 

--- a/src/ros2_medkit_integration_tests/test/features/test_update_status_subscription.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_update_status_subscription.test.py
@@ -28,7 +28,6 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
@@ -39,7 +38,7 @@ from ros2_medkit_test_utils.constants import (
     get_test_port,
 )
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
-from ros2_medkit_test_utils.launch_helpers import get_coverage_env
+from ros2_medkit_test_utils.launch_helpers import create_demo_nodes, create_gateway_node
 
 
 PORT = get_test_port(0)
@@ -57,42 +56,29 @@ def _get_test_plugin_path():
 
 def generate_test_description():
     """Launch gateway with update plugin and a demo node."""
-    coverage_env = get_coverage_env()
     plugin_path = _get_test_plugin_path()
 
-    gateway = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    gateway = create_gateway_node(
         name='gateway_update_sub',
-        output='screen',
-        parameters=[{
+        port=PORT,
+        extra_params={
             'server.host': '127.0.0.1',
-            'server.port': PORT,
-            'refresh_interval_ms': 1000,
             'updates.enabled': True,
             'plugins': ['test_update_backend'],
             'plugins.test_update_backend.path': plugin_path,
             'sse.max_clients': 10,
             'sse.max_subscriptions': 50,
-        }],
-        additional_env=coverage_env,
+        },
     )
 
     # Need at least one demo node so we have an entity for subscriptions
-    demo_node = launch_ros.actions.Node(
-        package='ros2_medkit_integration_tests',
-        executable='demo_engine_temp_sensor',
-        name='temp_sensor',
-        namespace='/powertrain/engine',
-        output='screen',
-        additional_env=coverage_env,
-    )
+    demo_nodes = create_demo_nodes(['temp_sensor'], lidar_faulty=False)
 
     return LaunchDescription([
         gateway,
         TimerAction(
             period=2.0,
-            actions=[demo_node],
+            actions=demo_nodes,
         ),
         launch_testing.actions.ReadyToTest(),
     ])
@@ -236,6 +222,7 @@ class TestUpdateStatusSubscription(GatewayTestCase):
         # Collect SSE events in background
         events = []
         stop_event = threading.Event()
+        connected_event = threading.Event()
 
         def collect_sse():
             try:
@@ -245,6 +232,7 @@ class TestUpdateStatusSubscription(GatewayTestCase):
                     timeout=30,
                     headers={'Accept': 'text/event-stream'},
                 ) as resp:
+                    connected_event.set()
                     for line in resp.iter_lines(decode_unicode=True):
                         if stop_event.is_set():
                             break
@@ -260,8 +248,10 @@ class TestUpdateStatusSubscription(GatewayTestCase):
         sse_thread = threading.Thread(target=collect_sse, daemon=True)
         sse_thread.start()
 
-        # Give SSE connection time to establish
-        time.sleep(1.0)
+        # Wait until the reader thread has opened the SSE stream, so we do not
+        # trigger the event source before the client is listening.
+        self.assertTrue(connected_event.wait(timeout=10.0),
+                        'SSE stream did not connect')
 
         # Trigger update prepare to generate status changes
         requests.put(

--- a/src/ros2_medkit_integration_tests/test/features/test_updates.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_updates.test.py
@@ -21,14 +21,13 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import TimerAction
-import launch_ros.actions
 import launch_testing
 import launch_testing.actions
 import requests
 
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, API_BASE_PATH, get_test_port
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
-from ros2_medkit_test_utils.launch_helpers import get_coverage_env
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
 
 
 PORT_NO_PLUGIN = get_test_port(0)
@@ -46,42 +45,27 @@ def _get_test_plugin_path():
 
 
 def generate_test_description():
-    """Launch two gateways: one without plugin (501 mode), one with demo plugin.
-
-    Uses raw Node construction instead of create_gateway_node() because we need
-    two gateway instances with distinct ROS node names.
-    """
-    coverage_env = get_coverage_env()
+    """Launch two gateways: one without plugin (501 mode), one with demo plugin."""
     plugin_path = _get_test_plugin_path()
 
-    gateway_no_plugin = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    gateway_no_plugin = create_gateway_node(
         name='gateway_no_plugin',
-        output='screen',
-        parameters=[{
+        port=PORT_NO_PLUGIN,
+        extra_params={
             'server.host': '127.0.0.1',
-            'server.port': PORT_NO_PLUGIN,
-            'refresh_interval_ms': 1000,
             'updates.enabled': True,
-        }],
-        additional_env=coverage_env,
+        },
     )
 
-    gateway_with_plugin = launch_ros.actions.Node(
-        package='ros2_medkit_gateway',
-        executable='gateway_node',
+    gateway_with_plugin = create_gateway_node(
         name='gateway_with_plugin',
-        output='screen',
-        parameters=[{
+        port=PORT_WITH_PLUGIN,
+        extra_params={
             'server.host': '127.0.0.1',
-            'server.port': PORT_WITH_PLUGIN,
-            'refresh_interval_ms': 1000,
             'updates.enabled': True,
             'plugins': ['test_update_backend'],
             'plugins.test_update_backend.path': plugin_path,
-        }],
-        additional_env=coverage_env,
+        },
     )
 
     return LaunchDescription([

--- a/src/ros2_medkit_log_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_log_bridge/test/test_integration.test.py
@@ -48,6 +48,9 @@ def generate_test_description():
             'healing_enabled': True,
             'healing_threshold': 1,
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     log_bridge_node = launch_ros.actions.Node(
@@ -59,6 +62,9 @@ def generate_test_description():
             'rosout_topic': '/rosout',
             'report_cooldown_sec': 0.0,  # no bridge cooldown in the test
         }],
+        # Give the node room to flush coverage data at shutdown before SIGKILL.
+        sigterm_timeout='30',
+        sigkill_timeout='15',
     )
 
     return (
@@ -135,11 +141,32 @@ class TestLogBridgeIntegration(unittest.TestCase):
             time.sleep(0.5)
         return fault
 
+    def publish_until(self, node_name, level, code_prefix, *, message,
+                      timeout=25.0):
+        """
+        Republish a log until a fault with the given code prefix appears.
+
+        An ERROR log promotes immediately, but the report reaching
+        fault_manager needs a second discovery hop: the bridge's ReportFault
+        client must have discovered fault_manager, else the fire-and-forget
+        report is dropped. That client readiness is not observable from here
+        and the report is one-shot, so re-emit the log and poll rather than
+        publishing once and racing the hop (which flaked on a loaded machine).
+        """
+        deadline = time.time() + timeout
+        fault = None
+        while time.time() < deadline:
+            self.publish_log(node_name, level, message)
+            fault = self.find_fault(self.list_faults(), code_prefix)
+            if fault is not None:
+                return fault
+        return fault
+
     def test_01_error_log_creates_attributed_fault(self):
         """An ERROR log becomes a CONFIRMED fault attributed to the node FQN."""
-        self.publish_log('planner_server', LOG_ERROR, 'failed to compute path')
-
-        fault = self.wait_for_fault('LOG_PLANNER_SERVER_')
+        fault = self.publish_until(
+            'planner_server', LOG_ERROR, 'LOG_PLANNER_SERVER_',
+            message='failed to compute path')
         self.assertIsNotNone(fault, 'expected a LOG_PLANNER_SERVER_* fault')
         self.assertEqual(fault.severity, Fault.SEVERITY_ERROR)
         # The fault must associate with the node FQN, not the raw logger name.

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/integration/test_opcua_secured.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/integration/test_opcua_secured.test.py
@@ -66,7 +66,9 @@ PASSWORD = 'secret'
 WRONG_PASSWORD = 'definitely-not-the-password'
 APP_URI_SERVER = 'urn:test:alarms:server'
 APP_URI_CLIENT = 'urn:selfpatch:medkit:opcua-client'
-ROS_DOMAIN_ID = '228'
+# 229 is the one free slot in this package's 220-229 range (the gtests take
+# 220-228); 228 would collide with test_opcua_identity's CMake-assigned domain.
+ROS_DOMAIN_ID = '229'
 
 ALARM_CODE = 'PLC_OVERPRESSURE'
 


### PR DESCRIPTION
# Pull Request

## Summary

Make integration-test gateways and fault managers survive shutdown under a coverage (gcov) build, route the inline copies through the shared helpers, and replace fixed sleeps with active waits.

Under coverage a gateway or fault manager flushes coverage data at shutdown, which can exceed the launch default SIGTERM window (~10s). The process is then SIGKILLed and exits with `-9`, which fails the post-shutdown exit-code check (`ALLOWED_EXIT_CODES = {0, -2, -15}`). Only `create_gateway_node` set a wide enough window; several tests built the node inline and missed it, and `create_fault_manager_node` had no window at all.

Shutdown / coverage:
- Extend `create_gateway_node` with `name=` and `extra_env=`, and give `create_fault_manager_node` the same `name=`/`extra_env=` plus `sigterm_timeout='30'` / `sigkill_timeout='15'`.
- Route the inline gateways and fault managers through the two helpers (`test_scripts_api`, `test_updates`, `test_update_status_subscription`, `test_triggers_persistent`, and the four aggregation tests). This fixes the SIGKILL failure, restores the coverage env the aggregation peers and fault managers had dropped, and removes four hand-copied shutdown-window constants.
- `test_tls` keeps its inline gateway (it loads from a params file) but gets the windows directly and a post-shutdown exit-code check it was missing.
- The fault-manager-side tests build the node inline in their own packages (they cannot import `create_fault_manager_node`, which lives downstream), so give the inline `fault_manager_node` the same windows directly in `test_rosbag_integration`, `test_integration`, `test_rosbag_entity_scope`, `test_entity_thresholds_integration` (fault_manager) and the `diagnostic_bridge`, `log_bridge` and `action_status_bridge` integration tests.
- Pass the coverage env to the two `subprocess.Popen` demo spawns.
- Route each subprocess's coverage to its own package: `create_fault_manager_node` and `create_demo_nodes` passed the default gateway package to `get_coverage_env`, so their `.gcda` were written into the gateway build dir. Pass `ros2_medkit_fault_manager` and `ros2_medkit_integration_tests` respectively.
- Give the same windows to every other coverage-instrumented C++ node that a post-shutdown exit-code check guards, not only the gateway/fault_manager: the three bridge nodes that are the subject under test (`diagnostic_bridge_node`, `log_bridge_node`, `action_status_bridge_node`), the demo nodes launched through `create_demo_nodes`, and the inline demo-node launches in the discovery, graph-provider and beacon feature tests. Each is small, but the shutdown checks reject `-9`, so a slow-runner gcov flush past the default SIGTERM window would SIGKILL them the same way.

Timing / isolation:
- Poll `GetRosbag` and `GetSnapshots` until the async capture is written instead of a fixed sleep plus a single call, and poll for the rosbag buffer publisher and the cleanup delete. The snapshot test relies on `_wait_for_snapshot` (which polls `GetSnapshots` for the real capture) as its gate instead of a pre-wait on the short-lived on-demand subscription.
- Republish the ERROR log in the `log_bridge` test until the fault appears: a single publish raced the bridge's report client discovering the fault manager (the second discovery hop), which the `/rosout` subscription wait does not cover.
- Gate the update SSE test on the reader thread opening the stream (a `threading.Event`) instead of a fixed sleep.
- `test_opcua_secured` hardcoded `ROS_DOMAIN_ID=228`, which collides with the domain CMake assigns `test_opcua_identity`; move it to the free 229.

ThreadSanitizer:
- `test_ros2_parameter_transport` TearDown called `executor->cancel()` while the spin thread was still inside `spin_some()`, racing the executor's notify-waitable (`ExecutorNotifyWaitable::is_ready` vs `trigger_entity_recollect`). Clear the run flag and join the spin thread before touching the executor; the `spin_some(10ms)` loop exits on its own, so `cancel()` is not needed.

CI:
- Give the sanitizer jobs timeout headroom so a slow runner does not cancel them mid-run: a full ASan run is ~55 min (bump 60 -> 90) and a full TSan run is ~40 min (bump 45 -> 60). Both were cancelling intermittently at the old limits.

---

## Issue

- closes #553

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Built the affected packages and ran the rerouted / retimed tests locally: `test_scripts_api` (the one that failed), `test_updates`, `test_update_status_subscription`, `test_cross_ecu_fanout`, `test_graph_event_discovery`, `test_graph_provider_unreachable`, the two fault-manager suites `test_integration` (snapshot poll) and `test_rosbag_integration` (rosbag poll), `log_bridge` `test_integration` (3 runs, to check the republish fix), and `test_ros2_parameter_transport` - all pass. `run-clang-tidy` on the changed C++ file returns 0.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
