### PR TITLE
ci: raise coverage and clang-tidy job timeouts to 90 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-    timeout-minutes: 45
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-    timeout-minutes: 45
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
# Pull Request

## Summary

The `coverage` job (ci.yml) and the `clang-tidy` job (quality.yml) both run with `timeout-minutes: 45`. Both now hit that limit on main, so the jobs are cancelled. The result is no coverage upload to Codecov and no clang-tidy result on main.

This raises both to 90 minutes.

`coverage` was cancelled at 45:06, 45:06 and 45:08 on three pushes in a row. Step times on the last cancelled run:

| Step | Time |
|---|---|
| setup (container, ROS 2, rosdep) | 4:01 |
| Build packages with coverage | 15:38 (cold ccache) |
| Run unit and integration tests | 14:47 |
| Generate coverage report | killed after 10:34 |

On a green run that last step takes 12:27, so the job needs about 48 minutes when the ccache is cold. The green runs before the timeouts were 39:02, 39:58, 42:13 and 42:43, so there was almost no margin left.

`clang-tidy` was cancelled at 45:06 and 45:08. Its slowest green run was 44:43 (compile database build 19:21, `Run clang-tidy` 21:38). With a warm ctcache it drops to about 23 minutes, so the job is very sensitive to a cache miss and goes over 45 minutes when the cache is cold.

90 minutes is the same value `sanitizer-asan` already uses in quality.yml. Step-level timeouts are not changed, so a hanging test is still caught by its own limit before the job limit.

---

## Issue

n/a - CI configuration fix.

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

CI on this PR runs both jobs. They should complete instead of being cancelled at 45 minutes.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
