### PR TITLE
fix(gateway): freeze-frame an entity that is serving last known values

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -949,11 +949,16 @@ Query and manage faults.
 
    **Snapshot Types:**
 
-   - ``freeze_frame``: Topic data captured at fault confirmation. Entity
-     frames for faults that were already confirmed when the gateway started
-     are captured at gateway start instead and carry
-     ``"capture_origin": "startup"`` in their ``x-medkit`` block;
-     ``captured_at`` always stamps when the values were read.
+   - ``freeze_frame``: Data captured at fault confirmation. Entity frames for
+     faults that were already confirmed when the gateway started are captured
+     at gateway start instead and carry ``"capture_origin": "startup"`` in
+     their ``x-medkit`` block. For a plugin-backed entity that reports its
+     link down, the values are the plugin's last known ones and may predate
+     the confirmation by the length of the outage; such entries carry
+     ``connected`` (the payload's link flag, ``false`` for the loss-of-comms
+     case) and ``source_timestamp`` (the payload's own timestamp, verbatim)
+     in ``x-medkit``, both only when the plugin's payload reports them.
+     ``captured_at`` always dates the capture, not the values.
    - ``rosbag``: Recording file available via bulk-data endpoint
 
    **Response codes:**

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -200,11 +200,13 @@ Configure how the gateway connects to the fault manager services and event topic
      - bool
      - ``true``
      - Zero-config freeze-frames for plugin-backed entities: when a fault from a
-       plugin-owned entity confirms, snapshot the entity's current data values
-       (via its plugin's DataProvider) and merge them into the fault detail's
+       plugin-owned entity confirms, snapshot the entity's data values as served
+       by its plugin's DataProvider and merge them into the fault detail's
        ``environment_data.snapshots``. Faults already confirmed at gateway start
        are caught up at startup; those frames read the values at start time (not
-       confirm time) and are marked ``x-medkit.capture_origin: startup``.
+       confirm time) and are marked ``x-medkit.capture_origin: startup``. For an
+       entity that reports its link down these are the plugin's last known
+       values, marked ``connected: false`` in the snapshot's ``x-medkit`` block.
        Explicit snapshot config in the fault manager always wins when present.
        Only active when plugins are loaded.
 

--- a/docs/tutorials/snapshots.rst
+++ b/docs/tutorials/snapshots.rst
@@ -176,12 +176,17 @@ row is written.
 **Plugin-backed entities** (``entity_freeze_frame.enabled``, gateway): PLC
 apps bridged by protocol plugins report faults under their bare SOVD entity
 id and their live values are not ROS topics, so the fault manager cannot
-capture them. Instead, the gateway snapshots the entity's current data
-values (from the owning plugin's ``DataProvider``, i.e. the latest polled
+capture them. Instead, the gateway snapshots the entity's data values as
+served by the owning plugin (its ``DataProvider``, i.e. the latest polled
 values) when the fault confirms, and merges them into the fault detail's
 ``environment_data.snapshots`` as a standard ``freeze_frame`` entry named
 after the entity - unless the fault manager already captured a freeze-frame
-for that fault (explicit config wins).
+for that fault (explicit config wins). When the entity reports its link down
+(the loss-of-comms case), the frozen values are the plugin's last known ones
+and may predate the confirmation by the length of the outage; the entry's
+``x-medkit`` block then carries ``connected: false`` and, when the plugin's
+payload includes one, ``source_timestamp`` (the payload's own timestamp)
+alongside ``captured_at``.
 
 Faults that are already confirmed when the gateway starts are caught up at
 startup: the gateway lists the confirmed faults and captures a frame for each
@@ -275,9 +280,11 @@ Snapshots are included inline in the fault response as ``environment_data``:
 
 **Snapshot Types:**
 
-- ``freeze_frame``: Topic data captured at fault confirmation (JSON format).
-  Entity frames caught up for faults that predate the gateway are captured at
-  gateway start instead, marked ``x-medkit.capture_origin: startup``.
+- ``freeze_frame``: Data captured at fault confirmation (JSON format). Entity
+  frames caught up for faults that predate the gateway are captured at
+  gateway start instead, marked ``x-medkit.capture_origin: startup``; a
+  plugin entity that reports its link down contributes its last known values,
+  marked ``connected: false`` in ``x-medkit``
 - ``rosbag``: Recording file available via bulk-data endpoint (binary format)
 
 **Get snapshots from fault response using jq:**

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
@@ -61,6 +61,8 @@ namespace ros2_medkit_gateway {
 class EntityFreezeFrameCapture {
  public:
   /// One captured frame: the entity's data values at fault-confirm time.
+  /// captured_at_ns dates the capture, not the values - a disconnected entity
+  /// serves its last known values, whose age is bounded only by the outage.
   struct Frame {
     std::string entity_id;
     nlohmann::json values;  ///< compact {resource_id: value} dict
@@ -68,6 +70,8 @@ class EntityFreezeFrameCapture {
     /// True when the frame comes from the startup catch-up: captured_at_ns is
     /// then the gateway's start, possibly long after the fault confirmed.
     bool startup_catchup{false};
+    std::optional<bool> connected;    ///< payload's top-level link flag, when reported
+    nlohmann::json source_timestamp;  ///< payload's own "timestamp" field verbatim (null when absent)
   };
 
   /// Resolves an entity id to its owning plugin's DataProvider (nullptr when
@@ -135,6 +139,13 @@ class EntityFreezeFrameCapture {
   /// needs frozen. The row of nulls a cold cache yields is rejected by
   /// values_have_data() instead.
   static bool content_has_live_data(const nlohmann::json & content);
+
+  /// True when the payload's top-level `connected` flag reports the link down.
+  /// Consulted only by the gateway's fault-trigger value fetcher: a down link
+  /// serves frozen last-known values, and a threshold rule must hold state on
+  /// them (fetcher yields nullopt) instead of firing on a stale number for the
+  /// whole outage. The freeze-frame paths deliberately ignore this flag.
+  static bool content_reports_disconnected(const nlohmann::json & content);
 
   /// True when a compact values dict holds at least one non-null value.
   /// Rejects the {} / all-null rows a cold poll cache or dead link yields.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/entity_freeze_frame_capture.hpp
@@ -129,9 +129,11 @@ class EntityFreezeFrameCapture {
   static nlohmann::json values_from_list_content(const nlohmann::json & content);
 
   /// True when list-data-shaped content (DataProvider::list_data or x-plc-data
-  /// route) carries real live values: not flagged disconnected, with a
-  /// non-empty items array. A PLC that is down must not freeze-frame a row
-  /// of nulls.
+  /// route) carries values at all: a non-empty items array. The entity's
+  /// `connected` flag is deliberately not consulted - a bridge serving its last
+  /// known values while the link is down is the case a loss-of-comms fault most
+  /// needs frozen. The row of nulls a cold cache yields is rejected by
+  /// values_have_data() instead.
   static bool content_has_live_data(const nlohmann::json & content);
 
   /// True when a compact values dict holds at least one non-null value.

--- a/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
@@ -129,9 +129,11 @@ bool EntityFreezeFrameCapture::content_has_live_data(const nlohmann::json & cont
   if (!content.is_object()) {
     return false;
   }
-  if (content.contains("connected") && content["connected"].is_boolean() && !content["connected"].get<bool>()) {
-    return false;
-  }
+  // Judged on the values, not on the link flag. A bridge that serves its last
+  // known values while disconnected is exactly what a loss-of-comms fault wants
+  // frozen - refusing on `connected: false` denied a frame to the one fault
+  // where the values before the link died are the whole story. The all-null row
+  // a genuinely cold cache yields is still rejected, by values_have_data().
   return content.contains("items") && content["items"].is_array() && !content["items"].empty();
 }
 

--- a/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/src/entity_freeze_frame_capture.cpp
@@ -137,6 +137,11 @@ bool EntityFreezeFrameCapture::content_has_live_data(const nlohmann::json & cont
   return content.contains("items") && content["items"].is_array() && !content["items"].empty();
 }
 
+bool EntityFreezeFrameCapture::content_reports_disconnected(const nlohmann::json & content) {
+  return content.is_object() && content.contains("connected") && content["connected"].is_boolean() &&
+         !content["connected"].get<bool>();
+}
+
 bool EntityFreezeFrameCapture::values_have_data(const nlohmann::json & values) {
   if (values.is_object()) {
     for (const auto & entry : values.items()) {
@@ -185,7 +190,7 @@ std::optional<EntityFreezeFrameCapture::Frame>
 EntityFreezeFrameCapture::frame_from_content(const std::string & entity_id, const std::string & fault_code,
                                              const nlohmann::json & content) {
   if (!content_has_live_data(content)) {
-    log_fallback_failure_once(fault_code, "entity '" + entity_id + "' reported no live values");
+    log_fallback_failure_once(fault_code, "entity '" + entity_id + "' returned no data items");
     return std::nullopt;
   }
   Frame frame;
@@ -196,6 +201,15 @@ EntityFreezeFrameCapture::frame_from_content(const std::string & entity_id, cons
     // ids): still a dead/cold row - no frame, same invariant as above.
     log_fallback_failure_once(fault_code, "entity '" + entity_id + "' values are all null");
     return std::nullopt;
+  }
+  // Provenance for the snapshot's x-medkit block: the payload's link flag and
+  // its own timestamp, when the plugin reports them. captured_at_ns dates the
+  // capture; a disconnected entity's values may be much older.
+  if (content.contains("connected") && content["connected"].is_boolean()) {
+    frame.connected = content["connected"].get<bool>();
+  }
+  if (content.contains("timestamp")) {
+    frame.source_timestamp = content["timestamp"];
   }
   frame.captured_at_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -1787,7 +1787,10 @@ void GatewayNode::init_fault_trigger_engine() {
       return std::nullopt;
     }
     const auto content = plugin_mgr_->fetch_entity_data_via_route(app_id);
-    if (!content || !EntityFreezeFrameCapture::content_has_live_data(*content)) {
+    // A down link serves frozen last-known values; nullopt holds rule state
+    // (fault_trigger_engine) instead of firing on a stale number all outage.
+    if (!content || !EntityFreezeFrameCapture::content_has_live_data(*content) ||
+        EntityFreezeFrameCapture::content_reports_disconnected(*content)) {
       return std::nullopt;
     }
     const auto values = EntityFreezeFrameCapture::values_from_list_content(*content);

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -252,6 +252,15 @@ json FaultHandlers::merge_entity_freeze_frames(json env_data,
       // absent marker = captured on the confirm edge.
       snap["capture_origin"] = "startup";
     }
+    // Value provenance, only when the plugin's payload reported it: a
+    // disconnected entity serves last-known values whose age captured_at_ns
+    // cannot convey.
+    if (frame.connected.has_value()) {
+      snap["connected"] = *frame.connected;
+    }
+    if (!frame.source_timestamp.is_null()) {
+      snap["source_timestamp"] = frame.source_timestamp;
+    }
     env_data["snapshots"].push_back(std::move(snap));
   }
   return env_data;
@@ -317,6 +326,13 @@ dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_jso
         }
         if (s.contains("capture_origin") && s["capture_origin"].is_string()) {
           snap["x-medkit"]["capture_origin"] = s["capture_origin"];
+        }
+        // Entity-frame provenance (merge_entity_freeze_frames), only when known.
+        if (s.contains("connected") && s["connected"].is_boolean()) {
+          snap["x-medkit"]["connected"] = s["connected"];
+        }
+        if (s.contains("source_timestamp")) {
+          snap["x-medkit"]["source_timestamp"] = s["source_timestamp"];
         }
       } else if (snapshot_type == "rosbag") {
         // Build absolute URI using entity path + fault_code as the bulk-data ID.

--- a/src/ros2_medkit_gateway/test/demo_nodes/test_route_data_plugin.cpp
+++ b/src/ros2_medkit_gateway/test/demo_nodes/test_route_data_plugin.cpp
@@ -40,6 +40,8 @@ using namespace ros2_medkit_gateway;
 class TestRouteDataPlugin : public GatewayPlugin, public IntrospectionProvider {
  public:
   static constexpr const char * kAppId = "test_route_plc_app";
+  /// Loss-of-comms twin: reports connected=false while serving last known values.
+  static constexpr const char * kDownAppId = "test_route_plc_down_app";
 
   std::string name() const override {
     return "test_route_data";
@@ -90,6 +92,15 @@ class TestRouteDataPlugin : public GatewayPlugin, public IntrospectionProvider {
     app.source = "plugin";
     result.new_entities.apps.push_back(std::move(app));
 
+    App down_app;
+    down_app.id = kDownAppId;
+    down_app.name = "Test Route PLC Down Process";
+    down_app.component_id = "test_route_plc";
+    down_app.external = true;
+    down_app.is_online = true;
+    down_app.source = "plugin";
+    result.new_entities.apps.push_back(std::move(down_app));
+
     return result;
   }
 
@@ -103,6 +114,15 @@ class TestRouteDataPlugin : public GatewayPlugin, public IntrospectionProvider {
       if (!entity) {
         return;
       }
+    }
+    if (entity_id == kDownAppId) {
+      // Loss-of-comms shape: link down, last known values still served.
+      res.send_json({{"connected", false},
+                     {"entity_id", entity_id},
+                     {"items", nlohmann::json::array({{{"name", "level"}, {"value", 42.0}, {"unit", "mm"}},
+                                                      {{"name", "alarm"}, {"value", false}}})},
+                     {"timestamp", 1234567800}});
+      return;
     }
     if (entity_id != kAppId) {
       res.send_error(404, ERR_RESOURCE_NOT_FOUND, "No PLC data mapped for entity: " + entity_id);

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -552,7 +552,8 @@ TEST_F(EntityFreezeFrameCaptureTest, RouteFallbackSkipsDisconnectedPlcWithNoValu
 /// @verifies REQ_INTEROP_088
 TEST_F(EntityFreezeFrameCaptureTest, DisconnectedEntityWithLastKnownValuesIsCaptured) {
   // The loss-of-comms case: the bridge reports the link down and still serves
-  // the values it last read. That is what the fault is about, so it is frozen.
+  // the values it last read. That is what the fault is about, so it is frozen,
+  // with the payload's link flag and own timestamp carried as provenance.
   EntityFreezeFrameCapture capture(
       node_.get(), *sub_exec_,
       [](const std::string &) -> DataProvider * {
@@ -560,7 +561,8 @@ TEST_F(EntityFreezeFrameCaptureTest, DisconnectedEntityWithLastKnownValuesIsCapt
       },
       [](const std::string &) -> std::optional<json> {
         return json{{"connected", false},
-                    {"items", json::array({{{"name", "level"}, {"value", 42.0}, {"stale", true}}})}};
+                    {"items", json::array({{{"name", "level"}, {"value", 42.0}}})},
+                    {"timestamp", 1234567890}};
       });
 
   ASSERT_TRUE(publish_and_wait(capture, make_confirmed_event("PLC_COMMS_LOST", {"route_plc_app"})));
@@ -568,6 +570,9 @@ TEST_F(EntityFreezeFrameCaptureTest, DisconnectedEntityWithLastKnownValuesIsCapt
   const auto frames = capture.frames_for("PLC_COMMS_LOST");
   ASSERT_EQ(frames.size(), 1u);
   EXPECT_EQ(frames[0].values["level"], 42.0);
+  ASSERT_TRUE(frames[0].connected.has_value());
+  EXPECT_FALSE(*frames[0].connected);
+  EXPECT_EQ(frames[0].source_timestamp, 1234567890);
 }
 
 /// @verifies REQ_INTEROP_088
@@ -597,10 +602,7 @@ TEST_F(EntityFreezeFrameCaptureTest, DataProviderWithoutLiveValuesCapturesNothin
   // items array (cold poll cache) or all-null values must not freeze-frame a
   // row of {} / nulls, connected or not.
   StaticContentDataProvider cold_provider("cold_app", json{{"items", json::array()}});
-  StaticContentDataProvider null_provider("null_app", json{{"items", json::array({{{"id", "level"}}})}});
-  // Down AND empty: nothing to freeze. (Down with a real last known value is a
-  // capture, covered separately.)
-  StaticContentDataProvider down_provider("down_app",
+  StaticContentDataProvider null_provider("null_app",
                                           json{{"connected", false}, {"items", json::array({{{"id", "level"}}})}});
   EntityFreezeFrameCapture capture(node_.get(), *sub_exec_, [&](const std::string & entity_id) -> DataProvider * {
     if (entity_id == "cold_app") {
@@ -609,19 +611,37 @@ TEST_F(EntityFreezeFrameCaptureTest, DataProviderWithoutLiveValuesCapturesNothin
     if (entity_id == "null_app") {
       return &null_provider;
     }
-    if (entity_id == "down_app") {
-      return &down_provider;
-    }
     return nullptr;
   });
 
   ASSERT_TRUE(wait_for_match());
-  auto event = make_confirmed_event("PLC_NO_LIVE_DATA", {"cold_app", "null_app", "down_app"});
+  auto event = make_confirmed_event("PLC_NO_LIVE_DATA", {"cold_app", "null_app"});
   for (int i = 0; i < 25; ++i) {
     publisher_->publish(event);
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_TRUE(capture.frames_for("PLC_NO_LIVE_DATA").empty());
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, DisconnectedDataProviderWithLastKnownValuesIsCaptured) {
+  // DataProvider flavour of the loss-of-comms case: list_data flags the link
+  // down but still serves the last known values - captured, with the link
+  // state on the frame.
+  StaticContentDataProvider down_provider(
+      "down_app", json{{"connected", false}, {"items", json::array({{{"id", "level"}, {"value", 5.5}}})}});
+  EntityFreezeFrameCapture capture(node_.get(), *sub_exec_, [&](const std::string & entity_id) -> DataProvider * {
+    return entity_id == "down_app" ? &down_provider : nullptr;
+  });
+
+  ASSERT_TRUE(publish_and_wait(capture, make_confirmed_event("PLC_PROVIDER_COMMS_LOST", {"down_app"})));
+
+  const auto frames = capture.frames_for("PLC_PROVIDER_COMMS_LOST");
+  ASSERT_EQ(frames.size(), 1u);
+  EXPECT_EQ(frames[0].values["level"], 5.5);
+  ASSERT_TRUE(frames[0].connected.has_value());
+  EXPECT_FALSE(*frames[0].connected);
+  EXPECT_TRUE(frames[0].source_timestamp.is_null());  // provider content has no timestamp field
 }
 
 /// @verifies REQ_INTEROP_088
@@ -655,6 +675,24 @@ TEST(ContentHasLiveData, GatesOnItemsNotOnTheLinkFlag) {
   EXPECT_FALSE(Capture::content_has_live_data(json{{"connected", true}, {"items", json::array()}}));
   EXPECT_FALSE(Capture::content_has_live_data(json{{"connected", true}}));
   EXPECT_FALSE(Capture::content_has_live_data(json::array()));
+}
+
+TEST(ContentReportsDisconnected, TriggerPathGateDiscriminatesFromFreezeFramePath) {
+  using Capture = EntityFreezeFrameCapture;
+  // The loss-of-comms payload: link down, last known values still served.
+  const json down_with_values{{"connected", false}, {"items", json::array({{{"name", "a"}, {"value", 1}}})}};
+  // The freeze-frame path (content_has_live_data alone) captures it...
+  EXPECT_TRUE(Capture::content_has_live_data(down_with_values));
+  // ...while the trigger value fetcher (gateway_node) also requires the link
+  // up, so it yields nullopt and threshold rules hold state on the outage
+  // instead of firing on a frozen number.
+  EXPECT_TRUE(Capture::content_reports_disconnected(down_with_values));
+  EXPECT_FALSE(Capture::content_reports_disconnected(
+      json{{"connected", true}, {"items", json::array({{{"name", "a"}, {"value", 1}}})}}));
+  // No flag (DataProvider list_data shape) or a non-boolean flag: not down.
+  EXPECT_FALSE(Capture::content_reports_disconnected(json{{"items", json::array()}}));
+  EXPECT_FALSE(Capture::content_reports_disconnected(json{{"connected", "no"}}));
+  EXPECT_FALSE(Capture::content_reports_disconnected(json::array()));
 }
 
 TEST(ValuesHaveData, RejectsEmptyAndAllNull) {
@@ -800,6 +838,41 @@ TEST(MergeEntityFreezeFrames, NoFramesNoChange) {
   json env_data = {{"snapshots", json::array()}};
   auto merged = FaultHandlers::merge_entity_freeze_frames(env_data, {});
   EXPECT_EQ(merged, env_data);
+}
+
+TEST(MergeEntityFreezeFrames, CarriesLinkStateAndSourceTimestampWhenKnown) {
+  // Loss-of-comms provenance: the payload's link flag and own timestamp ride
+  // the snapshot entry through to the wire x-medkit block - and only when the
+  // plugin actually reported them.
+  json env_data = {{"snapshots", json::array()}};
+  EntityFreezeFrameCapture::Frame down_frame;
+  down_frame.entity_id = "plc_app";
+  down_frame.values = {{"level", 42.0}};
+  down_frame.captured_at_ns = 1234;
+  down_frame.connected = false;
+  down_frame.source_timestamp = 1234567890;
+  EntityFreezeFrameCapture::Frame bare_frame;
+  bare_frame.entity_id = "other_app";
+  bare_frame.values = {{"temperature", 42.5}};
+  bare_frame.captured_at_ns = 5678;
+
+  auto merged = FaultHandlers::merge_entity_freeze_frames(env_data, {down_frame, bare_frame});
+  ASSERT_EQ(merged["snapshots"].size(), 2u);
+  EXPECT_EQ(merged["snapshots"][0]["connected"], false);
+  EXPECT_EQ(merged["snapshots"][0]["source_timestamp"], 1234567890);
+  EXPECT_FALSE(merged["snapshots"][1].contains("connected"));
+  EXPECT_FALSE(merged["snapshots"][1].contains("source_timestamp"));
+
+  // And onto the wire: build_sovd_fault_response surfaces them in x-medkit.
+  const auto detail = FaultHandlers::build_sovd_fault_response(
+      json{{"fault_code", "PLC_COMMS_LOST"}, {"status", "CONFIRMED"}}, merged, "/apps/plc_app");
+  ASSERT_TRUE(detail.environment_data.snapshots.has_value());
+  const auto & wire = *detail.environment_data.snapshots;
+  ASSERT_EQ(wire.size(), 2u);
+  EXPECT_EQ(wire[0]["x-medkit"]["connected"], false);
+  EXPECT_EQ(wire[0]["x-medkit"]["source_timestamp"], 1234567890);
+  EXPECT_FALSE(wire[1]["x-medkit"].contains("connected"));
+  EXPECT_FALSE(wire[1]["x-medkit"].contains("source_timestamp"));
 }
 
 int main(int argc, char ** argv) {

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -527,8 +527,10 @@ TEST_F(EntityFreezeFrameCaptureTest, RouteFallbackCapturesWhenPluginHasNoDataPro
 }
 
 /// @verifies REQ_INTEROP_088
-TEST_F(EntityFreezeFrameCaptureTest, RouteFallbackSkipsDisconnectedPlc) {
-  // A disconnected PLC must not freeze-frame a row of stale/null values.
+TEST_F(EntityFreezeFrameCaptureTest, RouteFallbackSkipsDisconnectedPlcWithNoValues) {
+  // A disconnected PLC with nothing cached must not freeze-frame a row of
+  // nulls. One that still serves its last known values does get a frame - see
+  // DisconnectedEntityWithLastKnownValuesIsCaptured.
   EntityFreezeFrameCapture capture(
       node_.get(), *sub_exec_,
       [](const std::string &) -> DataProvider * {
@@ -545,6 +547,27 @@ TEST_F(EntityFreezeFrameCaptureTest, RouteFallbackSkipsDisconnectedPlc) {
     std::this_thread::sleep_for(10ms);
   }
   EXPECT_TRUE(capture.frames_for("PLC_DISCONNECTED").empty());
+}
+
+/// @verifies REQ_INTEROP_088
+TEST_F(EntityFreezeFrameCaptureTest, DisconnectedEntityWithLastKnownValuesIsCaptured) {
+  // The loss-of-comms case: the bridge reports the link down and still serves
+  // the values it last read. That is what the fault is about, so it is frozen.
+  EntityFreezeFrameCapture capture(
+      node_.get(), *sub_exec_,
+      [](const std::string &) -> DataProvider * {
+        return nullptr;
+      },
+      [](const std::string &) -> std::optional<json> {
+        return json{{"connected", false},
+                    {"items", json::array({{{"name", "level"}, {"value", 42.0}, {"stale", true}}})}};
+      });
+
+  ASSERT_TRUE(publish_and_wait(capture, make_confirmed_event("PLC_COMMS_LOST", {"route_plc_app"})));
+
+  const auto frames = capture.frames_for("PLC_COMMS_LOST");
+  ASSERT_EQ(frames.size(), 1u);
+  EXPECT_EQ(frames[0].values["level"], 42.0);
 }
 
 /// @verifies REQ_INTEROP_088
@@ -571,12 +594,14 @@ TEST_F(EntityFreezeFrameCaptureTest, DataProviderWinsOverRouteFallback) {
 /// @verifies REQ_INTEROP_088
 TEST_F(EntityFreezeFrameCaptureTest, DataProviderWithoutLiveValuesCapturesNothing) {
   // Same "no row = nothing captured" invariant as the route path: an empty
-  // items array (cold poll cache), all-null values (down link) or a
-  // disconnected flag must not freeze-frame a row of {} / nulls.
+  // items array (cold poll cache) or all-null values must not freeze-frame a
+  // row of {} / nulls, connected or not.
   StaticContentDataProvider cold_provider("cold_app", json{{"items", json::array()}});
   StaticContentDataProvider null_provider("null_app", json{{"items", json::array({{{"id", "level"}}})}});
-  StaticContentDataProvider down_provider(
-      "down_app", json{{"connected", false}, {"items", json::array({{{"id", "level"}, {"value", 1.0}}})}});
+  // Down AND empty: nothing to freeze. (Down with a real last known value is a
+  // capture, covered separately.)
+  StaticContentDataProvider down_provider("down_app",
+                                          json{{"connected", false}, {"items", json::array({{{"id", "level"}}})}});
   EntityFreezeFrameCapture capture(node_.get(), *sub_exec_, [&](const std::string & entity_id) -> DataProvider * {
     if (entity_id == "cold_app") {
       return &cold_provider;
@@ -617,13 +642,15 @@ TEST_F(EntityFreezeFrameCaptureTest, OldestFaultEvictedPastMaxFaults) {
   EXPECT_FALSE(capture.frames_for("PLC_EVICT_C").empty());
 }
 
-TEST(ContentHasLiveData, GatesOnConnectedAndItems) {
+TEST(ContentHasLiveData, GatesOnItemsNotOnTheLinkFlag) {
   using Capture = EntityFreezeFrameCapture;
   EXPECT_TRUE(Capture::content_has_live_data(
       json{{"connected", true}, {"items", json::array({{{"name", "a"}, {"value", 1}}})}}));
   // No "connected" field: items alone are enough (plugin-defined shape).
   EXPECT_TRUE(Capture::content_has_live_data(json{{"items", json::array({{{"name", "a"}, {"value", 1}}})}}));
-  EXPECT_FALSE(Capture::content_has_live_data(
+  // Disconnected but still serving its last known values: this is the
+  // loss-of-comms case, and those values are the point of the frame.
+  EXPECT_TRUE(Capture::content_has_live_data(
       json{{"connected", false}, {"items", json::array({{{"name", "a"}, {"value", 1}}})}}));
   EXPECT_FALSE(Capture::content_has_live_data(json{{"connected", true}, {"items", json::array()}}));
   EXPECT_FALSE(Capture::content_has_live_data(json{{"connected", true}}));

--- a/src/ros2_medkit_integration_tests/test/features/test_entity_freeze_frame.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_entity_freeze_frame.test.py
@@ -27,6 +27,9 @@ proven end to end:
    shape): the demo route-data plugin exports only introspection + fault
    providers and serves live values through its registered x-plc-data route.
    The gateway captures the freeze-frame by dispatching that route in-process.
+   The plugin's second entity reports its link down (connected=false) while
+   still serving last known values - the loss-of-comms fault must freeze
+   those values and mark the frame disconnected in x-medkit.
 3. ROS-backed entity: a fault reported under a demo node's FQN carries a
    freeze-frame of that node's own published topics, captured by the fault
    manager's entity-default fallback.
@@ -53,6 +56,8 @@ PLUGIN_APP = 'test_plc_app'
 PLUGIN_FAULT_CODE = 'PLC_OVERPRESSURE'
 ROUTE_PLUGIN_APP = 'test_route_plc_app'
 ROUTE_PLUGIN_FAULT_CODE = 'PLC_ROUTE_LEVEL_HIGH'
+DOWN_PLUGIN_APP = 'test_route_plc_down_app'
+DOWN_PLUGIN_FAULT_CODE = 'PLC_ROUTE_COMMS_LOST'
 ROS_APP = 'temp_sensor'
 ROS_SOURCE = '/powertrain/engine/temp_sensor'
 ROS_FAULT_CODE = 'ENGINE_TEMP_SENSOR_DEGRADED'
@@ -91,8 +96,8 @@ def generate_test_description():
 class TestEntityFreezeFrame(GatewayTestCase):
     """Faults carry the faulting entity's own data with zero snapshot config."""
 
-    MIN_EXPECTED_APPS = 3
-    REQUIRED_APPS = {PLUGIN_APP, ROUTE_PLUGIN_APP, ROS_APP}
+    MIN_EXPECTED_APPS = 4
+    REQUIRED_APPS = {PLUGIN_APP, ROUTE_PLUGIN_APP, DOWN_PLUGIN_APP, ROS_APP}
 
     @classmethod
     def setUpClass(cls):
@@ -173,10 +178,11 @@ class TestEntityFreezeFrame(GatewayTestCase):
         self.assertIn('captured_at', x_medkit)
 
     def test_route_only_plugin_fault_carries_entity_values(self):
-        """A commercial-bridge-shaped plugin (no DataProvider, no
-        FaultProvider) still carries its entity's own values, captured via
-        in-process x-plc-data dispatch and served through the fault_manager
-        fall-through.
+        """Freeze-frame a commercial-bridge-shaped plugin entity.
+
+        With no DataProvider and no FaultProvider the entity still carries
+        its own values, captured via in-process x-plc-data dispatch and
+        served through the fault_manager fall-through.
 
         @verifies REQ_INTEROP_088
         """
@@ -213,6 +219,34 @@ class TestEntityFreezeFrame(GatewayTestCase):
             f'{ROUTE_PLUGIN_FAULT_CODE}',
             timeout=5)
         self.assertIn(clear_resp.status_code, (200, 204))
+
+    def test_route_only_plugin_disconnected_entity_carries_last_known_values(self):
+        """Freeze-frame a route-only plugin entity that reports its link down.
+
+        The last known values it serves are the point of a loss-of-comms
+        fault, and x-medkit marks the frame disconnected with the payload's
+        own timestamp.
+
+        @verifies REQ_INTEROP_088
+        """
+        self._report_fault(DOWN_PLUGIN_FAULT_CODE, DOWN_PLUGIN_APP)
+
+        frames = self._wait_for_freeze_frame(
+            f'/apps/{DOWN_PLUGIN_APP}', DOWN_PLUGIN_FAULT_CODE)
+        frame = next(
+            (f for f in frames if f.get('name') == DOWN_PLUGIN_APP), None)
+        self.assertIsNotNone(
+            frame, f'No frame named {DOWN_PLUGIN_APP} in {frames}')
+
+        # The plugin serves these as its last known values with connected=false.
+        self.assertEqual(frame['data'].get('level'), 42.0)
+        self.assertEqual(frame['data'].get('alarm'), False)
+
+        x_medkit = frame.get('x-medkit', {})
+        self.assertIn('full_data', x_medkit)
+        self.assertIn('captured_at', x_medkit)
+        self.assertEqual(x_medkit.get('connected'), False)
+        self.assertEqual(x_medkit.get('source_timestamp'), 1234567800)
 
     def test_ros_entity_fault_carries_own_topic_data(self):
         """A ROS-node fault carries the node's own published topic data.

--- a/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_fault_triggers_api.test.py
@@ -156,6 +156,36 @@ class TestFaultTriggersApi(GatewayTestCase):
                   'severity': 'ERROR'}, timeout=10)
         self.assertEqual(resp.status_code, 404, resp.text)
 
+    def test_07_disconnected_app_holds_rule_state(self):
+        """A rule on the down app never fires on its frozen last-known values.
+
+        test_route_plc_down_app reports connected=false while still serving
+        level=42.0. The trigger fetcher must treat that as unreadable
+        (nullopt), so the level-triggered engine holds state instead of firing
+        on a stale number for the whole outage - even though the same payload
+        does get freeze-framed (test_entity_freeze_frame.test.py).
+        """
+        resp = requests.post(
+            f'{self.BASE_URL}/apps/test_route_plc_down_app/fault-triggers',
+            json={'data_name': 'level', 'operator': '>=',
+                  'threshold': 10.0, 'fault_code': 'TEST_DOWN_LEVEL_HIGH',
+                  'severity': 'ERROR'}, timeout=10)
+        # Creation succeeds: data points are enumerable from last-known content.
+        self.assertEqual(resp.status_code, 201, resp.text)
+        rule = resp.json()
+
+        # 42.0 >= 10 would fire within a few 200 ms polls if the stale value
+        # were fetched; give it ample polls and require silence.
+        time.sleep(3.0)
+        self.assertIsNone(
+            self.poll_for_fault('TEST_DOWN_LEVEL_HIGH', timeout=1.0),
+            'rule fired on a disconnected app serving last-known values')
+
+        resp = requests.delete(
+            f'{self.BASE_URL}/apps/test_route_plc_down_app/fault-triggers'
+            f"/{rule['id']}", timeout=10)
+        self.assertEqual(resp.status_code, 204)
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #564.

`content_has_live_data()` rejected any payload whose entity reported
`connected: false`, so a loss-of-comms fault - the one fault whose freeze frame
is the whole point, showing what the device held right before it went away -
could never have one. The guard was aimed at the row of nulls a cold cache
yields, but that case is already caught by `values_have_data()` one step later.

The gate now judges the payload: a non-empty items array captures, whatever the
link flag says. `captured_at_ns` continues to state when the frame was taken, so
nothing is presented as fresher than it is, and a bridge that serves per-value
staleness keeps saying so on its own route.

Tests: `DisconnectedEntityWithLastKnownValuesIsCaptured` (new, fails before),
`ContentHasLiveData.GatesOnItemsNotOnTheLinkFlag`, and the two "nothing usable ->
no frame" tests re-pointed at the case they were really guarding (down *and*
empty). Full gateway suite: 3793 tests, 0 failures, 448 skipped.
