### PR TITLE
fix(gateway): plugin-provided entities own their bulk data and logs

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1000,16 +1000,20 @@ and **functions** (aggregated from hosted apps).
    storage backend or take full ownership of the log pipeline (see plugin development docs).
 
 ``GET /api/v1/components/{id}/logs``
-   Query log entries aggregated from the component's hosted apps. Resolves child apps via
-   the entity cache and queries each by exact FQN. Falls back to namespace prefix match only
-   when the component has no hosted apps but declares a non-empty namespace (manifest-only
-   deployments where the component groups topics rather than nodes). The response always
-   carries ``x-medkit.aggregation_level=component`` and ``aggregated=true``; the
-   ``app_count`` and ``aggregation_sources`` fields are populated only when hosted-app
-   aggregation is active and are omitted under the namespace-prefix fallback.
+   Query log entries aggregated from the component's hosted apps. Child apps resolve via
+   the entity cache using the same rule as fault scoping: an external app (plugin-provided,
+   no ROS binding) is queried by its bare entity id, every other app by its exact FQN, and
+   an external component also returns entries stored under its own id. When the component
+   declares a non-empty namespace, a namespace prefix query runs in addition and the results
+   are merged and deduplicated, so ROS nodes under the namespace keep contributing even when
+   the component also hosts external apps. The response always carries
+   ``x-medkit.aggregation_level=component`` and ``aggregated=true``; the ``app_count`` and
+   ``aggregation_sources`` fields are populated only when at least one hosted source
+   resolves.
 
 ``GET /api/v1/apps/{id}/logs``
-   Query log entries for the specific app node (exact match).
+   Query log entries for the specific app. A ROS-bound app is queried by its exact FQN; an
+   external app by its bare entity id (the id ``add_log_entry`` and fault reporting use).
 
 **Query parameters:**
 

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -988,9 +988,9 @@ Logs Endpoints
 --------------
 
 Query and configure the /rosout ring buffer for an entity. Supported entity types:
-**areas** (aggregated from hosted apps, namespace prefix fallback), **components** (aggregated from
-hosted apps, namespace prefix fallback for manifest-only deployments), **apps** (exact FQN match),
-and **functions** (aggregated from hosted apps).
+**areas** (aggregated from hosted apps, merged with a namespace prefix query), **components**
+(aggregated from hosted apps, merged with a namespace prefix query), **apps** (exact FQN match;
+external apps by bare entity id), and **functions** (aggregated from hosted apps).
 
 .. note::
 

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -979,6 +979,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_log_handlers test/test_log_handlers.cpp)
   target_link_libraries(test_log_handlers gateway_ros2)
 
+  # Log scope tests (entity -> log-source resolution shared by handlers and samplers)
+  ament_add_gtest(test_log_scope test/test_log_scope.cpp)
+  target_link_libraries(test_log_scope gateway_ros2)
+
   # Route descriptions tests (OpenAPI doc builder)
   ament_add_gtest(test_route_descriptions test/test_route_descriptions.cpp)
   target_link_libraries(test_route_descriptions gateway_ros2)
@@ -1155,6 +1159,7 @@ if(BUILD_TESTING)
       test_plugin_abi_conformance
       test_log_manager
       test_log_handlers
+      test_log_scope
       test_merge_pipeline
       test_runtime_linker
       test_route_descriptions

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/fault_scope.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/fault_scope.hpp
@@ -33,12 +33,15 @@ namespace faults {
 /// it claim faults it never reported.
 std::string resolve_app_source_fqn(const ThreadSafeEntityCache & cache, const std::string & app_id);
 
-/// Resolve the set of App effective-FQNs that fall within an entity's scope by
-/// walking the entity cache:
-///   - APP: the app's own effective FQN
-///   - COMPONENT: every hosted app's FQN
-///   - AREA: every app under the area and its (recursive) subareas
-///   - FUNCTION: every app hosted directly or via a hosted component
+/// Resolve the set of fault-reporting sources that fall within an entity's
+/// scope by walking the entity cache. Each hosted app contributes what
+/// `resolve_app_source_fqn` yields (bare entity id for an external app,
+/// effective FQN otherwise):
+///   - APP: the app's own source, if it owns one
+///   - COMPONENT: every hosted app's source, plus the component's own id when
+///     the component is external (protocol bridges report under that id)
+///   - AREA: every source under the area and its (recursive) subareas
+///   - FUNCTION: every source hosted directly or via a hosted component
 /// Returns an empty set for SERVER / UNKNOWN.
 ///
 /// Shared by the HTTP fault handlers (`GET /{entity}/faults`) and the ROS 2

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/fault_scope.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/fault_scope.hpp
@@ -26,6 +26,13 @@ class ThreadSafeEntityCache;
 
 namespace faults {
 
+/// Resolve the single fault-reporting source an app owns, or "" when it owns
+/// none. An external app (a plugin-introspected asset with no ROS binding)
+/// reports under its bare entity id; every other app owns its `effective_fqn()`.
+/// An unbound non-external app owns nothing - granting it its bare id would let
+/// it claim faults it never reported.
+std::string resolve_app_source_fqn(const ThreadSafeEntityCache & cache, const std::string & app_id);
+
 /// Resolve the set of App effective-FQNs that fall within an entity's scope by
 /// walking the entity cache:
 ///   - APP: the app's own effective FQN

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/bulkdata_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/bulkdata_handlers.hpp
@@ -112,14 +112,14 @@ namespace detail {
  * a ``detail`` namespace to signal "not part of the public API" while still
  * being directly unit-testable without spinning up a ``GatewayNode``.
  *
- * - APP / AREA: returns the entity's FQN or namespace path (single filter).
- * - FUNCTION: aggregates non-empty ``effective_fqn()`` values across all
- *   hosted apps (no fallback - functions are pure aggregated views).
- * - COMPONENT: aggregates from hosted apps; falls back to FQN/namespace_path
- *   only when the component has no hosted apps (manifest deployments where
- *   the component groups topics rather than nodes). This avoids the
- *   synthetic-component bug where empty fqn + empty namespace_path produced
- *   zero source filters.
+ * Every entity type resolves through ``faults::resolve_entity_source_fqns``,
+ * the same rule that scopes ``GET /{entity}/faults``: an external app owns
+ * its bare entity id, every other app its ``effective_fqn()``; an external
+ * component also owns its own id; AREA recurses subareas; FUNCTION follows
+ * app and component hosts. When resolution yields nothing, APP / AREA /
+ * COMPONENT fall back to the entity's FQN or namespace path (manifest-only
+ * deployments grouping topics rather than nodes); FUNCTION never falls back
+ * (pure aggregated view).
  *
  * @param cache Entity cache to resolve hosted apps in (used for FUNCTION /
  *              COMPONENT only)

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/logs/log_scope.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/logs/log_scope.hpp
@@ -1,0 +1,53 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+#include <tl/expected.hpp>
+
+#include "ros2_medkit_gateway/core/models/entity_types.hpp"
+
+namespace ros2_medkit_gateway {
+
+class LogManager;
+class ThreadSafeEntityCache;
+
+namespace logs {
+
+/// Query every log entry within an entity's scope.
+///
+/// Exact-match sources come from `faults::resolve_entity_source_fqns`, so the
+/// scope rule matches faults and bulk-data: an external app stores entries
+/// under its bare entity id, an external component also owns entries stored
+/// under its own id, areas recurse subareas and functions follow component
+/// hosts. COMPONENT and AREA additionally run `entity_fqn` as a namespace
+/// prefix query - hosted-app resolution must not disable it, or a manifest
+/// component that hosts an external app loses the ROS node entries under its
+/// namespace. APP falls back to `entity_fqn` (exact) when the resolver yields
+/// nothing. Both result sets are merged, deduped by entry id, sorted by id
+/// ascending and re-capped to the entity's configured max_entries.
+///
+/// `resolved_sources` (optional out) receives the exact-match source set for
+/// response metadata. Shared by the HTTP log handlers and the cyclic
+/// subscription "logs" sampler so both agree on entity -> log-source scoping.
+tl::expected<nlohmann::json, std::string>
+query_entity_logs(LogManager & log_mgr, const ThreadSafeEntityCache & cache, SovdEntityType type,
+                  const std::string & entity_id, const std::string & entity_fqn, const std::string & min_severity,
+                  const std::string & context_filter, std::set<std::string> * resolved_sources = nullptr);
+
+}  // namespace logs
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
@@ -307,13 +307,15 @@ class HandlerContext {
   }
 
   /**
-   * @brief Resolve a list of app IDs to their non-empty effective FQNs.
+   * @brief Resolve a list of app IDs to the fault-reporting sources they own.
    *
-   * Apps that are missing from the cache or that have an empty effective_fqn()
-   * are skipped silently. The returned vector preserves the input app_ids order
-   * (minus skipped entries) and may be empty. Apps whose effective_fqn() is
-   * already present in the result are skipped, so duplicates from manifest /
-   * runtime double-binds do not produce repeated downstream queries.
+   * Each app resolves through `faults::resolve_app_source_fqn()`: its
+   * `effective_fqn()`, or its bare entity id when the app is external (a
+   * plugin-introspected asset that reports under that id). Apps that are
+   * missing from the cache or that own no source are skipped silently. The
+   * returned vector preserves the input app_ids order (minus skipped entries)
+   * and may be empty. Duplicate sources from manifest / runtime double-binds
+   * are collapsed so they do not produce repeated downstream queries.
    *
    * Used by log_handlers and bulkdata_handlers to aggregate per-component /
    * per-function resource queries from the entity's hosted apps. Static + public
@@ -321,7 +323,7 @@ class HandlerContext {
    *
    * @param cache Entity cache to look up apps in
    * @param app_ids App IDs to resolve
-   * @return Effective FQNs for the apps that resolved
+   * @return Source FQNs for the apps that resolved
    */
   static std::vector<std::string> resolve_app_host_fqns(const ThreadSafeEntityCache & cache,
                                                         const std::vector<std::string> & app_ids);

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/handler_context.hpp
@@ -317,9 +317,10 @@ class HandlerContext {
    * and may be empty. Duplicate sources from manifest / runtime double-binds
    * are collapsed so they do not produce repeated downstream queries.
    *
-   * Used by log_handlers and bulkdata_handlers to aggregate per-component /
-   * per-function resource queries from the entity's hosted apps. Static + public
-   * to enable direct unit testing without standing up a full GatewayNode fixture.
+   * Order-preserving wrapper over the shared per-app rule for callers that
+   * resolve an explicit app-id list; whole-entity resolution goes through
+   * `resolve_entity_source_fqns`. Static + public for direct unit testing
+   * without standing up a full GatewayNode fixture.
    *
    * @param cache Entity cache to look up apps in
    * @param app_ids App IDs to resolve
@@ -329,31 +330,18 @@ class HandlerContext {
                                                         const std::vector<std::string> & app_ids);
 
   /**
-   * @brief Resolve an entity to the set of source FQNs it owns.
+   * @brief Resolve an entity to the set of reporting sources it owns.
    *
-   * Returns the FQNs of every ROS 2 node within the entity's scope. Used by
-   * fault handlers to filter `reporting_sources` so that per-entity routes
-   * never expose faults reported from outside the addressed entity.
+   * Thin adapter over `faults::resolve_entity_source_fqns` (the per-type
+   * mapping - incl. the external bare-id rule, subarea recursion and
+   * component-hosted functions - is documented there). Used by fault, log and
+   * bulk-data handlers so per-entity routes never expose resources reported
+   * from outside the addressed entity.
    *
-   * Mapping per entity type:
-   * - App: the app's `effective_fqn()` (single entry, or empty set if unbound
-   *   or if `ros_binding.namespace_pattern` is a wildcard - by design
-   *   `effective_fqn()` returns "" for those, so the entity simply has no
-   *   addressable ROS node and the scope check excludes every fault).
-   * - Component: `effective_fqn()` of every hosted app via
-   *   `get_apps_for_component()`.
-   * - Area: `effective_fqn()` of every app under the area, walking
-   *   `get_subareas()` recursively so nested areas (e.g. ``powertrain ->
-   *   engine``) resolve to the union of their descendants' apps.
-   * - Function: `effective_fqn()` of every app the function hosts directly
-   *   plus, for hosts that are component IDs, the apps inside those
-   *   components.
-   * - Unknown: empty set.
+   * Apps that own no source are silently dropped from the set so the scope
+   * check cannot match arbitrary FQNs against an empty prefix.
    *
-   * Apps whose `effective_fqn()` is empty are silently dropped from the set
-   * so the scope check cannot match arbitrary FQNs against an empty prefix.
-   *
-   * An empty result means "no apps are in scope" and callers must NEVER
+   * An empty result means "no sources are in scope" and callers must NEVER
    * interpret that as "no filter" - any fault must be treated as out of
    * scope. The exact response (404 for per-fault routes, an empty `items`
    * array for collection lists, 204 for collection clears) is up to the
@@ -361,7 +349,7 @@ class HandlerContext {
    *
    * @param cache Entity cache for lookups
    * @param entity Resolved entity info (from `validate_entity_for_route`)
-   * @return Set of FQNs that uniquely scopes faults to this entity
+   * @return Set of sources that uniquely scopes faults to this entity
    */
   static std::set<std::string> resolve_entity_source_fqns(const ThreadSafeEntityCache & cache,
                                                           const EntityInfo & entity);

--- a/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/fault_scope.cpp
@@ -25,24 +25,8 @@ namespace faults {
 namespace {
 
 void collect_app_fqn(const ThreadSafeEntityCache & cache, const std::string & app_id, std::set<std::string> & out) {
-  auto app = cache.get_app(app_id);
-  if (!app) {
-    return;
-  }
-  // External assets introspected by a protocol plugin (e.g. a PLC over OPC UA)
-  // report faults to the fault_manager under their own entity id, so that id is
-  // their sole fault-scope owner. This must be checked before effective_fqn():
-  // a manifest may declare a stray ros_binding on an external app, and the
-  // derived FQN would otherwise shadow the bare id and drop its faults from
-  // every rollup (#517, neighbor case).
-  if (app->external.value_or(false)) {
-    out.insert(app_id);
-    return;
-  }
-  auto fqn = app->effective_fqn();
+  auto fqn = resolve_app_source_fqn(cache, app_id);
   if (fqn.empty()) {
-    // A non-external app that merely failed to bind stays skipped: granting an
-    // unbound ROS app its bare id would let it claim faults it never reported.
     return;
   }
   out.insert(std::move(fqn));
@@ -120,6 +104,25 @@ bool source_matches_scope(const std::string & src, const std::set<std::string> &
 }
 
 }  // namespace
+
+std::string resolve_app_source_fqn(const ThreadSafeEntityCache & cache, const std::string & app_id) {
+  auto app = cache.get_app(app_id);
+  if (!app) {
+    return "";
+  }
+  // External assets introspected by a protocol plugin (e.g. a PLC over OPC UA)
+  // report faults to the fault_manager under their own entity id, so that id is
+  // their sole fault-scope owner. This must be checked before effective_fqn():
+  // a manifest may declare a stray ros_binding on an external app, and the
+  // derived FQN would otherwise shadow the bare id and drop its faults from
+  // every rollup (#517, neighbor case).
+  if (app->external.value_or(false)) {
+    return app_id;
+  }
+  // A non-external app that merely failed to bind owns nothing: granting an
+  // unbound ROS app its bare id would let it claim faults it never reported.
+  return app->effective_fqn();
+}
 
 std::set<std::string> resolve_entity_source_fqns(const ThreadSafeEntityCache & cache, SovdEntityType type,
                                                  const std::string & entity_id) {

--- a/src/ros2_medkit_gateway/src/core/logs/log_scope.cpp
+++ b/src/ros2_medkit_gateway/src/core/logs/log_scope.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/logs/log_scope.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/faults/fault_scope.hpp"
+#include "ros2_medkit_gateway/core/managers/log_manager.hpp"
+#include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+
+namespace ros2_medkit_gateway {
+namespace logs {
+
+namespace {
+
+using json = nlohmann::json;
+
+// Entry ids are "log_<n>" with a monotonic n (LogManager::entry_to_json).
+unsigned long long entry_id_num(const json & item) {
+  const std::string id = item.value("id", "");
+  const std::size_t off = id.rfind("log_", 0) == 0 ? 4 : 0;
+  return std::strtoull(id.c_str() + off, nullptr, 10);
+}
+
+}  // namespace
+
+tl::expected<json, std::string> query_entity_logs(LogManager & log_mgr, const ThreadSafeEntityCache & cache,
+                                                  SovdEntityType type, const std::string & entity_id,
+                                                  const std::string & entity_fqn, const std::string & min_severity,
+                                                  const std::string & context_filter,
+                                                  std::set<std::string> * resolved_sources) {
+  auto sources = faults::resolve_entity_source_fqns(cache, type, entity_id);
+  if (resolved_sources) {
+    *resolved_sources = sources;
+  }
+
+  std::vector<std::string> exact(sources.begin(), sources.end());
+  // Legacy APP fallback: an app that is not in the cache (or resolves to no
+  // source) keeps the entity.fqn exact query it always had.
+  if (type == SovdEntityType::APP && exact.empty() && !entity_fqn.empty()) {
+    exact.push_back(entity_fqn);
+  }
+  // Functions are pure aggregated views - no namespace fallback. APP has a
+  // single source. Only grouping entities own a namespace prefix.
+  const bool run_prefix = (type == SovdEntityType::COMPONENT || type == SovdEntityType::AREA) && !entity_fqn.empty();
+
+  json merged = json::array();
+  if (!exact.empty()) {
+    auto result = log_mgr.get_logs(exact, false, min_severity, context_filter, entity_id);
+    if (!result) {
+      return tl::make_unexpected(result.error());
+    }
+    merged = std::move(*result);
+  }
+
+  if (run_prefix) {
+    auto result = log_mgr.get_logs({entity_fqn}, true, min_severity, context_filter, entity_id);
+    if (!result) {
+      return tl::make_unexpected(result.error());
+    }
+    // Dedupe: an app FQN under the entity namespace is hit by both queries.
+    std::unordered_set<std::string> seen;
+    for (const auto & item : merged) {
+      seen.insert(item.value("id", ""));
+    }
+    for (auto & item : *result) {
+      if (seen.insert(item.value("id", "")).second) {
+        merged.push_back(std::move(item));
+      }
+    }
+    std::sort(merged.begin(), merged.end(), [](const json & a, const json & b) {
+      return entry_id_num(a) < entry_id_num(b);
+    });
+    // Each get_logs call caps individually; re-cap the union to the entity
+    // budget, keeping the most recent entries.
+    auto cfg = log_mgr.get_config(entity_id);
+    if (cfg && merged.size() > cfg->max_entries) {
+      merged.erase(merged.begin(), merged.begin() + static_cast<std::ptrdiff_t>(merged.size() - cfg->max_entries));
+    }
+  }
+
+  return merged;
+}
+
+}  // namespace logs
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -31,6 +31,8 @@
 #include "ros2_medkit_gateway/core/data/topic_data_provider.hpp"
 #include "ros2_medkit_gateway/core/discovery/refresh_debounce.hpp"
 #include "ros2_medkit_gateway/core/entity_validation.hpp"
+#include "ros2_medkit_gateway/core/faults/fault_scope.hpp"
+#include "ros2_medkit_gateway/core/logs/log_scope.hpp"
 #include "ros2_medkit_gateway/core/thread_pool_config.hpp"
 #include "ros2_medkit_gateway/param_utils.hpp"
 #include "ros2_medkit_gateway/plugins/ros_plugin_context.hpp"
@@ -41,41 +43,6 @@
 using namespace std::chrono_literals;
 
 namespace ros2_medkit_gateway {
-
-namespace {
-
-/// Filter faults by FQN prefix match on reporting_sources.
-/// Used for FUNCTION and COMPONENT entities that aggregate faults from hosted apps.
-nlohmann::json filter_faults_by_fqns(const nlohmann::json & fault_data, const std::set<std::string> & fqns) {
-  nlohmann::json filtered = nlohmann::json::array();
-  if (!fault_data.contains("faults") || !fault_data["faults"].is_array()) {
-    return filtered;
-  }
-  for (const auto & fault : fault_data["faults"]) {
-    if (!fault.contains("reporting_sources")) {
-      continue;
-    }
-    bool matches = false;
-    for (const auto & src : fault["reporting_sources"]) {
-      const std::string src_str = src.get<std::string>();
-      for (const auto & fqn : fqns) {
-        if (src_str.rfind(fqn, 0) == 0) {
-          matches = true;
-          break;
-        }
-      }
-      if (matches) {
-        break;
-      }
-    }
-    if (matches) {
-      filtered.push_back(fault);
-    }
-  }
-  return filtered;
-}
-
-}  // namespace
 
 GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medkit_gateway", options) {
   RCLCPP_INFO(get_logger(), "Initializing ROS 2 Medkit Gateway...");
@@ -1223,84 +1190,24 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
         if (!fault_mgr) {
           return tl::make_unexpected(std::string("FaultManager not available"));
         }
-        // Determine fault filtering based on entity type (mirrors fault_handlers.cpp logic)
         const auto & cache = get_thread_safe_cache();
         auto entity_ref = cache.find_entity(entity_id);
         if (!entity_ref) {
           return tl::make_unexpected("Entity not found: " + entity_id);
         }
-
-        if (entity_ref->type == SovdEntityType::FUNCTION) {
-          // FUNCTION: get all faults, filter by host app FQNs
-          auto result = fault_mgr->list_faults("");
-          if (!result.success) {
-            return tl::make_unexpected(result.error_message);
-          }
-          auto func = cache.get_function(entity_id);
-          if (!func || func->hosts.empty()) {
-            nlohmann::json empty_result = {{"faults", nlohmann::json::array()}, {"count", 0}};
-            return empty_result;
-          }
-          std::set<std::string> host_fqns;
-          for (const auto & app_id : func->hosts) {
-            auto app = cache.get_app(app_id);
-            if (app) {
-              auto fqn = app->effective_fqn();
-              if (!fqn.empty()) {
-                host_fqns.insert(std::move(fqn));
-              }
-            }
-          }
-          auto filtered = filter_faults_by_fqns(result.data, host_fqns);
-          result.data["faults"] = filtered;
-          result.data["count"] = filtered.size();
-          return result.data;
-        }
-
-        if (entity_ref->type == SovdEntityType::COMPONENT) {
-          // COMPONENT: get all faults, filter by hosted app FQNs
-          auto result = fault_mgr->list_faults("");
-          if (!result.success) {
-            return tl::make_unexpected(result.error_message);
-          }
-          auto app_ids = cache.get_apps_for_component(entity_id);
-          std::set<std::string> app_fqns;
-          for (const auto & app_id : app_ids) {
-            auto app = cache.get_app(app_id);
-            if (app) {
-              auto fqn = app->effective_fqn();
-              if (!fqn.empty()) {
-                app_fqns.insert(std::move(fqn));
-              }
-            }
-          }
-          auto filtered = filter_faults_by_fqns(result.data, app_fqns);
-          result.data["faults"] = filtered;
-          result.data["count"] = filtered.size();
-          return result.data;
-        }
-
-        // APP: use effective_fqn with prefix matching via list_faults
-        // AREA: use namespace_path with prefix matching via list_faults
-        std::string source_id;
-        if (entity_ref->type == SovdEntityType::APP) {
-          auto app = cache.get_app(entity_id);
-          if (app) {
-            source_id = app->effective_fqn();
-          }
-        } else if (entity_ref->type == SovdEntityType::AREA) {
-          auto area = cache.get_area(entity_id);
-          if (area) {
-            source_id = area->namespace_path;
-          }
-        }
-        if (source_id.empty()) {
-          return tl::make_unexpected("Entity no longer available: " + entity_id);
-        }
-        auto result = fault_mgr->list_faults(source_id);
+        // Same scoping as GET /{entity}/faults: shared source resolution
+        // (external app -> bare id, external component owns its own id) and
+        // the shared boundary-aware filter. A private variant here answered
+        // "Entity no longer available" for external apps whose effective_fqn
+        // is empty while REST returned the fault.
+        auto source_fqns = faults::resolve_entity_source_fqns(cache, entity_ref->type, entity_id);
+        auto result = fault_mgr->list_faults("");
         if (!result.success) {
           return tl::make_unexpected(result.error_message);
         }
+        auto filtered = faults::filter_faults_by_sources(result.data["faults"], source_fqns);
+        result.data["count"] = filtered.size();
+        result.data["faults"] = std::move(filtered);
         return result.data;
       },
       true);
@@ -1338,75 +1245,29 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
         if (!log_mgr) {
           return tl::make_unexpected(std::string("LogManager not available"));
         }
-        // Match log_handlers.cpp scoping logic:
-        // AREA/COMPONENT: entity fqn (namespace_path) with prefix_match=true
-        // FUNCTION: host app FQNs with prefix_match=false (exact)
-        // APP: entity fqn (effective_fqn) with prefix_match=false (exact)
         const auto & cache = get_thread_safe_cache();
         auto entity_ref = cache.find_entity(entity_id);
         if (!entity_ref) {
           return tl::make_unexpected("Entity not found: " + entity_id);
         }
-
-        if (entity_ref->type == SovdEntityType::FUNCTION) {
-          // Aggregate logs from all hosted apps (exact match)
-          auto func = cache.get_function(entity_id);
-          if (!func || func->hosts.empty()) {
-            nlohmann::json payload;
-            payload["items"] = nlohmann::json::array();
-            return payload;
+        // Same scoping as GET /{entity}/logs via the shared helper (external
+        // app -> bare id, external component owns its own id, plus the
+        // namespace-prefix merge for COMPONENT / AREA).
+        std::string entity_fqn;
+        if (entity_ref->type == SovdEntityType::COMPONENT) {
+          if (auto comp = cache.get_component(entity_id)) {
+            entity_fqn = comp->fqn;
           }
-          std::vector<std::string> host_fqns;
-          for (const auto & app_id : func->hosts) {
-            auto app = cache.get_app(app_id);
-            if (app) {
-              auto fqn = app->effective_fqn();
-              if (!fqn.empty()) {
-                host_fqns.push_back(std::move(fqn));
-              }
-            }
+        } else if (entity_ref->type == SovdEntityType::AREA) {
+          if (auto area = cache.get_area(entity_id)) {
+            entity_fqn = area->namespace_path;
           }
-          if (host_fqns.empty()) {
-            nlohmann::json payload;
-            payload["items"] = nlohmann::json::array();
-            return payload;
-          }
-          auto result = log_mgr->get_logs(host_fqns, false, "", "", entity_id);
-          if (!result.has_value()) {
-            return tl::make_unexpected(result.error());
-          }
-          nlohmann::json payload;
-          payload["items"] = std::move(*result);
-          return payload;
-        }
-
-        // AREA and COMPONENT: use namespace_path/fqn with prefix matching
-        // APP: use effective_fqn with exact matching
-        std::string fqn;
-        bool prefix_match = false;
-        if (entity_ref->type == SovdEntityType::AREA) {
-          auto area = cache.get_area(entity_id);
-          if (area) {
-            fqn = area->namespace_path;
-          }
-          prefix_match = true;
-        } else if (entity_ref->type == SovdEntityType::COMPONENT) {
-          auto comp = cache.get_component(entity_id);
-          if (comp) {
-            fqn = comp->fqn;
-          }
-          prefix_match = true;
         } else if (entity_ref->type == SovdEntityType::APP) {
-          auto app = cache.get_app(entity_id);
-          if (app) {
-            fqn = app->effective_fqn();
+          if (auto app = cache.get_app(entity_id)) {
+            entity_fqn = app->effective_fqn();
           }
         }
-
-        if (fqn.empty()) {
-          return tl::make_unexpected("Entity no longer available: " + entity_id);
-        }
-        auto result = log_mgr->get_logs({fqn}, prefix_match, "", "", entity_id);
+        auto result = logs::query_entity_logs(*log_mgr, cache, entity_ref->type, entity_id, entity_fqn, "", "");
         if (!result.has_value()) {
           return tl::make_unexpected(result.error());
         }

--- a/src/ros2_medkit_gateway/src/http/handlers/bulkdata_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/bulkdata_handlers.cpp
@@ -14,6 +14,8 @@
 
 #include "ros2_medkit_gateway/core/http/handlers/bulkdata_handlers.hpp"
 
+#include "ros2_medkit_gateway/core/faults/fault_scope.hpp"
+
 #include <algorithm>
 #include <cstdint>
 #include <filesystem>
@@ -109,6 +111,19 @@ std::vector<std::string> compute_bulkdata_source_filters(const ThreadSafeEntityC
     return HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_function(entity.id));
   }
 
+  if (entity.type == EntityType::APP) {
+    // A plugin-introspected app has no ROS binding, so fqn and namespace_path
+    // are both empty and the bare-fqn path below would return no filter at all -
+    // its rosbags and logs then belong to nobody and every download 404s. Its
+    // reporting source is its bare id, exactly as fault scoping resolves it.
+    std::string source = faults::resolve_app_source_fqn(cache, entity.id);
+    if (!source.empty()) {
+      std::vector<std::string> filters;
+      filters.push_back(std::move(source));
+      return filters;
+    }
+  }
+
   if (entity.type == EntityType::COMPONENT) {
     // Synthetic / runtime-discovered components have an empty fqn / namespace_path,
     // so the bare-fqn path used to silently return zero source filters and produce
@@ -116,6 +131,13 @@ std::vector<std::string> compute_bulkdata_source_filters(const ThreadSafeEntityC
     // apps first; manifest deployments where the component groups topics rather than
     // nodes still need the namespace prefix path, so fall through if no apps host it.
     auto filters = HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_component(entity.id));
+    // An external component reports faults under its own id too (a bridge raises
+    // PLC_COMMS_LOST there), so it owns that source as well - the same rule
+    // faults::collect_component_app_fqns already applies.
+    auto comp = cache.get_component(entity.id);
+    if (comp && comp->external.value_or(false)) {
+      filters.push_back(entity.id);
+    }
     if (!filters.empty()) {
       return filters;
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/bulkdata_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/bulkdata_handlers.cpp
@@ -21,6 +21,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
@@ -105,46 +106,26 @@ namespace detail {
 
 std::vector<std::string> compute_bulkdata_source_filters(const ThreadSafeEntityCache & cache,
                                                          const EntityInfo & entity) {
+  // One rule for every entity type: the same fault-scope resolution that drives
+  // GET /{entity}/faults (external app -> bare id, external component also owns
+  // its own id, AREA recurses subareas, FUNCTION follows component hosts).
+  // Rosbags are keyed by exact reporting source, so any private variant here
+  // makes a fault the entity lists advertise a bag that 404s - e.g. an
+  // area-scoped bulk_data_uri resolved through the area namespace never
+  // matched a bag stored under a hosted app's bare id.
+  auto sources = HandlerContext::resolve_entity_source_fqns(cache, entity);
+  if (!sources.empty()) {
+    return {sources.begin(), sources.end()};
+  }
+
   if (entity.type == EntityType::FUNCTION) {
-    // Functions are pure aggregated views over hosted apps - if no apps host the function,
-    // there is nothing to query. No fall-through to fqn/namespace_path.
-    return HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_function(entity.id));
+    // Functions are pure aggregated views over hosted apps - if no apps host
+    // the function, there is nothing to query. No fall-through.
+    return {};
   }
 
-  if (entity.type == EntityType::APP) {
-    // A plugin-introspected app has no ROS binding, so fqn and namespace_path
-    // are both empty and the bare-fqn path below would return no filter at all -
-    // its rosbags and logs then belong to nobody and every download 404s. Its
-    // reporting source is its bare id, exactly as fault scoping resolves it.
-    std::string source = faults::resolve_app_source_fqn(cache, entity.id);
-    if (!source.empty()) {
-      std::vector<std::string> filters;
-      filters.push_back(std::move(source));
-      return filters;
-    }
-  }
-
-  if (entity.type == EntityType::COMPONENT) {
-    // Synthetic / runtime-discovered components have an empty fqn / namespace_path,
-    // so the bare-fqn path used to silently return zero source filters and produce
-    // empty descriptor lists plus failed ownership checks on download. Resolve hosted
-    // apps first; manifest deployments where the component groups topics rather than
-    // nodes still need the namespace prefix path, so fall through if no apps host it.
-    auto filters = HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_component(entity.id));
-    // An external component reports faults under its own id too (a bridge raises
-    // PLC_COMMS_LOST there), so it owns that source as well - the same rule
-    // faults::collect_component_app_fqns already applies.
-    auto comp = cache.get_component(entity.id);
-    if (comp && comp->external.value_or(false)) {
-      filters.push_back(entity.id);
-    }
-    if (!filters.empty()) {
-      return filters;
-    }
-    // fall through to fqn/namespace_path
-  }
-
-  // For other entity types and manifest-only components, use FQN or namespace_path
+  // No resolvable hosted sources (manifest-only entities grouping topics rather
+  // than nodes, or apps missing from the cache): fall back to FQN or namespace_path.
   std::string filter = entity.fqn.empty() ? entity.namespace_path : entity.fqn;
   if (filter.empty()) {
     return {};
@@ -354,18 +335,15 @@ http::Result<http::BinaryResponse> BulkDataHandlers::download(const http::TypedR
           make_error(404, ERR_RESOURCE_NOT_FOUND, "Bulk-data not found", json{{"bulk_data_id", bulk_data_id}}));
     }
 
-    // Security check: verify rosbag belongs to this entity. For functions,
-    // check all hosting apps (aggregated view).
+    // Security check: the bag belongs to this entity only when the fault it
+    // was captured for is within the entity's source scope. Read the fault
+    // once and test with the shared boundary-aware matcher - the transport's
+    // get_fault(code, source) check is a raw prefix match, so app id "plc"
+    // would claim the assets of "plc_line1".
     auto source_filters = get_source_filters(entity);
-    bool fault_verified = false;
-    for (const auto & sf : source_filters) {
-      auto fault_result = fault_mgr->get_fault(fault_code, sf);
-      if (fault_result.success) {
-        fault_verified = true;
-        break;
-      }
-    }
-    if (!fault_verified) {
+    std::set<std::string> scope(source_filters.begin(), source_filters.end());
+    auto fault_result = fault_mgr->get_fault(fault_code, "");
+    if (!fault_result.success || !faults::fault_in_source_scope(fault_result.data, scope)) {
       return tl::unexpected(make_error(404, ERR_RESOURCE_NOT_FOUND, "Bulk-data not found for this entity",
                                        json{{"entity_id", path_info->entity_id}}));
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/handler_context.cpp
@@ -390,11 +390,11 @@ std::vector<std::string> HandlerContext::resolve_app_host_fqns(const ThreadSafeE
   fqns.reserve(app_ids.size());
   std::unordered_set<std::string> seen;
   for (const auto & app_id : app_ids) {
-    auto app = cache.get_app(app_id);
-    if (!app) {
-      continue;
-    }
-    auto fqn = app->effective_fqn();
+    // Same app -> source resolution as the fault-scope path, so a plugin app
+    // (external, no ROS binding) keeps its bare entity id here too. Resolving
+    // by effective_fqn() alone dropped it, and the empty filter set made every
+    // rosbag download and log query for its component match nothing.
+    auto fqn = faults::resolve_app_source_fqn(cache, app_id);
     if (fqn.empty()) {
       continue;
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
@@ -14,8 +14,8 @@
 
 #include "ros2_medkit_gateway/core/http/handlers/log_handlers.hpp"
 
-#include <iterator>
 #include <optional>
+#include <set>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -26,6 +26,7 @@
 
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/http/fan_out_helpers.hpp"
+#include "ros2_medkit_gateway/core/logs/log_scope.hpp"
 #include "ros2_medkit_gateway/core/managers/log_manager.hpp"
 #include "ros2_medkit_gateway/dto/json_reader.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -130,111 +131,52 @@ LogHandlers::get_logs(const http::TypedRequest & req) {
   dto::LogListXMedkit xm;
   bool xm_used = false;
 
-  // -----------------------------------------------------------------------
-  // FUNCTION - aggregate local hosted app logs + fan-out to peers
-  // -----------------------------------------------------------------------
-  if (entity.type == EntityType::FUNCTION) {
-    const auto & cache = ctx_.node()->get_thread_safe_cache();
-    auto func = cache.get_function(entity_id);
+  // Local query: one shared scope resolution for every entity type. Exact
+  // sources follow the fault-scope rule (external app -> bare id, external
+  // component owns its own id, areas recurse subareas, functions follow
+  // component hosts); COMPONENT and AREA additionally merge the entity.fqn
+  // namespace-prefix query, so a component whose apps are all external keeps
+  // the ROS node entries under its namespace.
+  const auto & cache = ctx_.node()->get_thread_safe_cache();
+  std::set<std::string> resolved;
+  auto local_logs = logs::query_entity_logs(*log_mgr, cache, entity.sovd_type(), entity_id, entity.fqn, min_severity,
+                                            context_filter, &resolved);
+  if (!local_logs) {
+    return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, local_logs.error()));
+  }
+  response.items = parse_local_items(*local_logs);
 
+  if (entity.type == EntityType::FUNCTION) {
     xm.entity_id = entity_id;
     xm.aggregation_level = "function";
     xm.aggregated = true;
     xm_used = true;
-
-    if (func && !func->hosts.empty()) {
-      auto host_fqns = HandlerContext::resolve_app_host_fqns(cache, func->hosts);
-      if (!host_fqns.empty()) {
-        auto logs = log_mgr->get_logs(host_fqns, false, min_severity, context_filter, entity_id);
-        if (!logs) {
-          return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-        }
-        response.items = parse_local_items(*logs);
-        xm.host_count = static_cast<int64_t>(host_fqns.size());
-        xm.aggregation_sources = std::vector<std::string>(host_fqns.begin(), host_fqns.end());
-      }
+    if (!resolved.empty()) {
+      xm.host_count = static_cast<int64_t>(resolved.size());
+      xm.aggregation_sources = std::vector<std::string>(resolved.begin(), resolved.end());
     }
   } else if (entity.type == EntityType::AREA) {
-    // ---------------------------------------------------------------------
-    // AREA - aggregate local app logs from all components + fan-out
-    // ---------------------------------------------------------------------
-    const auto & cache = ctx_.node()->get_thread_safe_cache();
-    auto comp_ids = cache.get_components_for_area(entity_id);
-
-    std::vector<std::string> host_fqns;
-    for (const auto & comp_id : comp_ids) {
-      auto comp_fqns = HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_component(comp_id));
-      host_fqns.insert(host_fqns.end(), std::make_move_iterator(comp_fqns.begin()),
-                       std::make_move_iterator(comp_fqns.end()));
-    }
-
     xm.entity_id = entity_id;
     xm.aggregation_level = "area";
     xm.aggregated = true;
     xm_used = true;
-
-    if (!host_fqns.empty()) {
-      auto logs = log_mgr->get_logs(host_fqns, false, min_severity, context_filter, entity_id);
-      if (!logs) {
-        return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-      }
-      response.items = parse_local_items(*logs);
-      xm.component_count = static_cast<int64_t>(comp_ids.size());
-      xm.app_count = static_cast<int64_t>(host_fqns.size());
-      xm.aggregation_sources = std::vector<std::string>(host_fqns.begin(), host_fqns.end());
-    } else {
-      auto logs = log_mgr->get_logs({entity.fqn}, true, min_severity, context_filter, entity_id);
-      if (!logs) {
-        return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-      }
-      response.items = parse_local_items(*logs);
+    if (!resolved.empty()) {
+      xm.component_count = static_cast<int64_t>(cache.get_components_for_area(entity_id).size());
+      xm.app_count = static_cast<int64_t>(resolved.size());
+      xm.aggregation_sources = std::vector<std::string>(resolved.begin(), resolved.end());
     }
   } else if (entity.type == EntityType::COMPONENT) {
-    // ---------------------------------------------------------------------
-    // COMPONENT - aggregate from hosted apps' fqns (mirrors AREA / FUNCTION
-    // semantics) and fall through to the entity.fqn prefix path only when
-    // the component has no hosted apps. Synthetic / runtime-discovered
-    // components have an empty fqn, so the bare prefix-match query that
-    // worked for manifest components silently returned zero items even
-    // when the component grouped 20+ active nodes.
-    // ---------------------------------------------------------------------
-    const auto & cache = ctx_.node()->get_thread_safe_cache();
-    auto host_fqns = HandlerContext::resolve_app_host_fqns(cache, cache.get_apps_for_component(entity_id));
-
     xm.entity_id = entity_id;
     xm.aggregation_level = "component";
     xm.aggregated = true;
     xm_used = true;
-
-    if (!host_fqns.empty()) {
-      auto logs = log_mgr->get_logs(host_fqns, false, min_severity, context_filter, entity_id);
-      if (!logs) {
-        return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-      }
-      response.items = parse_local_items(*logs);
-      xm.app_count = static_cast<int64_t>(host_fqns.size());
-      xm.aggregation_sources = std::vector<std::string>(host_fqns.begin(), host_fqns.end());
-    } else if (!entity.fqn.empty()) {
-      // Manifest component without hosted apps - keep the original namespace
-      // prefix path so manifest-only deployments still work.
-      auto logs = log_mgr->get_logs({entity.fqn}, true, min_severity, context_filter, entity_id);
-      if (!logs) {
-        return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-      }
-      response.items = parse_local_items(*logs);
+    if (!resolved.empty()) {
+      xm.app_count = static_cast<int64_t>(resolved.size());
+      xm.aggregation_sources = std::vector<std::string>(resolved.begin(), resolved.end());
     }
-  } else {
-    // ---------------------------------------------------------------------
-    // APP - local query + fan-out to peers. APP responses only carry an
-    // x-medkit block when fan-out actually produced observability output;
-    // tracked via xm_used (still false here) and the final apply step below.
-    // ---------------------------------------------------------------------
-    auto logs = log_mgr->get_logs({entity.fqn}, false, min_severity, context_filter, entity_id);
-    if (!logs) {
-      return tl::unexpected(make_error(503, ERR_SERVICE_UNAVAILABLE, logs.error()));
-    }
-    response.items = parse_local_items(*logs);
   }
+  // APP: x-medkit only appears when fan-out below produces observability
+  // output; tracked via xm_used (still false here).
 
   // Typed fan-out for collection endpoints. Replaces the legacy raw-JSON
   // `merge_peer_items` mutator: peer items come back as parsed `dto::LogEntry`

--- a/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
@@ -301,6 +301,46 @@ TEST_F(BulkDataSourceFiltersTest, ComponentWithExternalAppsReturnsBareEntityIds)
   EXPECT_EQ(filters[0], "plc_line1");
 }
 
+// APP provided by a protocol plugin - no ROS binding, so fqn and namespace_path
+// are empty and the generic path returned no filter at all: the rosbag the fault
+// detail advertises under /apps/<id>/bulk-data/rosbags/<code> belonged to nobody
+// and every download 404'd. Its bare id is its reporting source.
+TEST_F(BulkDataSourceFiltersTest, ExternalAppResolvesToItsBareEntityId) {
+  App device;
+  device.id = "twincat_runtime_device";
+  device.name = "TwinCAT 3 Runtime (device)";
+  device.component_id = "twincat_runtime";
+  device.external = true;
+  cache_.update_apps({device});
+
+  auto entity = make_entity_info(EntityType::APP, "twincat_runtime_device", "", "");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache_, entity);
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0], "twincat_runtime_device");
+}
+
+// An external COMPONENT reports faults under its own id as well (a bridge raises
+// PLC_COMMS_LOST there), so it owns that source alongside its hosted apps.
+TEST_F(BulkDataSourceFiltersTest, ExternalComponentAlsoOwnsItsOwnId) {
+  Component plc;
+  plc.id = "plc_hw2";
+  plc.name = "PLC";
+  plc.external = true;
+  cache_.update_components({plc});
+  App child;
+  child.id = "plc_hw2_device";
+  child.name = "PLC (device)";
+  child.component_id = "plc_hw2";
+  child.external = true;
+  cache_.update_apps({child});
+
+  auto entity = make_entity_info(EntityType::COMPONENT, "plc_hw2", "", "");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache_, entity);
+  std::set<std::string> as_set(filters.begin(), filters.end());
+  EXPECT_TRUE(as_set.count("plc_hw2_device"));
+  EXPECT_TRUE(as_set.count("plc_hw2"));
+}
+
 // COMPONENT with no hosted apps but non-empty fqn falls through to fqn path
 // (manifest deployment grouping topics rather than nodes).
 TEST_F(BulkDataSourceFiltersTest, ComponentManifestOnlyFallsThroughToFqn) {

--- a/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
@@ -282,6 +282,25 @@ TEST_F(BulkDataSourceFiltersTest, ComponentWithHostedAppsReturnsAppFqns) {
   EXPECT_TRUE(as_set.count("/powertrain/engine/rpm_sensor"));
 }
 
+// COMPONENT hosting plugin-provided apps - those apps have no ROS binding and
+// report faults under their bare entity id, so that id must become the filter.
+// Resolving by effective_fqn() alone yielded zero filters and the download
+// ownership check answered "Bulk-data not found for this entity" for a bag that
+// existed on disk.
+TEST_F(BulkDataSourceFiltersTest, ComponentWithExternalAppsReturnsBareEntityIds) {
+  App plc_app;
+  plc_app.id = "plc_line1";
+  plc_app.name = "PLC Line 1";
+  plc_app.component_id = "plc_hw";
+  plc_app.external = true;
+  cache_.update_apps({plc_app});
+
+  auto entity = make_entity_info(EntityType::COMPONENT, "plc_hw", "", "");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache_, entity);
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0], "plc_line1");
+}
+
 // COMPONENT with no hosted apps but non-empty fqn falls through to fqn path
 // (manifest deployment grouping topics rather than nodes).
 TEST_F(BulkDataSourceFiltersTest, ComponentManifestOnlyFallsThroughToFqn) {

--- a/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_bulkdata_handlers.cpp
@@ -19,8 +19,10 @@
 #include <string>
 
 #include "ros2_medkit_gateway/core/discovery/models/app.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/area.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/component.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/function.hpp"
+#include "ros2_medkit_gateway/core/faults/fault_scope.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/bulkdata_handlers.hpp"
 #include "ros2_medkit_gateway/core/http/http_utils.hpp"
@@ -403,10 +405,103 @@ TEST_F(BulkDataSourceFiltersTest, AppWithEmptyFqnAndNamespaceReturnsEmpty) {
   EXPECT_TRUE(filters.empty());
 }
 
-// AREA entity uses fqn directly - no aggregation in this helper.
+// AREA not present in the cache (no hosted apps resolvable) falls back to fqn.
 TEST_F(BulkDataSourceFiltersTest, AreaReturnsFqnAsFilter) {
   auto entity = make_entity_info(EntityType::AREA, "powertrain", "/powertrain", "/powertrain");
   auto filters = handlers::detail::compute_bulkdata_source_filters(cache_, entity);
   ASSERT_EQ(filters.size(), 1u);
   EXPECT_EQ(filters[0], "/powertrain");
+}
+
+// AREA with hosted apps resolves them like the fault scope does, recursing
+// subareas and keeping external bare ids. The namespace fallback alone never
+// matched a bag: list_rosbags_for_entity compares reporting sources exactly,
+// so /areas/<id>/faults advertised a bulk_data_uri that 404'd.
+TEST_F(BulkDataSourceFiltersTest, AreaResolvesHostedAppsIncludingSubareas) {
+  Area cell;
+  cell.id = "plc-cell";
+  cell.name = "PLC Cell";
+  cell.namespace_path = "/plc_cell";
+  Area sub;
+  sub.id = "cabinet";
+  sub.name = "Cabinet";
+  sub.namespace_path = "/plc_cell/cabinet";
+  sub.parent_area_id = "plc-cell";
+
+  Component plc;
+  plc.id = "s7-plc";
+  plc.name = "PLC";
+  plc.area = "cabinet";
+  App proc;
+  proc.id = "plc-process";
+  proc.name = "PLC Process";
+  proc.component_id = "s7-plc";
+  proc.external = true;
+
+  ThreadSafeEntityCache cache;
+  cache.update_all({cell, sub}, {plc}, {proc}, {});
+
+  auto entity = make_entity_info(EntityType::AREA, "plc-cell", "/plc_cell", "/plc_cell");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache, entity);
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0], "plc-process");
+}
+
+// FUNCTION whose host is a Component (not an app) resolves the component's
+// apps. The app-index lookup dropped component hosts: the function listed the
+// fault but its bag download 404'd.
+TEST_F(BulkDataSourceFiltersTest, FunctionWithComponentHostResolvesComponentApps) {
+  Component plc;
+  plc.id = "plc_hw";
+  plc.name = "PLC";
+  App proc;
+  proc.id = "plc-process";
+  proc.name = "PLC Process";
+  proc.component_id = "plc_hw";
+  proc.external = true;
+  Function func;
+  func.id = "level-control";
+  func.name = "Level Control";
+  func.hosts = {"plc_hw"};
+
+  ThreadSafeEntityCache cache;
+  cache.update_all({}, {plc}, {proc}, {func});
+
+  auto entity = make_entity_info(EntityType::FUNCTION, "level-control", "", "");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache, entity);
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0], "plc-process");
+}
+
+// Download ownership uses fault_in_source_scope over the computed filters:
+// exact match or '/'-boundary prefix only. A raw prefix match (the transport's
+// get_fault(code, source) semantics) would let app id "plc" claim the bag of
+// "plc_line1".
+TEST_F(BulkDataSourceFiltersTest, DownloadOwnershipScopeRejectsPrefixSiblingApp) {
+  App plc;
+  plc.id = "plc";
+  plc.name = "PLC";
+  plc.external = true;
+  App plc_line1;
+  plc_line1.id = "plc_line1";
+  plc_line1.name = "PLC Line 1";
+  plc_line1.external = true;
+
+  ThreadSafeEntityCache cache;
+  cache.update_all({}, {}, {plc, plc_line1}, {});
+
+  auto entity = make_entity_info(EntityType::APP, "plc", "", "");
+  auto filters = handlers::detail::compute_bulkdata_source_filters(cache, entity);
+  ASSERT_EQ(filters.size(), 1u);
+  EXPECT_EQ(filters[0], "plc");
+  std::set<std::string> scope(filters.begin(), filters.end());
+
+  nlohmann::json sibling_fault = {{"reporting_sources", {"plc_line1"}}};
+  EXPECT_FALSE(faults::fault_in_source_scope(sibling_fault, scope));
+
+  nlohmann::json own_fault = {{"reporting_sources", {"plc"}}};
+  EXPECT_TRUE(faults::fault_in_source_scope(own_fault, scope));
+
+  nlohmann::json child_fault = {{"reporting_sources", {"plc/axis1"}}};
+  EXPECT_TRUE(faults::fault_in_source_scope(child_fault, scope));
 }

--- a/src/ros2_medkit_gateway/test/test_handler_context.cpp
+++ b/src/ros2_medkit_gateway/test/test_handler_context.cpp
@@ -1331,6 +1331,17 @@ App make_app_with_binding(const std::string & id, const std::string & node_name,
   return a;
 }
 
+// An asset introspected by a protocol plugin (e.g. a PLC entity over OPC UA):
+// external=true, no ROS binding, so effective_fqn() is empty.
+App make_external_app(const std::string & app_id, const std::string & component_id) {
+  App a;
+  a.id = app_id;
+  a.name = app_id;
+  a.component_id = component_id;
+  a.external = true;
+  return a;
+}
+
 }  // namespace
 
 TEST(ResolveAppHostFqnsTest, EmptyAppListReturnsEmpty) {
@@ -1383,6 +1394,35 @@ TEST(ResolveAppHostFqnsTest, SkipsAppsWithEmptyEffectiveFqn) {
   auto fqns = HandlerContext::resolve_app_host_fqns(cache, {"no_binding", "temp_sensor"});
   ASSERT_EQ(fqns.size(), 1u);
   EXPECT_EQ(fqns[0], "/powertrain/engine/temp_sensor");
+}
+
+TEST(ResolveAppHostFqnsTest, ExternalAppResolvesToItsBareEntityId) {
+  // A plugin-introspected asset has no ROS binding, so effective_fqn() is empty,
+  // but it reports faults - and therefore owns its rosbags and logs - under its
+  // bare entity id. Dropping it here left the bulk-data / log filter set empty
+  // and every download for the hosting component answered "not found".
+  ThreadSafeEntityCache cache;
+  cache.update_apps({make_external_app("plc_line1", "plc_hw"),
+                     make_app_with_binding("temp_sensor", "temp_sensor", "/powertrain/engine")});
+
+  auto fqns = HandlerContext::resolve_app_host_fqns(cache, {"plc_line1", "temp_sensor"});
+  ASSERT_EQ(fqns.size(), 2u);
+  EXPECT_EQ(fqns[0], "plc_line1");
+  EXPECT_EQ(fqns[1], "/powertrain/engine/temp_sensor");
+}
+
+TEST(ResolveAppHostFqnsTest, ExternalAppWithStrayBindingStillResolvesToItsId) {
+  // Mirrors the fault-scope rule: a manifest stub may declare a ros_binding on
+  // an external app; the derived FQN must not shadow the id the plugin reports
+  // under, or the entity's bags become unreachable again.
+  ThreadSafeEntityCache cache;
+  App plc = make_external_app("plc_line1", "plc_hw");
+  plc.ros_binding = App::RosBinding{"process", "/plc", ""};
+  cache.update_apps({plc});
+
+  auto fqns = HandlerContext::resolve_app_host_fqns(cache, {"plc_line1"});
+  ASSERT_EQ(fqns.size(), 1u);
+  EXPECT_EQ(fqns[0], "plc_line1");
 }
 
 TEST(ResolveAppHostFqnsTest, AllAppsMissingReturnsEmpty) {
@@ -1443,17 +1483,6 @@ App make_owned_app(const std::string & app_id, const std::string & component_id,
                    const std::string & ns) {
   App a = make_app_with_binding(app_id, node_name, ns);
   a.component_id = component_id;
-  return a;
-}
-
-// An asset introspected by a protocol plugin (e.g. a PLC entity over OPC UA):
-// external=true, no ROS binding, so effective_fqn() is empty.
-App make_external_app(const std::string & app_id, const std::string & component_id) {
-  App a;
-  a.id = app_id;
-  a.name = app_id;
-  a.component_id = component_id;
-  a.external = true;
   return a;
 }
 

--- a/src/ros2_medkit_gateway/test/test_handler_context.cpp
+++ b/src/ros2_medkit_gateway/test/test_handler_context.cpp
@@ -1312,10 +1312,10 @@ TEST_F(AreaAggregationTest, AreaLogsWithNoComponentsFallsThrough) {
 // =============================================================================
 // resolve_app_host_fqns tests (no GatewayNode required)
 //
-// Used by log_handlers and bulkdata_handlers to aggregate per-component /
-// per-function resource queries from the entity's hosted apps. These tests
-// pin the silent-skip semantics (missing apps, empty effective_fqn) that
-// downstream callers rely on for the "synthetic component" fallback.
+// Order-preserving wrapper over faults::resolve_app_source_fqn for explicit
+// app-id lists. These tests pin the per-app rule (external -> bare id, stray
+// binding, bound_fqn preference) and the silent-skip semantics (missing apps,
+// empty effective_fqn).
 // =============================================================================
 
 namespace {

--- a/src/ros2_medkit_gateway/test/test_log_scope.cpp
+++ b/src/ros2_medkit_gateway/test/test_log_scope.cpp
@@ -1,0 +1,213 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+
+#include "ros2_medkit_gateway/core/discovery/models/app.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/area.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/component.hpp"
+#include "ros2_medkit_gateway/core/discovery/models/function.hpp"
+#include "ros2_medkit_gateway/core/logs/log_scope.hpp"
+#include "ros2_medkit_gateway/core/managers/log_manager.hpp"
+#include "ros2_medkit_gateway/core/models/thread_safe_entity_cache.hpp"
+#include "ros2_medkit_gateway/core/transports/log_source.hpp"
+
+using json = nlohmann::json;
+using namespace ros2_medkit_gateway;
+
+namespace {
+
+class NullLogSource : public LogSource {
+ public:
+  void start(EntryCallback) override {
+  }
+  void stop() override {
+  }
+};
+
+std::set<std::string> messages_of(const json & items) {
+  std::set<std::string> out;
+  for (const auto & item : items) {
+    out.insert(item.value("message", ""));
+  }
+  return out;
+}
+
+}  // namespace
+
+// =============================================================================
+// logs::query_entity_logs
+//
+// Pins the shared entity -> log-source scope used by GET /{entity}/logs and
+// the cyclic subscription "logs" sampler: exact sources follow the fault-scope
+// rule (external app -> bare id, external component owns its own id), while
+// COMPONENT / AREA merge the namespace-prefix query on top.
+// =============================================================================
+
+class LogScopeTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Manifest component with a namespace hosting one external app and one
+    // ROS-bound app.
+    Component cell;
+    cell.id = "plant_cell";
+    cell.name = "Plant Cell";
+    cell.namespace_path = "/plant";
+    cell.fqn = "/plant";
+    cell.area = "cell_area";
+
+    // External component with no apps (protocol bridge asset).
+    Component box;
+    box.id = "plc-box";
+    box.name = "PLC Box";
+    box.external = true;
+
+    App ext;
+    ext.id = "ext-plc";
+    ext.name = "External PLC";
+    ext.component_id = "plant_cell";
+    ext.external = true;
+
+    App temp;
+    temp.id = "temp";
+    temp.name = "Temp Sensor";
+    temp.component_id = "plant_cell";
+    App::RosBinding rb;
+    rb.node_name = "temp";
+    rb.namespace_pattern = "/plant";
+    temp.ros_binding = rb;
+
+    Area area;
+    area.id = "cell_area";
+    area.name = "Cell Area";
+    area.namespace_path = "/plant";
+
+    Function line;
+    line.id = "line_func";
+    line.name = "Line Function";
+    line.hosts = {"plant_cell"};  // Component host, not an app
+
+    cache_.update_all({area}, {cell, box}, {ext, temp}, {line});
+
+    mgr_.add_log_entry("ext-plc", "info", "plc entry", {});
+    mgr_.add_log_entry("/plant/node1", "info", "node1 entry", {});
+    mgr_.add_log_entry("/plant/temp", "info", "temp entry", {});
+    mgr_.add_log_entry("plc-box", "info", "box entry", {});
+    mgr_.add_log_entry("/other/node", "info", "other entry", {});
+  }
+
+  ThreadSafeEntityCache cache_;
+  LogManager mgr_{std::make_shared<NullLogSource>()};
+};
+
+// COMPONENT merges the exact query over resolved sources (bare id for the
+// external app, FQN for the bound app) with the namespace-prefix query.
+// Before the merge, a non-empty resolved set disabled the prefix path and the
+// /plant/* node entries silently vanished.
+TEST_F(LogScopeTest, ComponentMergesExternalAppAndNamespaceEntries) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::COMPONENT, "plant_cell", "/plant", "", "");
+  ASSERT_TRUE(result.has_value());
+  auto msgs = messages_of(*result);
+  EXPECT_TRUE(msgs.count("plc entry"));
+  EXPECT_TRUE(msgs.count("node1 entry"));
+  EXPECT_TRUE(msgs.count("temp entry"));
+  EXPECT_FALSE(msgs.count("other entry"));
+}
+
+// The bound app's entry is hit by both the exact and the prefix query - it
+// must appear exactly once, and the merged list stays sorted by id.
+TEST_F(LogScopeTest, ComponentDedupesEntriesMatchedByBothQueries) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::COMPONENT, "plant_cell", "/plant", "", "");
+  ASSERT_TRUE(result.has_value());
+  int temp_count = 0;
+  long long prev = -1;
+  for (const auto & item : *result) {
+    if (item.value("message", "") == "temp entry") {
+      ++temp_count;
+    }
+    const long long n = std::stoll(item.value("id", "log_0").substr(4));
+    EXPECT_GT(n, prev);
+    prev = n;
+  }
+  EXPECT_EQ(temp_count, 1);
+}
+
+// An external component owns entries stored under its own entity id even
+// with no hosted apps.
+TEST_F(LogScopeTest, ExternalComponentOwnsItsOwnIdEntries) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::COMPONENT, "plc-box", "", "", "");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(messages_of(*result), std::set<std::string>{"box entry"});
+}
+
+// An external app has an empty effective_fqn; its entries live under its bare
+// entity id. The raw {entity.fqn} query returned nothing for it.
+TEST_F(LogScopeTest, ExternalAppResolvesToBareEntityId) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::APP, "ext-plc", "", "", "");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(messages_of(*result), std::set<std::string>{"plc entry"});
+}
+
+// A ROS-bound app keeps its exact-FQN scope - no namespace bleed.
+TEST_F(LogScopeTest, BoundAppKeepsExactFqnScope) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::APP, "temp", "/plant/temp", "", "");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(messages_of(*result), std::set<std::string>{"temp entry"});
+}
+
+// A function hosting a Component resolves the component's apps (incl. the
+// external one) but never runs a namespace query.
+TEST_F(LogScopeTest, FunctionFollowsComponentHosts) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::FUNCTION, "line_func", "", "", "");
+  ASSERT_TRUE(result.has_value());
+  auto msgs = messages_of(*result);
+  EXPECT_TRUE(msgs.count("plc entry"));
+  EXPECT_TRUE(msgs.count("temp entry"));
+  EXPECT_FALSE(msgs.count("node1 entry"));
+}
+
+// AREA resolves hosted apps through its components and merges the namespace
+// prefix query, mirroring COMPONENT.
+TEST_F(LogScopeTest, AreaMergesHostedAppsAndNamespaceEntries) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::AREA, "cell_area", "/plant", "", "");
+  ASSERT_TRUE(result.has_value());
+  auto msgs = messages_of(*result);
+  EXPECT_TRUE(msgs.count("plc entry"));
+  EXPECT_TRUE(msgs.count("node1 entry"));
+  EXPECT_TRUE(msgs.count("temp entry"));
+  EXPECT_FALSE(msgs.count("other entry"));
+}
+
+// The resolved_sources out-param carries the exact-match set for x-medkit
+// metadata.
+TEST_F(LogScopeTest, ResolvedSourcesOutParamExposesExactSet) {
+  std::set<std::string> resolved;
+  auto result =
+      logs::query_entity_logs(mgr_, cache_, SovdEntityType::COMPONENT, "plant_cell", "/plant", "", "", &resolved);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(resolved.count("ext-plc"));
+  EXPECT_TRUE(resolved.count("/plant/temp"));
+}
+
+// Unknown entity types resolve to nothing.
+TEST_F(LogScopeTest, UnknownTypeReturnsEmpty) {
+  auto result = logs::query_entity_logs(mgr_, cache_, SovdEntityType::UNKNOWN, "whatever", "", "", "");
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->empty());
+}

--- a/src/ros2_medkit_integration_tests/test/features/test_external_app_fault_rollup.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_external_app_fault_rollup.test.py
@@ -36,6 +36,7 @@ report a fault under the bare id, then observe it on every rollup route.
 """
 
 import os
+import time
 import unittest
 
 from ament_index_python.packages import get_package_share_directory
@@ -49,12 +50,17 @@ from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
+from std_msgs.msg import Float32
+
 
 EXTERNAL_APP = 'plc-process'
 HOST_COMPONENT = 's7-plc'
 HOST_FUNCTION = 'level-control'
 HOST_AREA = 'plc-cell'
 FAULT_CODE = 'PLC_LEVEL_OVERFLOW'
+# Topic the test publishes so the fault_manager's rosbag ring buffer has data
+# to flush when the fault confirms (no demo nodes run in this launch).
+LEVEL_TOPIC = '/plc_cell/level'
 
 
 def generate_test_description():
@@ -67,7 +73,10 @@ def generate_test_description():
         fault_manager=True,
         # Negative threshold: the fault confirms after a couple of FAILED
         # events (see _report_fault, which reports several times).
-        fault_manager_params={'confirmation_threshold': -2},
+        fault_manager_params={
+            'confirmation_threshold': -2,
+            'snapshots.rosbag.include_topics': [LEVEL_TOPIC],
+        },
         gateway_params={
             'discovery.mode': 'hybrid',
             'discovery.manifest_path': manifest_path,
@@ -86,14 +95,18 @@ class TestExternalAppFaultRollup(GatewayTestCase):
 
     @classmethod
     def setUpClass(cls):
-        # Wait for the gateway + discovery (the external app, area and function
-        # must exist before we exercise the rollup routes).
-        super().setUpClass()
+        # Create the publisher BEFORE the gateway wait: the fault_manager's
+        # explicit-topic rosbag capture retries type discovery for only ~10s
+        # after startup, so LEVEL_TOPIC must be on the graph early.
         rclpy.init()
         cls._reporter = Node('external_app_fault_reporter')
+        cls._level_pub = cls._reporter.create_publisher(Float32, LEVEL_TOPIC, 10)
         cls._report_client = cls._reporter.create_client(
             ReportFault, '/fault_manager/report_fault'
         )
+        # Wait for the gateway + discovery (the external app, area and function
+        # must exist before we exercise the rollup routes).
+        super().setUpClass()
         assert cls._report_client.wait_for_service(timeout_sec=15.0), \
             'report_fault service not available'
 
@@ -131,6 +144,69 @@ class TestExternalAppFaultRollup(GatewayTestCase):
             # intentionally drop the reply future (see docstring).
             self._report_client.call_async(req)
             rclpy.spin_once(self._reporter, timeout_sec=0.1)
+
+    def _publish_level(self, seconds, period=0.05):
+        """Keep LEVEL_TOPIC flowing so the capture ring buffer is not empty."""
+        deadline = time.monotonic() + seconds
+        while time.monotonic() < deadline:
+            self._level_pub.publish(Float32(data=42.0))
+            time.sleep(period)
+
+    def test_external_app_bulk_data_uris_serve_the_captured_bag(self):
+        """The advertised bulk_data_uri serves the bag on app AND area routes.
+
+        The rosbag captured when the external app's fault confirms is keyed by
+        the fault's reporting source - the app's bare entity id. Every route
+        that lists the fault must also serve its bag. The area case is the
+        regression: ``GET /areas/plc-cell/faults/<code>`` advertises
+        ``/areas/plc-cell/bulk-data/rosbags/<code>``, which 404'd while the
+        area resolved its bulk-data scope through the namespace path instead
+        of its hosted apps' reporting sources.
+
+        Runs before the rollup test (method order is alphabetical) and reports
+        the same fault code; the report is idempotent for both tests.
+
+        @verifies REQ_INTEROP_072
+        """
+        # Fill the capture buffer around the confirmation edge: the bag is
+        # flushed once, on CONFIRMED, from whatever the buffer holds.
+        self._publish_level(seconds=0.5)
+        self._report_fault()
+        self._publish_level(seconds=1.0)
+
+        self.wait_for_fault(f'/apps/{EXTERNAL_APP}', FAULT_CODE)
+        bag_id = self.wait_for_fault_with_rosbag(f'/apps/{EXTERNAL_APP}')
+        self.assertEqual(bag_id, FAULT_CODE)
+
+        # App-level download: 200 + bytes.
+        app_uri = f'/apps/{EXTERNAL_APP}/bulk-data/rosbags/{FAULT_CODE}'
+        resp = self.get_raw(app_uri)
+        self.assertGreater(len(resp.content), 0, f'{app_uri} returned no bytes')
+
+        # Area rollup advertises an area-scoped URI for the same bag.
+        detail = self.wait_for_fault_detail(
+            f'/areas/{HOST_AREA}', snapshot_types={'rosbag'})
+        rosbag_snaps = [
+            s for s in detail['environment_data']['snapshots']
+            if s.get('type') == 'rosbag'
+        ]
+        self.assertTrue(
+            rosbag_snaps, 'area fault detail lost the rosbag snapshot')
+        area_uri = rosbag_snaps[0].get('bulk_data_uri')
+        self.assertEqual(
+            area_uri, f'/areas/{HOST_AREA}/bulk-data/rosbags/{FAULT_CODE}')
+
+        # The area listing shows the bag and the advertised URI downloads.
+        listing = self.get_json(f'/areas/{HOST_AREA}/bulk-data/rosbags')
+        listed_ids = [item.get('id') for item in listing.get('items', [])]
+        self.assertIn(FAULT_CODE, listed_ids)
+        resp = self.get_raw(area_uri)
+        self.assertGreater(len(resp.content), 0, f'{area_uri} returned no bytes')
+
+        # Function rollup resolves the same scope.
+        listing = self.get_json(f'/functions/{HOST_FUNCTION}/bulk-data/rosbags')
+        listed_ids = [item.get('id') for item in listing.get('items', [])]
+        self.assertIn(FAULT_CODE, listed_ids)
 
     def test_external_app_fault_appears_on_every_rollup(self):
         """The external app's fault surfaces on app, component, function, area.


### PR DESCRIPTION
Closes #558.

Fault scoping and bulk-data scoping disagreed about what source an entity owns,
so a plugin-provided entity could not download the rosbag its own fault detail
advertised.

- The per-app rule (external -> bare entity id, checked before `effective_fqn()`)
  moves out of the anonymous namespace into `faults::resolve_app_source_fqn`, and
  both `collect_app_fqn` and `HandlerContext::resolve_app_host_fqns` use it, so
  there is one definition of the rule rather than two that drift.
- `compute_bulkdata_source_filters` gains the two branches it was missing: an APP
  entity resolves through the same helper instead of falling through to an empty
  `fqn`, and an external COMPONENT owns its own id alongside its hosted apps -
  the same rule `collect_component_app_fqns` already applies for faults.

Logs go through the same resolver, so `LogManager::get_logs` is fixed with it.

Tests: `ExternalAppResolvesToItsBareEntityId`,
`ExternalAppWithStrayBindingStillResolvesToItsId`,
`ComponentWithExternalAppsReturnsBareEntityIds`, `ExternalComponentAlsoOwnsItsOwnId`.
Each fails on the pre-fix resolver. Full gateway suite: 4289 tests, 0 failures,
484 skipped; clang-format clean.

One behaviour change worth naming: a component that hosts external apps no longer
falls through to the `fqn` / `namespace_path` prefix filter, because that
fall-through only fires on an empty source set. That affects a manifest component
whose bags are sourced from a ROS namespace and which also hosts external apps.
