### PR TITLE
fix(gateway): freeze-frame the faults that were already raised at startup

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -949,7 +949,11 @@ Query and manage faults.
 
    **Snapshot Types:**
 
-   - ``freeze_frame``: Topic data captured at fault confirmation
+   - ``freeze_frame``: Topic data captured at fault confirmation. Entity
+     frames for faults that were already confirmed when the gateway started
+     are captured at gateway start instead and carry
+     ``"capture_origin": "startup"`` in their ``x-medkit`` block;
+     ``captured_at`` always stamps when the values were read.
    - ``rosbag``: Recording file available via bulk-data endpoint
 
    **Response codes:**

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -202,8 +202,11 @@ Configure how the gateway connects to the fault manager services and event topic
      - Zero-config freeze-frames for plugin-backed entities: when a fault from a
        plugin-owned entity confirms, snapshot the entity's current data values
        (via its plugin's DataProvider) and merge them into the fault detail's
-       ``environment_data.snapshots``. Explicit snapshot config in the fault
-       manager always wins when present. Only active when plugins are loaded.
+       ``environment_data.snapshots``. Faults already confirmed at gateway start
+       are caught up at startup; those frames read the values at start time (not
+       confirm time) and are marked ``x-medkit.capture_origin: startup``.
+       Explicit snapshot config in the fault manager always wins when present.
+       Only active when plugins are loaded.
 
 When ``fault_manager.namespace`` is set, the gateway also subscribes to the matching
 fault event topic (for example ``/robot1/fault_manager/events`` instead of the default

--- a/docs/requirements/specs/faults.rst
+++ b/docs/requirements/specs/faults.rst
@@ -56,5 +56,7 @@ Faults
    When a fault is confirmed, the system shall automatically capture diagnostic snapshots
    (freeze-frame topic data) and rosbag recordings as configured. Captured data shall be
    stored as environment data associated with the fault and accessible via the bulk-data
-   endpoints on the fault's reporting entity.
+   endpoints on the fault's reporting entity. For faults already confirmed when the
+   capturing component starts (e.g. the gateway restarts while a fault is standing), an
+   equivalent snapshot shall be captured at startup and marked with its capture origin.
 

--- a/docs/tutorials/snapshots.rst
+++ b/docs/tutorials/snapshots.rst
@@ -181,7 +181,17 @@ values (from the owning plugin's ``DataProvider``, i.e. the latest polled
 values) when the fault confirms, and merges them into the fault detail's
 ``environment_data.snapshots`` as a standard ``freeze_frame`` entry named
 after the entity - unless the fault manager already captured a freeze-frame
-for that fault (explicit config wins). Disable with:
+for that fault (explicit config wins).
+
+Faults that are already confirmed when the gateway starts are caught up at
+startup: the gateway lists the confirmed faults and captures a frame for each
+plugin-backed one, so a device standing in fault across a gateway restart
+still gets a frame. Catch-up frames carry ``"capture_origin": "startup"`` in
+their ``x-medkit`` block because their values were read at gateway start, not
+when the fault confirmed (which may be long before, since the fault manager
+persists faults); ``captured_at`` always stamps the moment the values were
+read. Frames without the marker were captured on the confirm edge. Disable
+with:
 
 .. code-block:: bash
 
@@ -265,7 +275,9 @@ Snapshots are included inline in the fault response as ``environment_data``:
 
 **Snapshot Types:**
 
-- ``freeze_frame``: Topic data captured at fault confirmation (JSON format)
+- ``freeze_frame``: Topic data captured at fault confirmation (JSON format).
+  Entity frames caught up for faults that predate the gateway are captured at
+  gateway start instead, marked ``x-medkit.capture_origin: startup``.
 - ``rosbag``: Recording file available via bulk-data endpoint (binary format)
 
 **Get snapshots from fault response using jq:**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
@@ -65,6 +65,9 @@ class EntityFreezeFrameCapture {
     std::string entity_id;
     nlohmann::json values;  ///< compact {resource_id: value} dict
     int64_t captured_at_ns{0};
+    /// True when the frame comes from the startup catch-up: captured_at_ns is
+    /// then the gateway's start, possibly long after the fault confirmed.
+    bool startup_catchup{false};
   };
 
   /// Resolves an entity id to its owning plugin's DataProvider (nullptr when
@@ -88,8 +91,10 @@ class EntityFreezeFrameCapture {
   /// Lists the faults that are already confirmed when this object starts, so
   /// their missed confirm edge can still be framed. Called once, on the capture
   /// thread (it may block on a service becoming available), never after the
-  /// destructor has joined that thread - so it must not outlive its owner.
-  using StandingFaultLister = std::function<std::vector<StandingFault>()>;
+  /// destructor has joined that thread - so it must not outlive its owner. Any
+  /// blocking wait inside must poll should_abort and bail when it turns true:
+  /// that is what lets the destructor's join interrupt the wait.
+  using StandingFaultLister = std::function<std::vector<StandingFault>(const std::function<bool()> & should_abort)>;
 
   /**
    * @param node ROS 2 node used to resolve the fault-events topic name and logger
@@ -133,6 +138,13 @@ class EntityFreezeFrameCapture {
   /// Rejects the {} / all-null rows a cold poll cache or dead link yields.
   static bool values_have_data(const nlohmann::json & values);
 
+  /// Parse a fault-transport ListFaults reply body into standing faults.
+  /// Returns nullopt when the body is not shaped like a ListFaults answer (no
+  /// "faults" array). Total over untrusted content: items that are not objects
+  /// or lack a string "fault_code" / array "reporting_sources" are skipped,
+  /// non-string source entries are dropped, nothing throws.
+  static std::optional<std::vector<StandingFault>> standing_faults_from_list_reply(const nlohmann::json & data);
+
  private:
   /// Subscription-worker side: filter for EVENT_CONFIRMED and enqueue only.
   void on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr & msg);
@@ -144,11 +156,22 @@ class EntityFreezeFrameCapture {
   /// plugins start reporting while the gateway is still wiring the capture, so
   /// a device that is in fault at boot confirms to nobody. Frames are
   /// process-local, so this restores what the missed edge would have produced
-  /// rather than duplicating anything. Runs on capture_thread_.
+  /// rather than duplicating anything. Runs on capture_thread_. Capped at
+  /// max_faults_ stored frames so the catch-up cannot FIFO-evict its own
+  /// earlier frames; fault codes with a confirm already queued are left to the
+  /// drain loop (one plugin read per confirm).
   void capture_standing_faults();
 
+  /// Bounded, abortable wait until the events subscription has a matched
+  /// publisher. Orders the standing-fault snapshot after matching: a confirm
+  /// published after the snapshot but before the reader matches would
+  /// otherwise be missed by both paths.
+  void wait_for_events_publisher(const std::function<bool()> & should_abort) const;
+
   /// Per-event capture (all plugin calls happen here, on capture_thread_).
-  void capture_for_event(const ros2_medkit_msgs::msg::FaultEvent & event);
+  /// Returns true when at least one frame was stored; startup_catchup marks
+  /// the stored frames as catch-up captures.
+  bool capture_for_event(const ros2_medkit_msgs::msg::FaultEvent & event, bool startup_catchup = false);
 
   /// Build a frame from list-data-shaped content, enforcing the shared
   /// no-row-of-nulls invariant on both capture paths.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
@@ -79,6 +79,18 @@ class EntityFreezeFrameCapture {
   /// same route - dispatched handlers must be thread-safe.
   using RouteDataFetcher = std::function<std::optional<nlohmann::json>(const std::string & entity_id)>;
 
+  /// One standing fault: its code and the entities that reported it.
+  struct StandingFault {
+    std::string fault_code;
+    std::vector<std::string> reporting_sources;
+  };
+
+  /// Lists the faults that are already confirmed when this object starts, so
+  /// their missed confirm edge can still be framed. Called once, on the capture
+  /// thread (it may block on a service becoming available), never after the
+  /// destructor has joined that thread - so it must not outlive its owner.
+  using StandingFaultLister = std::function<std::vector<StandingFault>()>;
+
   /**
    * @param node ROS 2 node used to resolve the fault-events topic name and logger
    * @param exec shared subscription executor; the fault-events subscription is
@@ -92,7 +104,7 @@ class EntityFreezeFrameCapture {
    */
   EntityFreezeFrameCapture(rclcpp::Node * node, ros2_common::Ros2SubscriptionExecutor & exec,
                            DataProviderResolver resolver, RouteDataFetcher route_fetcher = nullptr,
-                           size_t max_faults = 256);
+                           size_t max_faults = 256, StandingFaultLister standing_lister = nullptr);
 
   ~EntityFreezeFrameCapture();
 
@@ -127,6 +139,13 @@ class EntityFreezeFrameCapture {
 
   /// capture_thread_ main loop: drains queued confirm events.
   void capture_worker();
+
+  /// Frame the faults that were already confirmed when this object came up:
+  /// plugins start reporting while the gateway is still wiring the capture, so
+  /// a device that is in fault at boot confirms to nobody. Frames are
+  /// process-local, so this restores what the missed edge would have produced
+  /// rather than duplicating anything. Runs on capture_thread_.
+  void capture_standing_faults();
 
   /// Per-event capture (all plugin calls happen here, on capture_thread_).
   void capture_for_event(const ros2_medkit_msgs::msg::FaultEvent & event);
@@ -168,6 +187,9 @@ class EntityFreezeFrameCapture {
   std::deque<ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr> queue_;
   bool stop_{false};
   std::thread capture_thread_;
+
+  /// Lists faults already confirmed at construction; run once on that thread.
+  StandingFaultLister standing_lister_;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_slot.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2_common/ros2_subscription_slot.hpp
@@ -81,6 +81,11 @@ class Ros2SubscriptionSlot final {
   [[nodiscard]] const std::string & type_name() const noexcept {
     return type_name_;
   }
+  /// Publishers currently matched to this subscription (rcl graph query,
+  /// callable from any thread while the slot is alive; may throw on rcl error).
+  [[nodiscard]] size_t publisher_count() const {
+    return sub_->get_publisher_count();
+  }
 
  private:
   Ros2SubscriptionSlot(Ros2SubscriptionExecutor & exec, std::string topic, std::string type_name,

--- a/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
@@ -15,6 +15,7 @@
 #include "ros2_medkit_gateway/entity_freeze_frame_capture.hpp"
 
 #include <chrono>
+#include <thread>
 
 #include "ros2_medkit_gateway/fault_manager_paths.hpp"
 
@@ -28,6 +29,10 @@ constexpr size_t kMaxQueuedEvents = 64;
 /// fallback_logged_ bound: past this the set resets (re-arming one warn per
 /// code) instead of growing forever on churny/synthetic fault codes.
 constexpr size_t kMaxLoggedFaultCodes = 1024;
+
+/// Bound on waiting for the events subscription to match a publisher before
+/// the standing-fault snapshot; past it the catch-up proceeds best-effort.
+constexpr std::chrono::seconds kEventsMatchTimeout{10};
 
 /// Read a string field totally: json::value() throws type_error.302 when the
 /// key is present but not a string, and plugin content is untrusted.
@@ -50,6 +55,10 @@ EntityFreezeFrameCapture::EntityFreezeFrameCapture(rclcpp::Node * node, ros2_com
   // the subscription itself is created on the executor's dedicated _sub node so
   // it never races rcl's hash-map on the main node (issue #375).
   const auto fault_events_topic = build_fault_manager_events_topic(node);
+  // Volatile on purpose: a transient_local reader does not match the fault
+  // manager's volatile publisher, so upgrading the QoS here would break
+  // matching against older fault managers. The startup catch-up covers the
+  // pre-match window instead.
   auto slot = ros2_common::Ros2SubscriptionSlot::create_typed<ros2_medkit_msgs::msg::FaultEvent>(
       exec, fault_events_topic, rclcpp::QoS(100).reliable(),
       [this](std::shared_ptr<const ros2_medkit_msgs::msg::FaultEvent> msg) {
@@ -69,21 +78,23 @@ EntityFreezeFrameCapture::EntityFreezeFrameCapture(rclcpp::Node * node, ros2_com
 }
 
 EntityFreezeFrameCapture::~EntityFreezeFrameCapture() {
-  // Not a synchronous barrier: the slot posts an async destroy with a bounded
-  // deadline, so use-after-free safety also relies on the owner tearing down
-  // the subscription executor (joining its worker) before this object's node
-  // dies - keep that ordering in main.cpp / gateway_node shutdown.
-  subscription_slot_.reset();
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
     stop_ = true;
   }
   queue_cv_.notify_all();
   // Joins through any in-flight plugin call: a hung read delays shutdown
-  // rather than leaving a capture racing plugin unload.
+  // rather than leaving a capture racing plugin unload. Must precede the slot
+  // reset - the capture thread reads the slot's publisher count.
   if (capture_thread_.joinable()) {
     capture_thread_.join();
   }
+  // Not a synchronous barrier: the slot posts an async destroy with a bounded
+  // deadline, so use-after-free safety also relies on the owner tearing down
+  // the subscription executor (joining its worker) before this object's node
+  // dies - keep that ordering in main.cpp / gateway_node shutdown. Late
+  // callbacks before that teardown see stop_ and drop their event.
+  subscription_slot_.reset();
 }
 
 std::vector<EntityFreezeFrameCapture::Frame>
@@ -134,6 +145,38 @@ bool EntityFreezeFrameCapture::values_have_data(const nlohmann::json & values) {
     return false;
   }
   return !values.is_null();
+}
+
+std::optional<std::vector<EntityFreezeFrameCapture::StandingFault>>
+EntityFreezeFrameCapture::standing_faults_from_list_reply(const nlohmann::json & data) {
+  if (!data.is_object()) {
+    return std::nullopt;
+  }
+  // ListFaults answers under "faults" (see Ros2FaultServiceTransport).
+  const auto faults = data.find("faults");
+  if (faults == data.end() || !faults->is_array()) {
+    return std::nullopt;
+  }
+  std::vector<StandingFault> standing;
+  for (const auto & item : *faults) {
+    if (!item.is_object()) {
+      continue;
+    }
+    const auto code = item.find("fault_code");
+    const auto sources = item.find("reporting_sources");
+    if (code == item.end() || !code->is_string() || sources == item.end() || !sources->is_array()) {
+      continue;
+    }
+    StandingFault fault;
+    fault.fault_code = code->get<std::string>();
+    for (const auto & src : *sources) {
+      if (src.is_string()) {
+        fault.reporting_sources.push_back(src.get<std::string>());
+      }
+    }
+    standing.push_back(std::move(fault));
+  }
+  return standing;
 }
 
 std::optional<EntityFreezeFrameCapture::Frame>
@@ -210,37 +253,92 @@ void EntityFreezeFrameCapture::on_fault_event(const ros2_medkit_msgs::msg::Fault
   queue_cv_.notify_one();
 }
 
+void EntityFreezeFrameCapture::wait_for_events_publisher(const std::function<bool()> & should_abort) const {
+  if (!subscription_slot_) {
+    return;
+  }
+  const auto deadline = std::chrono::steady_clock::now() + kEventsMatchTimeout;
+  while (std::chrono::steady_clock::now() < deadline && !should_abort()) {
+    try {
+      if (subscription_slot_->publisher_count() > 0) {
+        return;
+      }
+    } catch (const std::exception &) {
+      return;  // graph query failed; proceed best-effort
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+}
+
 void EntityFreezeFrameCapture::capture_standing_faults() {
   if (!standing_lister_) {
     return;
   }
+  const auto should_abort = [this] {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    return stop_;
+  };
+  // Snapshot only after the events subscription has matched: a confirm
+  // published after the lister's snapshot but before the reader matched would
+  // be missed by both paths.
+  wait_for_events_publisher(should_abort);
+  if (should_abort()) {
+    return;
+  }
   // The lister blocks until the fault services answer, so it runs here rather
-  // than on a thread of its own: this thread is joined by the destructor, which
-  // is what keeps that wait from outliving the node it waits on.
-  const auto standing = standing_lister_();
+  // than on a thread of its own: this thread is joined by the destructor, and
+  // should_abort is what lets that join interrupt the wait.
+  std::vector<StandingFault> standing;
+  try {
+    standing = standing_lister_(should_abort);
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger_, "Entity freeze-frame startup catch-up failed: standing-fault lister threw: %s", e.what());
+    return;
+  } catch (...) {
+    RCLCPP_WARN(logger_, "Entity freeze-frame startup catch-up failed: standing-fault lister threw");
+    return;
+  }
+  // Codes with a confirm already queued belong to the drain loop: capturing
+  // them here too would read the plugin twice for one confirm.
+  std::unordered_set<std::string> queued_codes;
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    if (stop_) {
+      return;
+    }
+    for (const auto & queued : queue_) {
+      queued_codes.insert(queued->fault.fault_code);
+    }
+  }
   size_t framed = 0;
+  size_t over_cap = 0;
   for (const auto & fault : standing) {
-    {
-      std::lock_guard<std::mutex> lock(queue_mutex_);
-      if (stop_) {
-        return;
-      }
+    if (should_abort()) {
+      return;
     }
     if (fault.fault_code.empty() || fault.reporting_sources.empty()) {
       continue;
     }
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (frames_.count(fault.fault_code) != 0) {
-        continue;  // the live event beat us to it
-      }
+    if (queued_codes.count(fault.fault_code) != 0) {
+      continue;
+    }
+    if (framed >= max_faults_) {
+      ++over_cap;  // storing more would FIFO-evict this catch-up's own frames
+      continue;
     }
     ros2_medkit_msgs::msg::FaultEvent event;
     event.event_type = ros2_medkit_msgs::msg::FaultEvent::EVENT_CONFIRMED;
     event.fault.fault_code = fault.fault_code;
     event.fault.reporting_sources = fault.reporting_sources;
-    capture_for_event(event);
-    ++framed;
+    if (capture_for_event(event, /*startup_catchup=*/true)) {
+      ++framed;
+    }
+  }
+  if (over_cap > 0) {
+    RCLCPP_WARN(logger_,
+                "Entity freeze-frame startup catch-up truncated: %zu standing fault(s) beyond the retained-frame "
+                "bound of %zu",
+                over_cap, max_faults_);
   }
   if (framed > 0) {
     RCLCPP_INFO(logger_, "Entity freeze-frame: captured %zu fault(s) that were already confirmed at startup", framed);
@@ -268,7 +366,8 @@ void EntityFreezeFrameCapture::capture_worker() {
   }
 }
 
-void EntityFreezeFrameCapture::capture_for_event(const ros2_medkit_msgs::msg::FaultEvent & event) {
+bool EntityFreezeFrameCapture::capture_for_event(const ros2_medkit_msgs::msg::FaultEvent & event,
+                                                 bool startup_catchup) {
   const std::string & fault_code = event.fault.fault_code;
 
   std::vector<Frame> frames;
@@ -304,7 +403,12 @@ void EntityFreezeFrameCapture::capture_for_event(const ros2_medkit_msgs::msg::Fa
   }
 
   if (frames.empty()) {
-    return;
+    return false;
+  }
+  if (startup_catchup) {
+    for (auto & frame : frames) {
+      frame.startup_catchup = true;
+    }
   }
 
   std::lock_guard<std::mutex> lock(mutex_);
@@ -318,6 +422,7 @@ void EntityFreezeFrameCapture::capture_for_event(const ros2_medkit_msgs::msg::Fa
   frames_[fault_code] = std::move(frames);
 
   RCLCPP_DEBUG(logger_, "Captured entity freeze-frame(s) for fault '%s'", fault_code.c_str());
+  return true;
 }
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
@@ -40,11 +40,12 @@ std::string string_field(const nlohmann::json & item, const char * field) {
 
 EntityFreezeFrameCapture::EntityFreezeFrameCapture(rclcpp::Node * node, ros2_common::Ros2SubscriptionExecutor & exec,
                                                    DataProviderResolver resolver, RouteDataFetcher route_fetcher,
-                                                   size_t max_faults)
+                                                   size_t max_faults, StandingFaultLister standing_lister)
   : resolver_(std::move(resolver))
   , route_fetcher_(std::move(route_fetcher))
   , logger_(node->get_logger())
-  , max_faults_(max_faults > 0 ? max_faults : 1) {
+  , max_faults_(max_faults > 0 ? max_faults : 1)
+  , standing_lister_(std::move(standing_lister)) {
   // Resolve the topic from the gateway node (it owns fault_manager.namespace);
   // the subscription itself is created on the executor's dedicated _sub node so
   // it never races rcl's hash-map on the main node (issue #375).
@@ -209,7 +210,45 @@ void EntityFreezeFrameCapture::on_fault_event(const ros2_medkit_msgs::msg::Fault
   queue_cv_.notify_one();
 }
 
+void EntityFreezeFrameCapture::capture_standing_faults() {
+  if (!standing_lister_) {
+    return;
+  }
+  // The lister blocks until the fault services answer, so it runs here rather
+  // than on a thread of its own: this thread is joined by the destructor, which
+  // is what keeps that wait from outliving the node it waits on.
+  const auto standing = standing_lister_();
+  size_t framed = 0;
+  for (const auto & fault : standing) {
+    {
+      std::lock_guard<std::mutex> lock(queue_mutex_);
+      if (stop_) {
+        return;
+      }
+    }
+    if (fault.fault_code.empty() || fault.reporting_sources.empty()) {
+      continue;
+    }
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (frames_.count(fault.fault_code) != 0) {
+        continue;  // the live event beat us to it
+      }
+    }
+    ros2_medkit_msgs::msg::FaultEvent event;
+    event.event_type = ros2_medkit_msgs::msg::FaultEvent::EVENT_CONFIRMED;
+    event.fault.fault_code = fault.fault_code;
+    event.fault.reporting_sources = fault.reporting_sources;
+    capture_for_event(event);
+    ++framed;
+  }
+  if (framed > 0) {
+    RCLCPP_INFO(logger_, "Entity freeze-frame: captured %zu fault(s) that were already confirmed at startup", framed);
+  }
+}
+
 void EntityFreezeFrameCapture::capture_worker() {
+  capture_standing_faults();
   for (;;) {
     ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr event;
     {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1821,41 +1821,47 @@ void GatewayNode::init_entity_freeze_frame_capture(ros2_common::Ros2Subscription
       // Plugins start polling - and reporting - while this object is still
       // being wired, and a device that is in fault when the box boots confirms
       // immediately, to nobody. The capture asks for those on its own thread,
-      // which it joins on destruction, so the service wait cannot outlive the
-      // node it waits on.
-      [this]() {
+      // which it joins on destruction; should_abort lets that join interrupt
+      // the service wait.
+      [this](const std::function<bool()> & should_abort) {
         std::vector<EntityFreezeFrameCapture::StandingFault> standing;
-        if (!fault_service_transport_ || !fault_service_transport_->wait_for_services(std::chrono::seconds(10))) {
+        if (!fault_service_transport_) {
+          RCLCPP_WARN(get_logger(), "Standing-fault freeze-frame catch-up skipped: fault transport not initialised");
+          return standing;
+        }
+        // One deadline for the whole wait, polled in slices so shutdown can
+        // abort it (wait_for_services itself shares the slice across clients).
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        bool ready = false;
+        while (!ready && !should_abort()) {
+          const std::chrono::duration<double> remaining = deadline - std::chrono::steady_clock::now();
+          if (remaining <= std::chrono::duration<double>::zero()) {
+            break;
+          }
+          ready = fault_service_transport_->wait_for_services(std::min(std::chrono::duration<double>(0.5), remaining));
+        }
+        if (!ready) {
+          if (!should_abort()) {
+            RCLCPP_WARN(get_logger(),
+                        "Standing-fault freeze-frame catch-up skipped: fault services not available within 10s");
+          }
           return standing;
         }
         auto result = fault_service_transport_->list_faults("", false, true, false, false, false, false);
-        if (!result.success || !result.data.is_object()) {
+        if (!result.success) {
+          RCLCPP_WARN(get_logger(), "Standing-fault freeze-frame catch-up skipped: ListFaults failed: %s",
+                      result.error_message.c_str());
           return standing;
         }
-        // ListFaults answers under "faults" (see Ros2FaultServiceTransport).
-        const auto faults = result.data.find("faults");
-        if (faults == result.data.end() || !faults->is_array()) {
+        auto parsed = EntityFreezeFrameCapture::standing_faults_from_list_reply(result.data);
+        if (!parsed) {
+          RCLCPP_WARN(get_logger(), "Standing-fault freeze-frame catch-up skipped: malformed ListFaults reply");
           return standing;
         }
-        for (const auto & item : *faults) {
-          if (!item.is_object()) {
-            continue;
-          }
-          const auto code = item.find("fault_code");
-          const auto sources = item.find("reporting_sources");
-          if (code == item.end() || !code->is_string() || sources == item.end() || !sources->is_array()) {
-            continue;
-          }
-          EntityFreezeFrameCapture::StandingFault fault;
-          fault.fault_code = code->get<std::string>();
-          for (const auto & src : *sources) {
-            if (src.is_string()) {
-              fault.reporting_sources.push_back(src.get<std::string>());
-            }
-          }
-          standing.push_back(std::move(fault));
+        if (parsed->empty()) {
+          RCLCPP_INFO(get_logger(), "Standing-fault freeze-frame catch-up: no confirmed faults at startup");
         }
-        return standing;
+        return std::move(*parsed);
       });
 }
 

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1816,6 +1816,46 @@ void GatewayNode::init_entity_freeze_frame_capture(ros2_common::Ros2Subscription
       // as the capture fallback.
       [this](const std::string & entity_id) -> std::optional<nlohmann::json> {
         return plugin_mgr_ ? plugin_mgr_->fetch_entity_data_via_route(entity_id) : std::nullopt;
+      },
+      256,  // retained-frame bound (constructor default)
+      // Plugins start polling - and reporting - while this object is still
+      // being wired, and a device that is in fault when the box boots confirms
+      // immediately, to nobody. The capture asks for those on its own thread,
+      // which it joins on destruction, so the service wait cannot outlive the
+      // node it waits on.
+      [this]() {
+        std::vector<EntityFreezeFrameCapture::StandingFault> standing;
+        if (!fault_service_transport_ || !fault_service_transport_->wait_for_services(std::chrono::seconds(10))) {
+          return standing;
+        }
+        auto result = fault_service_transport_->list_faults("", false, true, false, false, false, false);
+        if (!result.success || !result.data.is_object()) {
+          return standing;
+        }
+        // ListFaults answers under "faults" (see Ros2FaultServiceTransport).
+        const auto faults = result.data.find("faults");
+        if (faults == result.data.end() || !faults->is_array()) {
+          return standing;
+        }
+        for (const auto & item : *faults) {
+          if (!item.is_object()) {
+            continue;
+          }
+          const auto code = item.find("fault_code");
+          const auto sources = item.find("reporting_sources");
+          if (code == item.end() || !code->is_string() || sources == item.end() || !sources->is_array()) {
+            continue;
+          }
+          EntityFreezeFrameCapture::StandingFault fault;
+          fault.fault_code = code->get<std::string>();
+          for (const auto & src : *sources) {
+            if (src.is_string()) {
+              fault.reporting_sources.push_back(src.get<std::string>());
+            }
+          }
+          standing.push_back(std::move(fault));
+        }
+        return standing;
       });
 }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -247,6 +247,11 @@ json FaultHandlers::merge_entity_freeze_frames(json env_data,
     snap["topic"] = "";  // entity data values, not a ROS topic
     snap["message_type"] = "";
     snap["captured_at_ns"] = frame.captured_at_ns;
+    if (frame.startup_catchup) {
+      // Values were read at gateway start, not when the fault confirmed;
+      // absent marker = captured on the confirm edge.
+      snap["capture_origin"] = "startup";
+    }
     env_data["snapshots"].push_back(std::move(snap));
   }
   return env_data;
@@ -309,6 +314,9 @@ dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_jso
         } catch (const json::exception & e) {
           snap["data"] = raw_data;
           snap["x-medkit"] = {{"topic", topic}, {"message_type", message_type}, {"parse_error", e.what()}};
+        }
+        if (s.contains("capture_origin") && s["capture_origin"].is_string()) {
+          snap["x-medkit"]["capture_origin"] = s["capture_origin"];
         }
       } else if (snapshot_type == "rosbag") {
         // Build absolute URI using entity path + fault_code as the bulk-data ID.

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -128,8 +128,18 @@ Ros2FaultServiceTransport::~Ros2FaultServiceTransport() {
 }
 
 bool Ros2FaultServiceTransport::wait_for_services(std::chrono::duration<double> timeout) {
-  return report_fault_client_->wait_for_service(timeout) && get_fault_client_->wait_for_service(timeout) &&
-         list_faults_client_->wait_for_service(timeout) && clear_fault_client_->wait_for_service(timeout);
+  // One deadline shared by all four waits: per-client timeouts would stack to
+  // 4x on an absent fault manager. Clamped to 0 (= non-blocking check) because
+  // a negative rclcpp timeout means wait forever.
+  const auto clamped = std::chrono::duration<double>(std::max(timeout.count(), 0.0));
+  const auto deadline =
+      std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::steady_clock::duration>(clamped);
+  const auto remaining = [deadline] {
+    return std::max(std::chrono::duration<double>(deadline - std::chrono::steady_clock::now()),
+                    std::chrono::duration<double>::zero());
+  };
+  return report_fault_client_->wait_for_service(remaining()) && get_fault_client_->wait_for_service(remaining()) &&
+         list_faults_client_->wait_for_service(remaining()) && clear_fault_client_->wait_for_service(remaining());
 }
 
 bool Ros2FaultServiceTransport::is_available() const {

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -17,10 +17,12 @@
 #include <atomic>
 #include <chrono>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <rclcpp/rclcpp.hpp>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -212,6 +214,7 @@ TEST_F(EntityFreezeFrameCaptureTest, ConfirmedPluginFaultCapturesEntityValues) {
   EXPECT_DOUBLE_EQ(frames[0].values.value("temperature", 0.0), 42.5);
   EXPECT_DOUBLE_EQ(frames[0].values.value("pressure", 0.0), 3.2);
   EXPECT_GT(frames[0].captured_at_ns, 0);
+  EXPECT_FALSE(frames[0].startup_catchup);  // live confirm edge, not catch-up
 }
 
 /// @verifies REQ_INTEROP_088
@@ -259,12 +262,12 @@ TEST_F(EntityFreezeFrameCaptureTest, StandingFaultsAreFramedWithoutAnyEvent) {
         return json{{"connected", true}, {"items", json::array({{{"name", "level"}, {"value", 7.0}}})}};
       },
       256,
-      []() -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+      [](const std::function<bool()> &) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
         return {{"PLC_STANDING", {"route_plc_app"}}};
       });
 
   // No publish at all - the frame must appear from the catch-up alone.
-  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  const auto deadline = std::chrono::steady_clock::now() + 15s;
   while (capture.frames_for("PLC_STANDING").empty() && std::chrono::steady_clock::now() < deadline) {
     std::this_thread::sleep_for(20ms);
   }
@@ -272,14 +275,15 @@ TEST_F(EntityFreezeFrameCaptureTest, StandingFaultsAreFramedWithoutAnyEvent) {
   ASSERT_EQ(frames.size(), 1u);
   EXPECT_EQ(frames[0].entity_id, "route_plc_app");
   EXPECT_DOUBLE_EQ(frames[0].values.value("level", 0.0), 7.0);
+  EXPECT_TRUE(frames[0].startup_catchup);  // consumers can tell catch-up frames apart
 }
 
 /// @verifies REQ_INTEROP_088
-TEST_F(EntityFreezeFrameCaptureTest, LiveConfirmFrameWinsOverStandingCatchUp) {
-  // Both paths carry the same fault code. The catch-up runs first, on the
-  // capture thread, and the confirm that arrived meanwhile is drained by the
-  // same thread afterwards - so the live frame is the one that survives.
-  // Distinct entity ids make the winner unambiguous.
+TEST_F(EntityFreezeFrameCaptureTest, QueuedLiveConfirmDedupesStandingCatchUp) {
+  // Both paths carry the same fault code and the confirm is already queued
+  // when the catch-up snapshots the queue: the catch-up must skip that code
+  // entirely (one plugin read per confirm, no double capture) and the drain
+  // loop's live frame is the one that lands.
   std::atomic<bool> published{false};
   std::atomic<bool> standing_sampled{false};
   EntityFreezeFrameCapture capture(
@@ -300,14 +304,14 @@ TEST_F(EntityFreezeFrameCaptureTest, LiveConfirmFrameWinsOverStandingCatchUp) {
         return json{{"connected", true}, {"items", json::array({{{"name", "level"}, {"value", level}}})}};
       },
       256,
-      [&published]() -> std::vector<EntityFreezeFrameCapture::StandingFault> {
-        // Hold the catch-up until the live confirm is in flight so the two
-        // genuinely overlap instead of running far apart.
+      [&published](const std::function<bool()> &) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        // Hold the catch-up until the live confirm has reached the queue so
+        // the standing entry and the queued event genuinely overlap.
         const auto deadline = std::chrono::steady_clock::now() + 5s;
         while (!published.load() && std::chrono::steady_clock::now() < deadline) {
           std::this_thread::sleep_for(10ms);
         }
-        std::this_thread::sleep_for(200ms);  // let the event reach the queue
+        std::this_thread::sleep_for(500ms);  // let the event reach the queue
         return {{"PLC_BOTH_PATHS", {"route_standing_app"}}};
       });
 
@@ -320,26 +324,142 @@ TEST_F(EntityFreezeFrameCaptureTest, LiveConfirmFrameWinsOverStandingCatchUp) {
   std::vector<EntityFreezeFrameCapture::Frame> frames;
   while (std::chrono::steady_clock::now() < deadline) {
     frames = capture.frames_for("PLC_BOTH_PATHS");
-    if (!frames.empty() && frames[0].entity_id == "route_live_app") {
+    if (!frames.empty()) {
       break;
     }
-    publisher_->publish(live);
     std::this_thread::sleep_for(20ms);
   }
 
-  // The catch-up precedes the drain loop, so it has necessarily sampled by the
-  // time the live frame lands.
-  EXPECT_TRUE(standing_sampled.load());
+  // The queued confirm dedupes the catch-up: the standing entity was never
+  // sampled and the only frame is the live one.
+  EXPECT_FALSE(standing_sampled.load());
   ASSERT_EQ(frames.size(), 1u);
   EXPECT_EQ(frames[0].entity_id, "route_live_app");
   EXPECT_DOUBLE_EQ(frames[0].values.value("level", 0.0), 99.0);
+  EXPECT_FALSE(frames[0].startup_catchup);
+}
 
-  // ...and nothing may overwrite it afterwards either.
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, ThrowingListerDoesNotKillCaptureThread) {
+  // The lister runs on the capture thread's entry path: an escaping exception
+  // there is std::terminate. It must be swallowed, and the drain loop must
+  // still capture live confirms afterwards.
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [this](const std::string & entity_id) -> DataProvider * {
+        return entity_id == "plc_app" ? provider_.get() : nullptr;
+      },
+      nullptr, 256,
+      [](const std::function<bool()> &) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        throw std::runtime_error("fault services exploded");
+      });
+
+  ASSERT_TRUE(publish_and_wait(capture, make_confirmed_event("PLC_AFTER_THROW", {"plc_app"})));
+  EXPECT_FALSE(capture.frames_for("PLC_AFTER_THROW").empty());
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, DestructionAbortsBlockedLister) {
+  // A lister stuck waiting for the fault services must not hold the
+  // destructor's join for its full timeout: should_abort turns true on stop.
+  std::atomic<bool> entered{false};
+  std::atomic<bool> abort_seen{false};
+  auto capture = std::make_unique<EntityFreezeFrameCapture>(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      nullptr, 256,
+      [&](const std::function<bool()> & should_abort) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        entered.store(true);
+        while (!should_abort()) {  // stands in for the bounded service wait
+          std::this_thread::sleep_for(10ms);
+        }
+        abort_seen.store(true);
+        return {};
+      });
+
+  const auto entry_deadline = std::chrono::steady_clock::now() + 15s;
+  while (!entered.load() && std::chrono::steady_clock::now() < entry_deadline) {
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_TRUE(entered.load());
+
+  const auto start = std::chrono::steady_clock::now();
+  capture.reset();
+  EXPECT_TRUE(abort_seen.load());
+  EXPECT_LT(std::chrono::steady_clock::now() - start, 5s);
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, ListerRunsOnlyAfterEventsPublisherMatched) {
+  // ~/events is reliable but volatile on both ends: a confirm published after
+  // the standing snapshot but before the reader matches would be missed by
+  // both paths. The catch-up must therefore wait for a matched publisher
+  // before calling the lister.
+  publisher_.reset();                  // no events publisher exists yet
+  std::this_thread::sleep_for(250ms);  // let the graph forget it
+  std::atomic<bool> publisher_created{false};
+  std::atomic<bool> lister_ran{false};
+  std::atomic<bool> saw_publisher{false};
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      nullptr, 256,
+      [&](const std::function<bool()> &) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        saw_publisher.store(publisher_created.load());
+        lister_ran.store(true);
+        return {};
+      });
+
+  // Ample time for an unordered catch-up to have run before any publisher.
   std::this_thread::sleep_for(500ms);
-  const auto settled = capture.frames_for("PLC_BOTH_PATHS");
-  ASSERT_EQ(settled.size(), 1u);
-  EXPECT_EQ(settled[0].entity_id, "route_live_app");
-  EXPECT_DOUBLE_EQ(settled[0].values.value("level", 0.0), 99.0);
+  publisher_created.store(true);
+  publisher_ = publisher_node_->create_publisher<FaultEvent>("/fault_manager/events", rclcpp::QoS(100).reliable());
+
+  const auto deadline = std::chrono::steady_clock::now() + 15s;
+  while (!lister_ran.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(10ms);
+  }
+  ASSERT_TRUE(lister_ran.load());
+  EXPECT_TRUE(saw_publisher.load());
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, CatchUpCapsStoredFramesAtMaxFaults) {
+  // max_faults = 2. The no-data fault must not consume the cap (nothing was
+  // stored for it), and the fault past the cap must be skipped instead of
+  // FIFO-evicting the catch-up's own earliest frame.
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      [](const std::string & entity_id) -> std::optional<json> {
+        if (entity_id == "route_no_data_app") {
+          return json{{"connected", false}};  // dead row: no frame stored
+        }
+        return json{{"connected", true}, {"items", json::array({{{"name", "level"}, {"value", 7.0}}})}};
+      },
+      /*max_faults=*/2,
+      [](const std::function<bool()> &) -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        return {{"PLC_CAP_NO_DATA", {"route_no_data_app"}},
+                {"PLC_CAP_A", {"route_a"}},
+                {"PLC_CAP_B", {"route_b"}},
+                {"PLC_CAP_C", {"route_c"}}};
+      });
+
+  const auto deadline = std::chrono::steady_clock::now() + 15s;
+  while (capture.frames_for("PLC_CAP_B").empty() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(20ms);
+  }
+  std::this_thread::sleep_for(300ms);  // would be enough for an uncapped C capture
+  EXPECT_TRUE(capture.frames_for("PLC_CAP_NO_DATA").empty());
+  EXPECT_FALSE(capture.frames_for("PLC_CAP_A").empty());  // not evicted by C
+  EXPECT_FALSE(capture.frames_for("PLC_CAP_B").empty());
+  EXPECT_TRUE(capture.frames_for("PLC_CAP_C").empty());  // past the cap
 }
 
 /// @verifies REQ_INTEROP_088
@@ -545,6 +665,46 @@ TEST(ValuesFromListContent, NonStringIdOrNameNeverThrows) {
   EXPECT_EQ(values, json({{"b", 2}}));
 }
 
+TEST(StandingFaultsFromListReply, ParsesWellFormedReply) {
+  const json data = {{"faults", json::array({json{{"fault_code", "F1"}, {"reporting_sources", json::array({"a", "b"})}},
+                                             json{{"fault_code", "F2"}, {"reporting_sources", json::array()}}})},
+                     {"count", 2}};
+  const auto standing = EntityFreezeFrameCapture::standing_faults_from_list_reply(data);
+  ASSERT_TRUE(standing.has_value());
+  ASSERT_EQ(standing->size(), 2u);
+  EXPECT_EQ((*standing)[0].fault_code, "F1");
+  EXPECT_EQ((*standing)[0].reporting_sources, (std::vector<std::string>{"a", "b"}));
+  EXPECT_EQ((*standing)[1].fault_code, "F2");
+  EXPECT_TRUE((*standing)[1].reporting_sources.empty());
+}
+
+TEST(StandingFaultsFromListReply, RepliesNotShapedLikeListFaultsYieldNullopt) {
+  // nullopt (vs empty vector) is what lets the caller warn on a malformed or
+  // renamed reply instead of silently disabling the catch-up.
+  using Capture = EntityFreezeFrameCapture;
+  EXPECT_FALSE(Capture::standing_faults_from_list_reply(json::array()).has_value());
+  EXPECT_FALSE(Capture::standing_faults_from_list_reply(json(3)).has_value());
+  EXPECT_FALSE(Capture::standing_faults_from_list_reply(json(nullptr)).has_value());
+  EXPECT_FALSE(Capture::standing_faults_from_list_reply(json::object()).has_value());  // no "faults" key
+  EXPECT_FALSE(Capture::standing_faults_from_list_reply(json{{"faults", "nope"}}).has_value());
+}
+
+TEST(StandingFaultsFromListReply, MalformedItemsAreSkippedNeverThrownOn) {
+  const json data = {
+      {"faults",
+       json::array({"not_an_object", json{{"reporting_sources", json::array({"a"})}},     // missing fault_code
+                    json{{"fault_code", 42}, {"reporting_sources", json::array({"a"})}},  // non-string fault_code
+                    json{{"fault_code", "NO_SOURCES"}},                                   // missing sources
+                    json{{"fault_code", "BAD_SOURCES"}, {"reporting_sources", "x"}},      // non-array sources
+                    json{{"fault_code", "MIXED"}, {"reporting_sources", json::array({"ok", 7, true, "also_ok"})}}})}};
+  std::optional<std::vector<EntityFreezeFrameCapture::StandingFault>> standing;
+  ASSERT_NO_THROW(standing = EntityFreezeFrameCapture::standing_faults_from_list_reply(data));
+  ASSERT_TRUE(standing.has_value());
+  ASSERT_EQ(standing->size(), 1u);
+  EXPECT_EQ((*standing)[0].fault_code, "MIXED");
+  EXPECT_EQ((*standing)[0].reporting_sources, (std::vector<std::string>{"ok", "also_ok"}));
+}
+
 TEST(MergeEntityFreezeFrames, AppendsWhenNoConfiguredFreezeFrame) {
   json env_data = {{"snapshots", json::array()}};
   EntityFreezeFrameCapture::Frame frame;
@@ -559,6 +719,20 @@ TEST(MergeEntityFreezeFrames, AppendsWhenNoConfiguredFreezeFrame) {
   EXPECT_EQ(snap["name"], "plc_app");
   EXPECT_EQ(json::parse(snap["data"].get<std::string>())["temperature"], 42.5);
   EXPECT_EQ(snap["captured_at_ns"], 1234);
+  EXPECT_FALSE(snap.contains("capture_origin"));  // confirm-edge frames carry no marker
+}
+
+TEST(MergeEntityFreezeFrames, StartupCatchUpFrameCarriesCaptureOrigin) {
+  json env_data = {{"snapshots", json::array()}};
+  EntityFreezeFrameCapture::Frame frame;
+  frame.entity_id = "plc_app";
+  frame.values = {{"temperature", 42.5}};
+  frame.captured_at_ns = 1234;
+  frame.startup_catchup = true;
+
+  auto merged = FaultHandlers::merge_entity_freeze_frames(env_data, {frame});
+  ASSERT_EQ(merged["snapshots"].size(), 1u);
+  EXPECT_EQ(merged["snapshots"][0]["capture_origin"], "startup");
 }
 
 TEST(MergeEntityFreezeFrames, ExplicitConfigWins) {

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -247,6 +247,102 @@ TEST_F(EntityFreezeFrameCaptureTest, NonConfirmedEventsAreIgnored) {
 }
 
 /// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, StandingFaultsAreFramedWithoutAnyEvent) {
+  // The startup case: the fault confirmed before this object subscribed, so no
+  // event will ever arrive for it. The lister supplies it instead.
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      [](const std::string &) -> std::optional<json> {
+        return json{{"connected", true}, {"items", json::array({{{"name", "level"}, {"value", 7.0}}})}};
+      },
+      256,
+      []() -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        return {{"PLC_STANDING", {"route_plc_app"}}};
+      });
+
+  // No publish at all - the frame must appear from the catch-up alone.
+  const auto deadline = std::chrono::steady_clock::now() + 5s;
+  while (capture.frames_for("PLC_STANDING").empty() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(20ms);
+  }
+  const auto frames = capture.frames_for("PLC_STANDING");
+  ASSERT_EQ(frames.size(), 1u);
+  EXPECT_EQ(frames[0].entity_id, "route_plc_app");
+  EXPECT_DOUBLE_EQ(frames[0].values.value("level", 0.0), 7.0);
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, LiveConfirmFrameWinsOverStandingCatchUp) {
+  // Both paths carry the same fault code. The catch-up runs first, on the
+  // capture thread, and the confirm that arrived meanwhile is drained by the
+  // same thread afterwards - so the live frame is the one that survives.
+  // Distinct entity ids make the winner unambiguous.
+  std::atomic<bool> published{false};
+  std::atomic<bool> standing_sampled{false};
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      [&standing_sampled](const std::string & entity_id) -> std::optional<json> {
+        double level = 0.0;
+        if (entity_id == "route_live_app") {
+          level = 99.0;
+        } else if (entity_id == "route_standing_app") {
+          level = 1.0;
+          standing_sampled.store(true);
+        } else {
+          return std::nullopt;
+        }
+        return json{{"connected", true}, {"items", json::array({{{"name", "level"}, {"value", level}}})}};
+      },
+      256,
+      [&published]() -> std::vector<EntityFreezeFrameCapture::StandingFault> {
+        // Hold the catch-up until the live confirm is in flight so the two
+        // genuinely overlap instead of running far apart.
+        const auto deadline = std::chrono::steady_clock::now() + 5s;
+        while (!published.load() && std::chrono::steady_clock::now() < deadline) {
+          std::this_thread::sleep_for(10ms);
+        }
+        std::this_thread::sleep_for(200ms);  // let the event reach the queue
+        return {{"PLC_BOTH_PATHS", {"route_standing_app"}}};
+      });
+
+  ASSERT_TRUE(wait_for_match());
+  const auto live = make_confirmed_event("PLC_BOTH_PATHS", {"route_live_app"});
+  publisher_->publish(live);
+  published.store(true);
+
+  const auto deadline = std::chrono::steady_clock::now() + 10s;
+  std::vector<EntityFreezeFrameCapture::Frame> frames;
+  while (std::chrono::steady_clock::now() < deadline) {
+    frames = capture.frames_for("PLC_BOTH_PATHS");
+    if (!frames.empty() && frames[0].entity_id == "route_live_app") {
+      break;
+    }
+    publisher_->publish(live);
+    std::this_thread::sleep_for(20ms);
+  }
+
+  // The catch-up precedes the drain loop, so it has necessarily sampled by the
+  // time the live frame lands.
+  EXPECT_TRUE(standing_sampled.load());
+  ASSERT_EQ(frames.size(), 1u);
+  EXPECT_EQ(frames[0].entity_id, "route_live_app");
+  EXPECT_DOUBLE_EQ(frames[0].values.value("level", 0.0), 99.0);
+
+  // ...and nothing may overwrite it afterwards either.
+  std::this_thread::sleep_for(500ms);
+  const auto settled = capture.frames_for("PLC_BOTH_PATHS");
+  ASSERT_EQ(settled.size(), 1u);
+  EXPECT_EQ(settled[0].entity_id, "route_live_app");
+  EXPECT_DOUBLE_EQ(settled[0].values.value("level", 0.0), 99.0);
+}
+
+/// @verifies REQ_INTEROP_088
 TEST_F(EntityFreezeFrameCaptureTest, FramesRetainedAcrossClearAndOverwrittenOnReconfirm) {
   EntityFreezeFrameCapture capture(node_.get(), *sub_exec_, [this](const std::string & entity_id) -> DataProvider * {
     return entity_id == "plc_app" ? provider_.get() : nullptr;

--- a/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
@@ -115,6 +115,31 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseWithFreezeFrame) {
   EXPECT_DOUBLE_EQ(snap["data"].get<double>(), 85.5);  // Primary value extracted
   EXPECT_EQ(snap["x-medkit"]["topic"], "/motor/temperature");
   EXPECT_EQ(snap["x-medkit"]["message_type"], "sensor_msgs/msg/Temperature");
+  EXPECT_FALSE(snap["x-medkit"].contains("capture_origin"));  // confirm-edge capture
+}
+
+// @verifies REQ_INTEROP_088
+TEST_F(FaultHandlersTest, BuildSovdFaultResponsePropagatesCaptureOrigin) {
+  // Startup catch-up frames (entity freeze-frames taken for faults that were
+  // already confirmed at gateway start) carry capture_origin through to the
+  // wire x-medkit block, so consumers can tell them from confirm-time frames.
+  ros2_medkit_msgs::msg::Fault fault;
+  fault.fault_code = "STANDING_FAULT";
+
+  json env_data = {{"snapshots", json::array({{{"type", "freeze_frame"},
+                                               {"snapshot_type", "freeze_frame"},
+                                               {"name", "plc_app"},
+                                               {"data", R"({"level": 7.0})"},
+                                               {"topic", ""},
+                                               {"message_type", ""},
+                                               {"captured_at_ns", 1234},
+                                               {"capture_origin", "startup"}}})}};
+
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_data, "/apps/plc_app"));
+
+  auto & snap = response["environment_data"]["snapshots"][0];
+  EXPECT_EQ(snap["type"], "freeze_frame");
+  EXPECT_EQ(snap["x-medkit"]["capture_origin"], "startup");
 }
 
 // Conversion layer must emit an explicit "snapshot_type" discriminator so

--- a/src/ros2_medkit_integration_tests/test/features/standing_fault_seeder.py
+++ b/src/ros2_medkit_integration_tests/test/features/standing_fault_seeder.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Seed a confirmed fault into the fault manager, then exit.
+
+Companion process for test_standing_fault_freeze_frame.test.py: it runs
+before the gateway is launched, reports a fault under a plugin entity id and
+exits 0 only once ListFaults shows the fault CONFIRMED. The launch file
+starts the gateway on this process's exit, so the gateway provably comes up
+with the fault already standing.
+"""
+
+import sys
+import time
+
+import rclpy
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ListFaults, ReportFault
+
+FAULT_CODE = 'PLC_STANDING_AT_BOOT'
+SOURCE_ID = 'test_plc_app'
+
+
+def main():
+    rclpy.init()
+    node = Node('standing_fault_seeder')
+    report = node.create_client(ReportFault, '/fault_manager/report_fault')
+    lister = node.create_client(ListFaults, '/fault_manager/list_faults')
+    if not report.wait_for_service(timeout_sec=30.0):
+        print('report_fault service not available', file=sys.stderr)
+        return 1
+    if not lister.wait_for_service(timeout_sec=30.0):
+        print('list_faults service not available', file=sys.stderr)
+        return 1
+
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        req = ReportFault.Request()
+        req.fault_code = FAULT_CODE
+        req.event_type = ReportFault.Request.EVENT_FAILED
+        req.severity = Fault.SEVERITY_ERROR
+        req.description = 'standing fault seeded before gateway start'
+        req.source_id = SOURCE_ID
+        future = report.call_async(req)
+        rclpy.spin_until_future_complete(node, future, timeout_sec=5.0)
+
+        list_req = ListFaults.Request()
+        list_req.statuses = [Fault.STATUS_CONFIRMED]
+        list_future = lister.call_async(list_req)
+        rclpy.spin_until_future_complete(node, list_future, timeout_sec=5.0)
+        response = list_future.result()
+        if response is not None and any(
+                f.fault_code == FAULT_CODE for f in response.faults):
+            print(f'{FAULT_CODE} confirmed; gateway may start now')
+            node.destroy_node()
+            rclpy.shutdown()
+            return 0
+        time.sleep(0.5)
+
+    print(f'{FAULT_CODE} never reached CONFIRMED', file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2_medkit_integration_tests/test/features/test_standing_fault_freeze_frame.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_standing_fault_freeze_frame.test.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Startup catch-up for zero-config entity freeze-frames.
+
+The fault manager is started first and a fault is confirmed under the demo
+data-provider plugin's app id BEFORE the gateway launches (the seeder process
+exits only once ListFaults shows the fault CONFIRMED, and the gateway is
+launched on that exit). The gateway therefore never sees the confirm event -
+its freeze-frame path must recover the standing fault via the startup
+catch-up, which lists confirmed faults at init and snapshots the entity's
+current values. The frame is marked ``capture_origin: startup`` because the
+values are read at gateway start, not at confirm time.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, RegisterEventHandler, TimerAction
+from launch.event_handlers import OnProcessExit
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+PLUGIN_APP = 'test_plc_app'
+FAULT_CODE = 'PLC_STANDING_AT_BOOT'
+
+
+def _get_plugin_path(so_name):
+    """Get path to a demo plugin .so."""
+    pkg_prefix = get_package_prefix('ros2_medkit_gateway')
+    return os.path.join(pkg_prefix, 'lib', 'ros2_medkit_gateway', so_name)
+
+
+def generate_test_description():
+    fault_manager = create_fault_manager_node(
+        extra_params={
+            # [''] is the launch-file spelling of "no default topics"
+            # (dropped by the node); the gateway's entity catch-up is the
+            # only path that can produce a freeze-frame here.
+            'snapshots.default_topics': [''],
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+    seeder = ExecuteProcess(
+        cmd=[
+            sys.executable,
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                'standing_fault_seeder.py',
+            ),
+        ],
+        name='standing_fault_seeder',
+        output='screen',
+    )
+
+    gateway = create_gateway_node(
+        extra_params={
+            'plugins': ['test_data_provider'],
+            'plugins.test_data_provider.path':
+                _get_plugin_path('libtest_data_provider_plugin.so'),
+        },
+    )
+
+    return (
+        LaunchDescription([
+            fault_manager,
+            TimerAction(period=1.0, actions=[seeder]),
+            # The gateway starts only after the fault stands CONFIRMED, so
+            # the confirm event is guaranteed to predate its subscription.
+            RegisterEventHandler(
+                OnProcessExit(target_action=seeder, on_exit=[gateway])
+            ),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {'gateway_node': gateway},
+    )
+
+
+class TestStandingFaultFreezeFrame(GatewayTestCase):
+    """A fault confirmed before gateway start still gets a freeze-frame."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {PLUGIN_APP}
+
+    @classmethod
+    def setUpClass(cls):
+        # The gateway launches only after the seeder has confirmed the fault,
+        # so the boot chain (fault manager + seeder + gateway) needs more
+        # headroom than the default health budget, which starts counting at
+        # ReadyToTest. Pre-wait here; the base class waits then pass quickly.
+        deadline = time.monotonic() + 60.0
+        while time.monotonic() < deadline:
+            try:
+                response = requests.get(f'{cls.BASE_URL}/health', timeout=2)
+                if response.status_code == 200:
+                    break
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(1.0)
+        super().setUpClass()
+
+    def test_standing_fault_snapshot_contains_freeze_frame(self):
+        """The standing fault's detail carries the entity's own values.
+
+        @verifies REQ_INTEROP_088
+        """
+        endpoint = f'/apps/{PLUGIN_APP}/faults/{FAULT_CODE}'
+        deadline = time.monotonic() + 30.0
+        frame = None
+        last = None
+        while time.monotonic() < deadline and frame is None:
+            try:
+                response = requests.get(
+                    f'{self.BASE_URL}{endpoint}', timeout=5)
+                if response.status_code == 200:
+                    last = response.json()
+                    snapshots = last.get(
+                        'environment_data', {}).get('snapshots', [])
+                    frame = next(
+                        (s for s in snapshots
+                         if s.get('type') == 'freeze_frame'
+                         and s.get('name') == PLUGIN_APP),
+                        None,
+                    )
+            except requests.exceptions.RequestException:
+                pass
+            if frame is None:
+                time.sleep(0.5)
+        self.assertIsNotNone(
+            frame,
+            f'No freeze_frame for {FAULT_CODE} within 30s; last: {last}',
+        )
+
+        # The frame holds the entity's current values from its DataProvider.
+        self.assertEqual(frame['data'].get('temperature'), 42.5)
+        self.assertEqual(frame['data'].get('pressure'), 3.2)
+
+        # Catch-up frames are marked: values were read at gateway start, not
+        # when the fault confirmed (which predates the gateway process).
+        x_medkit = frame.get('x-medkit', {})
+        self.assertEqual(x_medkit.get('capture_origin'), 'startup')
+        self.assertIn('full_data', x_medkit)
+        self.assertIn('captured_at', x_medkit)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check all processes exited cleanly (SIGTERM allowed)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )


### PR DESCRIPTION
Closes #562.

Plugins start reporting during `GatewayNode` construction, while the capture is
wired later from `main.cpp` (it needs the shared subscription executor, which is
built after the node). A device that is already in fault confirms in that window,
its `EVENT_CONFIRMED` is published to nobody, and since the capture only fires on
the confirm edge the fault stays frameless for as long as it is raised.

`capture_standing_fault_frames()` runs once the capture is live: it lists the
confirmed faults and enqueues a capture for each fault that has no frames yet.
Frames are process-local, so this restores what the missed edge would have
produced rather than duplicating anything, and `capture_missed_fault()` is a
no-op when the live event already captured the fault.

It runs detached, after `wait_for_services` with a bounded timeout, so startup
never blocks on the fault services being up. The synthetic event goes through the
same queue and worker as a real one, so the backlog bound and the plugin-call
threading rules are unchanged.

Worth naming: a frame captured this way holds the values at catch-up time, a
second or so after the confirm, not the values at the confirm itself. For a fault
that is standing at boot that is the only honest option - the earlier values no
longer exist anywhere.
