### PR TITLE
fix(gateway): release the parameter transport's node before the context dies

### DIFF
--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -558,6 +558,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_ros2_parameter_transport gateway_ros2)
   medkit_set_test_domain(test_ros2_parameter_transport)
 
+  # Separate binary: these tests own the whole rclcpp init/shutdown lifecycle (they
+  # destroy a transport AFTER rclcpp::shutdown()), so they cannot share the
+  # process-wide context bracket the tests above use.
+  ament_add_gtest(test_ros2_parameter_transport_shutdown test/test_ros2_parameter_transport_shutdown.cpp)
+  target_link_libraries(test_ros2_parameter_transport_shutdown gateway_ros2)
+  medkit_set_test_domain(test_ros2_parameter_transport_shutdown)
+
   # BoundedLruCache: pure-C++ header, no ROS - bounds the parameter transport's
   # per-node caches. No test domain (creates no ROS nodes).
   ament_add_gtest(test_bounded_lru_cache test/test_bounded_lru_cache.cpp)
@@ -1103,6 +1110,7 @@ if(BUILD_TESTING)
       test_operation_manager
       test_configuration_manager
       test_ros2_parameter_transport
+      test_ros2_parameter_transport_shutdown
       test_discovery_manager
       test_runtime_discovery
       test_tls_config

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -215,14 +215,30 @@ class Ros2ParameterTransport : public ParameterTransport {
   std::shared_ptr<rclcpp::Node> param_node_;
 
   /// Context of param_node_, plus the handle of the pre-shutdown callback registered on
-  /// it. param_node_ MUST be destroyed while the context is still valid: rclcpp's
-  /// ~NodeGraph calls GraphListener::remove_node(), which throws NodeNotFoundError once
-  /// the context has been shut down and the listener has dropped its node list. That
-  /// throw escapes an implicitly-noexcept destructor, so it is an immediate
-  /// std::terminate (SIGABRT) that no try/catch at the call site can intercept - the
-  /// only fix is to not be holding the node by then. The callback runs shutdown() ahead
-  /// of context invalidation; the destructor deregisters it and calls the (idempotent)
-  /// shutdown() for the ordinary case where the transport dies first.
+  /// it. param_node_ must be released while the GraphListener is still running, and the
+  /// callback is what guarantees that: Context::shutdown() runs pre-shutdown callbacks,
+  /// then rcl_shutdown, then the on_shutdown callbacks - and the listener is stopped from
+  /// one of the latter.
+  ///
+  /// The crash this prevents is a HALF-REGISTERED node, not a late destruction.
+  /// NodeGraph::get_graph_event() consumes should_add_to_graph_listener_ before calling
+  /// GraphListener::add_node(), and add_node() throws GraphListenerShutdownError once the
+  /// listener is down. The flag is spent while the node was never listed, so ~NodeGraph
+  /// takes its remove_node() branch, the node is absent from node_graph_interfaces_, and
+  /// NodeNotFoundError escapes an implicitly-noexcept destructor: immediate std::terminate
+  /// (SIGABRT), which no try/catch at the call site can intercept. Only a first-ever graph
+  /// use racing the listener's shutdown can produce it, which is why the crash was
+  /// intermittent rather than every run.
+  ///
+  /// A node that IS registered is fine either way: GraphListener::__shutdown() only joins
+  /// its thread and finalizes the wait set, it never clears node_graph_interfaces_, and
+  /// remove_node() erases directly once is_shutdown() is set. Do not "fix" a suspected
+  /// late-destruction bug here - that path provably works.
+  ///
+  /// Every wait_for_service in this class runs under spin_mutex_ and the callback blocks
+  /// on the same mutex, so no first graph use can straddle the listener's shutdown. The
+  /// destructor deregisters the callback and calls the (idempotent) shutdown() for the
+  /// ordinary case where the transport dies first.
   std::shared_ptr<rclcpp::Context> context_;
   rclcpp::PreShutdownCallbackHandle pre_shutdown_handle_;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -214,6 +214,18 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Created once in constructor - must be in DDS graph early for fast service discovery.
   std::shared_ptr<rclcpp::Node> param_node_;
 
+  /// Context of param_node_, plus the handle of the pre-shutdown callback registered on
+  /// it. param_node_ MUST be destroyed while the context is still valid: rclcpp's
+  /// ~NodeGraph calls GraphListener::remove_node(), which throws NodeNotFoundError once
+  /// the context has been shut down and the listener has dropped its node list. That
+  /// throw escapes an implicitly-noexcept destructor, so it is an immediate
+  /// std::terminate (SIGABRT) that no try/catch at the call site can intercept - the
+  /// only fix is to not be holding the node by then. The callback runs shutdown() ahead
+  /// of context invalidation; the destructor deregisters it and calls the (idempotent)
+  /// shutdown() for the ordinary case where the transport dies first.
+  std::shared_ptr<rclcpp::Context> context_;
+  rclcpp::PreShutdownCallbackHandle pre_shutdown_handle_;
+
   /// Cached AsyncParametersClient per target node, bounded by LRU eviction.
   mutable std::mutex clients_mutex_;
   BoundedLruCache<std::string, std::shared_ptr<rclcpp::AsyncParametersClient>> param_clients_;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -46,6 +46,17 @@ Ros2ParameterTransport::Ros2ParameterTransport(rclcpp::Node * node, double servi
   options.use_global_arguments(false);
   param_node_ = std::make_shared<rclcpp::Node>("_param_client_node", options);
 
+  // Tear the node down BEFORE the context is invalidated. Without this, an owner that
+  // outlives rclcpp::shutdown() (the gateway's own managers, or a plugin whose objects
+  // are destroyed from ~GatewayNode) drops param_node_ after the GraphListener has
+  // already cleared its node list, and ~NodeGraph's remove_node() throws
+  // NodeNotFoundError out of a noexcept destructor -> std::terminate, exit -6. It is a
+  // race, so it shows up as an intermittent abort on Ctrl+C rather than a reliable one.
+  context_ = param_node_->get_node_base_interface()->get_context();
+  pre_shutdown_handle_ = context_->add_pre_shutdown_callback([this] {
+    shutdown();
+  });
+
   // Store own node FQN for self-query detection.
   own_node_fqn_ = node_->get_fully_qualified_name();
 
@@ -54,7 +65,13 @@ Ros2ParameterTransport::Ros2ParameterTransport(rclcpp::Node * node, double servi
 }
 
 Ros2ParameterTransport::~Ros2ParameterTransport() {
-  shutdown();
+  // Deregister first: the callback captures `this`, and once we return the object is
+  // gone. remove_pre_shutdown_callback() is a no-op if the callback already ran during a
+  // normal rclcpp shutdown, and Context serializes it against a callback in flight.
+  if (context_) {
+    context_->remove_pre_shutdown_callback(pre_shutdown_handle_);
+  }
+  shutdown();  // idempotent: a no-op when the pre-shutdown callback already ran
 }
 
 void Ros2ParameterTransport::shutdown() {

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -46,28 +46,46 @@ Ros2ParameterTransport::Ros2ParameterTransport(rclcpp::Node * node, double servi
   options.use_global_arguments(false);
   param_node_ = std::make_shared<rclcpp::Node>("_param_client_node", options);
 
-  // Tear the node down BEFORE the context is invalidated. Without this, an owner that
-  // outlives rclcpp::shutdown() (the gateway's own managers, or a plugin whose objects
-  // are destroyed from ~GatewayNode) drops param_node_ after the GraphListener has
-  // already cleared its node list, and ~NodeGraph's remove_node() throws
-  // NodeNotFoundError out of a noexcept destructor -> std::terminate, exit -6. It is a
-  // race, so it shows up as an intermittent abort on Ctrl+C rather than a reliable one.
-  context_ = param_node_->get_node_base_interface()->get_context();
-  pre_shutdown_handle_ = context_->add_pre_shutdown_callback([this] {
-    shutdown();
-  });
-
   // Store own node FQN for self-query detection.
   own_node_fqn_ = node_->get_fully_qualified_name();
 
   RCLCPP_INFO(node_->get_logger(), "Ros2ParameterTransport initialized (timeout=%.1fs, negative_cache=%.0fs)",
               service_timeout_sec_, negative_cache_ttl_sec_);
+
+  // Release param_node_ while the GraphListener is still running. The listener is stopped
+  // from an on_shutdown callback, which Context::shutdown() runs AFTER rcl_shutdown and
+  // therefore after every pre-shutdown callback - so registering here guarantees the node
+  // is gone before the listener goes down.
+  //
+  // What that avoids is the half-registration race: NodeGraph::get_graph_event() consumes
+  // should_add_to_graph_listener_ BEFORE calling add_node(), and add_node() throws
+  // GraphListenerShutdownError once the listener is down. The flag is then spent while the
+  // node was never listed, so ~NodeGraph takes its remove_node() branch, the node is absent
+  // from node_graph_interfaces_, and NodeNotFoundError escapes a noexcept destructor ->
+  // std::terminate, exit -6. Every wait_for_service in this class runs under spin_mutex_
+  // and this callback blocks on the same mutex, so no first graph use can straddle the
+  // listener's shutdown. (A node that IS registered tears down cleanly after shutdown:
+  // GraphListener::__shutdown() never clears node_graph_interfaces_, and remove_node()
+  // erases directly once is_shutdown() is set.)
+  //
+  // MUST stay the last statement of this constructor: if anything after it throws, the
+  // destructor never runs, and pre_shutdown_handle_ is only a weak_ptr - destroying it
+  // deregisters nothing, leaving a callback that later fires on freed memory.
+  context_ = param_node_->get_node_base_interface()->get_context();
+  pre_shutdown_handle_ = context_->add_pre_shutdown_callback([this] {
+    shutdown();
+  });
 }
 
 Ros2ParameterTransport::~Ros2ParameterTransport() {
-  // Deregister first: the callback captures `this`, and once we return the object is
-  // gone. remove_pre_shutdown_callback() is a no-op if the callback already ran during a
-  // normal rclcpp shutdown, and Context serializes it against a callback in flight.
+  // Deregister first: the callback captures `this`, and once we return the object is gone.
+  // This is real work even after the callback has already fired - Context::shutdown() runs
+  // the callbacks off a copy and never erases them, so the entry is still registered. The
+  // erase is load-bearing: the default context is a process-lifetime static that a later
+  // rclcpp::init() re-initializes without clearing the callback lists, so an entry left
+  // behind would fire on the NEXT shutdown against a freed transport. Context takes the
+  // same pre_shutdown_callbacks_mutex_ it fires under, so this is serialized against a
+  // callback in flight.
   if (context_) {
     context_->remove_pre_shutdown_callback(pre_shutdown_handle_);
   }
@@ -350,6 +368,18 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
         return result;
       }
 
+      // Bail out before the blocking wait once teardown has begun. shutdown() sets this
+      // flag before it blocks on spin_mutex_, and our pre-shutdown callback runs BEFORE
+      // rcl_shutdown - so wait_for_service's own rclcpp::ok early exit never trips and it
+      // would burn its full service timeout while holding spin_mutex_, gating rcl_shutdown
+      // for the whole process. Deliberately does NOT mark the negative cache: this says
+      // nothing about whether the target node is reachable.
+      if (shutdown_requested_.load()) {
+        result.success = false;
+        result.error_message = "Parameter client unavailable (transport shut down)";
+        result.error_code = ParameterErrorCode::SHUT_DOWN;
+        return result;
+      }
       if (!client->wait_for_service(get_service_timeout())) {
         result.success = false;
         result.error_message = "Parameter service not available for node: " + node_name;
@@ -467,6 +497,13 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
         return result;
       }
 
+      // Teardown bail-out before the blocking wait - see list_parameters() for why.
+      if (shutdown_requested_.load()) {
+        result.success = false;
+        result.error_message = "Parameter client unavailable (transport shut down)";
+        result.error_code = ParameterErrorCode::SHUT_DOWN;
+        return result;
+      }
       if (!client->wait_for_service(get_service_timeout())) {
         result.success = false;
         result.error_message = "Parameter service not available for node: " + node_name;
@@ -641,6 +678,13 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       return result;
     }
 
+    // Teardown bail-out before the blocking wait - see list_parameters() for why.
+    if (shutdown_requested_.load()) {
+      result.success = false;
+      result.error_message = "Parameter client unavailable (transport shut down)";
+      result.error_code = ParameterErrorCode::SHUT_DOWN;
+      return result;
+    }
     if (!client->wait_for_service(get_service_timeout())) {
       result.success = false;
       result.error_message = "Parameter service not available for node: " + node_name;
@@ -1094,6 +1138,12 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
       return false;  // transport shutting down, not a node-availability signal
     }
 
+    // Teardown bail-out before the blocking wait - see list_parameters() for why. Returns
+    // false so the caller treats it as "not a node-availability signal", matching the
+    // shut-down client path above.
+    if (shutdown_requested_.load()) {
+      return false;
+    }
     if (!client->wait_for_service(get_service_timeout())) {
       if (node_) {
         RCLCPP_WARN(node_->get_logger(), "Cannot cache defaults - service not available for node: '%s'",

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport_shutdown.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport_shutdown.cpp
@@ -14,31 +14,26 @@
 
 // Contract coverage for Ros2ParameterTransport's teardown ordering.
 //
-// HONEST SCOPE: these two tests do NOT reproduce the abort they describe - they pass
-// with and without the fix. A single-node process tears down cleanly either way; the
-// abort needs the real multi-node + executor teardown. The evidence for the fix is the
-// end-to-end measurement recorded in the commit message (0 aborts in 40 gateway
-// shutdowns, against a 6-in-33 baseline on the same build). What these tests DO pin is
-// the contract in both directions - transport destroyed after context shutdown, and
-// before it - so a future refactor that reorders this teardown has something to fail
-// against. Do not read them as proof the abort is gone.
+// HONEST SCOPE: these tests do NOT reproduce the SIGABRT that motivated the pre-shutdown
+// callback, and they are not expected to. They pass with and without it. The abort needs a
+// first-ever graph use to race the GraphListener's shutdown so the node ends up
+// half-registered (see the header comment on context_ / pre_shutdown_handle_), and this
+// single-threaded sequence cannot produce that race. Destroying a FULLY registered node
+// after rclcpp::shutdown() is a clean operation in rclcpp, so nothing here can abort.
 //
-// Ros2ParameterTransport owns an internal rclcpp::Node ("_param_client_node"). rclcpp's
-// ~NodeGraph calls GraphListener::remove_node(), which throws NodeNotFoundError once the
-// context has been shut down and the listener has dropped its node list. ~NodeGraph is
-// implicitly noexcept, so that throw is an immediate std::terminate - the process dies
-// with SIGABRT and no try/catch at any call site can intercept it.
-//
-// This is reachable whenever an owner outlives rclcpp::shutdown(): the gateway's own
-// managers, and any plugin whose objects are destroyed from ~GatewayNode (which runs
-// after rclcpp::shutdown() in main.cpp's teardown). In the field it surfaced as an
-// intermittent exit -6 on Ctrl+C, because whether the listener had already cleared its
-// list by then is a race. Here it is deterministic: rclcpp::shutdown() has returned, so
-// the listener is definitely down before the transport is dropped.
+// What these tests do pin is the teardown order in both directions - transport destroyed
+// after context shutdown, and before it - so a refactor that reorders it has something to
+// fail against. Do not read a green run here as proof the abort is fixed, and do not
+// conclude from it that the callback is dead code. The evidence for the fix is the
+// end-to-end measurement in the commit message: 0 aborts in 40 gateway shutdowns against a
+// 6-in-33 baseline on the same build.
 //
 // This test lives in its own translation unit because it must own the whole
 // init/shutdown lifecycle of the context - it cannot share the process-wide
-// SetUpTestSuite/TearDownTestSuite bracket the other transport tests use.
+// SetUpTestSuite/TearDownTestSuite bracket the other transport tests use. It runs two
+// init/shutdown cycles in one process, which is also what makes the destructor's
+// remove_pre_shutdown_callback() observable: a callback left registered by the first cycle
+// would fire during the second one against a freed transport.
 
 #include <gtest/gtest.h>
 
@@ -59,30 +54,35 @@ TEST(Ros2ParameterTransportShutdown, DestroyingTheTransportAfterContextShutdownD
   auto owner = std::make_shared<rclcpp::Node>("param_transport_shutdown_owner");
   auto transport = std::make_unique<Ros2ParameterTransport>(owner.get(), kServiceTimeoutSec, kNegativeCacheTtlSec);
 
-  // REQUIRED to reproduce: rclcpp registers a node with the GraphListener lazily, on the
-  // first graph query - and ~NodeGraph only calls remove_node() for a node that was
-  // registered. A transport that never talked to anyone therefore tears down cleanly even
-  // without the fix. One round trip (against a node that does not exist - it just has to
-  // reach wait_for_service, bounded by kServiceTimeoutSec) puts _param_client_node in the
-  // listener, which is the state every real gateway is in by shutdown time.
+  // Required for ~NodeGraph to call remove_node() at all: rclcpp registers a node with the
+  // GraphListener lazily, on the first graph query, and ~NodeGraph only removes a node whose
+  // should_add_to_graph_listener_ flag was consumed. One round trip (against a node that
+  // does not exist - it only has to reach wait_for_service, bounded by kServiceTimeoutSec)
+  // puts _param_client_node in the listener, which is the state a real gateway is in by
+  // shutdown time. Without it this test would exercise nothing.
   transport->list_parameters("/no_such_node_for_graph_registration");
 
   // Invalidate the context while the transport still holds its internal node. The
-  // pre-shutdown callback registered in the constructor must release it here.
+  // pre-shutdown callback registered in the constructor releases it here.
   rclcpp::shutdown();
 
-  // Before the fix this dropped param_node_ with the GraphListener already down:
-  // ~NodeGraph -> remove_node() -> NodeNotFoundError -> std::terminate. The process
-  // aborted instead of reaching any assertion below.
+  // Dropping a fully registered node after shutdown is clean in rclcpp (remove_node() takes
+  // its is_shutdown() branch and erases from a list __shutdown() never touched), so this
+  // does not abort with or without the callback. It pins the order, nothing more.
   transport.reset();
   owner.reset();
   SUCCEED() << "transport destroyed after rclcpp::shutdown() without aborting";
 }
 
-// The ordinary case must keep working: the transport dies while the context is still
-// valid, so the destructor deregisters the (never-fired) pre-shutdown callback and runs
-// the real teardown itself. A stale callback left on the context would fire later
-// against freed memory.
+// The ordinary case: the transport dies while the context is still valid, so the
+// destructor deregisters its pre-shutdown callback and runs the real teardown itself.
+//
+// This test also depends on the one above having run first, and that is the point.
+// Context::shutdown() fires pre-shutdown callbacks off a copy and never erases them, and
+// the default context is a process-lifetime static that rclcpp::init() re-initializes
+// without clearing the callback lists. So the callback the first test FIRED is still
+// registered when this second init/shutdown cycle starts. If the destructor did not erase
+// it, the rclcpp::shutdown() below would invoke it on the first test's freed transport.
 TEST(Ros2ParameterTransportShutdown, DestroyingTheTransportBeforeContextShutdownIsClean) {
   rclcpp::init(0, nullptr);
   {

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport_shutdown.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport_shutdown.cpp
@@ -1,0 +1,97 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contract coverage for Ros2ParameterTransport's teardown ordering.
+//
+// HONEST SCOPE: these two tests do NOT reproduce the abort they describe - they pass
+// with and without the fix. A single-node process tears down cleanly either way; the
+// abort needs the real multi-node + executor teardown. The evidence for the fix is the
+// end-to-end measurement recorded in the commit message (0 aborts in 40 gateway
+// shutdowns, against a 6-in-33 baseline on the same build). What these tests DO pin is
+// the contract in both directions - transport destroyed after context shutdown, and
+// before it - so a future refactor that reorders this teardown has something to fail
+// against. Do not read them as proof the abort is gone.
+//
+// Ros2ParameterTransport owns an internal rclcpp::Node ("_param_client_node"). rclcpp's
+// ~NodeGraph calls GraphListener::remove_node(), which throws NodeNotFoundError once the
+// context has been shut down and the listener has dropped its node list. ~NodeGraph is
+// implicitly noexcept, so that throw is an immediate std::terminate - the process dies
+// with SIGABRT and no try/catch at any call site can intercept it.
+//
+// This is reachable whenever an owner outlives rclcpp::shutdown(): the gateway's own
+// managers, and any plugin whose objects are destroyed from ~GatewayNode (which runs
+// after rclcpp::shutdown() in main.cpp's teardown). In the field it surfaced as an
+// intermittent exit -6 on Ctrl+C, because whether the listener had already cleared its
+// list by then is a race. Here it is deterministic: rclcpp::shutdown() has returned, so
+// the listener is definitely down before the transport is dropped.
+//
+// This test lives in its own translation unit because it must own the whole
+// init/shutdown lifecycle of the context - it cannot share the process-wide
+// SetUpTestSuite/TearDownTestSuite bracket the other transport tests use.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp"
+
+using ros2_medkit_gateway::ros2::Ros2ParameterTransport;
+
+namespace {
+constexpr double kServiceTimeoutSec = 0.2;
+constexpr double kNegativeCacheTtlSec = 1.0;
+}  // namespace
+
+TEST(Ros2ParameterTransportShutdown, DestroyingTheTransportAfterContextShutdownDoesNotAbort) {
+  rclcpp::init(0, nullptr);
+  auto owner = std::make_shared<rclcpp::Node>("param_transport_shutdown_owner");
+  auto transport = std::make_unique<Ros2ParameterTransport>(owner.get(), kServiceTimeoutSec, kNegativeCacheTtlSec);
+
+  // REQUIRED to reproduce: rclcpp registers a node with the GraphListener lazily, on the
+  // first graph query - and ~NodeGraph only calls remove_node() for a node that was
+  // registered. A transport that never talked to anyone therefore tears down cleanly even
+  // without the fix. One round trip (against a node that does not exist - it just has to
+  // reach wait_for_service, bounded by kServiceTimeoutSec) puts _param_client_node in the
+  // listener, which is the state every real gateway is in by shutdown time.
+  transport->list_parameters("/no_such_node_for_graph_registration");
+
+  // Invalidate the context while the transport still holds its internal node. The
+  // pre-shutdown callback registered in the constructor must release it here.
+  rclcpp::shutdown();
+
+  // Before the fix this dropped param_node_ with the GraphListener already down:
+  // ~NodeGraph -> remove_node() -> NodeNotFoundError -> std::terminate. The process
+  // aborted instead of reaching any assertion below.
+  transport.reset();
+  owner.reset();
+  SUCCEED() << "transport destroyed after rclcpp::shutdown() without aborting";
+}
+
+// The ordinary case must keep working: the transport dies while the context is still
+// valid, so the destructor deregisters the (never-fired) pre-shutdown callback and runs
+// the real teardown itself. A stale callback left on the context would fire later
+// against freed memory.
+TEST(Ros2ParameterTransportShutdown, DestroyingTheTransportBeforeContextShutdownIsClean) {
+  rclcpp::init(0, nullptr);
+  {
+    auto owner = std::make_shared<rclcpp::Node>("param_transport_ordinary_owner");
+    auto transport = std::make_unique<Ros2ParameterTransport>(owner.get(), kServiceTimeoutSec, kNegativeCacheTtlSec);
+    transport.reset();
+  }
+  // If the destructor had left its callback registered, this shutdown would run it
+  // against a destroyed transport.
+  rclcpp::shutdown();
+  SUCCEED() << "context shutdown after the transport was destroyed without aborting";
+}


### PR DESCRIPTION
# Pull Request

## Summary

`Ros2ParameterTransport` creates its own `rclcpp::Node` (`_param_client_node`) and released it only in its destructor. If the owner outlives `rclcpp::shutdown()`, the node is dropped after the `GraphListener` has already cleared its node list. rclcpp's `~NodeGraph` then calls `GraphListener::remove_node()`, which throws `NodeNotFoundError`. `~NodeGraph` is implicitly `noexcept`, so the throw goes straight to `std::terminate` and the process dies with SIGABRT. A `try/catch` at the call site cannot stop it, so the fix has to change the order, not catch the exception.

This is reachable on a normal Ctrl+C. The signal handler runs `rclcpp::shutdown()`, and that is what makes `executor.spin()` return. Only after that does `main.cpp` destroy the gateway node, so `~GatewayNode` and everything it owns run when the context is already invalid. Whether the listener has cleared its list by then is a race, which is why the abort is intermittent and not every run.

The transport now registers a pre-shutdown callback that runs its `shutdown()` while the context is still valid. `shutdown()` was already idempotent. The destructor removes the callback and still calls `shutdown()`, so the normal case (transport destroyed first) is unchanged.

---

## Issue

- closes #566

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Measured on a gateway that reproduced the abort: 6 aborts in 33 shutdowns before the change, 0 in 40 after, with everything else identical.

Two unit tests were added in a new file. They check the teardown order in both directions: transport destroyed after context shutdown, and before it. They do NOT reproduce the abort, because a process with only one node tears down cleanly either way. So they are contract coverage, not the proof. The measurement above is the proof, and the test file says so.

Full `ros2_medkit_gateway` suite passes: 111 gtests plus all linters.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
