### PR TITLE
feat(graph_watchdog): plugin scaffolding + QoS-mismatch detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,10 @@ jobs:
           ccache -s
 
       - name: Run unit and integration tests
-        timeout-minutes: 15
+        # The suite grew past the old 15-minute budget: on lyrical it was already taking
+        # 14m13s on main, so any new package tipped it over. This is real work finishing, not
+        # a hang.
+        timeout-minutes: 25
         env:
           # FastRTPS 2.6 on Humble has a known use-after-free in the
           # discovery-teardown path (EDP::unpairWriterProxy) that segfaults

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -378,6 +378,19 @@ Functions
    forever. See :doc:`/tutorials/graph-provider` for the full prerequisites and a
    worked walkthrough, and :doc:`/config/graph-provider` for the threshold reference.
 
+``GET /api/v1/x-medkit-watchdog``
+   Get the graph watchdog's reliability status: which entities it has observed, which are
+   armed (past the bringup-quiesce warmup and therefore eligible to raise), and the cached
+   lifecycle state of any managed lifecycle nodes. Served by the
+   ``ros2_medkit_graph_watchdog`` plugin. Read-only; it raises nothing and changes nothing.
+
+   The payload carries ``schema_version``, the configured ``warmup_cycles``, a global state,
+   and a per-entity map. An entity that is present but not yet armed is normal during
+   bringup: the watchdog holds every raise until an entity has been continuously present for
+   ``warmup_cycles`` ticks, so a joining node does not read as a failure.
+
+   Use it to answer "why has the watchdog not reported anything yet" without reading logs.
+
    **Example Response:**
 
    .. code-block:: json

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -22,7 +22,7 @@
 #   ros2_medkit_sovd_service_interface: 1 -   9 (9 slots)
 #   ros2_medkit_fault_manager:         10 -  29 (20 slots)
 #   ros2_medkit_gateway:               30 -  74 (45 slots)
-#   ros2_medkit_graph_watchdog:        75 -  89 (15 slots)
+#   ros2_medkit_graph_watchdog:        75 -  89 (15 slots; launch tests share 89)
 #   ros2_medkit_diagnostic_bridge:     90 -  99 (10 slots)
 #   ros2_medkit_param_beacon:         100 - 104 (5 slots)
 #   ros2_medkit_topic_beacon:         105 - 109 (5 slots)

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -21,7 +21,8 @@
 # Allocated ranges:
 #   ros2_medkit_sovd_service_interface: 1 -   9 (9 slots)
 #   ros2_medkit_fault_manager:         10 -  29 (20 slots)
-#   ros2_medkit_gateway:               30 -  89 (60 slots)
+#   ros2_medkit_gateway:               30 -  74 (45 slots)
+#   ros2_medkit_graph_watchdog:        75 -  89 (15 slots)
 #   ros2_medkit_diagnostic_bridge:     90 -  99 (10 slots)
 #   ros2_medkit_param_beacon:         100 - 104 (5 slots)
 #   ros2_medkit_topic_beacon:         105 - 109 (5 slots)

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
@@ -316,6 +316,11 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         fault_code = 'ROSBAG_TEST_001'
 
         # Report fault - buffer should already have messages from background publishers
+        # The previous test's post-fault recording window diverts incoming messages away
+        # from the ring buffer, so right after it closes the buffer can be empty and
+        # flush_to_bag creates no bag. Wait for it to refill before reporting.
+        self.assertTrue(self._wait_for_buffered_data(),
+                        'ring buffer never refilled after the previous post-fault window')
         response = self._report_fault(fault_code, 'Rosbag integration test fault')
         self.assertTrue(response.accepted)
         print(f'Fault {fault_code} reported and confirmed')
@@ -344,6 +349,11 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         fault_code = 'ROSBAG_CLEANUP_TEST'
 
         # Report fault - buffer has messages from background publishers
+        # The previous test's post-fault recording window diverts incoming messages away
+        # from the ring buffer, so right after it closes the buffer can be empty and
+        # flush_to_bag creates no bag. Wait for it to refill before reporting.
+        self.assertTrue(self._wait_for_buffered_data(),
+                        'ring buffer never refilled after the previous post-fault window')
         response = self._report_fault(fault_code, 'Cleanup test fault')
         self.assertTrue(response.accepted)
 

--- a/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
+++ b/src/ros2_medkit_fault_manager/test/test_rosbag_integration.test.py
@@ -452,6 +452,11 @@ class TestRosbagCaptureIntegration(unittest.TestCase):
         fault_code = 'DURATION_TEST'
 
         # Report fault - buffer should have ~duration_sec worth of messages
+        # Same refill race as test_01/test_02: the previous test's post-fault window
+        # diverts messages away from the ring buffer, so reporting straight after it
+        # closes finds the buffer empty and no bag is created.
+        self.assertTrue(self._wait_for_buffered_data(),
+                        'ring buffer never refilled after the previous post-fault window')
         response = self._report_fault(fault_code, 'Duration test fault')
         self.assertTrue(response.accepted)
 

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -345,7 +345,7 @@ if(BUILD_TESTING)
   )
 
   include(ROS2MedkitTestDomain)
-  medkit_init_test_domains(START 30 END 89)
+  medkit_init_test_domains(START 30 END 74)
 
   # ─── Core purity check ────────────────────────────────────────────────────
   # Fails the build if any file under include/ros2_medkit_gateway/core/ or

--- a/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
@@ -298,8 +298,12 @@ ActionSendGoalResult OperationManager::send_component_action_goal(const std::str
 }
 
 namespace {
-/// Wall-clock budget for one CancelGoal round-trip. See the call site for why it is not tighter.
-constexpr std::chrono::duration<double> kCancelGoalTimeout{15.0};
+/// Floor for the CancelGoal budget. Cancel is a service call to the action server plus that
+/// server's own handling, so it is bounded by the SERVER, not by us; a very small configured
+/// service timeout would otherwise report a live cancel as a failure. The configured
+/// service_call_timeout_sec still wins whenever it is larger, so lowering it keeps bounding
+/// cancel like every other call in this file.
+constexpr double kCancelGoalFloorSec = 15.0;
 }  // namespace
 
 ActionCancelResult OperationManager::cancel_action_goal(const std::string & action_path, const std::string & goal_id) {
@@ -327,7 +331,9 @@ ActionCancelResult OperationManager::cancel_action_goal(const std::string & acti
   // handling, so it is bounded by the SERVER, not by us. 5s was enough on an idle machine and
   // not on a loaded one: under a busy CI container the request timed out and the cancel was
   // reported as a vendor error while the goal had in fact been accepted for cancellation.
-  result = action_transport_->cancel_goal(action_path, goal_id, kCancelGoalTimeout);
+  const auto cancel_timeout =
+      std::chrono::duration<double>(std::max(static_cast<double>(service_call_timeout_sec_), kCancelGoalFloorSec));
+  result = action_transport_->cancel_goal(action_path, goal_id, cancel_timeout);
 
   if (result.success && result.return_code == 0) {
     update_goal_status(goal_id, ActionGoalStatus::CANCELING);

--- a/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
@@ -15,8 +15,8 @@
 #include "ros2_medkit_gateway/core/managers/operation_manager.hpp"
 
 #include <algorithm>
-#include <chrono>
 #include <cctype>
+#include <chrono>
 #include <iomanip>
 #include <random>
 #include <regex>

--- a/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/operation_manager.cpp
@@ -15,6 +15,7 @@
 #include "ros2_medkit_gateway/core/managers/operation_manager.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <cctype>
 #include <iomanip>
 #include <random>
@@ -296,6 +297,11 @@ ActionSendGoalResult OperationManager::send_component_action_goal(const std::str
   return send_action_goal(action_path, resolved_type, goal, entity_id);
 }
 
+namespace {
+/// Wall-clock budget for one CancelGoal round-trip. See the call site for why it is not tighter.
+constexpr std::chrono::duration<double> kCancelGoalTimeout{15.0};
+}  // namespace
+
 ActionCancelResult OperationManager::cancel_action_goal(const std::string & action_path, const std::string & goal_id) {
   ActionCancelResult result;
   result.success = false;
@@ -317,7 +323,11 @@ ActionCancelResult OperationManager::cancel_action_goal(const std::string & acti
     return result;
   }
 
-  result = action_transport_->cancel_goal(action_path, goal_id, std::chrono::duration<double>(5.0));
+  // A CancelGoal round-trip is a service call to the action server plus that server's own
+  // handling, so it is bounded by the SERVER, not by us. 5s was enough on an idle machine and
+  // not on a loaded one: under a busy CI container the request timed out and the cancel was
+  // reported as a vendor error while the goal had in fact been accepted for cancellation.
+  result = action_transport_->cancel_goal(action_path, goal_id, kCancelGoalTimeout);
 
   if (result.success && result.return_code == 0) {
     update_goal_status(goal_id, ActionGoalStatus::CANCELING);

--- a/src/ros2_medkit_integration_tests/test/features/test_operations_api.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_operations_api.test.py
@@ -408,8 +408,11 @@ class TestOperationsApi(GatewayTestCase):
 
         @verifies REQ_INTEROP_036
         """
-        # Wait for the known action app to expose its async operation.
-        self.wait_for_operation('/apps/long_calibration', 'long_calibration')
+        # Wait for the operation to be usable, not merely listed: the name
+        # appears before the gateway has resolved the ROS interface type.
+        self.wait_for_operation_type_info(
+            '/apps/long_calibration', 'long_calibration',
+            ('goal', 'result', 'feedback'))
 
         # List executions - should return items array (may be empty)
         response = requests.get(

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_action_lifecycle.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_action_lifecycle.test.py
@@ -68,9 +68,18 @@ class TestScenarioActionLifecycle(GatewayTestCase):
     ENTITY_ENDPOINT = '/apps/long_calibration'
 
     def _ensure_operation_ready(self):
-        """Wait for the long_calibration operation to be discovered."""
-        self.wait_for_operation(
-            self.ENTITY_ENDPOINT, self.OPERATION_ID, max_wait=15.0
+        """Wait for the long_calibration operation to be USABLE, not just listed.
+
+        An operation appears under /operations as soon as it is discovered by
+        name, but the gateway cannot send a goal until it has also resolved the
+        underlying ROS interface type. Waiting on the name alone races that
+        second step, and creating an execution in the gap returns 500
+        x-medkit-ros2-action-unavailable, because the empty type string fails
+        typesupport lookup. Wait for the resolved schema instead.
+        """
+        self.wait_for_operation_type_info(
+            self.ENTITY_ENDPOINT, self.OPERATION_ID,
+            ('goal', 'result', 'feedback'), max_wait=15.0
         )
 
     def _create_action_execution(self, order=5):

--- a/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_action_lifecycle.test.py
+++ b/src/ros2_medkit_integration_tests/test/scenarios/test_scenario_action_lifecycle.test.py
@@ -135,9 +135,13 @@ class TestScenarioActionLifecycle(GatewayTestCase):
             f'Execution should be running or completed, got {status_data["status"]}',
         )
 
-        # Cancel the execution
+        # Cancel the execution. The client budget must exceed the gateway's: cancelling is
+        # a service round-trip to the action server (up to 2s to find the service plus the
+        # cancel budget itself), so a 10s client timeout would surface a slow-but-successful
+        # cancel as an opaque ReadTimeout instead of the server's own diagnosable error.
         response = self.delete_request(
             self._exec_endpoint(execution_id),
+            timeout=25,
             expected_status=204,
         )
         self.assertEqual(len(response.content), 0)

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -87,6 +87,14 @@ target_link_libraries(ros2_medkit_graph_watchdog nlohmann_json::nlohmann_json)
 install(TARGETS ros2_medkit_graph_watchdog LIBRARY DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
+  include(ROS2MedkitTestDomain)
+  # This package owns 75-89. The gtests below take one domain each through the shared macro,
+  # so the allocation table cannot drift from the literals and exhaustion is a configure
+  # error rather than a silent collision. The launch tests cannot use it: it writes
+  # ENVIRONMENT wholesale and they also need GATEWAY_TEST_PORT and the plugin path, so they
+  # keep an explicit assignment and share one domain under a RESOURCE_LOCK.
+  medkit_init_test_domains(START 75 END 89)
+
   find_package(ament_lint_auto REQUIRED)
   # uncrustify/cpplint conflict with project-wide clang-format (120 cols vs 100).
   # flake8/pep257 are excluded to match the rest of the workspace: no package here
@@ -145,7 +153,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_watchdog_clock test/test_watchdog_clock.cpp)
   target_include_directories(test_watchdog_clock PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
   medkit_target_dependencies(test_watchdog_clock rclcpp rosgraph_msgs)
-  set_tests_properties(test_watchdog_clock PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=75")
+  medkit_set_test_domain(test_watchdog_clock)
 
   ament_add_gtest(test_graph_watchdog_plugin
     test/test_graph_watchdog_plugin.cpp
@@ -159,7 +167,7 @@ if(BUILD_TESTING)
   medkit_target_dependencies(test_graph_watchdog_plugin
     ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs)
   target_link_libraries(test_graph_watchdog_plugin nlohmann_json::nlohmann_json)
-  set_tests_properties(test_graph_watchdog_plugin PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=76")
+  medkit_set_test_domain(test_graph_watchdog_plugin)
 
   ament_add_gtest(test_lifecycle_watcher
     test/test_lifecycle_watcher.cpp
@@ -167,7 +175,7 @@ if(BUILD_TESTING)
     ${LIFECYCLE_STATE_READER_SOURCES})
   target_include_directories(test_lifecycle_watcher PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
   medkit_target_dependencies(test_lifecycle_watcher ros2_medkit_gateway rclcpp lifecycle_msgs)
-  set_tests_properties(test_lifecycle_watcher PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=77")
+  medkit_set_test_domain(test_lifecycle_watcher)
 
   ament_add_gtest(test_reliability_gate
     test/test_reliability_gate.cpp
@@ -177,7 +185,7 @@ if(BUILD_TESTING)
   target_include_directories(test_reliability_gate PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
   medkit_target_dependencies(test_reliability_gate ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs)
   target_link_libraries(test_reliability_gate nlohmann_json::nlohmann_json)
-  set_tests_properties(test_reliability_gate PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=78")
+  medkit_set_test_domain(test_reliability_gate)
 
   # LifecycleShutdownSuppressor: needs a REAL ReliabilityGate (departed_lifecycle_state_of()
   # reads live from ctx.gate) - same real-Node/ROS_DOMAIN_ID rationale as test_reliability_gate
@@ -205,8 +213,8 @@ if(BUILD_TESTING)
   medkit_target_dependencies(test_qos_mismatch_integration
     ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs std_msgs)
   target_link_libraries(test_qos_mismatch_integration nlohmann_json::nlohmann_json)
-  set_tests_properties(test_qos_mismatch_integration PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=81"
-    TIMEOUT 120 RESOURCE_LOCK graph_watchdog_integration_domain)
+  medkit_set_test_domain(test_qos_mismatch_integration)
+  set_tests_properties(test_qos_mismatch_integration PROPERTIES TIMEOUT 120 RESOURCE_LOCK graph_watchdog_integration_domain)
 
   # === QoS-mismatch e2e (launch_testing) ===
   #

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -1,0 +1,233 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.8)
+project(ros2_medkit_graph_watchdog)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ros2_medkit_cmake REQUIRED)
+include(ROS2MedkitCompat)
+include(ROS2MedkitCcache)
+include(ROS2MedkitSanitizers)
+include(ROS2MedkitWarnings)
+
+find_package(ament_cmake REQUIRED)
+find_package(ros2_medkit_gateway REQUIRED)
+find_package(ros2_medkit_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
+find_package(tf2_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+# ros2_medkit_gateway only exports its include directories via ament (no
+# installed gateway_core/gateway_ros2 library - see its CMakeLists.txt), so
+# ros2_medkit_gateway exports its include dirs but installs no library target,
+# so these non-header-only helpers must be compiled in. Their
+# headers must come from the SAME tree: the installed package can be older than
+# the workspace, and then a reused source fails to see its own members.
+set(GATEWAY_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../ros2_medkit_gateway"
+    CACHE PATH "Path to ros2_medkit_gateway source (for reused non-header-only helpers)")
+set(GATEWAY_SRC_INCLUDE_DIR "${GATEWAY_SRC_DIR}/include")
+set(LIFECYCLE_STATE_READER_SOURCES
+  ${GATEWAY_SRC_DIR}/src/core/status/lifecycle_status_helpers.cpp
+  ${GATEWAY_SRC_DIR}/src/ros2/status/ros2_lifecycle_state_reader.cpp)
+# Fail early with a clear message if the reused gateway sources are missing
+# (e.g. building the package outside the workspace),
+# instead of a later non-obvious compile error.
+foreach(_gw_src ${LIFECYCLE_STATE_READER_SOURCES})
+  if(NOT EXISTS "${_gw_src}")
+    message(FATAL_ERROR
+      "ros2_medkit_graph_watchdog: required gateway source not found: ${_gw_src}. "
+      "Set -DGATEWAY_SRC_DIR to the ros2_medkit_gateway source tree "
+      "(default assumes the standard workspace layout).")
+  endif()
+endforeach()
+
+set(PARAMETER_TRANSPORT_SOURCES
+  ${GATEWAY_SRC_DIR}/src/ros2/transports/ros2_parameter_transport.cpp)
+foreach(_gw_src ${PARAMETER_TRANSPORT_SOURCES})
+  if(NOT EXISTS "${_gw_src}")
+    message(FATAL_ERROR
+      "ros2_medkit_graph_watchdog: required gateway source not found: ${_gw_src}. "
+      "Set -DGATEWAY_SRC_DIR to the ros2_medkit_gateway source tree.")
+  endif()
+endforeach()
+
+install(DIRECTORY include/ DESTINATION include)
+
+file(GLOB DETECTOR_SRCS CONFIGURE_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/src/detectors/*.cpp)
+
+add_library(ros2_medkit_graph_watchdog MODULE
+  src/graph_watchdog_plugin.cpp
+  src/graph_watchdog_plugin_exports.cpp
+  src/detector_registry.cpp
+  src/lifecycle_watcher.cpp
+  src/reliability_gate.cpp
+  ${LIFECYCLE_STATE_READER_SOURCES}
+  ${PARAMETER_TRANSPORT_SOURCES}
+  ${DETECTOR_SRCS})
+target_include_directories(ros2_medkit_graph_watchdog PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+medkit_target_dependencies(ros2_medkit_graph_watchdog
+  ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs tf2_msgs geometry_msgs)
+target_link_libraries(ros2_medkit_graph_watchdog nlohmann_json::nlohmann_json)
+install(TARGETS ros2_medkit_graph_watchdog LIBRARY DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # uncrustify/cpplint conflict with project-wide clang-format (120 cols vs 100).
+  # flake8/pep257 are excluded to match the rest of the workspace: no package here
+  # lints Python, including ros2_medkit_integration_tests, which holds every other
+  # launch test. copyright, lint_cmake and xmllint stay on.
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_uncrustify
+    ament_cmake_cpplint
+    ament_cmake_clang_format
+    ament_cmake_flake8
+    ament_cmake_pep257
+  )
+  ament_lint_auto_find_test_dependencies()
+
+  # ci.yml skips the ament_cmake_clang_format rosdep key in the build-and-test
+  # job (linters only run in the Jazzy quality job), so QUIET + FOUND check
+  # avoids hard-failing when the package is not installed.
+  find_package(ament_cmake_clang_format QUIET)
+  if(ament_cmake_clang_format_FOUND)
+    file(GLOB_RECURSE _format_files "include/*.hpp" "src/*.cpp" "test/*.cpp")
+    ament_clang_format(${_format_files}
+      CONFIG_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../../../.clang-format")
+  endif()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(rosgraph_msgs REQUIRED)
+
+  ament_add_gtest(test_warmup_tracker test/test_warmup_tracker.cpp)
+  target_include_directories(test_warmup_tracker PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+
+  ament_add_gtest(test_fault_request test/test_fault_request.cpp)
+  target_include_directories(test_fault_request PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_fault_request ros2_medkit_msgs)
+
+  ament_add_gtest(test_detector
+    test/test_detector.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_detector PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_detector rclcpp ros2_medkit_msgs ros2_medkit_gateway lifecycle_msgs)
+  target_link_libraries(test_detector nlohmann_json::nlohmann_json)
+
+  ament_add_gtest(test_detector_registry
+    test/test_detector_registry.cpp
+    src/detector_registry.cpp)
+  target_include_directories(test_detector_registry PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_detector_registry rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_detector_registry nlohmann_json::nlohmann_json)
+
+  ament_add_gtest(test_detector_config test/test_detector_config.cpp)
+  target_include_directories(test_detector_config PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_detector_config rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_detector_config nlohmann_json::nlohmann_json)
+
+  ament_add_gtest(test_watchdog_clock test/test_watchdog_clock.cpp)
+  target_include_directories(test_watchdog_clock PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_watchdog_clock rclcpp rosgraph_msgs)
+  set_tests_properties(test_watchdog_clock PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=75")
+
+  ament_add_gtest(test_graph_watchdog_plugin
+    test/test_graph_watchdog_plugin.cpp
+    src/graph_watchdog_plugin.cpp
+    src/graph_watchdog_plugin_exports.cpp
+    src/detector_registry.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_graph_watchdog_plugin PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_graph_watchdog_plugin
+    ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs)
+  target_link_libraries(test_graph_watchdog_plugin nlohmann_json::nlohmann_json)
+  set_tests_properties(test_graph_watchdog_plugin PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=76")
+
+  ament_add_gtest(test_lifecycle_watcher
+    test/test_lifecycle_watcher.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_lifecycle_watcher PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_lifecycle_watcher ros2_medkit_gateway rclcpp lifecycle_msgs)
+  set_tests_properties(test_lifecycle_watcher PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=77")
+
+  ament_add_gtest(test_reliability_gate
+    test/test_reliability_gate.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_reliability_gate PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_reliability_gate ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs)
+  target_link_libraries(test_reliability_gate nlohmann_json::nlohmann_json)
+  set_tests_properties(test_reliability_gate PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=78")
+
+  # LifecycleShutdownSuppressor: needs a REAL ReliabilityGate (departed_lifecycle_state_of()
+  # reads live from ctx.gate) - same real-Node/ROS_DOMAIN_ID rationale as test_reliability_gate
+  # above, unlike test_allowlist_suppressor (pure interface, no gate needed).
+  ament_add_gtest(test_qos_policy test/test_qos_policy.cpp)
+  target_include_directories(test_qos_policy PRIVATE include)
+  medkit_target_dependencies(test_qos_policy rmw)   # rmw is transitively found via rclcpp; no find_package needed
+
+  ament_add_gtest(test_aggregated_fault test/test_aggregated_fault.cpp)
+  target_include_directories(test_aggregated_fault PRIVATE include)
+  medkit_target_dependencies(test_aggregated_fault ros2_medkit_gateway rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_aggregated_fault nlohmann_json::nlohmann_json)
+
+  # Pure suppressor-chain interface: no raise_fault/clear_fault calls (no ReliabilityGate
+  # sources needed), no live rclcpp::Node, so no ROS_DOMAIN_ID is required - same as
+  # test_qos_policy above.
+  ament_add_gtest(test_qos_mismatch_integration
+    test/test_qos_mismatch_integration.cpp
+    src/detectors/qos_mismatch_detector.cpp
+    src/detector_registry.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_qos_mismatch_integration PRIVATE include)
+  medkit_target_dependencies(test_qos_mismatch_integration
+    ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs std_msgs)
+  target_link_libraries(test_qos_mismatch_integration nlohmann_json::nlohmann_json)
+  set_tests_properties(test_qos_mismatch_integration PROPERTIES ENVIRONMENT "ROS_DOMAIN_ID=81"
+    TIMEOUT 120 RESOURCE_LOCK graph_watchdog_integration_domain)
+
+  # === QoS-mismatch e2e (launch_testing) ===
+  #
+  # Acceptance gate: proves GRAPH_QOS_MISMATCH raises and clears through the
+  # REAL gateway + qos_mismatch_detector + fault_manager stack, not just against a
+  # fake ReportFault service (test_qos_mismatch_integration.cpp's job). See
+  # test/e2e/test_qos_e2e.test.py for the full story.
+  # The plugin .so path is injected straight from the build output via
+  # GRAPH_WATCHDOG_PLUGIN_PATH (see harness.py's graph_watchdog_plugin_path()).
+  find_package(launch_testing_ament_cmake REQUIRED)
+  set(_WATCHDOG_E2E_SO "$<TARGET_FILE:ros2_medkit_graph_watchdog>")
+
+  add_launch_test(test/e2e/test_qos_e2e.test.py TIMEOUT 180)
+  set_tests_properties(test_e2e_test_qos_e2e.test.py PROPERTIES
+    LABELS "integration;e2e"
+    # Shares the e2e domain and its lock rather than consuming another slot.
+    ENVIRONMENT "GATEWAY_TEST_PORT=19120;ROS_DOMAIN_ID=89;GRAPH_WATCHDOG_PLUGIN_PATH=${_WATCHDOG_E2E_SO}"
+    RESOURCE_LOCK graph_watchdog_e2e_domain)
+
+  ros2_medkit_relax_vendor_warnings()
+
+endif()
+
+ament_package()

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -1,0 +1,281 @@
+# ros2_medkit_graph_watchdog
+
+Gateway plugin that detects silent faults in the ROS 2 graph: failures where every
+node is up, nothing logs an error, and the robot is still broken.
+
+Detectors read the graph and raise faults through a `ReportFault` service client on the
+gateway node; the faults surface via FaultManager on the gateway `/faults` API.
+
+This package carries the plugin skeleton, the central reliability gate that holds raises
+until the graph has quiesced, and the first detector, `qos_mismatch`. The remaining
+silent-fault classes land in follow-up changes, each against its own issue; their fault
+codes are already reserved in the frozen `GRAPH_*` namespace (see "Fault codes").
+
+## Build
+
+With the gateway built and sourced:
+
+    colcon build --packages-select ros2_medkit_graph_watchdog
+    colcon test --packages-select ros2_medkit_graph_watchdog && colcon test-result --verbose
+
+## Load into the gateway
+
+    ros2 run ros2_medkit_gateway gateway_node --ros-args \
+      -p plugins:="[graph_watchdog]" \
+      -p "plugins.graph_watchdog.path:=$(ros2 pkg prefix ros2_medkit_graph_watchdog)/lib/ros2_medkit_graph_watchdog/libros2_medkit_graph_watchdog.so"
+
+## Configuration (`plugins.graph_watchdog.<key>`)
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `tick_interval_ms` | int | `1000` | Detector tick cadence. |
+| `warmup_cycles` | int | `5` | An entity must be continuously present for this many ticks before it arms. A mid-run restart re-warms it. Enforced centrally, see "Reliability (bringup-quiesce)" below. |
+| `prune_grace` | int | `60` | Default injected into every detector's own config before `configure()`; a per-detector `detectors.<id>.prune_grace` overrides it. Used by detectors that keep per-key bookkeeping. |
+| `detectors.<id>.mode` | string \| bool | `raise` | `raise` = push faults; `advisory` = observe, do not push; `off` = disabled. Bare `off`/`no` (YAML booleans) also disable; bare `on`/`yes` mean `raise`. |
+| `detectors.<id>.<field>` | any | - | Per-detector thresholds, passed to that detector's `configure()`. |
+
+**Nested delivery.** Keys are written dotted in YAML or `--ros-args`, and the gateway
+delivers them to the plugin as a nested object. A bare `off` is a YAML 1.1 boolean, so
+`mode: off` arrives as `false`, not the string `"off"`; both forms disable the detector.
+
+**Unknown keys are reported.** Anything under `detectors.<id>` that the detector does not
+read produces one startup warning naming the key and listing the ones that exist, so a
+typo like `allow_list:` for `allowlist:` cannot silently do nothing. A typo in the detector
+id itself is warned about the same way, with the registered ids listed.
+
+### `qos_mismatch` keys
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `mode` | string | `raise` | As above. |
+| `grace` | int | `3` | Consecutive ticks a topic must stay affected before it is reported. Endpoint discovery is not atomic, so a subscriber can be visible before a publisher's QoS is, which reads as starvation for a tick or two. |
+| `allowlist` | string[] | `[]` | Subscriber FQNs never reported. Exact match only. |
+
+
+## Where GRAPH_* faults hang
+
+Every `GRAPH_*` fault is raised with `source_id: graph_watchdog`. That is an App the
+plugin publishes itself, from its own `IntrospectionProvider`, marked `external: true`.
+So:
+
+- `GET /api/v1/apps/graph_watchdog/faults` lists them.
+- `GET /api/v1/components/<host>/faults` lists them too, because the App is attached to
+  the host Component and a Component resolves its fault scope through its child apps.
+
+It has to be an entity the plugin owns. Scoping these faults to the host Component
+directly - the obvious choice - makes them reachable from no endpoint at all:
+`collect_component_app_fqns` only puts a Component's own id in the scope set when
+`external` is true, and a runtime host Component built by `HostInfoProvider` never sets
+it. There is no server-level `/faults/{code}` route either, so the flat `/faults` list
+was the only place these faults existed.
+
+Hanging each fault on the FQN of the node it is ABOUT does not work either: fault
+identity in the store is `fault_code` alone (`fault_code TEXT PRIMARY KEY`) while
+`reporting_sources` accumulates into a set on that one record, and `fault_in_source_scope`
+requires EVERY source to be in scope - so two dead nodes would hide
+`GRAPH_NODE_DISAPPEARED` from both of their `/apps/<fqn>/faults` pages. One owned entity
+per code keeps exactly one reporting source per record; the affected nodes are named in
+the description.
+
+### Detectors
+
+#### `qos_mismatch` (GRAPH_QOS_MISMATCH)
+
+Watches every topic's publisher/subscriber QoS pairs and raises `GRAPH_QOS_MISMATCH`
+when a pair is RxO-incompatible on reliability, durability, liveliness kind, deadline, or
+liveliness lease duration - the policies that silently starve a subscriber (no data ever
+arrives, no error surfaces anywhere).
+
+**Two levels behind one fault code.** A subscriber incompatible with EVERY publisher on
+its topic receives nothing at all and raises the fault at `SEVERITY_ERROR`. A subscriber
+incompatible with *some* publisher but not all is reported at `SEVERITY_WARN`: DDS refuses
+that one pair, so that producer's data is discarded while the topic still looks alive and
+nothing anywhere reports it. That is a silent fault, not noise - an RxO-incompatible pair
+is a match DDS has already refused, not a heuristic. Since one fault code carries one
+severity, the emitted fault takes the worst finding in the sweep.
+
+The partial case is easy to hit: `/diagnostics` with several publishers, one of them
+hand-rolled `BEST_EFFORT`, and a `RELIABLE` aggregator - that publisher's diagnostics are
+dropped forever while everyone else's keep arriving.
+
+**The fault names the starved subscriber.** Each reason lists the node FQNs that hit it,
+e.g. `/tf: reliability: publisher BEST_EFFORT vs subscriber RELIABLE (receives nothing:
+/planner_server, /rviz)`, so finding the affected node does not need an ssh session and
+`ros2 topic info -v`.
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `mode` | string \| bool | `raise` | `raise` / `advisory` / `off` (framework seam). |
+| `grace` | int | `3` | Consecutive ticks a topic must stay affected before it is reported. |
+| `allowlist` | string[] | `[]` | Topic names never reported. Exact match. |
+
+`grace` exists because a single sweep used to raise, and the shipped fault_manager config
+carries `confirmation_threshold: -1` - so one sweep became a CONFIRMED ERROR immediately
+and, with `snapshots.rosbag.enabled`, pulled a black-box capture with it. Endpoint
+discovery is not atomic, so during bringup a subscriber can be visible before a
+publisher's QoS is, which reads exactly like starvation for a tick or two. A real QoS
+mismatch is static and still there N ticks later, so this costs almost no detection
+latency.
+
+`allowlist` exists because an operator's own tooling is not a robot fault. rviz2 builds
+every display's subscription from `rclcpp::QoS(5)` - RELIABLE - and does not negotiate
+down to what a `BEST_EFFORT` sensor publisher offers, so opening an Image or PointCloud2
+display on a driver topic reads as starvation. (`ros2 topic echo` and `ros2 bag record`
+are not affected: both inspect the publisher endpoints and fall back to `BEST_EFFORT`.)
+
+```yaml
+plugins:
+  graph_watchdog:
+    detectors:
+      qos_mismatch:
+        grace: 3
+        allowlist: ["/camera/image_raw"]   # an rviz2 display lives here
+```
+
+**RxO rule (Request <= Offered).** Publisher = offered, subscriber = requested; a pair
+is incompatible only in the one strict direction per policy:
+
+| Policy | Incompatible when |
+|--------|--------------------|
+| Reliability | publisher `BEST_EFFORT`, subscriber `RELIABLE` |
+| Durability | publisher `VOLATILE`, subscriber `TRANSIENT_LOCAL` |
+| Liveliness kind | publisher `AUTOMATIC`, subscriber `MANUAL_BY_TOPIC` |
+| Deadline | offered deadline > requested deadline (an unset/infinite publisher deadline is unbounded, so it fails any finite subscriber request) |
+| Liveliness lease | offered lease duration > requested lease duration (same unset/infinite handling) |
+
+The reverse direction (e.g. a `RELIABLE` publisher feeding a `BEST_EFFORT` subscriber)
+is compatible by design - the subscriber asked for no more than it is offered - even
+though the QoS profiles differ. For deadline and lease, an unspecified subscriber value
+means the subscriber does not constrain that policy, so it is always compatible. History
+and depth are not RxO-compatibility dimensions and are deliberately not checked.
+
+**Aggregated fault, not per-topic**, via the shared `AggregatedFault` helper
+(`aggregated_fault.hpp`): the fault_manager
+identifies a fault by `fault_code` alone, so one `GRAPH_QOS_MISMATCH` per mismatched
+topic would collide into a single record under the shared code. One graph-level fault
+enumerates every currently-mismatched topic; it clears (`EVENT_PASSED`) on every tick
+where nothing is mismatched, subject to the same `healing_enabled` requirement
+described in "Closing the loop" above to actually reach HEALED.
+
+**Exhaustive, not budgeted.** `qos_mismatch` reads no external service - `get_topic_names_and_types()` and
+`get_publishers_info_by_topic()` / `get_subscriptions_info_by_topic()` are local
+graph-cache queries, so every topic is checked every tick with no coverage-latency
+knob to configure. `/rosout` and `/parameter_events` are skipped (ROS 2 system topics
+with their own QoS conventions, not useful signal here).
+
+**Test tiers** (deliberately non-overlapping proof at each layer):
+
+1. **Unit** (`test/test_qos_policy.cpp`): pure `qos_incompatibility()` logic against
+   hand-built `rmw_qos_profile_t` values - the RxO trio, the reverse-direction
+   compatible case, identical-profile compatibility, and the never-raise guarantee for
+   `SYSTEM_DEFAULT`/`UNKNOWN` enums a live endpoint never actually reports.
+2. **Integration** (`test/test_qos_mismatch_integration.cpp`): a real publisher and
+   subscriber over real DDS, read through the actual
+   `get_publishers_info_by_topic()`/`get_subscriptions_info_by_topic()` API against a
+   fake `ReportFault` service - proving the detector reads the RESOLVED live profile
+   correctly, not just that the comparison function is correct. A second, concurrent
+   RxO-compatible-but-different-QoS topic pair proves the detector does not over-fire
+   on "QoS differs somewhere in the graph".
+3. **E2e** (`test/e2e/test_qos_e2e.test.py`): the Acceptance gate - a
+   real gateway process with the plugin `.so` loaded, a real fault_manager, and the
+   operator-visible `GET /api/v1/faults` surface, proving the whole raise/clear story
+   reaches a SOVD fault through the real tick timer against a reliability mismatch
+   (raise + clear round trip), a deadline mismatch, and a liveliness-lease-duration
+   mismatch (the description names each policy).
+
+## Reliability (bringup-quiesce)
+
+Silent-fault detectors are prone to bringup noise: a node joining the graph, a
+topic still being discovered, or a lifecycle node mid-transition all look like
+"something is wrong" for the first few ticks. The plugin enforces
+bringup-quiesce centrally so no individual detector has to reimplement it.
+
+- **Central gate.** `ctx.raise_fault(...)` runs every raise through a
+  `ReliabilityGate` before the fault client sends anything. A detector that
+  raises about a `source_id` that is still warming up, or a managed lifecycle
+  node that is not `active`, is silently suppressed - the detector's own logic
+  never has to know. This is transparent to detectors: nothing changes
+  in how they call `raise_fault`/`clear_fault`. **`clear_fault` is never
+  gated** - a fault can always be cleared regardless of warmup or lifecycle
+  state.
+- **Warmup.** `warmup_cycles` is live: an entity arms only once it has been
+  continuously present for `warmup_cycles` ticks. An entity that vanishes for
+  more than a short grace (a real mid-run restart) and reappears re-warms from
+  scratch; a transient one-tick discovery gap (DDS churn) is tolerated and does
+  not re-warm, so recurring churn cannot suppress an entity forever. Unknown
+  `source_id`s (e.g. a topic, not a tracked app) fall back to a global bringup
+  grace period keyed off the first tick the graph was seen non-empty; that grace
+  re-arms whenever the graph empties out, so a full-stack restart is covered too.
+- **Lifecycle.** Managed ROS 2 lifecycle nodes that are not in the `active`
+  state are suppressed. State is seeded via a `GetState` service call when a
+  lifecycle node is first discovered, then kept fresh via its
+  `~/transition_event` topic. A node still cached non-active shortly after
+  discovery is briefly re-seeded, so an `active` transition lost during the
+  subscription's endpoint-matching window self-heals instead of suppressing the
+  node forever. Seeds are bounded per tick so a batch bringup cannot stall the
+  tick loop. Non-managed nodes are never gated.
+- **Clock validity.** `ctx.clock->time_is_valid()` flags a paused or absent
+  `/clock` (e.g. a bag pauses or a sim crashes under `use_sim_time`). This is
+  **detector-consulted, not centrally enforced**: a time-based detector
+  (age/staleness/grace-period math) should check `time_is_valid()` and skip
+  its own math for the tick rather than raise a false positive on a frozen
+  clock. Detectors that don't do time math can ignore it.
+
+**Status endpoint.** `GET /api/v1/x-medkit-watchdog` returns the reliability
+core's state so an operator can tell "armed and quiet" (nothing wrong) apart
+from "still warming up" (nothing raised yet because the gate hasn't armed)
+apart from a dead watchdog (503 if the gate was never initialized):
+
+```json
+{
+  "x-medkit-watchdog": {
+    "schema_version": "1.0.0",
+    "warmup_cycles": 5,
+    "global_state": "armed",
+    "entities": [
+      {
+        "id": "/nav/planner",
+        "first_seen_tick": 3,
+        "armed": true,
+        "state": "armed",
+        "lifecycle": "active"
+      }
+    ]
+  }
+}
+```
+
+`state` is `"armed"` only when both warmup is done and lifecycle (if managed)
+is `active`; otherwise it is `"warming_up"`. `lifecycle` is the raw lifecycle
+state label, or `null` for entities with no tracked lifecycle state.
+
+**What detectors see.** Nothing changes in how a detector raises or
+clears a fault - the gate is applied transparently inside `ctx.raise_fault()`
+itself. The two things a detector opts into explicitly are
+`ctx.clock->time_is_valid()` (skip age/grace math on a stalled clock) and
+`tf_static_qos()` (a `transient_local` QoS helper for subscribing to
+`/tf_static`, whose publishers latch so a late subscriber must match the
+durability to receive them).
+
+## Adding a detector 
+
+1. Create `src/detectors/<id>.cpp`.
+2. Subclass `Detector`; implement `id()` and `tick(DetectorContext&)`. Read the
+   graph via `ctx.gateway_node`; create any subscription on `ctx.gateway_node`
+   while holding `*ctx.node_mutex`. Raise/clear faults with
+   `ctx.raise_fault(code, severity, desc, source_id)` /
+   `ctx.clear_fault(code, source_id)` using a code from `graph_fault_codes.hpp`
+   and a non-empty `source_id` (the affected node/entity).
+3. Add `REGISTER_DETECTOR(YourDetector, "<id>")` at file scope.
+
+A detector's source needs no CMake or registry edit (sources are globbed);
+adding a per-detector unit test is the one shared touch - it adds an
+`ament_add_gtest` entry to the test block.
+
+## Fault codes
+
+Frozen in `include/ros2_medkit_graph_watchdog/graph_fault_codes.hpp`:
+`GRAPH_QOS_MISMATCH`, `GRAPH_ORPHAN`, `GRAPH_NODE_DISAPPEARED`, `GRAPH_TF_STALE`,
+`GRAPH_PARAM_DRIFT`, `GRAPH_LATENCY_BUDGET`, plus one extension of the frozen
+namespace for a new capability beyond the original six: `GRAPH_NODE_INACTIVE`.
+

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -1,0 +1,185 @@
+graph_watchdog design
+=====================
+
+Role
+----
+Detects silent faults in the ROS 2 graph. A ``GatewayPlugin``
+hosting a fleet of detectors; each detector observes the ROS 2 graph and raises
+faults via a ``ReportFault`` service client on the gateway node. Faults reach the
+SOVD ``/faults`` API via FaultManager - the plugin injects no entities. Its only
+HTTP surface is a read-only reliability status route (see `Reliability core`_
+below).
+
+Structure
+---------
+- **Plugin shell** (``GraphWatchdogPlugin``): loads via the gateway plugin ABI
+  (v7). In ``set_context`` it casts the context with ``as_ros_plugin_context``,
+  creates one ``rclcpp::Client<ReportFault>`` on the gateway node, and starts a
+  tick wall timer on that node. No child node, no extra executor/thread - the
+  gateway spins its own node.
+- **Detector pattern**: ``Detector`` + ``DetectorContext``; each detector is one
+  self-registering file under ``src/detectors/`` (``REGISTER_DETECTOR``), globbed
+  by CMake so parallel authors never edit a shared file. A detector's source
+  needs no CMake or registry edit; adding a per-detector unit test is the one
+  shared touch - it adds an ``ament_add_gtest`` entry to the test block.
+- **Fault-code contract**: the frozen ``GRAPH_*`` namespace.
+- **mode seam**: ``raise`` / ``advisory`` / ``off`` per detector.
+- **Reliability core**: see the dedicated section below - central warmup and
+  lifecycle gating enforced inside ``raise_fault``, detector-consulted clock
+  validity, and the ``x-medkit-watchdog`` status route.
+
+Reliability core
+-----------------
+- **ReliabilityGate** composes two independent trackers and is the single entry
+  point both the tick loop and the HTTP route go through:
+
+  - ``WarmupTracker`` (pure, no ROS): an entity arms once continuously present
+    for ``warmup_cycles`` ticks. A disappearance longer than a short forget
+    grace followed by a reappearance (a real mid-run restart) re-warms it from
+    scratch; a transient one-tick discovery gap is absorbed and does not
+    re-warm, so recurring DDS churn cannot re-arm (and thus permanently
+    suppress) a still-running entity. Unknown ``source_id``\ s (e.g. a topic,
+    not a tracked app) fall back to a global bringup grace window keyed off the
+    first tick the graph was seen non-empty, which re-arms whenever the graph
+    empties out so a full-stack restart gets the grace again.
+  - ``LifecycleWatcher`` (event-driven): discovers managed ``rclcpp_lifecycle``
+    nodes from the introspection snapshot, seeds their state via a
+    ``GetState`` service call, then keeps it fresh by subscribing to each
+    node's ``~/transition_event`` topic (reliable + volatile, matching the
+    ``rcl_lifecycle`` publisher). A node still cached non-active shortly after
+    discovery is briefly re-seeded via ``GetState`` so an ``active`` transition
+    lost during the subscription's DDS endpoint-matching window self-heals
+    rather than suppressing the node for the process lifetime; the blocking
+    seeds are bounded per tick so a batch bringup cannot stall the tick loop.
+    The subscription callback holds only a ``weak_ptr`` to the watcher's shared
+    state, so a callback in flight during teardown bails instead of touching
+    freed memory. Non-managed nodes are never gated - ``node_ok`` returns true
+    for them unconditionally.
+- **Central enforcement.** ``DetectorContext::raise_fault`` runs every raise
+  through ``reliability_allows(gate, source_id)`` before the fault client
+  sends anything; a detector raising about a still-warming-up entity or a
+  lifecycle-inactive node is silently suppressed, transparent to the
+  detector. ``clear_fault`` is never gated - a fault can always be cleared. A
+  null gate (not yet wired) always allows, so unit tests that construct a
+  bare ``DetectorContext`` are unaffected.
+- **Clock validity is detector-consulted, not central.**
+  ``WatchdogClock::time_is_valid()`` flags a paused or absent ``/clock`` under
+  ``use_sim_time`` by comparing wall-clock advancement against sim-time
+  advancement on each ``mark_tick()``. Unlike warmup/lifecycle, this is not
+  enforced inside ``raise_fault`` - a time-based detector must check it
+  itself and skip its own age/grace-period math for the tick when it is
+  false.
+- **tf_static QoS helper.** ``tf_static_qos()`` returns a depth-1
+  ``transient_local`` ``rclcpp::QoS``, available to detectors alongside
+  ``time_is_valid()``. ``/tf_static`` publishers latch with transient-local
+  durability, so a late subscriber must match it; the actual ``/tf_static``
+  subscription belongs to a later detector.
+- **Status endpoint.** ``GraphWatchdogPlugin::get_routes()`` registers
+  ``GET x-medkit-watchdog`` (mounted at ``/api/v1/x-medkit-watchdog`` by the
+  gateway), returning ``ReliabilityGate::status_json()``: schema version,
+  ``warmup_cycles``, a ``global_state`` (``armed``/``warming_up``), and one
+  entry per known entity (``id``, ``first_seen_tick``, ``armed``, ``state``,
+  ``lifecycle``). Returns 503 with ``ERR_SERVICE_UNAVAILABLE`` if the gate has
+  not been constructed yet or has already been torn down by ``shutdown()``.
+- **Build note.** ``LifecycleWatcher`` reuses the gateway's own
+  lifecycle-state helpers (``lifecycle_status_helpers.cpp``,
+  ``ros2_lifecycle_state_reader.cpp``) compiled in via ``GATEWAY_SRC_DIR`` -
+  the same non-header-only reuse pattern other gateway plugins use - rather than reimplementing lifecycle-state
+  parsing.
+
+Detectors
+---------
+``qos_mismatch`` is the detector this package ships first. The remaining silent-fault
+classes land in follow-up changes, each against its own issue.
+
+``qos_mismatch`` is the second detector and raises ``GRAPH_QOS_MISMATCH``. It
+watches every topic's publisher/subscriber QoS pairs rather than parameter values: each
+tick it enumerates every topic via ``get_topic_names_and_types()`` and, for each one,
+every currently-connected publisher and subscriber (``get_publishers_info_by_topic`` /
+``get_subscriptions_info_by_topic``, which report the RESOLVED live profile - never a
+hand-built one), checking each pub x sub pair for incompatibility.
+
+**Two levels behind one fault code.** Per-pair incompatibility is not reported uniformly.
+A subscriber incompatible with EVERY publisher on its topic receives nothing and raises at
+``SEVERITY_ERROR``. A subscriber incompatible with some publisher but not all raises at
+``SEVERITY_WARN``: DDS refuses that one pair, so that producer's data is silently
+discarded while the topic keeps looking alive - a real silent fault, since an
+RxO-incompatible pair is a match DDS has already computed, not a heuristic. One fault code
+carries one severity, so the emitted fault reflects the worst finding in the sweep. Before
+this split the partial case was indistinguishable from healthy, which meant e.g. a second
+``/tf`` broadcaster or a hand-rolled ``BEST_EFFORT`` publisher on ``/diagnostics`` went
+unreported forever.
+
+**RxO rule.** ``qos_policy.hpp``'s ``qos_incompatibility(pub, sub)`` implements RxO
+(Request <= Offered) compatibility for the QoS policies that silently starve a
+subscriber with no error surfaced anywhere in the graph: reliability, durability,
+liveliness kind, deadline, and liveliness lease duration. Publisher = offered,
+subscriber = requested; a pair is incompatible only in the one strict direction per
+policy - a ``BEST_EFFORT`` publisher against a ``RELIABLE`` subscriber, a ``VOLATILE``
+publisher against a ``TRANSIENT_LOCAL`` subscriber, an ``AUTOMATIC``-liveliness
+publisher against a ``MANUAL_BY_TOPIC`` subscriber, or an offered deadline / lease
+duration greater than the requested one. The reverse direction (e.g. a ``RELIABLE``
+publisher feeding a ``BEST_EFFORT`` subscriber) is compatible by design - the subscriber
+asked for no more than it is offered - even though the QoS profiles differ, which is
+exactly the discriminator the integration and e2e tests each pin with a positive control
+(see "Test tiers" below). For deadline and lease, an unspecified/infinite offer is
+unbounded (fails any finite request), while an unspecified subscriber value does not
+constrain the policy (always compatible); history and depth are not RxO dimensions and
+are not checked. The checks match only concrete incompatible enum pairs, so
+``SYSTEM_DEFAULT``/``UNKNOWN`` (never
+reported by a live endpoint, which always carries the resolved profile) never raise.
+
+**Aggregation via the shared helper.** ``qos_mismatch`` is the first detector to use
+the new ``AggregatedFault`` helper (``aggregated_fault.hpp``), factored out of
+a shared helper so later detectors do not each reimplement the same
+level-triggered raise/clear pattern. The rationale is
+(see "Aggregation rationale" above): the fault_manager identifies a fault by
+``fault_code`` alone, so one ``GRAPH_QOS_MISMATCH`` per mismatched topic would collide
+into a single record under the shared code. The detector keeps one ``AggregatedFault``
+instance for the whole graph and, each tick, hands it every currently-mismatched
+topic's description (keyed by topic name so a repeat mismatch on the same topic
+overwrites rather than duplicates); an empty map on a clean tick clears
+(``EVENT_PASSED``), level-triggered semantics (see
+"Closing the loop" in the README for the ``healing_enabled`` requirement to actually
+reach HEALED). ``graph_source_id()``, also in ``aggregated_fault.hpp``, is the same
+host-Component-id-or-literal-fallback logic - the detectors'
+aggregated faults land under the same ``source_id``.
+
+**Coverage is exhaustive, not budgeted.** Unlike a call-budgeted
+round-robin sweep (bounded by a parameter-service transport call budget),
+``qos_mismatch`` reads no external service - ``get_topic_names_and_types()`` and the
+two ``get_*_info_by_topic()`` calls are local graph-cache queries, so every topic is
+checked every tick with no coverage-latency trade-off to configure or budget knob to
+tune. ``/rosout`` and ``/parameter_events`` are skipped - ROS 2 system topics with
+their own well-known QoS conventions, not useful signal for this detector. The sweep
+polls ``ctx.cancelled`` between topics so a shutdown mid-sweep bails promptly, the same
+shutdown-responsiveness contract every detector honors.
+
+**Test tiers.** Three tiers each prove a different layer, deliberately not
+overlapping:
+
+1. **Unit** (``test_qos_policy.cpp``): pure ``qos_incompatibility()`` logic against
+   hand-built ``rmw_qos_profile_t`` values - the RxO trio (reliability, durability,
+   liveliness), the reverse-direction compatible case, identical-profile compatibility,
+   and the never-raise guarantee for ``SYSTEM_DEFAULT``/``UNKNOWN`` enums a live
+   endpoint never actually reports.
+2. **Integration** (``test_qos_mismatch_integration.cpp``): a real ``rclcpp::Node``
+   publisher/subscriber pair over real DDS, read through the actual
+   ``get_publishers_info_by_topic``/``get_subscriptions_info_by_topic`` API - proving
+   the detector reads the RESOLVED live profile correctly, not just that the pure
+   comparison function is correct - against a fake ``ReportFault`` service. A second,
+   concurrent RxO-compatible-but-different-QoS topic pair proves the detector does not
+   over-fire on "QoS differs somewhere in the graph".
+3. **E2e** (``test/e2e/test_qos_e2e.test.py``): the Acceptance gate - a
+   real gateway process with the plugin ``.so`` loaded, a real fault_manager, and the
+   operator-visible ``GET /api/v1/faults`` surface, proving the whole raise/clear story
+   reaches a SOVD fault through the real tick timer, not just the detector's own
+   ``tick()`` called directly.
+
+
+Status
+---------------
+The plugin loads, ticks the graph, and shuts down cleanly. The reliability core is
+real and already ticking, and all six silent-fault detector classes are live and
+raising through it. The remaining silent-fault classes land in follow-up changes,
+each against its own issue.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/aggregated_fault.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/aggregated_fault.hpp
@@ -1,0 +1,159 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"  // full IntrospectionInput
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Id of the synthetic App that owns every GRAPH_* fault. The plugin publishes it as an
+/// external entity from its own IntrospectionProvider (graph_watchdog_plugin.cpp).
+///
+/// It must be an entity the plugin owns, not a borrowed one. Scoping these faults to the
+/// host Component - the obvious choice, and what this used to do - makes them reachable
+/// from NO endpoint: `collect_component_app_fqns` (fault_scope.cpp) only puts a
+/// component's bare id in the scope set when `external` is true, and a runtime host
+/// Component built by HostInfoProvider never sets it, so `/components/<host>/faults` and
+/// the scoped detail route both drop the fault. There is no server-level
+/// `/faults/{code}` route either, so the flat `/faults` list was the only place these
+/// faults existed.
+///
+/// Hanging each fault on the FQN of the node it is ABOUT does not work either:
+/// fault identity in the store is `fault_code` alone (`fault_code TEXT PRIMARY KEY`),
+/// and `reporting_sources` accumulates into a set on that one record while
+/// `fault_in_source_scope` requires EVERY source to be in scope. Two dead nodes would
+/// therefore hide GRAPH_NODE_DISAPPEARED from both of their `/apps/<fqn>/faults` pages.
+/// One owned entity per code keeps exactly one source per record.
+///
+/// Same shape as the ADS plugin's device entity, for the same reason.
+inline constexpr const char * kGraphWatchdogEntityId = "graph_watchdog";
+
+/// The source_id every aggregated GRAPH_* fault is raised under. Constant by design:
+/// see kGraphWatchdogEntityId. The snapshot is unused - it is kept in the signature
+/// because every call site already has the context in hand.
+inline std::string graph_source_id(const DetectorContext & /*ctx*/) {
+  return kGraphWatchdogEntityId;
+}
+
+/// Level-triggered aggregate emitter for one fault code. Each tick a detector
+/// hands emit() the currently-affected entities (ordered key -> detail phrase).
+/// Non-empty -> raise ONE fault enumerating them; empty -> clear. Emitting every
+/// tick is intentional: the fault_manager debounce advances toward CONFIRMED
+/// while affected and, with healing_enabled, toward HEALED while clear.
+class AggregatedFault {
+ public:
+  /// Cap on the generated description. One aggregated fault names every affected entity, so
+  /// on a large graph the raw text grows without bound - an oversized ReportFault description
+  /// then travels into every /faults payload and the fault_manager's store. param_drift's
+  /// hand-rolled aggregation applies the same cap; this keeps every detector that uses the
+  /// helper consistent with it.
+  static constexpr std::size_t kMaxDescriptionChars = 480;
+
+  AggregatedFault(const char * code, std::uint8_t severity) : code_(code), severity_(severity) {
+  }
+
+  void emit(DetectorContext & ctx, const std::map<std::string, std::string> & affected) const {
+    const std::string source = graph_source_id(ctx);
+    if (affected.empty()) {
+      ctx.clear_fault(code_, source);
+      return;
+    }
+    ctx.raise_fault(code_, severity_, describe(affected), source);
+  }
+
+  /// emit() with a caller-chosen ORDER for the description.
+  ///
+  /// The map overload above lists entities lexicographically, which is fine when every
+  /// entry is equally interesting. It is not fine when the set mixes long-standing entries
+  /// with a brand-new one and the text is capped: the new entry can sort last and be cut.
+  /// `order` names the keys of `affected` in the order they should appear; any key of
+  /// `affected` missing from `order` is appended afterwards, so a caller can never silently
+  /// drop an entity by getting the ordering wrong.
+  void emit_ordered(DetectorContext & ctx, const std::map<std::string, std::string> & affected,
+                    const std::vector<std::string> & order) const {
+    const std::string source = graph_source_id(ctx);
+    if (affected.empty()) {
+      ctx.clear_fault(code_, source);
+      return;
+    }
+    ctx.raise_fault(code_, severity_, describe_ordered(affected, order), source);
+  }
+
+  /// Join the affected entities into one description, capped at kMaxDescriptionChars.
+  /// Public so the cap is directly unit-testable; the truncation marker is inside the cap,
+  /// so the returned string never exceeds it.
+  static std::string describe(const std::map<std::string, std::string> & affected) {
+    std::vector<std::string> keys;
+    keys.reserve(affected.size());
+    for (const auto & [key, detail] : affected) {
+      (void)detail;
+      keys.push_back(key);
+    }
+    return describe_ordered(affected, keys);
+  }
+
+  /// describe() over an explicit key order. Keys of `affected` not named in `order` are
+  /// appended in map order, so a partial or stale `order` degrades to the old behaviour
+  /// rather than dropping entities.
+  static std::string describe_ordered(const std::map<std::string, std::string> & affected,
+                                      const std::vector<std::string> & order) {
+    std::string desc;
+    std::set<std::string> emitted;
+    const auto append = [&desc](const std::string & key, const std::string & detail) {
+      if (!desc.empty()) {
+        desc += "; ";
+      }
+      desc += detail.empty() ? key : detail;
+    };
+    for (const auto & key : order) {
+      const auto it = affected.find(key);
+      if (it == affected.end() || !emitted.insert(key).second) {
+        continue;
+      }
+      append(key, it->second);
+      if (desc.size() > kMaxDescriptionChars) {
+        break;  // nothing appended later can shrink it - stop building and cap below
+      }
+    }
+    if (desc.size() <= kMaxDescriptionChars) {
+      for (const auto & [key, detail] : affected) {
+        if (emitted.count(key) != 0) {
+          continue;
+        }
+        append(key, detail);
+        if (desc.size() > kMaxDescriptionChars) {
+          break;
+        }
+      }
+    }
+    if (desc.size() > kMaxDescriptionChars) {
+      desc = desc.substr(0, kMaxDescriptionChars - 3) + "...";
+    }
+    return desc;
+  }
+
+ private:
+  const char * code_;
+  std::uint8_t severity_;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
@@ -1,0 +1,133 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+
+#include "ros2_medkit_graph_watchdog/fault_request.hpp"
+
+namespace ros2_medkit_gateway {
+struct IntrospectionInput;
+}
+
+namespace ros2_medkit_graph_watchdog {
+
+class WatchdogClock;    // defined in watchdog_clock.hpp
+class ReliabilityGate;  // defined in reliability_gate.hpp; only a pointer is stored here.
+
+// Out-of-line so detector.hpp does not need the full ReliabilityGate type (keeps the
+// header free of lifecycle_msgs). Defined in reliability_gate.cpp. Returns true when
+// gate is null (not yet wired) or the entity is armed + lifecycle-ok.
+bool reliability_allows(const ReliabilityGate * gate, const std::string & source_id);
+
+/// QoS for subscribing to /tf_static: publishers latch with transient-local
+/// durability, so a late subscriber must match it to receive the static transforms.
+inline rclcpp::QoS tf_static_qos() {
+  return rclcpp::QoS(1).transient_local();
+}
+
+/// Raise = push faults; Advisory = observe but do not push; Off =
+/// skipped by the tick loop (never constructed into the active set).
+enum class DetectorMode { Raise, Advisory, Off };
+
+/// Single decision point for whether a detector's findings become faults.
+inline bool mode_emits(DetectorMode mode) {
+  return mode == DetectorMode::Raise;
+}
+
+/// Handed to a detector on every tick. Detectors read the ROS graph and raise or
+/// clear faults via raise_fault()/clear_fault() rather than the public fault_client member.
+struct DetectorContext {
+  rclcpp::Node * gateway_node = nullptr;   ///< Graph introspection + subscription host.
+  std::mutex * node_mutex = nullptr;       ///< Hold when creating subscriptions on gateway_node.
+  WatchdogClock * clock = nullptr;         ///< sim_time-aware now().
+  const ReliabilityGate * gate = nullptr;  ///< Central reliability gate; null until wired by the plugin.
+  DetectorMode mode = DetectorMode::Raise;
+  rclcpp::Client<ros2_medkit_msgs::srv::ReportFault>::SharedPtr fault_client;
+  const ros2_medkit_gateway::IntrospectionInput * snapshot =
+      nullptr;                                    ///< entities this tick (id + bound_fqn); null in bare-context tests
+  const std::atomic<bool> * cancelled = nullptr;  ///< plugin shutdown flag; a long sweep polls it (null => never)
+
+  void raise_fault(const std::string & code, uint8_t severity, const std::string & description,
+                   const std::string & source_id) {
+    if (!mode_emits(mode) || !fault_client) {
+      return;  // Advisory/Off suppressed, or client not yet wired.
+    }
+    if (source_id.empty()) {
+      if (gateway_node) {
+        RCLCPP_WARN_ONCE(gateway_node->get_logger(),
+                         "graph_watchdog: dropping fault '%s' with empty source_id (detector contract violation)",
+                         code.c_str());
+      }
+      return;
+    }
+    if (!reliability_allows(gate, source_id)) {
+      return;  // entity warming up or lifecycle-inactive: suppressed by the reliability core.
+    }
+    if (!fault_client->service_is_ready()) {
+      return;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
+    }
+    fault_client->async_send_request(std::make_shared<ros2_medkit_msgs::srv::ReportFault::Request>(
+        make_fault_report(source_id, code, severity, description)));
+  }
+
+  void clear_fault(const std::string & code, const std::string & source_id) {
+    if (!mode_emits(mode) || !fault_client) {
+      return;  // Advisory/Off suppressed, or client not yet wired.
+    }
+    if (source_id.empty()) {
+      if (gateway_node) {
+        RCLCPP_WARN_ONCE(gateway_node->get_logger(),
+                         "graph_watchdog: dropping fault-clear '%s' with empty source_id (detector contract violation)",
+                         code.c_str());
+      }
+      return;
+    }
+    if (!fault_client->service_is_ready()) {
+      return;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
+    }
+    fault_client->async_send_request(
+        std::make_shared<ros2_medkit_msgs::srv::ReportFault::Request>(make_fault_clear(source_id, code)));
+  }
+};
+
+/// A silent-fault detector. adds one subclass per file in src/detectors/.
+class Detector {
+ public:
+  virtual ~Detector() = default;
+  virtual std::string id() const = 0;  ///< e.g. "qos_mismatch".
+  virtual void configure(const nlohmann::json & /*config*/) {
+  }
+  virtual void tick(DetectorContext & ctx) = 0;  ///< Observe; raise/clear via ctx.
+
+  /// Test-only observability hook: how many identities this detector's internal
+  /// tracker currently holds (0 = not applicable / no bounded tracker). Lets
+  /// integration tests assert a tracker's map stays bounded under prune without
+  /// exposing the tracker itself through the public interface. Default 0 for
+  /// detectors with no such tracker.
+  virtual std::size_t tracked_count_for_test() const {
+    return 0;
+  }
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config.hpp
@@ -1,0 +1,97 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"  // collect_unknown_detector_keys
+
+// The gateway delivers per-plugin config as a NESTED json:
+// extract_plugin_config (param_utils.hpp) un-nests dotted keys, so a YAML param
+// plugins.graph_watchdog.detectors.<id>.<field> arrives as
+// config["detectors"]["<id>"]["<field>"], NOT the literal flat key
+// "detectors.<id>.<field>". These helpers read that nested shape.
+namespace ros2_medkit_graph_watchdog {
+
+/// Resolve a detector's mode from nested plugin config (config["detectors"][id]["mode"]).
+/// Returns Raise when absent. When `warnings` is non-null, a present-but-unrecognized
+/// value appends one entry to it instead of being dropped silently.
+///
+/// A BARE `off` in YAML never arrives here as a string. rcl_yaml_param_parser follows
+/// YAML 1.1, so `off`/`Off`/`OFF`/`no`/`n` are typed BOOL false and `on`/`yes` BOOL true;
+/// only a QUOTED "off" stays a STRING. Since `off` is the value operators actually write,
+/// a string-only reader silently leaves the detector in Raise - i.e. the detector the
+/// operator just disabled keeps pushing faults at the robot, with nothing in the log to
+/// connect the two. Reading the boolean form is what makes
+///   detectors.<id>.mode: off
+/// mean what it says. `true` maps to Raise so `mode: on` reads naturally too.
+inline DetectorMode parse_detector_mode(const nlohmann::json & config, const std::string & id,
+                                        std::vector<std::string> * warnings = nullptr) {
+  if (!config.contains("detectors") || !config["detectors"].is_object()) {
+    return DetectorMode::Raise;
+  }
+  const auto & detectors = config["detectors"];
+  if (!detectors.contains(id) || !detectors[id].is_object()) {
+    return DetectorMode::Raise;
+  }
+  const auto & entry = detectors[id];
+  if (!entry.contains("mode")) {
+    return DetectorMode::Raise;
+  }
+  const auto & mode_value = entry["mode"];
+  if (mode_value.is_boolean()) {
+    return mode_value.get<bool>() ? DetectorMode::Raise : DetectorMode::Off;
+  }
+  if (mode_value.is_string()) {
+    const std::string mode = mode_value.get<std::string>();
+    if (mode == "raise") {
+      return DetectorMode::Raise;
+    }
+    if (mode == "advisory") {
+      return DetectorMode::Advisory;
+    }
+    if (mode == "off") {
+      return DetectorMode::Off;
+    }
+  }
+  if (warnings != nullptr) {
+    warnings->push_back("detector '" + id + "': unrecognized mode " + mode_value.dump() +
+                        "; expected \"raise\", \"advisory\" or \"off\" - falling back to raise");
+  }
+  return DetectorMode::Raise;
+}
+
+/// Collect a detector's own fields (config["detectors"][id] minus the reserved "mode").
+inline nlohmann::json extract_detector_config(const nlohmann::json & config, const std::string & id) {
+  nlohmann::json out = nlohmann::json::object();
+  if (!config.contains("detectors") || !config["detectors"].is_object()) {
+    return out;
+  }
+  const auto & detectors = config["detectors"];
+  if (!detectors.contains(id) || !detectors[id].is_object()) {
+    return out;
+  }
+  for (const auto & item : detectors[id].items()) {
+    if (item.key() != "mode") {
+      out[item.key()] = item.value();
+    }
+  }
+  return out;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
@@ -27,7 +27,7 @@ namespace ros2_medkit_graph_watchdog {
 /// (GraphWatchdogPlugin::set_context). They are plumbing, not a detector's own keys, so a
 /// detector that ignores one must never report it as an operator typo.
 inline const std::set<std::string> & plugin_injected_detector_keys() {
-  static const std::set<std::string> keys{"tick_interval_ms"};
+  static const std::set<std::string> keys{"prune_grace", "tick_interval_ms"};
   return keys;
 }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
@@ -1,0 +1,81 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+// Deliberately ROS-free (no detector.hpp, no rclcpp): the pure policy headers that need
+// this - param_drift_policy.hpp and friends - are unit-tested without a ROS build.
+namespace ros2_medkit_graph_watchdog {
+
+/// Keys the PLUGIN injects into every detector's config before calling configure()
+/// (GraphWatchdogPlugin::set_context). They are plumbing, not a detector's own keys, so a
+/// detector that ignores one must never report it as an operator typo.
+inline const std::set<std::string> & plugin_injected_detector_keys() {
+  static const std::set<std::string> keys{"tick_interval_ms"};
+  return keys;
+}
+
+/// Mirrors GraphWatchdogPlugin's own tick_interval_ms_ default, for the detectors that need
+/// the tick period before the plugin has injected it (bare-context unit tests).
+inline constexpr int kDefaultTickIntervalMs = 1000;
+
+/// Floor for a clock-jump threshold, expressed in tick periods.
+///
+/// Every clock-jump check compares the delta between consecutive evaluate() calls, and that
+/// delta is the whole tick period (sweep duration + tick_interval_ms), not a fixed quantity.
+/// A threshold below the tick period therefore makes EVERY ordinary tick look like a
+/// discontinuity: streaks are zeroed, entries re-baseline, and the detector can never raise -
+/// silently, with nothing in the log. A tick has to overrun its period by this factor before
+/// it counts as a real clock jump rather than a slow sweep.
+inline constexpr double kJumpThreshTickPeriods = 3.0;
+
+/// Smallest jump threshold that is safe at a given tick period.
+inline constexpr double min_jump_thresh_sec(int tick_interval_ms) {
+  return kJumpThreshTickPeriods * static_cast<double>(tick_interval_ms) / 1000.0;
+}
+
+/// Append one warning per key in `detector_cfg` that the detector does not read.
+///
+/// extract_detector_config() copies EVERY key under detectors.<id> verbatim, and a
+/// detector's own reader then looks up only the handful of names it knows. A key matching
+/// none of them is dropped with nothing in the log. That fails silently in the direction
+/// that costs the operator most: write `ignore_globs:` where the detector reads `ignore:`
+/// and the suppression never takes effect, so the faults you meant to silence keep coming
+/// and nothing connects them to the typo. Detectors pass their own known-key set here.
+inline void collect_unknown_detector_keys(const nlohmann::json & detector_cfg, const std::set<std::string> & known_keys,
+                                          std::vector<std::string> & warnings) {
+  if (!detector_cfg.is_object()) {
+    return;
+  }
+  std::string known_list;
+  for (const auto & key : known_keys) {
+    if (!known_list.empty()) {
+      known_list += ", ";
+    }
+    known_list += key;
+  }
+  for (const auto & item : detector_cfg.items()) {
+    if (known_keys.count(item.key()) != 0 || plugin_injected_detector_keys().count(item.key()) != 0) {
+      continue;
+    }
+    warnings.push_back("unknown config key '" + item.key() + "'; it has no effect (known keys: " + known_list + ")");
+  }
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_registry.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_registry.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+using DetectorFactory = std::function<std::unique_ptr<Detector>()>;
+
+/// Process-wide registry of detector factories. Populated at dlopen time by the
+/// REGISTER_DETECTOR static initializers compiled into the plugin .so.
+class DetectorRegistry {
+ public:
+  static DetectorRegistry & instance();
+
+  ~DetectorRegistry() = default;
+  DetectorRegistry(const DetectorRegistry &) = delete;
+  DetectorRegistry & operator=(const DetectorRegistry &) = delete;
+  DetectorRegistry(DetectorRegistry &&) = delete;
+  DetectorRegistry & operator=(DetectorRegistry &&) = delete;
+
+  void register_factory(const std::string & id, DetectorFactory factory);
+  std::vector<std::unique_ptr<Detector>> create_all() const;
+
+ private:
+  DetectorRegistry() = default;
+  std::vector<std::pair<std::string, DetectorFactory>> factories_;
+};
+
+}  // namespace ros2_medkit_graph_watchdog
+
+/// Declare + self-register a detector. One detector per file in src/detectors/;
+/// add this macro at file scope. The static initializer runs at dlopen; no CMake
+/// edit and no registry edit are needed (sources are globbed).
+#define REGISTER_DETECTOR(CLASS, ID)                                                       \
+  namespace {                                                                              \
+  const bool CLASS##_registered = [] {                                                     \
+    ::ros2_medkit_graph_watchdog::DetectorRegistry::instance().register_factory((ID), [] { \
+      return std::make_unique<CLASS>();                                                    \
+    });                                                                                    \
+    return true;                                                                           \
+  }();                                                                                     \
+  }  // namespace

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/fault_request.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/fault_request.hpp
@@ -1,0 +1,50 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+
+// ReportFault request builders. Header-only (depends only on the msg package) so
+// the raise/clear payload is unit-testable without rclcpp or a PluginContext.
+// fault_manager rejects any ReportFault with an empty source_id, so both builders
+// MUST populate it from the reporting entity.
+namespace ros2_medkit_graph_watchdog {
+
+/// Build a fault RAISE request (FAILED event).
+inline ros2_medkit_msgs::srv::ReportFault::Request make_fault_report(const std::string & source_id,
+                                                                     const std::string & fault_code, uint8_t severity,
+                                                                     const std::string & description) {
+  ros2_medkit_msgs::srv::ReportFault::Request req;
+  req.fault_code = fault_code;
+  req.event_type = ros2_medkit_msgs::srv::ReportFault::Request::EVENT_FAILED;
+  req.severity = severity;
+  req.description = description;
+  req.source_id = source_id;
+  return req;
+}
+
+/// Build a fault CLEAR request (PASSED event). source_id must match the raise.
+inline ros2_medkit_msgs::srv::ReportFault::Request make_fault_clear(const std::string & source_id,
+                                                                    const std::string & fault_code) {
+  ros2_medkit_msgs::srv::ReportFault::Request req;
+  req.fault_code = fault_code;
+  req.event_type = ros2_medkit_msgs::srv::ReportFault::Request::EVENT_PASSED;
+  req.source_id = source_id;
+  return req;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_fault_codes.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_fault_codes.hpp
@@ -1,0 +1,29 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+// Frozen GRAPH_* fault-code namespace. All silent-fault
+// detectors and downstream consumers reference these exact strings,
+// so a code here is an external contract: never rename or repurpose one.
+namespace ros2_medkit_graph_watchdog::graph_fault_codes {
+inline constexpr const char * kQosMismatch = "GRAPH_QOS_MISMATCH";
+inline constexpr const char * kOrphan = "GRAPH_ORPHAN";
+inline constexpr const char * kNodeDisappeared = "GRAPH_NODE_DISAPPEARED";
+inline constexpr const char * kTfStale = "GRAPH_TF_STALE";
+inline constexpr const char * kParamDrift = "GRAPH_PARAM_DRIFT";
+inline constexpr const char * kLatencyBudget = "GRAPH_LATENCY_BUDGET";
+// Extension of the frozen namespace above (new capability, beyond the original
+// six classes): a node the operator declared must-be-active is present but not active.
+inline constexpr const char * kNodeInactive = "GRAPH_NODE_INACTIVE";
+}  // namespace ros2_medkit_graph_watchdog::graph_fault_codes

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
@@ -1,0 +1,141 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+
+#include "ros2_medkit_gateway/core/plugins/gateway_plugin.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_context.hpp"
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_gateway/plugins/ros_plugin_context.hpp"
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/watchdog_clock.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+class ReliabilityGate;  // defined in reliability_gate.hpp; kept out of this header (see gate_ below).
+
+/// Gateway plugin: hosts the silent-fault detector fleet. It wires the fault client
+/// and the tick loop, and fans each tick out to every registered detector.
+///
+/// Also an IntrospectionProvider, for one reason: it publishes the single App that
+/// every GRAPH_* fault is scoped to (see graph_watchdog_entity_id()). Without an entity
+/// it owns, a graph-level fault is reachable from no scoped endpoint at all - see
+/// aggregated_fault.hpp for the full story.
+class GraphWatchdogPlugin : public ros2_medkit_gateway::GatewayPlugin,
+                            public ros2_medkit_gateway::IntrospectionProvider {
+ public:
+  // Out-of-line (even though = default) so every TU calling `new GraphWatchdogPlugin()`
+  // does not need to instantiate ~unique_ptr<ReliabilityGate>() for the constructor's
+  // exception-unwind path (gate_ is only forward-declared here; ReliabilityGate is
+  // complete in graph_watchdog_plugin.cpp, where this is actually defined).
+  GraphWatchdogPlugin();
+  ~GraphWatchdogPlugin() override;
+  GraphWatchdogPlugin(const GraphWatchdogPlugin &) = delete;
+  GraphWatchdogPlugin & operator=(const GraphWatchdogPlugin &) = delete;
+  GraphWatchdogPlugin(GraphWatchdogPlugin &&) = delete;
+  GraphWatchdogPlugin & operator=(GraphWatchdogPlugin &&) = delete;
+
+  std::string name() const override {
+    return "graph_watchdog";
+  }
+  void configure(const nlohmann::json & config) override;
+  void set_context(ros2_medkit_gateway::PluginContext & context) override;
+  std::vector<PluginRoute> get_routes() override;
+  void shutdown() override;
+
+  /// Publishes exactly one entity: the App that owns every GRAPH_* fault. It is attached
+  /// to the host Component when the snapshot carries one, so the faults also roll up to
+  /// `/components/<host>/faults` (a Component resolves its scope through its child apps).
+  ros2_medkit_gateway::IntrospectionResult introspect(const ros2_medkit_gateway::IntrospectionInput & input) override;
+
+  uint64_t tick_count() const {
+    return tick_count_.load();
+  }
+
+ private:
+  void load_parameters();
+  void run_tick_loop();  ///< Body of tick_thread_: tick() + interruptible sleep, until shutdown.
+  void tick();
+  /// Departed-lifecycle retention horizon (ticks) for the ReliabilityGate's
+  /// LifecycleWatcher: prune_ticks + node_death's own miss_grace + 1, where prune_ticks
+  /// = max(prune_grace_, miss_grace + 1) mirrors node_death's own prune_ticks_ clamp.
+  /// Must outlive node_death's own reclaim tick (T_depart + miss_grace + prune_ticks),
+  /// not just its first suppression-evaluation tick, so a durable
+  /// lifecycle_clean_shutdown veto is silently RECLAIMED before the cached label
+  /// expires rather than lapsing into a permanent re-raise - see the .cpp for the full
+  /// derivation. Reads "detectors.node_death.miss_grace" directly off
+  /// `config_snapshot` (node_death's own configure() has not run yet at the point this
+  /// is needed - see set_context()).
+  int compute_departed_retention_ticks(const nlohmann::json & config_snapshot) const;
+
+  ros2_medkit_gateway::RosPluginContext * ctx_ = nullptr;
+  nlohmann::json config_;
+  std::mutex config_mutex_;
+
+  int tick_interval_ms_ = 1000;
+  int warmup_cycles_ = 5;
+  // Plugin-scope prune grace (ticks) injected into every detector's own config as
+  // "prune_grace" (extract_detector_config() otherwise strips plugin-scope keys) -
+  // see graph_watchdog_plugin.cpp's configure loop.
+  int prune_grace_ = 60;
+
+  std::unique_ptr<WatchdogClock> clock_;
+  std::unique_ptr<ReliabilityGate> gate_;  ///< Incomplete type here is fine: dtor is out-of-line (.cpp).
+  rclcpp::Client<ros2_medkit_msgs::srv::ReportFault>::SharedPtr fault_client_;
+
+  // The tick runs on a DEDICATED plugin thread, NOT a gateway wall-timer/executor
+  // callback. Detectors do blocking parameter/service reads; the gateway's small
+  // executor is safe only because blocking never happens on an executor thread (see
+  // the gateway's main.cpp). shutdown() joins this thread BEFORE tearing down members,
+  // so tick() needs no lock against teardown; tick_mutex_ then only serializes the
+  // get_routes() status handler against that teardown.
+  std::thread tick_thread_;
+  std::condition_variable tick_cv_;
+  std::mutex tick_cv_mutex_;
+  bool tick_loop_exited_ = false;  ///< set (under tick_cv_mutex_) when run_tick_loop() leaves its loop
+  // A pre-shutdown callback stops the tick thread while the rclcpp context is STILL valid (it runs
+  // before context invalidation, even on a SIGINT). Detectors do rcl graph/service reads on the tick
+  // thread; if the context invalidates mid-read, rcl ABORTS (SIGABRT) rather than throwing, so it
+  // cannot be caught - the thread must be quiesced first. shutdown() (called from teardown) alone is
+  // too late: on SIGINT the context is already dead by then.
+  rclcpp::Context::SharedPtr context_;
+  rclcpp::PreShutdownCallbackHandle pre_shutdown_handle_;
+  std::mutex node_mutex_;
+  std::mutex tick_mutex_;  ///< Serializes the get_routes() handler against shutdown()'s member teardown.
+
+  std::vector<std::pair<std::unique_ptr<Detector>, DetectorMode>> detectors_;
+
+  std::atomic<uint64_t> tick_count_{0};
+  std::atomic<bool> shutdown_requested_{false};  ///< stop signal for the tick loop; set by BOTH the
+                                                 ///< pre-shutdown callback and shutdown()
+  std::atomic<bool> teardown_done_{false};       ///< idempotency guard for shutdown()'s member teardown.
+                                                 ///< Kept separate from shutdown_requested_ so the
+                                                 ///< pre-shutdown callback stopping the tick loop cannot
+                                                 ///< trip shutdown() into skipping the thread join.
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
@@ -1,0 +1,136 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include <lifecycle_msgs/msg/transition_event.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"  // IntrospectionInput
+#include "ros2_medkit_gateway/ros2/status/ros2_lifecycle_state_reader.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Fallback departed-lifecycle retention horizon (ticks) when a caller does not compute
+/// its own (e.g. a unit test constructing a LifecycleWatcher/ReliabilityGate directly).
+/// Production wiring (GraphWatchdogPlugin::set_context()) always passes an explicit
+/// value derived from the plugin's own prune_grace / node_death's miss_grace.
+inline constexpr int kDefaultDepartedRetentionTicks = 60;
+
+/// What a departure looked like, as far as ~/transition_event let us observe it. The last
+/// label alone cannot tell a lifecycle-manager shutdown from an error termination:
+/// `finalized` is the resting state of BOTH a completed shutdown and a failed on_error
+/// (ON_ERROR_FAILURE/ON_ERROR_ERROR out of `errorprocessing`), which is exactly how a driver
+/// signals an unrecoverable hardware fault. So carry the extra evidence.
+struct DepartedLifecycle {
+  std::string label;              ///< last cached lifecycle label at the moment of departure
+  bool saw_transition = false;    ///< at least one ~/transition_event arrived for this node
+  bool error_terminated = false;  ///< the node passed through `errorprocessing`
+};
+
+/// Tracks managed lifecycle nodes and caches their state label ("active" etc.),
+/// seeded via GetState and kept fresh via ~/transition_event. Non-managed nodes are
+/// never tracked (node_ok returns true for them).
+class LifecycleWatcher {
+ public:
+  LifecycleWatcher(rclcpp::Node * gateway_node, std::mutex * node_mutex,
+                   int departed_retention_ticks = kDefaultDepartedRetentionTicks);
+  ~LifecycleWatcher();
+  LifecycleWatcher(const LifecycleWatcher &) = delete;
+  LifecycleWatcher & operator=(const LifecycleWatcher &) = delete;
+  LifecycleWatcher(LifecycleWatcher &&) = delete;
+  LifecycleWatcher & operator=(LifecycleWatcher &&) = delete;
+
+  /// Discover managed nodes from the snapshot (find_lifecycle_get_state_path over
+  /// App::services): seed+subscribe new ones, drop vanished ones. `tick` is the
+  /// plugin's own tick counter (threaded through from ReliabilityGate::update()) -
+  /// used to timestamp a departure into `recently_departed_` and to prune stale
+  /// entries from it.
+  void update(const ros2_medkit_gateway::IntrospectionInput & snapshot, std::uint64_t tick);
+
+  bool node_ok(const std::string & app_id) const;  // true if untracked or "active"
+  std::optional<std::string> state_of(const std::string & app_id) const;
+  /// Last cached lifecycle label of a node that WAS tracked but is no longer present in
+  /// the snapshot (departed within `departed_retention_ticks` ticks of "now"), keyed by
+  /// its stable fqn (App::effective_fqn(), NOT App::id - mirrors node_death's own keying,
+  /// see node_death_detector.cpp). nullopt if the fqn never departed or has aged out of
+  /// retention. Does NOT return a still-present node's state - node_death only ever
+  /// queries fqns already absent from the graph.
+  std::optional<DepartedLifecycle> departed_state_of(const std::string & fqn) const;
+  void reset();  // drop all subscriptions (shutdown)
+
+  void set_state_for_test(const std::string & app_id, const std::string & label);
+  /// Test-only: how much of the bounded GetState self-heal budget a tracked node has left.
+  /// -1 if the node is not tracked. Lets a test assert that a re-seed job cut by the per-tick
+  /// blocking budget was not charged for a read it never issued.
+  int reseeds_remaining_for_test(const std::string & app_id) const;
+  /// Test-only seam: inject a departed-lifecycle entry directly, without driving a
+  /// managed node through discovery + real removal - lets a suppressor unit test drive
+  /// departed_state_of() without a live GetState/transition_event round-trip. Defaults
+  /// describe an observed, non-error departure; pass error_terminated to stage the
+  /// failed-on_error shape.
+  void set_departed_state_for_test(const std::string & fqn, const std::string & label, bool saw_transition = true,
+                                   bool error_terminated = false);
+
+ private:
+  struct Tracked {
+    std::string state_label;
+    /// Stable fqn (App::effective_fqn()), captured at first sighting - carried into
+    /// recently_departed_ on departure so it can be looked up by the same key
+    /// node_death itself uses (App::id is not stable across a sibling's death, see
+    /// node_death_detector.cpp).
+    std::string fqn;
+    rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>::SharedPtr sub;
+    /// Bounded self-heal budget: re-seed via GetState while the cached label is
+    /// non-active, to recover an `active` transition_event lost during the DDS
+    /// endpoint-matching window right after the (volatile) subscription is created.
+    int reseeds_remaining = 0;
+    /// Set by the ~/transition_event callback - see DepartedLifecycle for why the last
+    /// label alone is not enough to classify a departure.
+    bool saw_transition = false;
+    bool error_terminated = false;
+  };
+  /// Everything the volatile ~/transition_event callback touches lives behind this
+  /// shared_ptr. The callback captures a weak_ptr (never a raw `this`): a callback that
+  /// races teardown either locked first (keeping this alive for its duration) or finds
+  /// lock() empty and bails, so it never dereferences a destroyed mutex/map. The
+  /// executor holds its own strong ref to an already-dispatched Subscription, so
+  /// dropping the sub from `tracked` does not cancel a callback already in flight - the
+  /// weak_ptr guard is what makes that in-flight callback safe.
+  struct SharedState {
+    std::mutex mutex;
+    std::unordered_map<std::string, Tracked> tracked;  // key = App::id
+    /// A departed node's observed departure, keyed by its stable fqn (NOT App::id) -
+    /// value = {departure, departed_tick}. Populated on the drop path in update() just
+    /// before a tracked entry is erased; pruned (in update(), keyed off `tick`) once
+    /// `tick - departed_tick > retention_ticks_`.
+    std::map<std::string, std::pair<DepartedLifecycle, std::uint64_t>> recently_departed_;
+    bool shutdown_requested = false;
+  };
+  rclcpp::Node * node_;
+  std::mutex * node_mutex_;
+  std::shared_ptr<ros2_medkit_gateway::Ros2LifecycleStateReader> reader_;
+  std::shared_ptr<SharedState> state_;
+  int retention_ticks_;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/qos_policy.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/qos_policy.hpp
@@ -1,0 +1,143 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <rmw/qos_profiles.h>
+#include <rmw/types.h>
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Whether a QoS duration policy value is finite: not RMW_DURATION_UNSPECIFIED ({0,0}, "not
+/// set", the most permissive value for an offer) and not RMW_DURATION_INFINITE (also unbounded).
+inline bool qos_duration_is_finite(const rmw_time_t & t) {
+  constexpr rmw_time_t kUnspecified = RMW_DURATION_UNSPECIFIED;
+  constexpr rmw_time_t kInfinite = RMW_DURATION_INFINITE;
+  const bool is_unspecified = t.sec == kUnspecified.sec && t.nsec == kUnspecified.nsec;
+  const bool is_infinite = t.sec == kInfinite.sec && t.nsec == kInfinite.nsec;
+  return !is_unspecified && !is_infinite;
+}
+
+/// Nanosecond value of a QoS duration, for RxO magnitude comparison. Saturates instead of
+/// wrapping: rmw_time_t::sec is uint64_t, so a malformed profile carrying a huge-but-finite
+/// second count would overflow the multiply and come back as a SMALL nanosecond value -
+/// which reads as a tighter deadline than it is and flips the RxO verdict. Saturating keeps
+/// an absurd duration on the permissive side of every comparison, the same side
+/// RMW_DURATION_INFINITE sits on.
+inline uint64_t qos_duration_ns(const rmw_time_t & t) {
+  constexpr uint64_t kNsPerSec = 1000000000ull;
+  constexpr uint64_t kMax = std::numeric_limits<uint64_t>::max();
+  if (t.sec > kMax / kNsPerSec) {
+    return kMax;
+  }
+  const uint64_t sec_ns = t.sec * kNsPerSec;
+  return sec_ns > kMax - t.nsec ? kMax : sec_ns + t.nsec;
+}
+
+/// RxO (Request <= Offered) compatibility for the QoS policies that silently starve a
+/// subscriber. Publisher = offered, subscriber = requested. Returns a human reason when
+/// incompatible, empty string when compatible. The reliability/durability/liveliness-kind
+/// checks match only concrete incompatible enum pairs, so SYSTEM_DEFAULT/UNKNOWN (never
+/// reported by a live endpoint, which carries the resolved profile) never raise. Deadline and
+/// liveliness lease duration are RxO-compatibility dimensions too and are checked below; history
+/// and depth are NOT RxO-compatibility dimensions (they affect what gets buffered/resent, not
+/// whether the reader/writer match), so we deliberately do not check them.
+inline std::string qos_incompatibility(const rmw_qos_profile_t & pub, const rmw_qos_profile_t & sub) {
+  if (sub.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE &&
+      pub.reliability == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT) {
+    return "reliability: publisher BEST_EFFORT vs subscriber RELIABLE";
+  }
+  if (sub.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL &&
+      pub.durability == RMW_QOS_POLICY_DURABILITY_VOLATILE) {
+    return "durability: publisher VOLATILE vs subscriber TRANSIENT_LOCAL";
+  }
+  if (sub.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC &&
+      pub.liveliness == RMW_QOS_POLICY_LIVELINESS_AUTOMATIC) {
+    return "liveliness: publisher AUTOMATIC vs subscriber MANUAL_BY_TOPIC";
+  }
+  if (qos_duration_is_finite(sub.deadline) &&
+      (!qos_duration_is_finite(pub.deadline) || qos_duration_ns(pub.deadline) > qos_duration_ns(sub.deadline))) {
+    return "deadline: publisher deadline exceeds subscriber's requested deadline";
+  }
+  if (qos_duration_is_finite(sub.liveliness_lease_duration) &&
+      (!qos_duration_is_finite(pub.liveliness_lease_duration) ||
+       qos_duration_ns(pub.liveliness_lease_duration) > qos_duration_ns(sub.liveliness_lease_duration))) {
+    return "liveliness lease: publisher lease duration exceeds subscriber's requested lease duration";
+  }
+  return "";
+}
+
+/// How a subscriber fares against the publishers on its topic.
+enum class SubscriberQosVerdict {
+  Ok,       ///< RxO-compatible with every publisher.
+  Partial,  ///< Incompatible with at least one publisher, but at least one works.
+  Starved,  ///< Incompatible with EVERY publisher - it receives nothing at all.
+};
+
+struct SubscriberQosResult {
+  SubscriberQosVerdict verdict = SubscriberQosVerdict::Ok;
+  std::string reason;  ///< Representative incompatibility; empty when Ok.
+};
+
+/// Classify one subscriber against the publishers on its topic.
+///
+/// Partial is reported, not swallowed. An RxO-incompatible pair is not a heuristic - it is
+/// a match DDS has already refused, so the data on that edge is discarded and no error is
+/// raised anywhere. On a topic with several publishers (a second /tf broadcaster, a
+/// hand-rolled BEST_EFFORT publisher next to /diagnostics' aggregator) the subscriber keeps
+/// receiving everyone else's traffic, so nothing looks wrong while one producer's output
+/// silently goes nowhere. That is precisely the class of failure this plugin exists to
+/// surface; the severity split is what keeps it from reading as loudly as total starvation.
+///
+/// An empty publisher set is Ok here: a subscriber with no publishers is an orphan, which
+/// is the orphan detector's concern, not a QoS fault.
+inline SubscriberQosResult classify_subscriber_qos(const std::vector<rmw_qos_profile_t> & pubs,
+                                                   const rmw_qos_profile_t & sub) {
+  SubscriberQosResult result;
+  if (pubs.empty()) {
+    return result;
+  }
+  std::size_t incompatible = 0;
+  for (const auto & pub : pubs) {
+    const auto reason = qos_incompatibility(pub, sub);
+    if (reason.empty()) {
+      continue;
+    }
+    ++incompatible;
+    if (result.reason.empty()) {
+      result.reason = reason;
+    }
+  }
+  if (incompatible == 0) {
+    return result;
+  }
+  result.verdict = incompatible == pubs.size() ? SubscriberQosVerdict::Starved : SubscriberQosVerdict::Partial;
+  return result;
+}
+
+/// Whether a subscriber is STARVED on a topic: it has publishers but is RxO-incompatible with
+/// ALL of them, so it receives nothing. Returns a representative reason when starved, empty
+/// otherwise. Kept as the narrow "receives nothing" predicate; use classify_subscriber_qos()
+/// to also see the partial case.
+inline std::string subscriber_starvation(const std::vector<rmw_qos_profile_t> & pubs, const rmw_qos_profile_t & sub) {
+  const auto result = classify_subscriber_qos(pubs, sub);
+  return result.verdict == SubscriberQosVerdict::Starved ? result.reason : "";
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/reliability_gate.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/reliability_gate.hpp
@@ -1,0 +1,98 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"  // IntrospectionInput
+#include "ros2_medkit_graph_watchdog/lifecycle_watcher.hpp"
+#include "ros2_medkit_graph_watchdog/warmup_tracker.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Central gate composing per-entity warmup (WarmupTracker) with ROS lifecycle state
+/// (LifecycleWatcher). An entity is allowed to raise a fault once it has been armed
+/// (continuously present for warmup_cycles ticks) and its lifecycle state (if managed)
+/// is "active". Unknown source_ids (e.g. topics, not tracked apps) fall back to a
+/// global bringup grace period keyed off the first tick the graph was non-empty.
+class ReliabilityGate {
+ public:
+  ReliabilityGate(int warmup_cycles, rclcpp::Node * gateway_node, std::mutex * node_mutex,
+                  int departed_retention_ticks = kDefaultDepartedRetentionTicks);
+
+  /// Feed a fresh introspection snapshot at `tick`: updates per-entity warmup,
+  /// lifecycle tracking, and the global bringup marker.
+  void update(const ros2_medkit_gateway::IntrospectionInput & snapshot, uint64_t tick);
+
+  /// True if `source_id` is allowed to raise a fault: known entities must be armed
+  /// and lifecycle-ok; unknown entities fall back to the global warmup window.
+  bool allows_raise(const std::string & source_id) const;
+
+  /// Raw lifecycle state label for `app_id` (delegates to the internal
+  /// LifecycleWatcher), or nullopt if `app_id` is not a tracked managed lifecycle
+  /// node. Additive, const, plugin-internal seam for detectors that need the raw
+  /// label rather than the gated node_ok()/allows_raise() boolean (e.g.
+  /// lifecycle_expectation_detector, which enforces its OWN grace instead of the
+  /// gate's - see that detector's design note on why it cannot use
+  /// reliability_allows()).
+  std::optional<std::string> lifecycle_state_of(const std::string & app_id) const;
+
+  /// How a node that departed the graph within the gate's departed-retention horizon
+  /// left it, keyed by its stable fqn (delegates to the internal LifecycleWatcher).
+  /// nullopt if the fqn never departed, or has aged out of retention. Additive, const,
+  /// plugin-internal seam for LifecycleShutdownSuppressor.
+  std::optional<DepartedLifecycle> departed_lifecycle_state_of(const std::string & fqn) const;
+
+  /// SOVD `x-medkit-watchdog` extension payload: schema_version, warmup_cycles,
+  /// global_state, and per-entity state/armed/lifecycle.
+  nlohmann::json status_json() const;
+
+  /// Drop lifecycle subscriptions (shutdown path).
+  void reset();
+
+  /// Test seam: inject a lifecycle state label for `app_id` so a test can drive the
+  /// composed warmup + lifecycle path (an armed entity whose lifecycle is non-active)
+  /// through allows_raise()/status_json() without a live managed node.
+  void set_lifecycle_state_for_test(const std::string & app_id, const std::string & label);
+
+  /// Test-only seam: inject a departed-lifecycle entry directly (delegates to the
+  /// internal LifecycleWatcher) so a suppressor unit test can drive
+  /// departed_lifecycle_state_of() without a live GetState/transition_event round-trip
+  /// or a real node removal.
+  void set_departed_lifecycle_state_for_test(const std::string & fqn, const std::string & label,
+                                             bool saw_transition = true, bool error_terminated = false);
+
+ private:
+  // update() runs on the plugin's tick thread; status_json() runs on an HTTP handler
+  // thread. warmup_ (an unordered_map) and the scalars below have no internal lock, so
+  // gate_mutex_ serializes the writer (update) against the cross-thread reader
+  // (status_json). lifecycle_ is separately self-synchronized and is deliberately updated
+  // OUTSIDE gate_mutex_ (it does blocking reads); allows_raise() is a reader that only
+  // runs on the tick thread (sequentially after update), so it needs no lock.
+  mutable std::mutex gate_mutex_;
+  WarmupTracker warmup_;
+  LifecycleWatcher lifecycle_;
+  int warmup_cycles_;
+  uint64_t last_tick_ = 0;
+  bool graph_seen_ = false;
+  uint64_t graph_first_tick_ = 0;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/warmup_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/warmup_tracker.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Per-entity bringup-quiesce. An entity is "armed" once it has been continuously
+/// present for `warmup_cycles` ticks. An entity that vanishes for more than
+/// `forget_grace` ticks and later reappears is treated as a restart and re-warmed; a
+/// shorter gap is treated as transient discovery churn and does NOT re-warm. Pure; no ROS.
+class WarmupTracker {
+ public:
+  /// A one-tick ROS 2 graph-poll gap is indistinguishable from a real restart, and DDS
+  /// discovery churn routinely drops a node from a single poll without it restarting.
+  /// Absorbing a few missed ticks stops that churn from perpetually re-arming (and thus
+  /// permanently suppressing) an entity whose gaps recur faster than the warmup window.
+  static constexpr uint64_t kDefaultForgetGrace = 2;
+
+  struct Entry {
+    uint64_t first_seen;  ///< tick the current continuous-presence streak began (drives arming)
+    uint64_t last_seen;   ///< most recent tick the entity was present (drives forget grace)
+  };
+
+  explicit WarmupTracker(int warmup_cycles, uint64_t forget_grace = kDefaultForgetGrace)
+    : warmup_cycles_(warmup_cycles < 0 ? 0 : warmup_cycles), forget_grace_(forget_grace) {
+  }
+
+  /// Record the entity ids present at `tick`. New ids get first_seen=tick; a still-known
+  /// id keeps its original first_seen and refreshes last_seen; an id missing for longer
+  /// than forget_grace_ ticks is forgotten so a later reappearance re-warms.
+  void update(const std::vector<std::string> & present_ids, uint64_t tick) {
+    std::unordered_set<std::string> present(present_ids.begin(), present_ids.end());
+    for (auto it = entries_.begin(); it != entries_.end();) {
+      const bool missing = present.count(it->first) == 0;
+      if (missing && (tick - it->second.last_seen) > forget_grace_) {
+        it = entries_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+    for (const auto & id : present_ids) {
+      auto [it, inserted] = entries_.try_emplace(id, Entry{tick, tick});
+      if (!inserted) {
+        it->second.last_seen = tick;  // continuous (or within-grace) presence keeps first_seen
+      }
+    }
+  }
+
+  bool is_known(const std::string & id) const {
+    return entries_.count(id) > 0;
+  }
+
+  bool is_armed(const std::string & id, uint64_t tick) const {
+    auto it = entries_.find(id);
+    if (it == entries_.end()) {
+      return false;
+    }
+    return (tick - it->second.first_seen) >= static_cast<uint64_t>(warmup_cycles_);
+  }
+
+  const std::unordered_map<std::string, Entry> & entries() const {
+    return entries_;
+  }
+
+ private:
+  int warmup_cycles_;
+  uint64_t forget_grace_;
+  std::unordered_map<std::string, Entry> entries_;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/watchdog_clock.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/watchdog_clock.hpp
@@ -1,0 +1,63 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Thin wrapper over the owning node's clock. Honors use_sim_time (node clock).
+/// time_is_valid() flags a paused/absent /clock so time-based detectors can skip
+/// their age/grace math instead of firing a false positive.
+class WatchdogClock {
+ public:
+  explicit WatchdogClock(rclcpp::Node * node)
+    : clock_(node->get_clock()), use_sim_time_(node->get_parameter_or("use_sim_time", false)) {
+  }
+
+  rclcpp::Time now() const {
+    return clock_->now();
+  }
+
+  /// Called once per tick by the plugin. Samples sim + wall time to detect a stall.
+  void mark_tick() {
+    const rclcpp::Time sim_now = clock_->now();
+    const auto wall_now = std::chrono::steady_clock::now();
+    if (have_sample_ && use_sim_time_) {
+      const bool wall_advanced = (wall_now - last_wall_) > std::chrono::milliseconds(1);
+      const bool sim_advanced = sim_now.nanoseconds() > last_sim_ns_;
+      valid_ = !(wall_advanced && !sim_advanced);
+    }
+    last_sim_ns_ = sim_now.nanoseconds();
+    last_wall_ = wall_now;
+    have_sample_ = true;
+  }
+
+  bool time_is_valid() const {
+    return valid_;
+  }
+
+ private:
+  rclcpp::Clock::SharedPtr clock_;
+  bool use_sim_time_;
+  bool have_sample_ = false;
+  int64_t last_sim_ns_ = 0;
+  std::chrono::steady_clock::time_point last_wall_{};
+  bool valid_ = true;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/package.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_medkit_graph_watchdog</name>
+  <version>0.6.0</version>
+  <description>Gateway plugin that detects silent faults in the ROS 2 graph: QoS mismatches, topic-name typos, dead nodes, stale transforms, parameter drift, lifecycle expectations and pipeline timing budgets.</description>
+  <maintainer email="bartoszburda93@gmail.com">bburda</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>ros2_medkit_cmake</buildtool_depend>
+  <depend>ros2_medkit_gateway</depend>
+  <depend>ros2_medkit_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>nlohmann-json-dev</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>tf2_msgs</depend>
+  <depend>geometry_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+
+  <!-- Config-plumbing + QoS e2e (test/e2e/, launch_testing) -->
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>python3-requests</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>tf2_ros</test_depend>
+  <test_depend>ros2_medkit_fault_manager</test_depend>
+  <test_depend>ros2_medkit_integration_tests</test_depend>
+  <test_depend>ament_index_python</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detector_registry.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detector_registry.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+DetectorRegistry & DetectorRegistry::instance() {
+  static DetectorRegistry registry;  // Meyers singleton: safe under static-init order.
+  return registry;
+}
+
+void DetectorRegistry::register_factory(const std::string & id, DetectorFactory factory) {
+  factories_.emplace_back(id, std::move(factory));
+}
+
+std::vector<std::unique_ptr<Detector>> DetectorRegistry::create_all() const {
+  std::vector<std::unique_ptr<Detector>> detectors;
+  detectors.reserve(factories_.size());
+  for (const auto & [id, factory] : factories_) {
+    (void)id;
+    detectors.push_back(factory());
+  }
+  return detectors;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/qos_mismatch_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/qos_mismatch_detector.cpp
@@ -122,6 +122,7 @@ class QosMismatchDetector : public Detector {
     log_warnings_once(ctx);
 
     std::map<std::string, std::string> affected;  // topic -> "<topic>: <reasons>"
+    std::vector<std::string> newly_affected;      // crossed the gate this tick -> named first
     bool any_starved = false;
     std::set<std::string> seen_topics;
     const auto topics = ctx.gateway_node->get_topic_names_and_types();
@@ -180,6 +181,13 @@ class QosMismatchDetector : public Detector {
       if (!starved_by_reason.empty()) {
         any_starved = true;
       }
+      // A topic crossing the gate on THIS tick is the new information. The description is
+      // capped, and affected topics are otherwise listed lexicographically, so without this
+      // a newly starved subscriber on a late-sorting topic would produce no operator-visible
+      // change at all: the code is already raised and the text is already full.
+      if (streak_[topic] == grace_ + 1) {
+        newly_affected.push_back(topic);
+      }
       affected[topic] = describe_topic(topic, starved_by_reason, partial_by_reason);
     }
     // Drop streaks for topics that left the graph, so the map cannot grow without bound on
@@ -192,7 +200,7 @@ class QosMismatchDetector : public Detector {
     // ERROR as soon as any subscriber anywhere receives nothing at all, WARN when every
     // finding is a degraded-but-alive topic.
     AggregatedFault aggregated{graph_fault_codes::kQosMismatch, any_starved ? kStarvedSeverity : kPartialSeverity};
-    aggregated.emit(ctx, affected);
+    aggregated.emit_ordered(ctx, affected, newly_affected);
   }
 
  private:

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/qos_mismatch_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/qos_mismatch_detector.cpp
@@ -1,0 +1,245 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <cstdint>
+#include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/msg/fault.hpp>
+
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+#include "ros2_medkit_graph_watchdog/qos_policy.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+namespace {
+// Fault severity scale: SEVERITY_WARN=1, SEVERITY_ERROR=2 (ros2_medkit_msgs/msg/Fault.msg).
+// A starved subscriber never receives data at all - stronger than a drifted parameter.
+constexpr std::uint8_t kStarvedSeverity = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
+// A partially-incompatible subscriber still receives the other publishers, so the topic is
+// degraded rather than dead. Reported, but not at the same level as total starvation.
+constexpr std::uint8_t kPartialSeverity = ros2_medkit_msgs::msg::Fault::SEVERITY_WARN;
+
+/// Consecutive affected ticks a topic needs before it is reported.
+///
+/// Without this a single sweep raises, and the shipped fault_manager config carries
+/// `confirmation_threshold: -1`, so that one sweep is CONFIRMED ERROR immediately and -
+/// with `snapshots.rosbag.enabled` - pulls a black-box capture with it. Endpoint discovery
+/// is not atomic: during bringup a subscriber can be visible before a publisher's QoS is,
+/// which reads exactly like starvation for a tick or two. A genuine QoS mismatch is static,
+/// still there N ticks later, so persistence costs almost no detection latency and removes
+/// the whole transient class.
+constexpr int kDefaultGrace = 3;
+
+/// Human-readable owner of an endpoint, for the fault description.
+std::string endpoint_name(const rclcpp::TopicEndpointInfo & endpoint) {
+  const std::string ns = endpoint.node_namespace();
+  const std::string name = endpoint.node_name();
+  if (ns.empty() || ns == "/") {
+    return "/" + name;
+  }
+  return ns + "/" + name;
+}
+
+std::string join_names(const std::set<std::string> & names) {
+  std::string out;
+  for (const auto & name : names) {
+    if (!out.empty()) {
+      out += ", ";
+    }
+    out += name;
+  }
+  return out;
+}
+}  // namespace
+
+/// Watches every topic and raises GRAPH_QOS_MISMATCH when a subscriber is RxO-incompatible
+/// with a publisher on its topic (see qos_policy.hpp). Two levels behind one fault code:
+///
+/// - STARVED: incompatible with EVERY publisher, so it receives nothing -> ERROR.
+/// - PARTIAL: incompatible with some publisher but not all -> WARN. DDS refuses that one
+///   pair, so that producer's data is discarded while the topic still looks alive; nothing
+///   else in the system reports it.
+///
+/// A subscriber with zero publishers is an orphan (a different detector), not a QoS fault.
+/// See design doc / [[project_graph_watchdog_zero_config]].
+class QosMismatchDetector : public Detector {
+ public:
+  std::string id() const override {
+    return "qos_mismatch";
+  }
+
+  void configure(const nlohmann::json & config) override {
+    std::vector<std::string> warnings;
+    if (config.contains("grace")) {
+      if (config["grace"].is_number_integer() && config["grace"].get<int>() >= 0) {
+        grace_ = config["grace"].get<int>();
+      } else {
+        warnings.push_back("'grace' must be a non-negative integer; keeping the default (" +
+                           std::to_string(kDefaultGrace) + ")");
+      }
+    }
+    if (config.contains("allowlist")) {
+      if (config["allowlist"].is_array()) {
+        for (const auto & entry : config["allowlist"]) {
+          if (entry.is_string() && !entry.get<std::string>().empty()) {
+            allowlist_.insert(entry.get<std::string>());
+          } else {
+            warnings.push_back("'allowlist' entries must be non-empty topic names; skipping one");
+          }
+        }
+      } else {
+        warnings.push_back("'allowlist' must be a string array of topic names; ignoring it");
+      }
+    }
+    collect_unknown_detector_keys(config, known_keys(), warnings);
+    warnings_ = std::move(warnings);
+    streak_.clear();
+  }
+
+  void tick(DetectorContext & ctx) override {
+    if (!ctx.gateway_node) {
+      return;
+    }
+    log_warnings_once(ctx);
+
+    std::map<std::string, std::string> affected;  // topic -> "<topic>: <reasons>"
+    bool any_starved = false;
+    std::set<std::string> seen_topics;
+    const auto topics = ctx.gateway_node->get_topic_names_and_types();
+    for (const auto & [topic, types] : topics) {
+      (void)types;
+      if (ctx.cancelled && ctx.cancelled->load()) {
+        return;  // shutting down: do not emit a clear built from a partial sweep
+      }
+      // /rosout and /parameter_events are ROS 2 system topics with their own
+      // well-known QoS conventions - not useful signal for this detector.
+      if (topic == "/rosout" || topic == "/parameter_events") {
+        continue;
+      }
+      // An operator's own tool is not a robot fault. rviz2 builds every display's
+      // subscription from rclcpp::QoS(5) - RELIABLE - and does not negotiate down to a
+      // BEST_EFFORT sensor publisher, so opening an Image display on a driver topic reads
+      // as starvation. Without this lever the only way to silence that is turning the
+      // whole detector off.
+      if (allowlist_.count(topic) != 0) {
+        continue;
+      }
+      seen_topics.insert(topic);
+
+      const auto pubs = ctx.gateway_node->get_publishers_info_by_topic(topic);
+      if (pubs.empty()) {
+        continue;  // no publishers -> not a QoS starvation (orphan detector's concern)
+      }
+      std::vector<rmw_qos_profile_t> pub_qos;
+      pub_qos.reserve(pubs.size());
+      for (const auto & pub : pubs) {
+        pub_qos.push_back(pub.qos_profile().get_rmw_qos_profile());
+      }
+      // reason -> the subscribers hitting it. Keyed by reason so several subscribers
+      // failing the same policy collapse into one phrase, but each still NAMES itself:
+      // without that, "reliability: publisher BEST_EFFORT vs subscriber RELIABLE" on a
+      // topic with a dozen subscribers still leaves the operator to ssh in and run
+      // `ros2 topic info -v` to find the starved one - the step the fault exists to remove.
+      std::map<std::string, std::set<std::string>> starved_by_reason;
+      std::map<std::string, std::set<std::string>> partial_by_reason;
+      for (const auto & sub : ctx.gateway_node->get_subscriptions_info_by_topic(topic)) {
+        const auto result = classify_subscriber_qos(pub_qos, sub.qos_profile().get_rmw_qos_profile());
+        if (result.verdict == SubscriberQosVerdict::Starved) {
+          starved_by_reason[result.reason].insert(endpoint_name(sub));
+        } else if (result.verdict == SubscriberQosVerdict::Partial) {
+          partial_by_reason[result.reason].insert(endpoint_name(sub));
+        }
+      }
+      if (starved_by_reason.empty() && partial_by_reason.empty()) {
+        streak_.erase(topic);
+        continue;
+      }
+      // Persistence gate, per topic so one flapping topic never delays another.
+      if (++streak_[topic] <= grace_) {
+        continue;
+      }
+      if (!starved_by_reason.empty()) {
+        any_starved = true;
+      }
+      affected[topic] = describe_topic(topic, starved_by_reason, partial_by_reason);
+    }
+    // Drop streaks for topics that left the graph, so the map cannot grow without bound on
+    // a graph that churns topic names.
+    for (auto it = streak_.begin(); it != streak_.end();) {
+      it = seen_topics.count(it->first) == 0 ? streak_.erase(it) : std::next(it);
+    }
+
+    // One fault code carries one severity, so it reflects the worst finding in the sweep:
+    // ERROR as soon as any subscriber anywhere receives nothing at all, WARN when every
+    // finding is a degraded-but-alive topic.
+    AggregatedFault aggregated{graph_fault_codes::kQosMismatch, any_starved ? kStarvedSeverity : kPartialSeverity};
+    aggregated.emit(ctx, affected);
+  }
+
+ private:
+  static const std::set<std::string> & known_keys() {
+    static const std::set<std::string> keys{"grace", "allowlist"};
+    return keys;
+  }
+
+  static std::string describe_topic(const std::string & topic,
+                                    const std::map<std::string, std::set<std::string>> & starved_by_reason,
+                                    const std::map<std::string, std::set<std::string>> & partial_by_reason) {
+    std::string detail = topic + ": ";
+    bool first = true;
+    for (const auto & [reason, names] : starved_by_reason) {
+      if (!first) {
+        detail += "; ";
+      }
+      detail += reason + " (receives nothing: " + join_names(names) + ")";
+      first = false;
+    }
+    for (const auto & [reason, names] : partial_by_reason) {
+      if (!first) {
+        detail += "; ";
+      }
+      detail += reason + " (one publisher discarded, still receiving others: " + join_names(names) + ")";
+      first = false;
+    }
+    return detail;
+  }
+
+  void log_warnings_once(const DetectorContext & ctx) {
+    if (warnings_.empty() || warnings_logged_ || !ctx.gateway_node) {
+      return;
+    }
+    for (const auto & warning : warnings_) {
+      RCLCPP_WARN(ctx.gateway_node->get_logger(), "graph_watchdog qos_mismatch: %s", warning.c_str());
+    }
+    warnings_logged_ = true;
+  }
+
+  int grace_ = kDefaultGrace;
+  std::set<std::string> allowlist_;
+  std::map<std::string, int> streak_;  ///< topic -> consecutive affected ticks
+  std::vector<std::string> warnings_;
+  bool warnings_logged_ = false;
+};
+
+REGISTER_DETECTOR(QosMismatchDetector, "qos_mismatch")
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
@@ -1,0 +1,391 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"  // kGraphWatchdogEntityId
+#include "ros2_medkit_graph_watchdog/detector_config.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+namespace {
+// Mirrors NodeDeathDetector's own kDefaultMissGrace (node_death_detector.cpp, anonymous
+// namespace, not reachable from here) - kept in sync by convention since this is only a
+// fallback used when config carries no explicit "detectors.node_death.miss_grace".
+constexpr int kDefaultNodeDeathMissGrace = 2;
+}  // namespace
+
+ros2_medkit_gateway::IntrospectionResult
+GraphWatchdogPlugin::introspect(const ros2_medkit_gateway::IntrospectionInput & input) {
+  ros2_medkit_gateway::IntrospectionResult result;
+  ros2_medkit_gateway::App app;
+  app.id = kGraphWatchdogEntityId;
+  app.name = "Graph watchdog";
+  app.description = "Graph-level silent-fault detectors; every GRAPH_* fault is scoped here";
+  // This App stands for the graph itself, not for a ROS node, so it has no binding to
+  // derive an FQN from. Without `external` the fault scope resolves it to an empty FQN
+  // and drops it (fault_scope.cpp's resolve_app_source_fqn), which would leave every
+  // GRAPH_* fault exactly as unreachable as it was under the host Component.
+  app.external = true;
+  app.is_online = true;
+  app.source = "plugin";
+  // Attach to the host Component so the faults also roll up to /components/<host>/faults
+  // (a Component resolves its scope through its child apps). With no Component in the
+  // snapshot the App still stands alone and /apps/graph_watchdog/faults works.
+  if (!input.components.empty() && !input.components.front().id.empty()) {
+    app.component_id = input.components.front().id;
+  }
+  result.new_entities.apps.push_back(std::move(app));
+  return result;
+}
+
+GraphWatchdogPlugin::GraphWatchdogPlugin() = default;
+GraphWatchdogPlugin::~GraphWatchdogPlugin() {
+  shutdown();
+}
+
+void GraphWatchdogPlugin::configure(const nlohmann::json & config) {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  config_ = config;
+}
+
+void GraphWatchdogPlugin::load_parameters() {
+  std::lock_guard<std::mutex> lock(config_mutex_);
+  if (config_.contains("tick_interval_ms") && config_["tick_interval_ms"].is_number_integer()) {
+    const int candidate = config_["tick_interval_ms"].get<int>();
+    if (candidate > 0) {
+      tick_interval_ms_ = candidate;
+    } else {
+      log_warn("ignoring non-positive tick_interval_ms=" + std::to_string(candidate) + "; keeping " +
+               std::to_string(tick_interval_ms_));
+    }
+  }
+  if (config_.contains("warmup_cycles") && config_["warmup_cycles"].is_number_integer()) {
+    const int candidate = config_["warmup_cycles"].get<int>();
+    if (candidate >= 0) {
+      warmup_cycles_ = candidate;
+    } else {
+      log_warn("ignoring negative warmup_cycles=" + std::to_string(candidate));
+    }
+  }
+  if (config_.contains("prune_grace") && config_["prune_grace"].is_number_integer()) {
+    const int candidate = config_["prune_grace"].get<int>();
+    if (candidate >= 0) {
+      prune_grace_ = candidate;
+    } else {
+      log_warn("ignoring negative prune_grace=" + std::to_string(candidate));
+    }
+  }
+}
+
+int GraphWatchdogPlugin::compute_departed_retention_ticks(const nlohmann::json & config_snapshot) const {
+  // Read "detectors.node_death.miss_grace" directly off the full config tree (mirroring
+  // node_death_detector.cpp's own nested read of the same field) - node_death's own
+  // configure() has not run yet at the point set_context() needs this value, so its
+  // own kDefaultMissGrace/clamping cannot be reused directly here.
+  int node_death_miss_grace = kDefaultNodeDeathMissGrace;
+  int node_death_prune_grace = prune_grace_;
+  if (config_snapshot.contains("detectors") && config_snapshot["detectors"].is_object()) {
+    const auto & detectors = config_snapshot["detectors"];
+    if (detectors.contains("node_death") && detectors["node_death"].is_object()) {
+      const auto & node_death_cfg = detectors["node_death"];
+      if (node_death_cfg.contains("miss_grace") && node_death_cfg["miss_grace"].is_number_integer()) {
+        const int candidate = node_death_cfg["miss_grace"].get<int>();
+        if (candidate >= 0) {
+          node_death_miss_grace = candidate;
+        }
+      }
+      // Same reason we read miss_grace here: prune_grace is a per-detector key whose
+      // plugin-scope value is only a default, so the retention window must be computed from
+      // whatever node_death will ACTUALLY clamp its prune_ticks_ to. Reading prune_grace_
+      // unconditionally would under-run the retention whenever an operator raises
+      // detectors.node_death.prune_grace, and node_death would then re-raise a
+      // cleanly-shut-down node it should have silently reclaimed (see the formula below).
+      if (node_death_cfg.contains("prune_grace") && node_death_cfg["prune_grace"].is_number_integer()) {
+        const int candidate = node_death_cfg["prune_grace"].get<int>();
+        if (candidate >= 0) {
+          node_death_prune_grace = candidate;
+        }
+      }
+    }
+  }
+  // prune_ticks mirrors node_death's OWN prune_ticks_ clamp (node_death_detector.cpp's
+  // configure()): max(prune_grace, miss_grace + 1). The departed-lifecycle label must
+  // survive not just past the FIRST tick node_death evaluates suppression on
+  // (T_depart + miss_grace, see test_node_death_integration.cpp's
+  // CleanShutdownDepartureAtMissGraceBoundaryIsSuppressed), but all the way through
+  // node_death's own RECLAIM tick (T_depart + miss_grace + prune_ticks): only a durable
+  // suppressor (lifecycle_clean_shutdown IS one, see suppressor.hpp) may feed
+  // NodeLivenessTracker::prune(), and that reclaim can only happen while the suppressor
+  // still actively vetoes the id - i.e. while the label is still cached. If the label
+  // expired even one tick earlier (the old `max(prune_grace, miss_grace + 1)` retention
+  // - the SAME length as prune_ticks, but anchored miss_grace ticks later at
+  // T_depart instead of T_death), the suppressor would abstain right at the reclaim
+  // tick, node_death would RAISE instead of silently reclaiming, and - because the
+  // label is now gone for good - the id could never be suppressed again: a permanent
+  // false GRAPH_NODE_DISAPPEARED for a cleanly-shut-down node. The extra "+1" keeps one
+  // full tick of margin past the reclaim tick itself. See
+  // test_node_death_integration.cpp's CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention
+  // for the regression this formula fixes.
+  const int prune_ticks = std::max(node_death_prune_grace, node_death_miss_grace + 1);
+  return prune_ticks + node_death_miss_grace + 1;
+}
+
+void GraphWatchdogPlugin::set_context(ros2_medkit_gateway::PluginContext & context) {
+  ctx_ = ros2_medkit_gateway::as_ros_plugin_context(context);
+  load_parameters();
+  if (!ctx_ || !ctx_->node()) {
+    log_error("no ROS node in context; graph_watchdog disabled");
+    return;
+  }
+  auto * node = ctx_->node();
+  clock_ = std::make_unique<WatchdogClock>(node);
+
+  nlohmann::json config_snapshot;
+  {
+    std::lock_guard<std::mutex> lock(config_mutex_);
+    config_snapshot = config_;
+  }
+
+  // Computed BEFORE gate_ is constructed: node_death's own configure() (which normally
+  // owns its miss_grace default) has not run yet at this point.
+  const int departed_retention_ticks = compute_departed_retention_ticks(config_snapshot);
+  gate_ = std::make_unique<ReliabilityGate>(warmup_cycles_, node, &node_mutex_, departed_retention_ticks);
+  fault_client_ = node->create_client<ros2_medkit_msgs::srv::ReportFault>("/fault_manager/report_fault");
+
+  std::set<std::string> seen_ids;
+  for (auto & detector : DetectorRegistry::instance().create_all()) {
+    const std::string id = detector->id();
+    if (!seen_ids.insert(id).second) {
+      log_warn("duplicate detector id '" + id + "'; skipping the duplicate");
+      continue;
+    }
+    std::vector<std::string> mode_warnings;
+    const DetectorMode mode = parse_detector_mode(config_snapshot, id, &mode_warnings);
+    for (const auto & warning : mode_warnings) {
+      log_warn(warning);
+    }
+    if (mode == DetectorMode::Off) {
+      continue;
+    }
+    try {
+      // extract_detector_config() isolates each detector to config["detectors"][id], so a
+      // plugin-scope knob never reaches a detector on its own. Inject them under names every
+      // detector treats as plugin plumbing rather than operator keys (see
+      // plugin_injected_detector_keys()): node_death needs the tick period to turn its
+      // tick-counted grace into a wall-clock window, and every prune-aware detector reads
+      // prune_grace.
+      auto dcfg = extract_detector_config(config_snapshot, id);
+      dcfg["tick_interval_ms"] = tick_interval_ms_;
+      // prune_grace is a plugin-scope DEFAULT, not an override: every prune-aware detector
+      // documents it in its own key table and reads it off the config it is handed, so
+      // `detectors.tf_stale.prune_grace` must win over the plugin-scope value. Injecting it
+      // unconditionally silently discarded the per-detector setting.
+      if (!dcfg.contains("prune_grace")) {
+        dcfg["prune_grace"] = prune_grace_;
+      }
+      detector->configure(dcfg);
+    } catch (const std::exception & e) {
+      log_error("detector '" + id + "' configure() threw: " + std::string(e.what()) + "; skipping");
+      continue;
+    }
+    detectors_.emplace_back(std::move(detector), mode);
+  }
+
+  // A typo in the detector ID itself is the worst of the config typos: the whole block
+  // becomes a no-op, so `detectors.param_drfit.mode: off` leaves a detector the operator
+  // explicitly disabled still raising on the robot. Nothing downstream can catch it -
+  // extract_detector_config only ever looks up ids it already knows - so compare the
+  // configured ids against the registered set here, where both are in hand.
+  if (config_snapshot.contains("detectors") && config_snapshot["detectors"].is_object()) {
+    std::string registered;
+    for (const auto & id : seen_ids) {
+      if (!registered.empty()) {
+        registered += ", ";
+      }
+      registered += id;
+    }
+    for (const auto & item : config_snapshot["detectors"].items()) {
+      if (seen_ids.count(item.key()) == 0) {
+        log_warn("config block 'detectors." + item.key() + "' matches no registered detector and has no effect" +
+                 " (registered: " + registered + ")");
+      }
+    }
+  }
+
+  // Run the tick on a dedicated thread, NOT a gateway wall-timer: detectors do blocking
+  // parameter/service reads, and the gateway's small executor is only safe because
+  // blocking never runs on an executor thread (see the gateway's main.cpp). This keeps
+  // the blocking off the executor's callback group entirely.
+  tick_thread_ = std::thread([this] {
+    run_tick_loop();
+  });
+
+  // Quiesce the tick thread BEFORE rclcpp invalidates the context (this runs even on a SIGINT,
+  // ahead of context invalidation). It signals shutdown and waits, bounded, for run_tick_loop() to
+  // leave its loop so no detector is mid-rcl-read when the context dies. It does NOT join the
+  // thread (shutdown()/the destructor own that) - it only makes the thread quiescent.
+  context_ = node->get_node_base_interface()->get_context();
+  pre_shutdown_handle_ = context_->add_pre_shutdown_callback([this] {
+    {
+      std::lock_guard<std::mutex> lock(tick_cv_mutex_);
+      shutdown_requested_.store(true);
+    }
+    tick_cv_.notify_all();
+    std::unique_lock<std::mutex> lock(tick_cv_mutex_);
+    tick_cv_.wait_for(lock, std::chrono::seconds(2), [this] {
+      return tick_loop_exited_;
+    });
+  });
+
+  log_info("graph_watchdog up: " + std::to_string(detectors_.size()) + " detector(s)");
+}
+
+void GraphWatchdogPlugin::run_tick_loop() {
+  while (!shutdown_requested_.load()) {
+    tick();
+    std::unique_lock<std::mutex> lock(tick_cv_mutex_);
+    tick_cv_.wait_for(lock, std::chrono::milliseconds(tick_interval_ms_), [this] {
+      return shutdown_requested_.load();
+    });
+  }
+  // Announce that no more ticks (and so no more rcl reads) will run. The pre-shutdown callback
+  // waits on this so the context is not invalidated while a tick is mid-flight.
+  {
+    std::lock_guard<std::mutex> lock(tick_cv_mutex_);
+    tick_loop_exited_ = true;
+  }
+  tick_cv_.notify_all();
+}
+
+void GraphWatchdogPlugin::tick() {
+  if (shutdown_requested_.load()) {
+    return;
+  }
+  // No tick_mutex_ here: shutdown() joins this thread before tearing down any member, so
+  // tick() can never race teardown. Running lock-free is what keeps the blocking reads
+  // below from stalling the get_routes() status handler (which does take tick_mutex_).
+  tick_count_.fetch_add(1);
+  // The gate update runs first and can throw: get_entity_snapshot()'s contract is not
+  // enforced, and LifecycleWatcher::update() calls create_subscription() (invalid topic
+  // name, RCLError, bad_alloc). An escape would kill the tick thread and every detector,
+  // so guard it like each detector->tick() below.
+  ros2_medkit_gateway::IntrospectionInput snapshot;
+  try {
+    clock_->mark_tick();
+    if (ctx_) {
+      snapshot = ctx_->get_entity_snapshot();
+    }
+    if (gate_) {
+      gate_->update(snapshot, tick_count_.load());
+    }
+  } catch (const std::exception & e) {
+    log_error("graph_watchdog gate update threw: " + std::string(e.what()));
+  }
+  auto * node = ctx_ ? ctx_->node() : nullptr;
+  for (auto & [detector, mode] : detectors_) {
+    // Bail between detectors so shutdown() (which joins this thread) is not held for a full
+    // sweep of blocking reads once teardown has been requested.
+    if (shutdown_requested_.load()) {
+      return;
+    }
+    DetectorContext dctx;
+    dctx.gateway_node = node;
+    dctx.node_mutex = &node_mutex_;
+    dctx.clock = clock_.get();
+    dctx.gate = gate_.get();
+    dctx.mode = mode;
+    dctx.fault_client = fault_client_;
+    dctx.snapshot = &snapshot;
+    dctx.cancelled = &shutdown_requested_;
+    try {
+      detector->tick(dctx);
+    } catch (const std::exception & e) {
+      log_error("detector '" + detector->id() + "' threw: " + e.what());
+    }
+  }
+}
+
+void GraphWatchdogPlugin::shutdown() {
+  // Guard on teardown_done_, NOT shutdown_requested_: the pre-shutdown callback may already have set
+  // shutdown_requested_ to quiesce the tick loop, and guarding on that would make this early-return
+  // WITHOUT joining tick_thread_, leaving a joinable std::thread to std::terminate() at destruction.
+  if (teardown_done_.exchange(true)) {
+    return;
+  }
+  // Deregister the pre-shutdown callback (it captures `this`): a no-op if it already ran during a
+  // normal rclcpp shutdown, but it prevents a stale callback firing on a destroyed plugin when the
+  // plugin is torn down without an rclcpp shutdown.
+  if (context_) {
+    context_->remove_pre_shutdown_callback(pre_shutdown_handle_);
+  }
+  // Wake the tick loop out of its sleep and JOIN it before touching any member: after the
+  // join no tick runs, so the teardown below cannot race an in-flight tick. (A tick
+  // in progress finishes first; its blocking reads are bounded by the parameter
+  // transport's own service timeout, so the join cannot hang on an unresponsive node.)
+  // Set the stop flag under tick_cv_mutex_ before notifying so the signal cannot fall into the gap
+  // between the tick loop testing shutdown_requested_ and entering wait_for(): re-acquiring the mutex
+  // the waiter holds while it re-checks the predicate guarantees it observes the flag we just set,
+  // bounding shutdown latency to well under one tick interval. This is a latency optimization, not
+  // a correctness requirement - wait_for()'s timeout and predicate already backstop a missed wakeup.
+  {
+    std::lock_guard<std::mutex> lock(tick_cv_mutex_);
+    shutdown_requested_.store(true);
+  }
+  tick_cv_.notify_all();
+  if (tick_thread_.joinable()) {
+    tick_thread_.join();
+  }
+  // Fence the get_routes() status handler (the only other member reader) against teardown.
+  std::lock_guard<std::mutex> lock(tick_mutex_);
+  detectors_.clear();
+  fault_client_.reset();
+  clock_.reset();
+  if (gate_) {
+    gate_->reset();
+  }
+  gate_.reset();
+}
+
+std::vector<GraphWatchdogPlugin::PluginRoute> GraphWatchdogPlugin::get_routes() {
+  auto handler = [this](const ros2_medkit_gateway::PluginRequest &, ros2_medkit_gateway::PluginResponse & res) {
+    // tick_mutex_ guards gate_ against shutdown()'s teardown (which also holds it after
+    // joining the tick thread), so the pointer cannot be reset mid-read. The concurrent
+    // tick-thread gate_->update() is made safe against this status read by the gate's OWN
+    // internal gate_mutex_ (status_json() and update() both take it); status_json() does
+    // no blocking I/O, so this handler never stalls behind the detectors' blocking reads.
+    std::lock_guard<std::mutex> lock(tick_mutex_);
+    if (!gate_) {
+      res.send_error(503, ros2_medkit_gateway::ERR_SERVICE_UNAVAILABLE,
+                     "graph_watchdog reliability gate not initialized");
+      return;
+    }
+    res.send_json(gate_->status_json());
+  };
+  std::vector<PluginRoute> routes;
+  routes.push_back({"GET", R"(x-medkit-watchdog)", std::move(handler)});
+  return routes;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin_exports.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin_exports.cpp
@@ -1,0 +1,35 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_gateway/core/plugins/gateway_plugin.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_types.hpp"
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp"
+
+extern "C" GATEWAY_PLUGIN_EXPORT int plugin_api_version() {
+  return ros2_medkit_gateway::PLUGIN_API_VERSION;
+}
+
+extern "C" GATEWAY_PLUGIN_EXPORT ros2_medkit_gateway::GatewayPlugin * create_plugin() {
+  return new ros2_medkit_graph_watchdog::GraphWatchdogPlugin();
+}
+
+// Without this export the gateway never calls introspect(), the graph_watchdog App is
+// never published, and every GRAPH_* fault goes back to being scoped to an entity that
+// does not exist - reachable from no endpoint. The static_cast down to the concrete type
+// is required: GatewayPlugin and IntrospectionProvider are unrelated bases, so the two
+// subobject addresses differ.
+extern "C" GATEWAY_PLUGIN_EXPORT ros2_medkit_gateway::IntrospectionProvider *
+get_introspection_provider(ros2_medkit_gateway::GatewayPlugin * plugin) {
+  return static_cast<ros2_medkit_graph_watchdog::GraphWatchdogPlugin *>(plugin);
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
@@ -1,0 +1,341 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/lifecycle_watcher.hpp"
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/status/lifecycle_state_reader.hpp"  // find_lifecycle_get_state_path
+
+namespace ros2_medkit_graph_watchdog {
+
+namespace {
+
+/// Cap the number of blocking GetState calls per update() so a batch bringup (Nav2 /
+/// MoveIt activating many lifecycle nodes at once) cannot stall the tick loop - and the
+/// x-medkit-watchdog handler that shares tick_mutex_ - for seconds. Nodes beyond the cap
+/// are still subscribed (so no transition is missed); they seed on a later tick.
+constexpr int kMaxGetStateSeedsPerTick = 8;
+
+/// A count cap alone does not bound the STALL: each GetState blocks up to the reader's
+/// timeout (500 ms default) when a managed node is slow/unresponsive, so 8 timed-out
+/// seeds still freezes the tick loop for ~4 s. On a real Nav2 stack (~15 lifecycle nodes,
+/// one stuck mid-transition) this stalled detection for tens of seconds at bringup. So
+/// also bound the total blocking time per tick: stop seeding once this wall-clock budget
+/// is spent and defer the rest to the next tick. Worst-case blocking is then one in-flight
+/// timeout (~500 ms), never N of them; async ~/transition_event keeps state fresh meanwhile.
+constexpr std::chrono::milliseconds kGetStateBudgetPerTick{150};
+
+/// How many extra GetState re-seeds a tracked-but-non-active node gets to self-heal a
+/// missed activation. Two ticks of coverage comfortably outlast the tens-of-ms DDS
+/// endpoint-matching window; after that a matched subscription catches every transition.
+constexpr int kReseedAttempts = 2;
+
+/// The error branch of the default lifecycle state machine. A node reaches it from any
+/// primary state via ON_ERROR, and leaves it either back to `unconfigured` (ON_ERROR_SUCCESS,
+/// the default on_error) or into `finalized` (ON_ERROR_FAILURE / ON_ERROR_ERROR).
+constexpr const char * kErrorProcessingLabel = "errorprocessing";
+
+/// The GetState service for a managed lifecycle node is always published at
+/// "<node>/get_state" (rclcpp_lifecycle's "~/get_state" resolved relative to the
+/// node); ~/transition_event resolves the same way, so swapping the trailing
+/// segment derives the topic without needing a second discovery pass.
+std::string derive_transition_event_topic(const std::string & get_state_path) {
+  static constexpr char kGetStateSuffix[] = "/get_state";
+  static constexpr char kTransitionEventSuffix[] = "/transition_event";
+  const std::size_t suffix_len = std::char_traits<char>::length(kGetStateSuffix);
+  if (get_state_path.size() >= suffix_len &&
+      get_state_path.compare(get_state_path.size() - suffix_len, suffix_len, kGetStateSuffix) == 0) {
+    return get_state_path.substr(0, get_state_path.size() - suffix_len) + kTransitionEventSuffix;
+  }
+  // Shouldn't happen: find_lifecycle_get_state_path always returns a ".../get_state"
+  // path. Degrade gracefully (append) rather than throw on an unexpected shape.
+  return get_state_path + kTransitionEventSuffix;
+}
+
+}  // namespace
+
+LifecycleWatcher::LifecycleWatcher(rclcpp::Node * gateway_node, std::mutex * node_mutex, int departed_retention_ticks)
+  : node_(gateway_node)
+  , node_mutex_(node_mutex)
+  , reader_(std::make_shared<ros2_medkit_gateway::Ros2LifecycleStateReader>(gateway_node))
+  , state_(std::make_shared<SharedState>())
+  , retention_ticks_(departed_retention_ticks) {
+}
+
+LifecycleWatcher::~LifecycleWatcher() {
+  reset();
+}
+
+void LifecycleWatcher::update(const ros2_medkit_gateway::IntrospectionInput & snapshot, std::uint64_t tick) {
+  {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    if (state_->shutdown_requested) {
+      return;
+    }
+    // Prune stale departed-lifecycle entries BEFORE this tick's own departures (if any)
+    // are recorded below, so a fqn that departs on this very tick is never immediately
+    // pruned by the same pass.
+    for (auto it = state_->recently_departed_.begin(); it != state_->recently_departed_.end();) {
+      const std::uint64_t departed_tick = it->second.second;
+      // tick is monotonic, so tick >= departed_tick and the unsigned subtraction cannot wrap.
+      if (tick - departed_tick > static_cast<std::uint64_t>(retention_ticks_)) {
+        it = state_->recently_departed_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  // Current set of managed (GetState + ChangeState) node ids, their GetState path, and
+  // stable fqn (App::effective_fqn()) - the fqn is captured into a new Tracked entry
+  // below and carried into recently_departed_ on departure.
+  std::unordered_map<std::string, std::string> current_paths;
+  std::unordered_map<std::string, std::string> current_fqns;
+  for (const auto & app : snapshot.apps) {
+    const auto get_state_path = ros2_medkit_gateway::find_lifecycle_get_state_path(app.services);
+    if (!get_state_path) {
+      continue;
+    }
+    current_paths.emplace(app.id, *get_state_path);
+    current_fqns.emplace(app.id, app.effective_fqn());
+  }
+
+  // Drop nodes that are no longer managed. Erasing the entry drops the last strong ref
+  // to a Subscription created on node_, whose ~Subscription mutates node_'s topic
+  // registry and waitset - the same structures create_subscription touches. Take
+  // node_mutex_ then state->mutex here to mirror the creation-side lock order
+  // (node_mutex_ -> state->mutex); the callback only takes state->mutex, so this adds no
+  // inversion.
+  {
+    std::lock_guard<std::mutex> node_lock(*node_mutex_);
+    std::lock_guard<std::mutex> state_lock(state_->mutex);
+    for (auto it = state_->tracked.begin(); it != state_->tracked.end();) {
+      if (current_paths.find(it->first) == current_paths.end()) {
+        state_->recently_departed_[it->second.fqn] = {
+            DepartedLifecycle{it->second.state_label, it->second.saw_transition, it->second.error_terminated}, tick};
+        it = state_->tracked.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  // Select the GetState work for this tick (bounded), and the new nodes to subscribe.
+  // A node needs a (blocking) GetState if it is newly managed, or if it is tracked but
+  // still cached non-active with self-heal budget left - re-seeding recovers an `active`
+  // transition_event that was published during the sub's DDS matching window and lost.
+  struct SeedJob {
+    std::string id;
+    std::string path;
+    bool is_new;
+  };
+  std::vector<SeedJob> jobs;
+  std::vector<std::pair<std::string, std::string>> new_nodes;  // (id, get_state_path)
+  {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    for (const auto & [id, path] : current_paths) {
+      auto it = state_->tracked.find(id);
+      if (it == state_->tracked.end()) {
+        new_nodes.emplace_back(id, path);
+        if (static_cast<int>(jobs.size()) < kMaxGetStateSeedsPerTick) {
+          jobs.push_back({id, path, true});
+        }
+      } else if (it->second.state_label != "active" && it->second.reseeds_remaining > 0 &&
+                 static_cast<int>(jobs.size()) < kMaxGetStateSeedsPerTick) {
+        // NOT charged here: the blocking loop below can break on its wall-clock budget before
+        // reaching this job, and a job that never issued a GetState must not spend an attempt.
+        // One node stuck mid-transition eats the whole 150ms budget on its own timeout, so every
+        // job queued behind it that tick used to be skipped AND charged - two ticks of that
+        // drained both attempts with zero reads. The consequences are permanent for the process:
+        // a node whose seed never ran keeps label "" (never gated, and a require_active
+        // expectation on it is silently never enforced), and one seeded non-active that then
+        // activates inside the subscription's matching window keeps that label forever (every
+        // fault suppressed, plus a permanent false GRAPH_NODE_INACTIVE).
+        jobs.push_back({id, path, false});
+      }
+    }
+  }
+
+  // Blocking GetState calls - run WITHOUT any lock held (the reader spins a private
+  // executor inline up to its timeout; holding state->mutex would serialize every
+  // concurrent status read behind it).
+  std::unordered_map<std::string, std::string> seeded;
+  std::vector<std::string> reseeds_performed;  // re-seed jobs whose GetState actually ran
+  const auto seed_deadline = std::chrono::steady_clock::now() + kGetStateBudgetPerTick;
+  for (const auto & job : jobs) {
+    seeded[job.id] = reader_->get_state(job.path).value_or("");
+    if (!job.is_new) {
+      reseeds_performed.push_back(job.id);
+    }
+    // Stop once the per-tick blocking budget is spent; the unseeded jobs are already
+    // subscribed (new nodes) or keep their reseed budget (tracked nodes), so they are
+    // re-picked and seeded on a later tick without the tick loop ever stalling here.
+    if (std::chrono::steady_clock::now() >= seed_deadline) {
+      break;
+    }
+  }
+
+  // Subscribe newly-managed nodes and apply their seed. rclcpp_lifecycle publishes
+  // ~/transition_event reliable + volatile (rcl_lifecycle uses the default publisher QoS
+  // with no durability override). A transient_local subscriber would be QoS-incompatible
+  // with a volatile publisher and silently receive zero messages, so stay volatile. The
+  // callback captures a weak_ptr to SharedState (never a raw `this`) so it stays safe if
+  // the watcher is torn down while a callback is in flight.
+  for (const auto & new_node : new_nodes) {
+    // Bind to named references (not a captured structured binding, which is a C++20
+    // extension) so the callback below can capture `id` under C++17.
+    const std::string & id = new_node.first;
+    const std::string & get_state_path = new_node.second;
+    const std::string topic = derive_transition_event_topic(get_state_path);
+    const auto qos = rclcpp::QoS(rclcpp::KeepLast(10)).reliable();
+    std::weak_ptr<SharedState> weak_state = state_;
+
+    std::lock_guard<std::mutex> node_lock(*node_mutex_);
+    std::lock_guard<std::mutex> state_lock(state_->mutex);
+    if (state_->shutdown_requested) {
+      return;
+    }
+    auto sub = node_->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
+        topic, qos, [weak_state, id](const lifecycle_msgs::msg::TransitionEvent::ConstSharedPtr & msg) {
+          auto shared = weak_state.lock();
+          if (!shared) {
+            return;  // watcher torn down; nothing to update
+          }
+          std::lock_guard<std::mutex> cb_lock(shared->mutex);
+          if (shared->shutdown_requested) {
+            return;
+          }
+          auto it = shared->tracked.find(id);
+          if (it != shared->tracked.end()) {
+            it->second.state_label = msg->goal_state.label;
+            it->second.saw_transition = true;
+            // `errorprocessing` on either end of the edge means this node took the error
+            // branch. It is sticky for the node's whole tracked lifetime: ON_ERROR_FAILURE
+            // and ON_ERROR_ERROR both land in `finalized`, so by the time we see the final
+            // label the error edge is already behind us.
+            if (msg->start_state.label == kErrorProcessingLabel || msg->goal_state.label == kErrorProcessingLabel) {
+              it->second.error_terminated = true;
+            }
+          }
+        });
+    auto & tracked = state_->tracked[id];
+    tracked.sub = std::move(sub);
+    tracked.reseeds_remaining = kReseedAttempts;
+    const auto seed_it = seeded.find(id);
+    tracked.state_label = (seed_it != seeded.end()) ? seed_it->second : "";
+    // Captured at first sighting: current_fqns is built from the same snapshot pass
+    // that produced current_paths, so an id here is always present in current_fqns too.
+    const auto fqn_it = current_fqns.find(id);
+    tracked.fqn = (fqn_it != current_fqns.end()) ? fqn_it->second : "";
+  }
+
+  // Apply re-seed results to already-tracked nodes. Never overwrite a good cached label
+  // with an empty (failed/timed-out) seed.
+  {
+    std::lock_guard<std::mutex> lock(state_->mutex);
+    // Charge the self-heal budget only for reads that actually happened (see the selection
+    // loop). A node whose job was cut by the budget keeps its attempts and is re-picked next tick.
+    for (const auto & id : reseeds_performed) {
+      auto it = state_->tracked.find(id);
+      if (it != state_->tracked.end() && it->second.reseeds_remaining > 0) {
+        it->second.reseeds_remaining -= 1;
+      }
+    }
+    for (const auto & job : jobs) {
+      if (job.is_new) {
+        continue;
+      }
+      const auto seed_it = seeded.find(job.id);
+      if (seed_it == seeded.end() || seed_it->second.empty()) {
+        continue;
+      }
+      auto it = state_->tracked.find(job.id);
+      if (it != state_->tracked.end()) {
+        it->second.state_label = seed_it->second;
+      }
+    }
+  }
+}
+
+bool LifecycleWatcher::node_ok(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  const auto it = state_->tracked.find(app_id);
+  if (it == state_->tracked.end()) {
+    return true;
+  }
+  // An empty label means the one-shot GetState seed failed and no transition_event
+  // has arrived. Treat unknown as "do not gate": transition_event is volatile and
+  // never backfills an already-active node, so gating on an empty label would
+  // suppress that node's faults forever. Only a KNOWN non-active label gates.
+  return it->second.state_label.empty() || it->second.state_label == "active";
+}
+
+std::optional<std::string> LifecycleWatcher::state_of(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  const auto it = state_->tracked.find(app_id);
+  if (it == state_->tracked.end()) {
+    return std::nullopt;
+  }
+  return it->second.state_label;
+}
+
+std::optional<DepartedLifecycle> LifecycleWatcher::departed_state_of(const std::string & fqn) const {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  const auto it = state_->recently_departed_.find(fqn);
+  if (it == state_->recently_departed_.end()) {
+    return std::nullopt;
+  }
+  return it->second.first;
+}
+
+void LifecycleWatcher::reset() {
+  // Symmetric with subscription creation (node_mutex_ then state->mutex): clearing
+  // tracked_ drops the subs, and ~Subscription mutates node_'s topic registry.
+  std::lock_guard<std::mutex> node_lock(*node_mutex_);
+  std::lock_guard<std::mutex> state_lock(state_->mutex);
+  state_->shutdown_requested = true;
+  state_->tracked.clear();
+}
+
+int LifecycleWatcher::reseeds_remaining_for_test(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  const auto it = state_->tracked.find(app_id);
+  return it == state_->tracked.end() ? -1 : it->second.reseeds_remaining;
+}
+
+void LifecycleWatcher::set_state_for_test(const std::string & app_id, const std::string & label) {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  auto & tracked = state_->tracked[app_id];
+  tracked.state_label = label;
+  // This seam stands in for a live ~/transition_event round-trip, so it must record the same
+  // thing that callback does: we WATCHED the node reach this label. Leaving saw_transition false
+  // would make every shim-driven departure look like a node found already sitting in its final
+  // state, which is a different (and deliberately unclassifiable) case. Use
+  // set_departed_state_for_test() to stage that one.
+  tracked.saw_transition = true;
+}
+
+void LifecycleWatcher::set_departed_state_for_test(const std::string & fqn, const std::string & label,
+                                                   bool saw_transition, bool error_terminated) {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  state_->recently_departed_[fqn] = {DepartedLifecycle{label, saw_transition, error_terminated}, 0};
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/reliability_gate.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/reliability_gate.cpp
@@ -1,0 +1,120 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+ReliabilityGate::ReliabilityGate(int warmup_cycles, rclcpp::Node * gateway_node, std::mutex * node_mutex,
+                                 int departed_retention_ticks)
+  : warmup_(warmup_cycles)
+  , lifecycle_(gateway_node, node_mutex, departed_retention_ticks)
+  , warmup_cycles_(warmup_cycles < 0 ? 0 : warmup_cycles) {
+}
+
+void ReliabilityGate::update(const ros2_medkit_gateway::IntrospectionInput & snapshot, uint64_t tick) {
+  std::vector<std::string> ids;
+  ids.reserve(snapshot.apps.size());
+  for (const auto & app : snapshot.apps) {
+    ids.push_back(app.id);
+  }
+  // LifecycleWatcher is internally synchronized and does BLOCKING GetState reads: update
+  // it OUTSIDE gate_mutex_ so the status handler is never blocked behind a blocking read.
+  // The tick counter stays uint64_t end to end: narrowing it to int here would wrap after
+  // INT_MAX ticks (~13.6 years at a 200 ms cadence) and corrupt departed-entry retention on a
+  // long-lived gateway. Cheap to keep wide, so do not rely on "it never gets that far".
+  lifecycle_.update(snapshot, tick);
+
+  // warmup_ and the bringup scalars have no internal lock; the tick runs on the plugin
+  // worker thread while status_json() reads them on an HTTP thread, so gate_mutex_ makes
+  // this writer and that reader mutually exclusive.
+  std::lock_guard<std::mutex> lock(gate_mutex_);
+  // Re-arm the global bringup grace whenever the graph empties out. Without this,
+  // graph_seen_ latches on the first-ever non-empty snapshot and never re-arms, so
+  // after a full-stack restart (apps -> empty -> refill) last_tick_ - graph_first_tick_
+  // already exceeds warmup_cycles_ and unknown (topic/graph) sources get no grace on the
+  // second bringup - defeating the exact false-positive suppression this gate exists for.
+  // This keeps the global grace in step with WarmupTracker's per-entity re-warm.
+  if (ids.empty()) {
+    graph_seen_ = false;
+  } else if (!graph_seen_) {
+    graph_seen_ = true;
+    graph_first_tick_ = tick;
+  }
+  warmup_.update(ids, tick);
+  last_tick_ = tick;
+}
+
+bool ReliabilityGate::allows_raise(const std::string & source_id) const {
+  if (warmup_.is_known(source_id)) {
+    return warmup_.is_armed(source_id, last_tick_) && lifecycle_.node_ok(source_id);
+  }
+  // Unknown source_id: global bringup grace only.
+  if (!graph_seen_) {
+    return false;
+  }
+  return (last_tick_ - graph_first_tick_) >= static_cast<uint64_t>(warmup_cycles_);
+}
+
+nlohmann::json ReliabilityGate::status_json() const {
+  // Reader side of gate_mutex_ (see update()). Held across the lifecycle_ reads too - they
+  // take the lifecycle SharedState mutex (order gate_mutex_ -> lifecycle mutex, never the
+  // reverse) and do no blocking I/O, so this cannot stall.
+  std::lock_guard<std::mutex> lock(gate_mutex_);
+  nlohmann::json entities = nlohmann::json::array();
+  for (const auto & [id, entry] : warmup_.entries()) {
+    const bool armed = warmup_.is_armed(id, last_tick_);
+    const auto lc = lifecycle_.state_of(id);
+    const bool suppressed = !armed || !lifecycle_.node_ok(id);
+    entities.push_back({{"id", id},
+                        {"first_seen_tick", entry.first_seen},
+                        {"armed", armed},
+                        {"state", suppressed ? "warming_up" : "armed"},
+                        {"lifecycle", lc.has_value() ? nlohmann::json(*lc) : nlohmann::json(nullptr)}});
+  }
+  const bool global_armed = graph_seen_ && (last_tick_ - graph_first_tick_) >= static_cast<uint64_t>(warmup_cycles_);
+  return {{"x-medkit-watchdog",
+           {{"schema_version", "1.0.0"},
+            {"warmup_cycles", warmup_cycles_},
+            {"global_state", global_armed ? "armed" : "warming_up"},
+            {"entities", std::move(entities)}}}};
+}
+
+std::optional<std::string> ReliabilityGate::lifecycle_state_of(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(gate_mutex_);
+  return lifecycle_.state_of(app_id);
+}
+
+std::optional<DepartedLifecycle> ReliabilityGate::departed_lifecycle_state_of(const std::string & fqn) const {
+  std::lock_guard<std::mutex> lock(gate_mutex_);
+  return lifecycle_.departed_state_of(fqn);
+}
+
+void ReliabilityGate::reset() {
+  lifecycle_.reset();
+}
+
+void ReliabilityGate::set_lifecycle_state_for_test(const std::string & app_id, const std::string & label) {
+  lifecycle_.set_state_for_test(app_id, label);
+}
+
+void ReliabilityGate::set_departed_lifecycle_state_for_test(const std::string & fqn, const std::string & label,
+                                                            bool saw_transition, bool error_terminated) {
+  lifecycle_.set_departed_state_for_test(fqn, label, saw_transition, error_terminated);
+}
+
+bool reliability_allows(const ReliabilityGate * gate, const std::string & source_id) {
+  return gate == nullptr || gate->allows_raise(source_id);
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -1,0 +1,327 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared launch_testing harness for ros2_medkit_graph_watchdog e2e tests.
+
+Brings up a real gateway_node with the graph_watchdog plugin (.so) loaded,
+a real fault_manager (memory storage, healing enabled), and caller-supplied
+demo nodes - the only way to prove that nested plugin config actually
+reaches a live detector through the real config-delivery path
+(extract_plugin_config -> detector_config.hpp -> a detector's own
+configure()). A C++ unit test cannot prove this: it hand-builds already-
+nested JSON and calls configure() directly, bypassing the real gateway
+parameter plumbing entirely - which is exactly what hid the flat/nested
+bug this harness exists to catch a regression of.
+
+Reuses the `ros2_medkit_test_utils` launch factories
+(create_gateway_node, create_fault_manager_node, create_demo_nodes) so this
+harness stays in lockstep with how the real gateway/fault_manager are
+launched elsewhere. Requires `ros2_medkit_integration_tests` as a
+package.xml test_depend (see CMakeLists.txt) so that package is importable
+on PYTHONPATH once the workspace's install/setup.bash is sourced.
+"""
+
+import os
+import time
+
+import requests
+from ros2_medkit_test_utils.constants import get_test_port
+from ros2_medkit_test_utils.launch_helpers import (
+    create_demo_nodes,
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_testing.actions
+
+API_BASE_PATH = '/api/v1'
+
+
+def create_watchdog_test_launch(
+    *,
+    detector_params=None,
+    demo_nodes=None,
+    port=None,
+    demo_delay=2.0,
+    healing_enabled=True,
+):
+    """Build a ``LaunchDescription`` that loads graph_watchdog into a real gateway.
+
+    Parameters
+    ----------
+    detector_params : dict or None
+        Extra ``plugins.graph_watchdog.*`` ROS parameters (nested-dotted YAML
+        keys, e.g. ``'plugins.graph_watchdog.detectors.param_drift.mode'``),
+        merged on top of the ``plugins``/``plugins.graph_watchdog.path``
+        parameters this factory always sets.
+    demo_nodes : list of str or None
+        Node keys from ``ros2_medkit_test_utils.launch_helpers.DEMO_NODE_REGISTRY``.
+        ``None`` means no demo nodes.
+    port : int or None
+        Gateway HTTP port. ``None`` uses ``get_test_port()`` (the
+        ``GATEWAY_TEST_PORT`` env var set per-CTest-target by CMake).
+    demo_delay : float
+        Seconds to delay demo nodes + fault_manager after gateway start.
+    healing_enabled : bool
+        Passed to the fault_manager as ``healing_enabled`` so a detector's
+        level-triggered PASSED clears can actually advance the debounce
+        counter to HEALED (see the plugin README, "Closing the loop").
+
+    Returns
+    -------
+    tuple[LaunchDescription, dict]
+        ``(launch_description, context_dict)`` expected by launch_testing.
+        ``context_dict`` maps ``'gateway_node'`` to the gateway Node action.
+
+    """
+    if port is None:
+        port = get_test_port()
+
+    params = {
+        'plugins': ['graph_watchdog'],
+        'plugins.graph_watchdog.path': graph_watchdog_plugin_path(),
+    }
+    if detector_params:
+        params.update(detector_params)
+
+    gateway_node = create_gateway_node(port=port, extra_params=params)
+
+    delayed_actions = create_demo_nodes(demo_nodes if demo_nodes is not None else [])
+    delayed_actions.append(create_fault_manager_node(
+        extra_params={
+            'healing_enabled': healing_enabled,
+            # AUTOSAR DEM-style debounce: -2 confirms a fault on its very first
+            # FAILED report instead of requiring several ticks to accumulate,
+            # so the positive-control assertion is fast and deterministic.
+            'confirmation_threshold': -2,
+        },
+    ))
+
+    delayed = TimerAction(period=demo_delay, actions=delayed_actions)
+
+    launch_description = LaunchDescription([
+        gateway_node,
+        delayed,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+    return (
+        launch_description,
+        {'gateway_node': gateway_node},
+    )
+
+
+def graph_watchdog_plugin_path():
+    """Resolve the built ``libros2_medkit_graph_watchdog.so`` path.
+
+    Unlike the other packages this harness launches (installed and
+    ament-index-registered via colcon), ``ros2_medkit_graph_watchdog`` is a
+    plugin whose .so is located from the build tree in local/CI builds -
+    ``ament_index_python.get_package_prefix()`` cannot resolve it. CMake
+    instead injects the exact build-output path via the
+    ``GRAPH_WATCHDOG_PLUGIN_PATH`` env var (see ``set_tests_properties`` in
+    CMakeLists.txt).
+
+    Returns
+    -------
+    str
+        Absolute path to the built plugin ``.so``.
+
+    Raises
+    ------
+    RuntimeError
+        If ``GRAPH_WATCHDOG_PLUGIN_PATH`` is not set.
+
+    """
+    path = os.environ.get('GRAPH_WATCHDOG_PLUGIN_PATH')
+    if not path:
+        raise RuntimeError(
+            'GRAPH_WATCHDOG_PLUGIN_PATH not set - set it via '
+            'set_tests_properties(... ENVIRONMENT ...) in CMakeLists.txt to '
+            'the built libros2_medkit_graph_watchdog.so path.'
+        )
+    return path
+
+
+def wait_until_watchdog_armed(port, timeout=60.0, interval=0.5):
+    """Poll ``GET /api/v1/x-medkit-watchdog`` until the plugin is live and armed.
+
+    Any assertion that a fault is ABSENT must gate on this first. Absence is the
+    default outcome of a stack that never came up, and nothing else in a watchdog
+    launch fails on one: the gateway logs and carries on when a plugin fails to
+    dlopen, ``load_plugins``' return count is never checked, and a REST bind
+    failure is caught inside the server thread. All of those still exit 0, so the
+    post-shutdown exit-code check stays green too, and ``poll_faults`` swallows
+    every transport error and returns ``None`` on timeout - exactly what an
+    ``assertIsNone`` wants to see.
+
+    This route is registered by the plugin itself (``get_routes()``), and its
+    entity list is filled by the tick thread's gate update, so a 200 carrying
+    entities proves BOTH that the .so loaded and that the tick loop ran.
+    ``global_state == 'armed'`` additionally proves the bringup grace elapsed,
+    i.e. the gate would have permitted a raise during the window that follows.
+
+    Parameters
+    ----------
+    port : int
+        Gateway HTTP port.
+    timeout : float
+        Maximum time to wait in seconds.
+    interval : float
+        Sleep between retries in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` once the plugin reports at least one entity and a global
+        ``armed`` state, ``False`` on timeout.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/x-medkit-watchdog', timeout=5)
+            if response.status_code == 200:
+                status = response.json().get('x-medkit-watchdog', {})
+                if status.get('entities') and status.get('global_state') == 'armed':
+                    return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return False
+
+
+def poll_faults(port, code, timeout=30.0, interval=0.5):
+    """Poll the GLOBAL ``GET /faults`` endpoint until `code` appears.
+
+    Uses the default (no ``status`` query param) filter, which the gateway
+    resolves to pending+confirmed only (active faults) - see
+    ``FaultStatusFilter`` defaults in ``http_utils.hpp``.
+
+    Parameters
+    ----------
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` to look for (e.g. ``'GRAPH_PARAM_DRIFT'``).
+    timeout : float
+        Maximum time to wait in seconds.
+    interval : float
+        Sleep between retries in seconds.
+
+    Returns
+    -------
+    dict or None
+        The matching fault list item, or ``None`` if it never appears
+        within `timeout` seconds.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', timeout=5)
+            if response.status_code == 200:
+                for item in response.json().get('items', []):
+                    if item.get('fault_code') == code:
+                        return item
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def poll_entity_faults(port, entity_path, code, timeout=30.0, interval=0.5):
+    """Poll a SCOPED fault list (``GET /<entity_path>/faults``) until `code` appears.
+
+    The flat ``/faults`` list carries every fault regardless of scoping, so it cannot
+    tell whether a fault is actually reachable from an entity. This can: the gateway
+    resolves an entity's scope to a set of reporting-source FQNs and drops any fault
+    whose sources are not in it, so a fault raised under an id that owns no scope is
+    absent here while still present in ``/faults``.
+
+    Parameters
+    ----------
+    port : int
+        Gateway HTTP port.
+    entity_path : str
+        Entity path below the API base, e.g. ``'apps/graph_watchdog'``.
+    code : str
+        The ``fault_code`` to look for.
+    timeout : float
+        Maximum time to wait in seconds.
+    interval : float
+        Sleep between retries in seconds.
+
+    Returns
+    -------
+    dict or None
+        The matching fault list item, or ``None`` if it never appears.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/{entity_path}/faults', timeout=5)
+            if response.status_code == 200:
+                for item in response.json().get('items', []):
+                    if item.get('fault_code') == code:
+                        return item
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def poll_cleared(port, code, timeout=30.0, interval=0.5):
+    """Poll the GLOBAL ``GET /faults`` endpoint until `code` is absent.
+
+    Uses the same default (active-only) query as :func:`poll_faults`, so
+    this succeeds once `code` is no longer pending/confirmed - i.e. it has
+    been cleared or healed.
+
+    Parameters
+    ----------
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` expected to disappear from the active-fault list.
+    timeout : float
+        Maximum time to wait in seconds.
+    interval : float
+        Sleep between retries in seconds.
+
+    Returns
+    -------
+    bool
+        ``True`` once `code` is absent from the default query, ``False`` on
+        timeout.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', timeout=5)
+            if response.status_code == 200:
+                codes = {item.get('fault_code') for item in response.json().get('items', [])}
+                if code not in codes:
+                    return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return False

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_qos_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_qos_e2e.test.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""QoS-mismatch e2e: proves GRAPH_QOS_MISMATCH raises and clears through the REAL
+gateway + qos_mismatch_detector + fault_manager stack. This is the acceptance gate
+for its design issue.
+
+Unlike test_qos_mismatch_integration.cpp (which drives the detector directly against
+a fake ReportFault service and a bare rclcpp::Node), this launches the REAL gateway
+process with the graph_watchdog plugin (.so) loaded and a real fault_manager, and
+polls the operator-visible ``GET /api/v1/faults`` surface - the only way to prove the
+detector's raise/clear actually reaches a SOVD fault through the real tick-timer and
+config-delivery path (see harness.py's module docstring for why a C++ test alone
+cannot give this proof).
+
+Two real rclpy nodes are created directly in this test process (mirrors the pattern
+in ros2_medkit_integration_tests' test_external_component_fault_rollup.test.py, which
+creates a plain rclpy Node in-process rather than launching a separate executable):
+
+- a publisher on ``/probe`` with BEST_EFFORT reliability (never changes)
+- a subscriber on ``/probe``, first RELIABLE (raises the mismatch), then replaced
+  with a BEST_EFFORT one (clears it)
+
+QoS endpoint discovery (participant/publication/subscription builtin-topic data) is
+populated by DDS's own background discovery, independent of executor spinning - the
+same rationale as test_qos_mismatch_integration.cpp - so these nodes are never spun;
+they only need to stay alive so their advertised QoS remains visible to the gateway.
+
+test_04/test_05 extend the same launch with two more RxO-incompatibility dimensions
+(deadline, liveliness lease duration - see qos_policy.hpp's qos_incompatibility()):
+each uses its OWN topic and its OWN pub/sub node pair, created and destroyed within the
+test method itself, so the shared GRAPH_QOS_MISMATCH aggregate (one fault_code covering
+every currently-mismatched topic, same rationale as node_death's aggregate) returns to
+empty before the next scenario - proving each dimension raises and is named on its own,
+not merely riding along on the /probe reliability mismatch above.
+"""
+
+import os
+import sys
+import unittest
+
+import launch_testing
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+from std_msgs.msg import String
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import (  # noqa: E402
+    create_watchdog_test_launch,
+    poll_cleared,
+    poll_entity_faults,
+    poll_faults,
+)
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+
+PORT = get_test_port()
+
+# Fast tick cadence + short warmup so the whole story (gateway/fault_manager startup,
+# real DDS endpoint discovery, per-app arm, global bringup grace) comfortably fits
+# inside the poll_faults()/poll_cleared() timeouts below without a hand-tuned
+# pre-sleep - see the identical rationale in test_config_plumbing_e2e.test.py.
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+
+TOPIC = '/probe'
+TOPIC_DEADLINE = '/probe_deadline'
+TOPIC_LEASE = '/probe_lease'
+FAULT_CODE = 'GRAPH_QOS_MISMATCH'
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+    }
+    return create_watchdog_test_launch(
+        detector_params=detector_params,
+        demo_nodes=None,
+        port=PORT,
+        # Clearing GRAPH_QOS_MISMATCH after the QoS fix must reach HEALED (absent
+        # from the default active-fault query) - see harness.py's healing_enabled doc.
+        healing_enabled=True,
+    )
+
+
+class TestQosMismatchE2e(unittest.TestCase):
+    """GRAPH_QOS_MISMATCH raises on a real RxO-incompatible pub/sub pair, clears on fix."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._pub_node = Node('qos_e2e_pub')
+        pub_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+        cls._pub = cls._pub_node.create_publisher(String, TOPIC, pub_qos)
+
+        cls._sub_node = Node('qos_e2e_sub')
+        reliable_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE)
+        cls._sub = cls._sub_node.create_subscription(String, TOPIC, lambda _msg: None, reliable_qos)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._sub_node.destroy_node()
+        cls._pub_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_01_mismatch_raises_naming_topic(self):
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        self.assertIsNotNone(
+            fault,
+            f'{FAULT_CODE} never raised for a BEST_EFFORT publisher / RELIABLE '
+            f'subscriber pair on {TOPIC}',
+        )
+        self.assertIn(TOPIC, fault.get('description', ''))
+
+    def test_02_fault_is_reachable_from_its_entity(self):
+        # The acceptance criterion for scoping. The flat /faults list carries a fault
+        # whatever its source_id is, so it cannot show whether an operator can actually
+        # OPEN the fault on an entity. Scoped to the host Component - the obvious
+        # choice, and what this used to do - the answer is no: the gateway only puts a
+        # Component's own id in its fault scope when `external` is set, and a runtime
+        # host Component never sets it, so the fault existed in exactly one place, the
+        # global list. Only a real gateway can prove the fix; a C++ test on
+        # introspect() proves the plugin RETURNS an entity, not that the fault is
+        # reachable through it.
+        fault = poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE, timeout=60.0)
+        self.assertIsNotNone(
+            fault,
+            f'{FAULT_CODE} is not reachable at /apps/graph_watchdog/faults - the '
+            'entity the plugin publishes does not own the fault it raises',
+        )
+
+    def test_03_matching_qos_clears(self):
+        # Replace the RELIABLE subscriber with a BEST_EFFORT one on a fresh node
+        # (distinct node name - avoids racing the old node's DDS teardown, same
+        # rationale as test_qos_mismatch_integration.cpp).
+        type(self)._sub_node.destroy_node()
+        best_effort_qos = QoSProfile(depth=10, reliability=ReliabilityPolicy.BEST_EFFORT)
+        type(self)._sub_node = Node('qos_e2e_sub2')
+        type(self)._sub = type(self)._sub_node.create_subscription(
+            String, TOPIC, lambda _msg: None, best_effort_qos)
+
+        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0)
+        self.assertTrue(
+            cleared,
+            f'{FAULT_CODE} did not clear after the subscriber QoS was fixed to '
+            'BEST_EFFORT',
+        )
+
+    def test_04_deadline_mismatch_raises_naming_deadline(self):
+        # Publisher: no deadline set (defaults to RMW_DURATION_UNSPECIFIED - the most
+        # permissive offer). Subscriber: a finite requested deadline. RxO-incompatible -
+        # see qos_policy.hpp's qos_incompatibility() deadline branch.
+        pub_node = Node('qos_e2e_deadline_pub')
+        pub_qos = QoSProfile(depth=10)
+        pub = pub_node.create_publisher(String, TOPIC_DEADLINE, pub_qos)
+
+        sub_node = Node('qos_e2e_deadline_sub')
+        sub_qos = QoSProfile(depth=10, deadline=Duration(seconds=0.1))
+        sub = sub_node.create_subscription(String, TOPIC_DEADLINE, lambda _msg: None, sub_qos)
+
+        try:
+            fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+            self.assertIsNotNone(
+                fault,
+                f'{FAULT_CODE} never raised for a no-deadline publisher / 0.1s-deadline '
+                f'subscriber pair on {TOPIC_DEADLINE}',
+            )
+            self.assertIn('deadline', fault.get('description', ''))
+        finally:
+            del sub
+            del pub
+            sub_node.destroy_node()
+            pub_node.destroy_node()
+
+        # Both endpoints gone -> the topic itself drops out of the aggregate, returning
+        # GRAPH_QOS_MISMATCH to empty before the next scenario (see module docstring).
+        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0)
+        self.assertTrue(
+            cleared,
+            f'{FAULT_CODE} did not clear after both {TOPIC_DEADLINE} endpoints were destroyed',
+        )
+
+    def test_05_liveliness_lease_mismatch_raises_naming_lease(self):
+        # Publisher: no liveliness lease duration set (defaults to unspecified).
+        # Subscriber: a finite requested lease duration. RxO-incompatible - see
+        # qos_policy.hpp's qos_incompatibility() liveliness-lease branch.
+        pub_node = Node('qos_e2e_lease_pub')
+        pub_qos = QoSProfile(depth=10)
+        pub = pub_node.create_publisher(String, TOPIC_LEASE, pub_qos)
+
+        sub_node = Node('qos_e2e_lease_sub')
+        sub_qos = QoSProfile(depth=10, liveliness_lease_duration=Duration(seconds=0.1))
+        sub = sub_node.create_subscription(String, TOPIC_LEASE, lambda _msg: None, sub_qos)
+
+        try:
+            fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+            self.assertIsNotNone(
+                fault,
+                f'{FAULT_CODE} never raised for a no-lease publisher / 0.1s-lease '
+                f'subscriber pair on {TOPIC_LEASE}',
+            )
+            self.assertIn('lease', fault.get('description', ''))
+        finally:
+            del sub
+            del pub
+            sub_node.destroy_node()
+            pub_node.destroy_node()
+
+        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0)
+        self.assertTrue(
+            cleared,
+            f'{FAULT_CODE} did not clear after both {TOPIC_LEASE} endpoints were destroyed',
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_aggregated_fault.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_aggregated_fault.cpp
@@ -1,0 +1,76 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+using ros2_medkit_graph_watchdog::AggregatedFault;
+
+namespace {
+
+std::map<std::string, std::string> affected_entries(int count, std::size_t detail_chars) {
+  std::map<std::string, std::string> affected;
+  for (int i = 0; i < count; ++i) {
+    // Zero-padded so map order is the insertion order, keeping the test deterministic.
+    const std::string key = "entity_" + std::string(4 - std::to_string(i).size(), '0') + std::to_string(i);
+    affected.emplace(key, std::string(detail_chars, 'x'));
+  }
+  return affected;
+}
+
+}  // namespace
+
+TEST(AggregatedFaultDescribe, JoinsEntriesWithSemicolons) {
+  const auto desc = AggregatedFault::describe({{"a", "first"}, {"b", "second"}});
+  EXPECT_EQ(desc, "first; second");
+}
+
+TEST(AggregatedFaultDescribe, FallsBackToTheKeyWhenTheDetailIsEmpty) {
+  const auto desc = AggregatedFault::describe({{"/scan", ""}, {"/tf", "tf detail"}});
+  EXPECT_EQ(desc, "/scan; tf detail");
+}
+
+TEST(AggregatedFaultDescribe, ShortDescriptionIsNotTruncated) {
+  const auto desc = AggregatedFault::describe(affected_entries(3, 10));
+  EXPECT_LE(desc.size(), AggregatedFault::kMaxDescriptionChars);
+  EXPECT_EQ(desc.find("..."), std::string::npos);
+}
+
+// One aggregated fault names EVERY affected entity, so a large graph would otherwise
+// produce an unbounded ReportFault description that travels into every /faults payload.
+TEST(AggregatedFaultDescribe, ManyEntitiesAreCappedWithAnEllipsis) {
+  const auto desc = AggregatedFault::describe(affected_entries(500, 40));
+  EXPECT_EQ(desc.size(), AggregatedFault::kMaxDescriptionChars);  // cap INCLUDES the marker
+  EXPECT_EQ(desc.substr(desc.size() - 3), "...");
+}
+
+// A single oversized entry must be capped too - the truncation cannot rely on there
+// being a later entry to trip the check.
+TEST(AggregatedFaultDescribe, ASingleOversizedEntryIsCapped) {
+  const auto desc = AggregatedFault::describe(affected_entries(1, AggregatedFault::kMaxDescriptionChars * 2));
+  EXPECT_EQ(desc.size(), AggregatedFault::kMaxDescriptionChars);
+  EXPECT_EQ(desc.substr(desc.size() - 3), "...");
+}
+
+// Exactly at the cap must NOT gain an ellipsis: truncating a description that already
+// fits would silently drop real content.
+TEST(AggregatedFaultDescribe, ExactlyAtTheCapIsLeftAlone) {
+  const auto desc = AggregatedFault::describe(affected_entries(1, AggregatedFault::kMaxDescriptionChars));
+  EXPECT_EQ(desc.size(), AggregatedFault::kMaxDescriptionChars);
+  EXPECT_EQ(desc.find("..."), std::string::npos);
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector.cpp
@@ -1,0 +1,70 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <atomic>
+
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::DetectorMode;
+using ros2_medkit_graph_watchdog::mode_emits;
+
+TEST(DetectorMode, OnlyRaiseEmits) {
+  EXPECT_TRUE(mode_emits(DetectorMode::Raise));
+  EXPECT_FALSE(mode_emits(DetectorMode::Advisory));
+  EXPECT_FALSE(mode_emits(DetectorMode::Off));
+}
+
+// Locks the no-crash-on-unwired-client contract: a detector may be ticked
+// before the plugin has wired a fault_client (or in a unit test that never
+// wires one at all). fault_client is left null (default); gateway_node is
+// also left null here since source_id is non-empty and the null-client guard
+// short-circuits before the gateway_node-dependent empty-source_id branch is
+// ever reached.
+TEST(DetectorContext, RaiseAndClearFaultDoNotCrashWithNullFaultClient) {
+  for (const DetectorMode mode : {DetectorMode::Raise, DetectorMode::Advisory, DetectorMode::Off}) {
+    DetectorContext ctx;
+    ctx.mode = mode;
+    EXPECT_NO_THROW(ctx.raise_fault("GRAPH_QOS_MISMATCH", 2, "description", "/nav/planner"));
+    EXPECT_NO_THROW(ctx.clear_fault("GRAPH_QOS_MISMATCH", "/nav/planner"));
+  }
+}
+
+TEST(TfStaticQos, IsTransientLocalDepthOne) {
+  const auto q = ros2_medkit_graph_watchdog::tf_static_qos();
+  EXPECT_EQ(q.durability(), rclcpp::DurabilityPolicy::TransientLocal);
+}
+
+// null gate must not crash raise_fault (a detector may tick before the gate is wired)
+TEST(DetectorContextGate, NullGateDoesNotCrash) {
+  ros2_medkit_graph_watchdog::DetectorContext ctx;  // gate defaults null, fault_client null
+  ctx.mode = ros2_medkit_graph_watchdog::DetectorMode::Raise;
+  EXPECT_NO_THROW(ctx.raise_fault("GRAPH_X", 2, "d", "/e"));
+}
+
+// snapshot/cancelled default null (bare-context tests never see a gateway snapshot or the
+// plugin's shutdown flag), and cancelled wires straight through to the caller's atomic.
+TEST(DetectorContext, SnapshotAndCancelledDefaultNullAndWireThrough) {
+  DetectorContext ctx;
+  EXPECT_EQ(ctx.snapshot, nullptr);
+  EXPECT_EQ(ctx.cancelled, nullptr);
+
+  std::atomic<bool> cancel{false};
+  ctx.cancelled = &cancel;
+  EXPECT_FALSE(ctx.cancelled->load());
+  cancel.store(true);
+  EXPECT_TRUE(ctx.cancelled->load());
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector_config.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector_config.cpp
@@ -1,0 +1,108 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/detector_config.hpp"
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+using ros2_medkit_graph_watchdog::collect_unknown_detector_keys;
+using ros2_medkit_graph_watchdog::DetectorMode;
+using ros2_medkit_graph_watchdog::extract_detector_config;
+using ros2_medkit_graph_watchdog::parse_detector_mode;
+
+// The gateway delivers NESTED config (extract_plugin_config un-nests dotted keys).
+nlohmann::json nested() {
+  return {{"detectors",
+           {{"qos", {{"mode", "off"}, {"threshold", 5}}}, {"tf", {{"mode", "advisory"}}}, {"other", {{"x", 1}}}}}};
+}
+
+TEST(DetectorConfig, ParsesModeFromNested) {
+  EXPECT_EQ(parse_detector_mode(nested(), "qos"), DetectorMode::Off);
+  EXPECT_EQ(parse_detector_mode(nested(), "tf"), DetectorMode::Advisory);
+  EXPECT_EQ(parse_detector_mode(nested(), "absent"), DetectorMode::Raise);  // missing -> Raise
+}
+TEST(DetectorConfig, UnknownModeFallsBackToRaiseAndWarns) {
+  const nlohmann::json cfg = {{"detectors", {{"qos", {{"mode", "bogus"}}}}}};
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(cfg, "qos", &warnings), DetectorMode::Raise);
+  ASSERT_EQ(warnings.size(), 1u);  // a silent fallback to Raise is the costly direction
+  EXPECT_NE(warnings[0].find("qos"), std::string::npos);
+}
+
+// A BARE `off` in YAML is typed BOOL false by rcl_yaml_param_parser (YAML 1.1), so it
+// never arrives as a string. Reading only strings left the detector the operator just
+// disabled still raising - the exact failure direction that must not be silent.
+TEST(DetectorConfig, YamlBooleanFalseMeansOff) {
+  const nlohmann::json cfg = {{"detectors", {{"qos", {{"mode", false}}}}}};
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(cfg, "qos", &warnings), DetectorMode::Off);
+  EXPECT_TRUE(warnings.empty());  // a recognized form must not warn
+}
+
+TEST(DetectorConfig, YamlBooleanTrueMeansRaise) {
+  const nlohmann::json cfg = {{"detectors", {{"qos", {{"mode", true}}}}}};
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(cfg, "qos", &warnings), DetectorMode::Raise);
+  EXPECT_TRUE(warnings.empty());
+}
+
+TEST(DetectorConfig, ExplicitRaiseStringIsRecognized) {
+  const nlohmann::json cfg = {{"detectors", {{"qos", {{"mode", "raise"}}}}}};
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(cfg, "qos", &warnings), DetectorMode::Raise);
+  EXPECT_TRUE(warnings.empty());  // spelled out explicitly, so not a typo
+}
+
+TEST(DetectorConfig, NonScalarModeWarnsRatherThanBeingDropped) {
+  const nlohmann::json cfg = {{"detectors", {{"qos", {{"mode", nlohmann::json::array({"off"})}}}}}};
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(cfg, "qos", &warnings), DetectorMode::Raise);
+  EXPECT_EQ(warnings.size(), 1u);
+}
+
+TEST(DetectorConfig, AbsentModeNeverWarns) {
+  std::vector<std::string> warnings;
+  EXPECT_EQ(parse_detector_mode(nested(), "absent", &warnings), DetectorMode::Raise);
+  EXPECT_TRUE(warnings.empty());  // not configuring a detector is not an error
+}
+
+TEST(DetectorConfig, UnknownKeysAreReportedAgainstTheKnownSet) {
+  const nlohmann::json cfg = {{"ignore_globs", nlohmann::json::array({"*_stamp"})}, {"baseline", false}};
+  std::vector<std::string> warnings;
+  collect_unknown_detector_keys(cfg, {"baseline", "ignore"}, warnings);
+  ASSERT_EQ(warnings.size(), 1u);  // `baseline` is known; only the misspelt key warns
+  EXPECT_NE(warnings[0].find("ignore_globs"), std::string::npos);
+  EXPECT_NE(warnings[0].find("ignore"), std::string::npos);  // names the set it should have matched
+}
+
+TEST(DetectorConfig, NoUnknownKeyWarningsWhenEverythingIsKnown) {
+  const nlohmann::json cfg = {{"baseline", false}, {"ignore", nlohmann::json::array()}};
+  std::vector<std::string> warnings;
+  collect_unknown_detector_keys(cfg, {"baseline", "ignore"}, warnings);
+  EXPECT_TRUE(warnings.empty());
+}
+TEST(DetectorConfig, ExtractsOwnFieldsExcludingMode) {
+  const auto cfg = extract_detector_config(nested(), "qos");
+  EXPECT_EQ(cfg.value("threshold", 0), 5);
+  EXPECT_FALSE(cfg.contains("mode"));  // mode is consumed by parse_detector_mode
+  EXPECT_FALSE(cfg.contains("x"));     // other detector's field must not leak
+}
+TEST(DetectorConfig, MissingDetectorYieldsEmpty) {
+  EXPECT_TRUE(extract_detector_config(nested(), "absent").empty());
+  EXPECT_TRUE(extract_detector_config(nlohmann::json::object(), "qos").empty());
+}
+}  // namespace

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector_registry.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_detector_registry.cpp
@@ -1,0 +1,53 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+
+namespace {
+
+// Test-only detector proving registration -> create -> tick. Not shipped.
+class NoopDetector : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "noop";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+  }
+};
+
+REGISTER_DETECTOR(NoopDetector, "noop")
+
+}  // namespace
+
+TEST(DetectorRegistry, SelfRegistersAndCreates) {
+  auto detectors = ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all();
+  const bool has_noop = std::any_of(detectors.begin(), detectors.end(), [](const auto & d) {
+    return d->id() == "noop";
+  });
+  EXPECT_TRUE(has_noop);
+}
+
+TEST(DetectorRegistry, CreatedDetectorTicksWithoutThrow) {
+  auto detectors = ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all();
+  ros2_medkit_graph_watchdog::DetectorContext ctx;  // empty context is fine for a no-op
+  for (auto & d : detectors) {
+    if (d->id() == "noop") {
+      EXPECT_NO_THROW(d->tick(ctx));
+    }
+  }
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_fault_request.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_fault_request.cpp
@@ -1,0 +1,37 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_graph_watchdog/fault_request.hpp"
+
+using ros2_medkit_graph_watchdog::make_fault_clear;
+using ros2_medkit_graph_watchdog::make_fault_report;
+using Req = ros2_medkit_msgs::srv::ReportFault::Request;
+
+TEST(FaultRequest, ReportIsFailedEventWithAllFields) {
+  const auto req = make_fault_report("/nav/planner", "GRAPH_QOS_MISMATCH", 2, "qos mismatch on /scan");
+  EXPECT_EQ(req.event_type, Req::EVENT_FAILED);
+  EXPECT_EQ(req.fault_code, "GRAPH_QOS_MISMATCH");
+  EXPECT_EQ(req.severity, 2);
+  EXPECT_EQ(req.description, "qos mismatch on /scan");
+  EXPECT_EQ(req.source_id, "/nav/planner");
+}
+
+TEST(FaultRequest, ClearIsPassedEventWithSourceId) {
+  const auto req = make_fault_clear("/nav/planner", "GRAPH_QOS_MISMATCH");
+  EXPECT_EQ(req.event_type, Req::EVENT_PASSED);
+  EXPECT_EQ(req.fault_code, "GRAPH_QOS_MISMATCH");
+  EXPECT_FALSE(req.source_id.empty());  // fault_manager rejects empty source_id
+  EXPECT_EQ(req.source_id, "/nav/planner");
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
@@ -1,0 +1,542 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/core/plugins/gateway_plugin.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_http_types.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_types.hpp"
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_gateway/plugins/ros_plugin_context.hpp"
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp"
+
+// The plugin's extern "C" exports (graph_watchdog_plugin_exports.cpp) are compiled
+// directly into this test binary (see CMakeLists.txt); forward-declare their
+// prototypes here since there is no installed header for out-of-process dlopen callers.
+extern "C" int plugin_api_version();
+extern "C" ros2_medkit_gateway::GatewayPlugin * create_plugin();
+extern "C" ros2_medkit_gateway::IntrospectionProvider *
+get_introspection_provider(ros2_medkit_gateway::GatewayPlugin * plugin);
+
+namespace {
+
+// Test-only detectors proving the fan-out loop: fan-out over multiple detectors,
+// per-detector try/catch isolation, and Off-mode skip. Not shipped. Self-register
+// via REGISTER_DETECTOR, so every test in this binary that calls
+// DetectorRegistry::instance().create_all() (i.e. every GraphWatchdogPlugin
+// instance built in this file) picks them up.
+std::atomic<int> g_counting_ticks{0};
+std::atomic<int> g_off_ticks{0};
+
+class CountingDetector : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "counting";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+    g_counting_ticks.fetch_add(1);
+  }
+};
+
+class ThrowingDetector : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "throwing";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+    throw std::runtime_error("boom");
+  }
+};
+
+class OffDetector : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "offd";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+    g_off_ticks.fetch_add(1);
+  }
+};
+
+// Records the exact config the plugin hands to configure(), so the injection rules for
+// plugin-scope keys can be asserted on the detector side rather than inferred.
+std::mutex g_captured_mutex;
+nlohmann::json g_captured_config;
+
+class ConfigCapturingDetector : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "capturing";
+  }
+  void configure(const nlohmann::json & config) override {
+    std::lock_guard<std::mutex> lk(g_captured_mutex);
+    g_captured_config = config;
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+  }
+};
+
+REGISTER_DETECTOR(CountingDetector, "counting")
+REGISTER_DETECTOR(ThrowingDetector, "throwing")
+REGISTER_DETECTOR(OffDetector, "offd")
+REGISTER_DETECTOR(ConfigCapturingDetector, "capturing")
+
+}  // namespace
+
+namespace {
+// In-memory sink standing in for the real httplib::Response the gateway would pass.
+struct TestResponseSink {
+  int status = 0;
+  nlohmann::json body;
+};
+}  // namespace
+
+// Minimal stand-in bodies for PluginRequest/PluginResponse: the real implementations
+// live in ros2_medkit_gateway's gateway_core, which this test binary does not link (see
+// the GATEWAY_SRC_DIR comment in CMakeLists.txt - only headers are exported by the
+// installed package). The x-medkit-watchdog route handler under test only calls
+// res.send_json()/res.send_error(), so a tiny in-memory sink is enough - no real HTTP
+// server needed (contrast with graph_provider's route test, which spins up httplib for
+// an end-to-end check; not needed here since the handler ignores the request entirely).
+namespace ros2_medkit_gateway {
+PluginRequest::PluginRequest(const void * impl) : impl_(impl) {
+}
+PluginResponse::PluginResponse(void * impl) : impl_(impl) {
+}
+void PluginResponse::send_json(const nlohmann::json & data) {
+  auto * sink = static_cast<TestResponseSink *>(impl_);
+  sink->status = 200;
+  sink->body = data;
+}
+void PluginResponse::send_error(int status, const std::string & /*error_code*/, const std::string & message,
+                                const nlohmann::json & /*parameters*/) {
+  auto * sink = static_cast<TestResponseSink *>(impl_);
+  sink->status = status;
+  sink->body = {{"error", message}};
+}
+}  // namespace ros2_medkit_gateway
+
+// Fake context. Copy the pure-virtual overrides from the gateway's own
+// BareContext in ros2_medkit_gateway/test/test_entity_change_scope.cpp
+// (which now derives from RosPluginContext), then point node() at test_node_.
+// Only node() is exercised here; the rest throw / return empty.
+class FakeContext : public ros2_medkit_gateway::RosPluginContext {
+ public:
+  explicit FakeContext(rclcpp::Node * node) : node_(node) {
+  }
+  rclcpp::Node * node() const override {
+    return node_;
+  }
+  std::optional<ros2_medkit_gateway::PluginEntityInfo> get_entity(const std::string &) const override {
+    return std::nullopt;
+  }
+  std::vector<ros2_medkit_gateway::PluginEntityInfo> get_child_apps(const std::string &) const override {
+    return {};
+  }
+  nlohmann::json list_entity_faults(const std::string &) const override {
+    return nlohmann::json::array();
+  }
+  std::optional<ros2_medkit_gateway::PluginEntityInfo>
+  validate_entity_for_route(const ros2_medkit_gateway::PluginRequest &, ros2_medkit_gateway::PluginResponse &,
+                            const std::string &) const override {
+    return std::nullopt;
+  }
+  void register_capability(ros2_medkit_gateway::SovdEntityType, const std::string &) override {
+  }
+  void register_entity_capability(const std::string &, const std::string &) override {
+  }
+  std::vector<std::string> get_type_capabilities(ros2_medkit_gateway::SovdEntityType) const override {
+    return {};
+  }
+  std::vector<std::string> get_entity_capabilities(const std::string &) const override {
+    return {};
+  }
+  ros2_medkit_gateway::LockAccessResult check_lock(const std::string &, const std::string &,
+                                                   const std::string &) const override {
+    return {};
+  }
+  tl::expected<ros2_medkit_gateway::LockInfo, ros2_medkit_gateway::LockError>
+  acquire_lock(const std::string &, const std::string &, const std::vector<std::string> &, int) override {
+    return tl::make_unexpected(ros2_medkit_gateway::LockError{});
+  }
+  tl::expected<void, ros2_medkit_gateway::LockError> release_lock(const std::string &, const std::string &) override {
+    return {};
+  }
+  ros2_medkit_gateway::ResourceChangeNotifier * get_resource_change_notifier() override {
+    return nullptr;
+  }
+  ros2_medkit_gateway::ConditionRegistry * get_condition_registry() override {
+    return nullptr;
+  }
+
+ private:
+  rclcpp::Node * node_;
+};
+
+// FakeContext variant that always reports one app in the entity snapshot, so the
+// ReliabilityGate the plugin owns has something real to warm up and arm.
+class FakeContextWithApp : public FakeContext {
+ public:
+  using FakeContext::FakeContext;
+  ros2_medkit_gateway::IntrospectionInput get_entity_snapshot() const override {
+    ros2_medkit_gateway::IntrospectionInput input;
+    ros2_medkit_gateway::App app;
+    app.id = "/watched_app";
+    input.apps.push_back(app);
+    return input;
+  }
+};
+
+// Reports a sliding window of app ids that CHANGES every snapshot, so the gate's
+// WarmupTracker inserts + erases map entries each tick (not just refreshes one). This
+// makes the concurrent-status test exercise the insert/erase-vs-range-for iterator flavor
+// of the gate race, not only the scalar/field-write flavor.
+class FakeContextChurningApps : public FakeContext {
+ public:
+  using FakeContext::FakeContext;
+  ros2_medkit_gateway::IntrospectionInput get_entity_snapshot() const override {
+    const int n = counter_.fetch_add(1);
+    ros2_medkit_gateway::IntrospectionInput input;
+    for (int k = 0; k < 3; ++k) {
+      ros2_medkit_gateway::App app;
+      app.id = "/churn_" + std::to_string((n + k) % 8);  // sliding window -> one id leaves + one enters
+      input.apps.push_back(app);
+    }
+    return input;
+  }
+
+ private:
+  mutable std::atomic<int> counter_{0};
+};
+
+class GraphWatchdogPluginTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    gateway_node_ = std::make_shared<rclcpp::Node>("fake_gateway_node");
+  }
+  void TearDown() override {
+    gateway_node_.reset();
+  }
+  rclcpp::Node::SharedPtr gateway_node_;
+};
+
+// prune_grace is documented in each prune-aware detector's own key table, and every one of
+// them reads it off the config it is handed. Injecting the plugin-scope value unconditionally
+// meant `detectors.<id>.prune_grace` was copied in by extract_detector_config() and then
+// silently overwritten, with no warning - the operator set a key that could never take effect.
+TEST_F(GraphWatchdogPluginTest, PerDetectorPruneGraceWinsOverThePluginScopeDefault) {
+  {
+    std::lock_guard<std::mutex> lk(g_captured_mutex);
+    g_captured_config = nlohmann::json::object();
+  }
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+  plugin.configure(nlohmann::json{
+      {"tick_interval_ms", 50}, {"prune_grace", 60}, {"detectors", {{"capturing", {{"prune_grace", 7}}}}}});
+  plugin.set_context(ctx);
+  plugin.shutdown();
+
+  std::lock_guard<std::mutex> lk(g_captured_mutex);
+  ASSERT_TRUE(g_captured_config.contains("prune_grace"));
+  EXPECT_EQ(g_captured_config["prune_grace"].get<int>(), 7)
+      << "detectors.capturing.prune_grace must reach the detector, not the plugin-scope 60";
+}
+
+TEST_F(GraphWatchdogPluginTest, PluginScopePruneGraceStillAppliesWhenTheDetectorSetsNone) {
+  {
+    std::lock_guard<std::mutex> lk(g_captured_mutex);
+    g_captured_config = nlohmann::json::object();
+  }
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 50}, {"prune_grace", 42}});
+  plugin.set_context(ctx);
+  plugin.shutdown();
+
+  std::lock_guard<std::mutex> lk(g_captured_mutex);
+  ASSERT_TRUE(g_captured_config.contains("prune_grace"));
+  EXPECT_EQ(g_captured_config["prune_grace"].get<int>(), 42) << "the plugin-scope value is still the default";
+}
+
+TEST_F(GraphWatchdogPluginTest, ExportsAdvertiseCorrectApiVersion) {
+  EXPECT_EQ(plugin_api_version(), ros2_medkit_gateway::PLUGIN_API_VERSION);
+}
+
+TEST_F(GraphWatchdogPluginTest, FactoryCreatesNamedPlugin) {
+  std::unique_ptr<ros2_medkit_gateway::GatewayPlugin> plugin(create_plugin());
+  ASSERT_NE(plugin, nullptr);
+  EXPECT_EQ(plugin->name(), "graph_watchdog");
+}
+
+TEST_F(GraphWatchdogPluginTest, LifecycleRunsTickAndShutsDownCleanly) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+
+  // The gateway would spin its own node; the test plays that role so the
+  // plugin's wall timer (created on the gateway node) actually fires.
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 50}});
+  plugin.set_context(ctx);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (plugin.tick_count() == 0 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_GT(plugin.tick_count(), 0u);
+
+  EXPECT_NO_THROW(plugin.shutdown());
+  EXPECT_NO_THROW(plugin.shutdown());  // idempotent
+
+  exec.cancel();
+  spin.join();
+}
+
+TEST_F(GraphWatchdogPluginTest, FansOutTicksSkipsOffModeAndIsolatesThrowingDetector) {
+  g_counting_ticks.store(0);
+  g_off_ticks.store(0);
+
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 50}, {"detectors", {{"offd", {{"mode", "off"}}}}}});
+  plugin.set_context(ctx);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (g_counting_ticks.load() == 0 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  // Fan-out runs: the counting detector ticked.
+  EXPECT_GT(g_counting_ticks.load(), 0);
+  // Off-mode detector is skipped entirely, never built into the active set.
+  EXPECT_EQ(g_off_ticks.load(), 0);
+  // The throwing detector fires on every tick alongside the others; the loop's
+  // per-detector try/catch isolates it, so the plugin keeps ticking without
+  // crashing the process.
+  EXPECT_GT(plugin.tick_count(), 0u);
+
+  EXPECT_NO_THROW(plugin.shutdown());
+
+  exec.cancel();
+  spin.join();
+}
+
+namespace {
+std::vector<ros2_medkit_gateway::GatewayPlugin::PluginRoute>::const_iterator
+find_watchdog_route(const std::vector<ros2_medkit_gateway::GatewayPlugin::PluginRoute> & routes) {
+  return std::find_if(routes.begin(), routes.end(), [](const ros2_medkit_gateway::GatewayPlugin::PluginRoute & r) {
+    return r.method == "GET" && r.pattern.find("x-medkit-watchdog") != std::string::npos;
+  });
+}
+}  // namespace
+
+TEST_F(GraphWatchdogPluginTest, ExposesWatchdogStatusRoute) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+
+  // Spin the gateway node so the tick timer actually fires + the gate updates,
+  // same pattern as LifecycleRunsTickAndShutsDownCleanly above.
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 50}, {"warmup_cycles", 2}});
+  plugin.set_context(ctx);
+
+  const auto routes = plugin.get_routes();
+  const auto route_it = find_watchdog_route(routes);
+  ASSERT_NE(route_it, routes.end()) << "expected a GET x-medkit-watchdog route";
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (plugin.tick_count() == 0 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_GT(plugin.tick_count(), 0u);
+
+  // Drive the handler directly (FakeContext reports an empty entity snapshot, so this
+  // exercises the empty-entities-array shape; WatchdogStatusRouteReportsEntityLifecycle
+  // AndArmedState below exercises a populated snapshot).
+  TestResponseSink sink;
+  ros2_medkit_gateway::PluginRequest req(nullptr);
+  ros2_medkit_gateway::PluginResponse res(&sink);
+  route_it->handler(req, res);
+
+  EXPECT_EQ(sink.status, 200);
+  ASSERT_TRUE(sink.body.contains("x-medkit-watchdog"));
+  const auto & doc = sink.body["x-medkit-watchdog"];
+  EXPECT_TRUE(doc.contains("schema_version"));
+  EXPECT_TRUE(doc.contains("warmup_cycles"));
+  EXPECT_TRUE(doc.contains("global_state"));
+  ASSERT_TRUE(doc.contains("entities"));
+  EXPECT_TRUE(doc["entities"].is_array());
+
+  EXPECT_NO_THROW(plugin.shutdown());
+  exec.cancel();
+  spin.join();
+}
+
+TEST_F(GraphWatchdogPluginTest, WatchdogStatusRouteReportsEntityLifecycleAndArmedState) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContextWithApp ctx(gateway_node_.get());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  // warmup_cycles=1 with a fast tick: "/watched_app" (constant across every snapshot)
+  // should be armed well within the poll window below.
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 50}, {"warmup_cycles", 1}});
+  plugin.set_context(ctx);
+
+  const auto routes = plugin.get_routes();
+  const auto route_it = find_watchdog_route(routes);
+  ASSERT_NE(route_it, routes.end());
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (plugin.tick_count() < 3 && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_GE(plugin.tick_count(), 3u);
+
+  TestResponseSink sink;
+  ros2_medkit_gateway::PluginRequest req(nullptr);
+  ros2_medkit_gateway::PluginResponse res(&sink);
+  route_it->handler(req, res);
+
+  ASSERT_TRUE(sink.body.contains("x-medkit-watchdog"));
+  const auto & doc = sink.body["x-medkit-watchdog"];
+  ASSERT_TRUE(doc["entities"].is_array());
+  ASSERT_FALSE(doc["entities"].empty());
+  const auto & entity = doc["entities"][0];
+  EXPECT_EQ(entity["id"], "/watched_app");
+  EXPECT_EQ(entity["state"], "armed");
+  EXPECT_TRUE(entity["armed"].get<bool>());
+  EXPECT_TRUE(entity.contains("lifecycle"));  // untracked (non-lifecycle) node -> null, but key present
+
+  EXPECT_NO_THROW(plugin.shutdown());
+  exec.cancel();
+  spin.join();
+}
+
+// The tick now runs on a dedicated thread that mutates the gate's warmup_ map + scalars,
+// while the x-medkit-watchdog handler reads them on a different (HTTP) thread. gate_mutex_
+// must make that race-free. This hammers the handler concurrently with fast ticks so CI's
+// TSan job flags any missing synchronization (and it must not crash under a normal build).
+TEST_F(GraphWatchdogPluginTest, StatusHandlerRaceFreeAgainstConcurrentTicks) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContextChurningApps ctx(gateway_node_.get());  // churns warmup_ (insert+erase) every tick
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 5}, {"warmup_cycles", 1}});
+  plugin.set_context(ctx);
+
+  const auto routes = plugin.get_routes();
+  const auto route_it = find_watchdog_route(routes);
+  ASSERT_NE(route_it, routes.end());
+
+  int calls = 0;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+  while (std::chrono::steady_clock::now() < deadline) {
+    TestResponseSink sink;
+    ros2_medkit_gateway::PluginRequest req(nullptr);
+    ros2_medkit_gateway::PluginResponse res(&sink);
+    route_it->handler(req, res);  // reads gate state concurrently with the ticking worker
+    ASSERT_EQ(sink.status, 200);
+    ASSERT_TRUE(sink.body.contains("x-medkit-watchdog"));
+    ++calls;
+  }
+  EXPECT_GT(calls, 0);
+
+  EXPECT_NO_THROW(plugin.shutdown());
+  exec.cancel();
+  spin.join();
+}
+
+// Every GRAPH_* fault is raised under one entity id (aggregated_fault.hpp). If the plugin
+// never publishes that entity, the faults are reachable from no scoped endpoint at all -
+// which is where they were before: scoped to the host Component, whose bare id the fault
+// scope only accepts when `external` is set, and HostInfoProvider never sets it.
+TEST_F(GraphWatchdogPluginTest, PublishesTheEntityItsFaultsAreScopedTo) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  ros2_medkit_gateway::IntrospectionInput input;
+  ros2_medkit_gateway::Component host;
+  host.id = "revpi5";
+  input.components.push_back(host);
+
+  const auto result = plugin.introspect(input);
+  ASSERT_EQ(result.new_entities.apps.size(), 1u);
+  const auto & app = result.new_entities.apps.front();
+  EXPECT_EQ(app.id, ros2_medkit_graph_watchdog::kGraphWatchdogEntityId);
+  // Without external, resolve_app_source_fqn() returns effective_fqn() - empty for an App
+  // with no ROS binding - and the fault is dropped from every rollup.
+  EXPECT_TRUE(app.external.value_or(false));
+  EXPECT_TRUE(app.is_online);
+  // Attached to the host Component so the faults also roll up to /components/<host>/faults.
+  EXPECT_EQ(app.component_id, "revpi5");
+}
+
+TEST_F(GraphWatchdogPluginTest, PublishesTheEntityEvenWithNoHostComponent) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  const auto result = plugin.introspect(ros2_medkit_gateway::IntrospectionInput{});
+  ASSERT_EQ(result.new_entities.apps.size(), 1u);
+  EXPECT_EQ(result.new_entities.apps.front().id, ros2_medkit_graph_watchdog::kGraphWatchdogEntityId);
+  EXPECT_TRUE(result.new_entities.apps.front().component_id.empty());
+}
+
+// The gateway only calls introspect() through this export. Without it the entity is never
+// published and the scoping fix above is dead code.
+TEST_F(GraphWatchdogPluginTest, ExportsTheIntrospectionProvider) {
+  auto * plugin = create_plugin();
+  ASSERT_NE(plugin, nullptr);
+  auto * provider = get_introspection_provider(plugin);
+  ASSERT_NE(provider, nullptr);
+  EXPECT_EQ(provider->introspect(ros2_medkit_gateway::IntrospectionInput{}).new_entities.apps.size(), 1u);
+  delete plugin;
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
@@ -1,0 +1,288 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include <lifecycle_msgs/msg/transition_event.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"  // App, IntrospectionInput, ServiceInfo
+#include "ros2_medkit_graph_watchdog/lifecycle_watcher.hpp"
+
+class LifecycleWatcherTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    node_ = std::make_shared<rclcpp::Node>("lifecycle_watcher_test_node");
+  }
+  void TearDown() override {
+    node_.reset();
+  }
+  rclcpp::Node::SharedPtr node_;
+  std::mutex mtx_;
+};
+
+TEST_F(LifecycleWatcherTest, UntrackedNodeIsAlwaysOk) {
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+  EXPECT_TRUE(w.node_ok("/not_a_lifecycle_node"));  // non-managed -> never gated
+  EXPECT_FALSE(w.state_of("/not_a_lifecycle_node").has_value());
+}
+
+TEST_F(LifecycleWatcherTest, ActiveAllowedInactiveSuppressed) {
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+  w.set_state_for_test("/nav/planner", "active");
+  w.set_state_for_test("/nav/controller", "inactive");
+  EXPECT_TRUE(w.node_ok("/nav/planner"));
+  EXPECT_FALSE(w.node_ok("/nav/controller"));
+  EXPECT_EQ(w.state_of("/nav/planner").value(), "active");
+}
+
+TEST_F(LifecycleWatcherTest, EmptyStateIsTreatedAsUnknownNotGated) {
+  // A tracked node whose one-shot GetState seed failed has an empty label; since
+  // transition_event is volatile and never backfills an already-active node,
+  // gating on empty would suppress its faults forever. node_ok must NOT gate it.
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+  w.set_state_for_test("/seed_failed", "");
+  EXPECT_TRUE(w.node_ok("/seed_failed"));
+}
+
+namespace {
+// Build a snapshot whose single App looks like a managed lifecycle node (GetState +
+// ChangeState services), so update() discovers it, seeds it, and subscribes to its
+// ~/transition_event.
+ros2_medkit_gateway::IntrospectionInput managed_node_snapshot(const std::string & id) {
+  ros2_medkit_gateway::ServiceInfo get_state;
+  get_state.full_path = id + "/get_state";
+  get_state.type = "lifecycle_msgs/srv/GetState";
+  ros2_medkit_gateway::ServiceInfo change_state;
+  change_state.full_path = id + "/change_state";
+  change_state.type = "lifecycle_msgs/srv/ChangeState";
+
+  ros2_medkit_gateway::App app;
+  app.id = id;
+  app.bound_fqn = id;  // `id` already looks like a full fqn in every caller (e.g. "/tnode")
+  app.services = {get_state, change_state};
+
+  ros2_medkit_gateway::IntrospectionInput in;
+  in.apps.push_back(app);
+  return in;
+}
+
+// N managed nodes in one snapshot, so a single update() queues more GetState work than the
+// per-tick blocking budget can possibly run.
+ros2_medkit_gateway::IntrospectionInput managed_nodes_snapshot(const std::vector<std::string> & ids) {
+  ros2_medkit_gateway::IntrospectionInput in;
+  for (const auto & id : ids) {
+    in.apps.push_back(managed_node_snapshot(id).apps.front());
+  }
+  return in;
+}
+}  // namespace
+
+// Exercises the REAL mechanism (not the set_state_for_test shim): update() discovers a
+// managed node, derives its ~/transition_event topic, subscribes, and the callback writes
+// the cached label from a live TransitionEvent - then the drop path forgets a vanished
+// node. A broken topic derivation or a callback that never updates would fail here where
+// the shim-based tests stay green.
+TEST_F(LifecycleWatcherTest, UpdateSubscribesAndCallbackUpdatesState) {
+  const std::string id = "/tnode";
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+
+  // Publisher matching the subscriber QoS (reliable, volatile), created on the gateway
+  // node so its own subscription receives the message.
+  auto pub = node_->create_publisher<lifecycle_msgs::msg::TransitionEvent>(
+      id + "/transition_event", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+
+  // No GetState service exists, so the seed times out to an empty label (ungated). The
+  // subscription is what we are testing.
+  w.update(managed_node_snapshot(id), /*tick=*/1);
+  ASSERT_TRUE(w.state_of(id).has_value());  // now tracked
+  EXPECT_TRUE(w.node_ok(id));               // empty seed -> ungated
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  std::thread spin([&exec]() {
+    exec.spin();
+  });
+
+  // Drive an "inactive" transition. Retry because a volatile publisher only delivers to a
+  // subscription that has finished endpoint matching.
+  lifecycle_msgs::msg::TransitionEvent msg;
+  msg.goal_state.label = "inactive";
+  bool flipped = false;
+  for (int i = 0; i < 100 && !flipped; ++i) {
+    pub->publish(msg);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    flipped = (w.state_of(id).value_or("") == "inactive");
+  }
+  exec.cancel();
+  spin.join();
+
+  EXPECT_TRUE(flipped);         // callback wrote the label from the live message
+  EXPECT_FALSE(w.node_ok(id));  // known non-active -> gated
+
+  // Drop path: the node vanishes from a later snapshot and is forgotten.
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/2);
+  EXPECT_FALSE(w.state_of(id).has_value());
+}
+
+// The failed-on_error death, over a live TransitionEvent rather than the injection seam:
+// on_activate fails, on_error fails, the node lands in `finalized` and the process exits.
+// The departure record must carry that it went through `errorprocessing`, otherwise the
+// last label alone reads exactly like a lifecycle-manager shutdown.
+TEST_F(LifecycleWatcherTest, DepartureThroughErrorProcessingIsRecordedAsErrorTerminated) {
+  const std::string id = "/failing_driver";
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+  auto pub = node_->create_publisher<lifecycle_msgs::msg::TransitionEvent>(
+      id + "/transition_event", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+
+  w.update(managed_node_snapshot(id), /*tick=*/1);
+  ASSERT_TRUE(w.state_of(id).has_value());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  std::thread spin([&exec]() {
+    exec.spin();
+  });
+
+  // errorprocessing -> finalized is the ON_ERROR_FAILURE / ON_ERROR_ERROR edge.
+  lifecycle_msgs::msg::TransitionEvent msg;
+  msg.start_state.label = "errorprocessing";
+  msg.goal_state.label = "finalized";
+  bool arrived = false;
+  for (int i = 0; i < 100 && !arrived; ++i) {
+    pub->publish(msg);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    arrived = (w.state_of(id).value_or("") == "finalized");
+  }
+  exec.cancel();
+  spin.join();
+  ASSERT_TRUE(arrived);
+
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/2);
+  const auto departed = w.departed_state_of(id);
+  ASSERT_TRUE(departed.has_value());
+  EXPECT_EQ(departed->label, "finalized");
+  EXPECT_TRUE(departed->saw_transition);
+  EXPECT_TRUE(departed->error_terminated) << "the errorprocessing edge must survive into the departure record";
+}
+
+// The ordinary shutdown, same path: active -> shuttingdown -> finalized never touches the
+// error branch, so the departure stays classifiable as clean.
+TEST_F(LifecycleWatcherTest, OrdinaryShutdownDepartureIsNotErrorTerminated) {
+  const std::string id = "/managed_ok";
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+  auto pub = node_->create_publisher<lifecycle_msgs::msg::TransitionEvent>(
+      id + "/transition_event", rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
+
+  w.update(managed_node_snapshot(id), /*tick=*/1);
+  ASSERT_TRUE(w.state_of(id).has_value());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node_);
+  std::thread spin([&exec]() {
+    exec.spin();
+  });
+
+  lifecycle_msgs::msg::TransitionEvent msg;
+  msg.start_state.label = "shuttingdown";
+  msg.goal_state.label = "finalized";
+  bool arrived = false;
+  for (int i = 0; i < 100 && !arrived; ++i) {
+    pub->publish(msg);
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    arrived = (w.state_of(id).value_or("") == "finalized");
+  }
+  exec.cancel();
+  spin.join();
+  ASSERT_TRUE(arrived);
+
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/2);
+  const auto departed = w.departed_state_of(id);
+  ASSERT_TRUE(departed.has_value());
+  EXPECT_TRUE(departed->saw_transition);
+  EXPECT_FALSE(departed->error_terminated);
+}
+
+// The self-heal budget must be charged for reads that HAPPENED, not for jobs that were
+// merely selected. None of these nodes has a real GetState service, so every read blocks to
+// the reader's timeout (~500ms) while the per-tick blocking budget is 150ms: the very first
+// read overruns it and the loop breaks, leaving the rest of the queue unread. Charging at
+// selection time spent an attempt on every one of them. Two ticks of that and the whole
+// budget was gone with almost no reads issued - and both outcomes are permanent for the
+// process, because transition_event only fires on a FUTURE transition.
+TEST_F(LifecycleWatcherTest, ReseedBudgetIsNotChargedForAJobTheTickBudgetSkipped) {
+  const std::vector<std::string> ids{"/m0", "/m1", "/m2", "/m3", "/m4", "/m5", "/m6", "/m7"};
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+
+  // Tick 1: all are new -> subscribed, each with a full self-heal budget, label "" (seeds
+  // either timed out or never ran).
+  w.update(managed_nodes_snapshot(ids), /*tick=*/1);
+  int initial_total = 0;
+  for (const auto & id : ids) {
+    ASSERT_TRUE(w.state_of(id).has_value()) << id << " must be tracked";
+    initial_total += w.reseeds_remaining_for_test(id);
+  }
+  ASSERT_GT(initial_total, 0) << "every newly tracked node starts with a self-heal budget";
+
+  // Tick 2: every node is tracked and non-active, so all of them are selected as re-seed
+  // jobs - but the budget only allows the first read.
+  w.update(managed_nodes_snapshot(ids), /*tick=*/2);
+  int remaining_total = 0;
+  for (const auto & id : ids) {
+    remaining_total += w.reseeds_remaining_for_test(id);
+  }
+  EXPECT_GT(remaining_total, initial_total - static_cast<int>(ids.size()))
+      << "charging every selected job would leave " << initial_total - static_cast<int>(ids.size())
+      << "; a job the per-tick budget skipped must keep its attempts";
+}
+
+// fqn capture + departed-lifecycle retention: a tracked node's stable fqn
+// (App::effective_fqn(), captured at first sighting) is what departed_state_of() is
+// keyed by, and its last-known label stays retrievable through that fqn for exactly
+// `retention_ticks` ticks past its departure tick, then ages out.
+TEST_F(LifecycleWatcherTest, DepartedNodeRetainsLastLabelByFqnThenPrunes) {
+  const std::string fqn = "/managed_departed";
+  constexpr int kRetentionTicks = 3;
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_, kRetentionTicks);
+
+  // Track it (managed_node_snapshot() sets bound_fqn == id, so effective_fqn() == fqn).
+  w.update(managed_node_snapshot(fqn), /*tick=*/1);
+  ASSERT_TRUE(w.state_of(fqn).has_value());
+  EXPECT_FALSE(w.departed_state_of(fqn).has_value())  // still present -> never "departed"
+      << "a still-tracked node must never be reported by departed_state_of()";
+
+  w.set_state_for_test(fqn, "finalized");
+
+  // Vanishes at tick 10: recorded into recently_departed_ with departed_tick=10.
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/10);
+  ASSERT_TRUE(w.departed_state_of(fqn).has_value());
+  EXPECT_EQ(w.departed_state_of(fqn).value().label, "finalized");
+  EXPECT_FALSE(w.state_of(fqn).has_value());  // no longer "currently tracked"
+
+  // Still within retention (tick - departed_tick == retention_ticks, not yet pruned -
+  // pruning only fires on strictly GREATER than retention_ticks).
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/10 + kRetentionTicks);
+  EXPECT_TRUE(w.departed_state_of(fqn).has_value())
+      << "an entry exactly at the retention boundary must still be retrievable";
+
+  // One tick past retention -> pruned.
+  w.update(ros2_medkit_gateway::IntrospectionInput{}, /*tick=*/10 + kRetentionTicks + 1);
+  EXPECT_FALSE(w.departed_state_of(fqn).has_value());
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_qos_mismatch_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_qos_mismatch_integration.cpp
@@ -1,0 +1,333 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Drives the REAL mechanism: real nodes publish/subscribe on real DDS topics with
+// deliberately mismatched QoS, and the detector reads the live RESOLVED profiles via
+// gateway_node->get_publishers_info_by_topic()/get_subscriptions_info_by_topic() -
+// never hand-built rmw_qos_profile_t values (that is test_qos_policy.cpp's job) - and
+// raises/clears through a real ReportFault service round-trip to a fake fault_manager.
+// NOT a full-gateway e2e (that is test/e2e/test_qos_e2e.test.py); this proves the
+// detector end to end within its own scope.
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/msg/fault.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+#include <std_msgs/msg/string.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+
+using ros2_medkit_gateway::IntrospectionInput;
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::DetectorMode;
+using ros2_medkit_graph_watchdog::graph_fault_codes::kQosMismatch;
+using ReportFault = ros2_medkit_msgs::srv::ReportFault;
+using StringMsg = std_msgs::msg::String;
+using namespace std::chrono_literals;
+
+namespace {
+// The detector class is file-local in qos_mismatch_detector.cpp but self-registers via
+// REGISTER_DETECTOR, which runs when that .cpp is linked into this test. Pull an
+// instance from the registry (no production factory needed).
+std::unique_ptr<ros2_medkit_graph_watchdog::Detector> make_qos_mismatch() {
+  for (auto & d : ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all()) {
+    if (d->id() == "qos_mismatch") {
+      return std::move(d);
+    }
+  }
+  return nullptr;
+}
+// Aggregated fault source: no Component in the test snapshot, so graph_source_id()
+// falls back to this literal (see aggregated_fault.hpp).
+constexpr const char * kGraphSource = "graph_watchdog";
+}  // namespace
+
+class QosMismatchIntegrationTest : public ::testing::Test {
+ protected:
+  // Must run before the FIRST test's fixture is constructed - see the identical
+  // rationale in test_param_drift_integration.cpp.
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  void SetUp() override {
+    gateway_ = std::make_shared<rclcpp::Node>("qm_it_gateway");
+    sink_ = std::make_shared<rclcpp::Node>("qm_it_sink");
+    srv_ = sink_->create_service<ReportFault>(
+        "/fault_manager/report_fault",
+        [this](const std::shared_ptr<ReportFault::Request> req, std::shared_ptr<ReportFault::Response> resp) {
+          {
+            std::lock_guard<std::mutex> lk(mtx_);
+            received_.push_back(*req);
+          }
+          resp->accepted = true;  // ReportFault.srv response field is `bool accepted`
+        });
+    client_ = gateway_->create_client<ReportFault>("/fault_manager/report_fault");
+    exec_.add_node(gateway_);
+    exec_.add_node(sink_);
+    spin_ = std::thread([this]() {
+      exec_.spin();
+    });
+    ASSERT_TRUE(client_->wait_for_service(5s));
+  }
+
+  void TearDown() override {
+    exec_.cancel();
+    if (spin_.joinable()) {
+      spin_.join();
+    }
+    exec_.remove_node(gateway_);
+    exec_.remove_node(sink_);
+    client_.reset();
+    srv_.reset();
+    sink_.reset();
+    probe_pub_.reset();
+    probe_sub_.reset();
+    ok_pub_.reset();
+    ok_sub_.reset();
+    probe_pub_node_.reset();
+    probe_sub_node_.reset();
+    ok_pub_node_.reset();
+    ok_sub_node_.reset();
+    gateway_.reset();
+  }
+
+  DetectorContext make_ctx(DetectorMode mode) {
+    DetectorContext ctx;
+    ctx.gateway_node = gateway_.get();
+    ctx.node_mutex = &node_mutex_;
+    ctx.mode = mode;
+    ctx.gate = nullptr;  // ungated
+    ctx.fault_client = client_;
+    ctx.snapshot = &snapshot_;  // empty -> aggregated source falls back to kGraphSource
+    return ctx;
+  }
+
+  // Pub/sub QoS endpoint discovery (rmw participant builtin-topic data) is populated by
+  // the middleware's own background discovery, not by executor spinning - so these
+  // helper nodes are never added to exec_. They just need to stay alive for the DDS
+  // entities (and thus their advertised QoS) to remain visible to the gateway node.
+  static rclcpp::Publisher<StringMsg>::SharedPtr make_publisher(rclcpp::Node::SharedPtr & node_out,
+                                                                const std::string & node_name,
+                                                                const std::string & topic, const rclcpp::QoS & qos) {
+    node_out = std::make_shared<rclcpp::Node>(node_name);
+    return node_out->create_publisher<StringMsg>(topic, qos);
+  }
+
+  static rclcpp::Subscription<StringMsg>::SharedPtr make_subscription(rclcpp::Node::SharedPtr & node_out,
+                                                                      const std::string & node_name,
+                                                                      const std::string & topic,
+                                                                      const rclcpp::QoS & qos) {
+    node_out = std::make_shared<rclcpp::Node>(node_name);
+    return node_out->create_subscription<StringMsg>(topic, qos, [](StringMsg::UniquePtr) {});
+  }
+
+  // How many matching faults are currently in the log (for absence checks + snapshots).
+  std::size_t count_faults(const std::string & source_id, uint8_t event_type) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    std::size_t n = 0;
+    for (const auto & r : received_) {
+      if (r.source_id == source_id && r.fault_code == kQosMismatch && r.event_type == event_type) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+  // True if any recorded FAILED for `source_id` carries a description containing EVERY needle.
+  bool any_failed_desc_contains(const std::string & source_id, const std::vector<std::string> & needles) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    for (const auto & r : received_) {
+      if (r.source_id != source_id || r.fault_code != kQosMismatch ||
+          r.event_type != ReportFault::Request::EVENT_FAILED) {
+        continue;
+      }
+      bool all = true;
+      for (const auto & needle : needles) {
+        if (r.description.find(needle) == std::string::npos) {
+          all = false;
+          break;
+        }
+      }
+      if (all) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Tick until a NEW matching fault appears beyond `baseline_count` (arrived AFTER the
+  // trigger), or timeout. 130 iterations at 100ms is a 13s window, comfortably over the
+  // >=5s real DDS endpoint-discovery window pub/sub QoS visibility needs.
+  bool poll_for_new(const std::string & source_id, uint8_t event_type, std::size_t baseline_count,
+                    ros2_medkit_graph_watchdog::Detector & det, DetectorContext & ctx) {
+    for (int i = 0; i < 130; ++i) {
+      det.tick(ctx);
+      std::this_thread::sleep_for(100ms);
+      if (count_faults(source_id, event_type) > baseline_count) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  rclcpp::Node::SharedPtr gateway_, sink_;
+  rclcpp::Service<ReportFault>::SharedPtr srv_;
+  rclcpp::Client<ReportFault>::SharedPtr client_;
+  rclcpp::executors::MultiThreadedExecutor exec_;
+  std::thread spin_;
+  std::mutex mtx_, node_mutex_;
+  std::vector<ReportFault::Request> received_;
+  IntrospectionInput snapshot_;  // owned, empty entity snapshot (no Component -> literal source)
+
+  rclcpp::Node::SharedPtr probe_pub_node_, probe_sub_node_, ok_pub_node_, ok_sub_node_;
+  rclcpp::Publisher<StringMsg>::SharedPtr probe_pub_, ok_pub_;
+  rclcpp::Subscription<StringMsg>::SharedPtr probe_sub_, ok_sub_;
+};
+
+// The full story in one test: a mismatched pair raises the aggregate naming its topic; a
+// concurrent RxO-compatible-but-different pair on another topic never appears in any
+// raised description (proves the detector discriminates, not just "QoS differs somewhere
+// in the graph"); fixing the mismatched pair's QoS clears the aggregate.
+TEST_F(QosMismatchIntegrationTest, MismatchRaisesNamesTopicOkNeverNamedThenClearsOnFix) {
+  // /probe: BEST_EFFORT pub + RELIABLE sub -> RxO-incompatible.
+  probe_pub_ = make_publisher(probe_pub_node_, "qm_it_probe_pub", "/probe", rclcpp::QoS(10).best_effort());
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_probe_sub", "/probe", rclcpp::QoS(10).reliable());
+
+  // /ok: RELIABLE pub + BEST_EFFORT sub -> RxO-compatible despite differing QoS.
+  ok_pub_ = make_publisher(ok_pub_node_, "qm_it_ok_pub", "/ok", rclcpp::QoS(10).reliable());
+  ok_sub_ = make_subscription(ok_sub_node_, "qm_it_ok_sub", "/ok", rclcpp::QoS(10).best_effort());
+
+  auto det = make_qos_mismatch();
+  ASSERT_TRUE(det) << "qos_mismatch did not self-register - REGISTER_DETECTOR did not run";
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  EXPECT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before, *det, ctx));
+
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/probe"}));
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"/ok"}))
+      << "/ok (RxO-compatible-but-different QoS) must never be named in an aggregated raise";
+
+  // Fix: replace the RELIABLE /probe sub with a BEST_EFFORT one (distinct node name -
+  // avoids racing the old node's DDS teardown) -> the mismatch resolves.
+  probe_sub_.reset();
+  probe_sub_node_.reset();
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_probe_sub2", "/probe", rclcpp::QoS(10).best_effort());
+
+  const auto passed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED);
+  EXPECT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_PASSED, passed_before, *det, ctx));
+}
+
+// The fault has to say WHICH subscriber is starved. Without the name, an operator reading
+// "reliability: publisher BEST_EFFORT vs subscriber RELIABLE" on a topic with a dozen
+// subscribers still has to ssh in and run `ros2 topic info -v` - the step this removes.
+TEST_F(QosMismatchIntegrationTest, DescriptionNamesTheStarvedSubscriber) {
+  probe_pub_ = make_publisher(probe_pub_node_, "qm_it_named_pub", "/probe_named", rclcpp::QoS(10).best_effort());
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_named_sub", "/probe_named", rclcpp::QoS(10).reliable());
+
+  auto det = make_qos_mismatch();
+  ASSERT_TRUE(det);
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, before, *det, ctx));
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/probe_named", "qm_it_named_sub"}))
+      << "the aggregated description must name the starved subscriber, not just its topic";
+}
+
+// A subscriber that still receives from another publisher is NOT starved, but the pair DDS
+// refused is still dropping one producer's data with nothing reporting it. That is the
+// silent fault this detector exists for, so it is reported - one level down.
+TEST_F(QosMismatchIntegrationTest, PartialIncompatibilityRaisesAtWarnNotError) {
+  // /probe_partial: one BEST_EFFORT and one RELIABLE publisher, RELIABLE subscriber.
+  // The subscriber matches the RELIABLE publisher and never matches the other one.
+  probe_pub_ = make_publisher(probe_pub_node_, "qm_it_part_bad", "/probe_partial", rclcpp::QoS(10).best_effort());
+  ok_pub_ = make_publisher(ok_pub_node_, "qm_it_part_good", "/probe_partial", rclcpp::QoS(10).reliable());
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_part_sub", "/probe_partial", rclcpp::QoS(10).reliable());
+
+  auto det = make_qos_mismatch();
+  ASSERT_TRUE(det);
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, before, *det, ctx))
+      << "a publisher whose data DDS discards must not be silent just because another one works";
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/probe_partial", "qm_it_part_sub"}));
+
+  std::lock_guard<std::mutex> lk(mtx_);
+  bool saw_warn = false;
+  for (const auto & r : received_) {
+    if (r.fault_code == kQosMismatch && r.event_type == ReportFault::Request::EVENT_FAILED) {
+      EXPECT_EQ(r.severity, ros2_medkit_msgs::msg::Fault::SEVERITY_WARN)
+          << "nothing here is fully starved, so the sweep's worst finding is a degraded topic";
+      saw_warn = true;
+    }
+  }
+  EXPECT_TRUE(saw_warn);
+}
+
+// An operator's own tool is not a robot fault: rviz2 subscribes RELIABLE and never
+// negotiates down to a BEST_EFFORT sensor publisher. Before the allowlist the only lever
+// was turning the whole detector off.
+TEST_F(QosMismatchIntegrationTest, AllowlistedTopicIsNeverReported) {
+  probe_pub_ = make_publisher(probe_pub_node_, "qm_it_allow_pub", "/probe_allow", rclcpp::QoS(10).best_effort());
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_allow_sub", "/probe_allow", rclcpp::QoS(10).reliable());
+
+  auto det = make_qos_mismatch();
+  ASSERT_TRUE(det);
+  det->configure({{"allowlist", nlohmann::json::array({"/probe_allow"})}});
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  for (int i = 0; i < 40; ++i) {  // 4s, well past the >=5s-window helper's own raise latency
+    det->tick(ctx);
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"/probe_allow"}));
+}
+
+// One sweep used to raise, and the shipped fault_manager confirms on the first report and
+// pulls a rosbag capture with it. Endpoint discovery is not atomic, so a transient
+// half-discovered pair looked exactly like starvation.
+TEST_F(QosMismatchIntegrationTest, GraceDefersTheRaise) {
+  probe_pub_ = make_publisher(probe_pub_node_, "qm_it_grace_pub", "/probe_grace", rclcpp::QoS(10).best_effort());
+  probe_sub_ = make_subscription(probe_sub_node_, "qm_it_grace_sub", "/probe_grace", rclcpp::QoS(10).reliable());
+
+  auto det = make_qos_mismatch();
+  ASSERT_TRUE(det);
+  // Large enough that no run of this test can tick past it before the assertion below.
+  det->configure({{"grace", 10000}});
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  for (int i = 0; i < 60; ++i) {  // 6s, past the endpoint-discovery window the other tests need
+    det->tick(ctx);
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "a topic must stay affected for grace+1 consecutive ticks before it is reported";
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_qos_policy.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_qos_policy.cpp
@@ -1,0 +1,255 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/qos_policy.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+
+namespace {
+using ros2_medkit_graph_watchdog::classify_subscriber_qos;
+using ros2_medkit_graph_watchdog::qos_duration_ns;
+using ros2_medkit_graph_watchdog::qos_incompatibility;
+using ros2_medkit_graph_watchdog::subscriber_starvation;
+using ros2_medkit_graph_watchdog::SubscriberQosVerdict;
+rmw_qos_profile_t base() {
+  return rmw_qos_profile_default;
+}
+
+TEST(QosPolicy, BestEffortPubReliableSubIsIncompatible) {
+  auto pub = base();
+  pub.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, ReliablePubBestEffortSubIsCompatible) {
+  auto pub = base();
+  pub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, VolatilePubTransientLocalSubIsIncompatible) {
+  auto pub = base();
+  pub.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+  auto sub = base();
+  sub.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, AutomaticPubManualSubIsIncompatible) {
+  auto pub = base();
+  pub.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+  auto sub = base();
+  sub.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, IdenticalDefaultProfilesAreCompatible) {
+  EXPECT_TRUE(qos_incompatibility(base(), base()).empty());
+}
+TEST(QosPolicy, UnresolvedProfilesNeverRaise) {
+  // A live TopicEndpointInfo reports a RESOLVED profile, never SYSTEM_DEFAULT/UNKNOWN;
+  // the strict RxO pairs below simply never match those enums, so nothing is raised.
+  auto pub = base();
+  pub.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+
+TEST(SubscriberStarvation, StarvedWhenSolelyIncompatiblePublisher) {
+  auto pub = base();
+  pub.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_FALSE(subscriber_starvation({pub}, sub).empty());  // receives from no publisher
+}
+TEST(SubscriberStarvation, NotStarvedWhenAnyPublisherCompatible) {
+  // Mixed-QoS publisher set: one incompatible + one compatible -> the subscriber still gets
+  // data from the compatible publisher, so this must NOT be flagged (the multi-publisher FP).
+  auto bad = base();
+  bad.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  auto good = base();
+  good.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_TRUE(subscriber_starvation({bad, good}, sub).empty());
+  EXPECT_TRUE(subscriber_starvation({good, bad}, sub).empty());  // order-independent
+}
+TEST(SubscriberStarvation, NoPublishersIsNotStarvation) {
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_TRUE(subscriber_starvation({}, sub).empty());  // an orphan, not a QoS fault
+}
+
+// classify_subscriber_qos separates "receives nothing" from "one producer is being
+// discarded". The second case used to be indistinguishable from healthy.
+TEST(ClassifySubscriberQos, StarvedWhenNoPublisherMatches) {
+  auto pub = base();
+  pub.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  const auto result = classify_subscriber_qos({pub, pub}, sub);
+  EXPECT_EQ(result.verdict, SubscriberQosVerdict::Starved);
+  EXPECT_FALSE(result.reason.empty());
+}
+
+TEST(ClassifySubscriberQos, PartialWhenOnlySomePublishersMatch) {
+  // /diagnostics shape: several publishers, one hand-rolled BEST_EFFORT, RELIABLE
+  // aggregator. DDS never matches that pair, so those diagnostics are discarded forever
+  // while the aggregator keeps receiving everyone else's - and nothing errors anywhere.
+  auto bad = base();
+  bad.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  auto good = base();
+  good.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_EQ(classify_subscriber_qos({bad, good}, sub).verdict, SubscriberQosVerdict::Partial);
+  EXPECT_EQ(classify_subscriber_qos({good, bad}, sub).verdict, SubscriberQosVerdict::Partial);  // order-independent
+  EXPECT_FALSE(classify_subscriber_qos({bad, good}, sub).reason.empty());
+}
+
+TEST(ClassifySubscriberQos, OkWhenEveryPublisherMatches) {
+  auto good = base();
+  good.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  const auto result = classify_subscriber_qos({good, good}, sub);
+  EXPECT_EQ(result.verdict, SubscriberQosVerdict::Ok);
+  EXPECT_TRUE(result.reason.empty());
+}
+
+TEST(ClassifySubscriberQos, NoPublishersIsOkNotPartial) {
+  auto sub = base();
+  sub.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  EXPECT_EQ(classify_subscriber_qos({}, sub).verdict, SubscriberQosVerdict::Ok);  // orphan detector's concern
+}
+
+// --- deadline RxO ---
+
+TEST(QosPolicy, DeadlineUnspecifiedPubFiniteSubIsIncompatible) {
+  auto pub = base();
+  pub.deadline = {0, 0};
+  auto sub = base();
+  sub.deadline = {0, 100000000};  // 100ms
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, DeadlineBothInfiniteIsCompatible) {
+  auto pub = base();
+  pub.deadline = RMW_DURATION_INFINITE;
+  auto sub = base();
+  sub.deadline = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, DeadlineUnspecifiedSubIsCompatibleRegardlessOfPub) {
+  auto pub = base();
+  pub.deadline = {0, 200000000};  // 200ms, finite
+  auto sub = base();
+  sub.deadline = {0, 0};  // unspecified
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, DeadlineInfiniteSubIsCompatible) {
+  auto pub = base();
+  pub.deadline = {0, 200000000};  // 200ms, finite
+  auto sub = base();
+  sub.deadline = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, DeadlineFinitePubLessEqualSubIsCompatible) {
+  auto pub = base();
+  pub.deadline = {0, 50000000};  // 50ms
+  auto sub = base();
+  sub.deadline = {0, 100000000};  // 100ms
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, DeadlineFinitePubExceedsSubIsIncompatible) {
+  auto pub = base();
+  pub.deadline = {0, 200000000};  // 200ms
+  auto sub = base();
+  sub.deadline = {0, 100000000};  // 100ms
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+
+// --- liveliness lease duration RxO ---
+
+TEST(QosPolicy, LeaseUnspecifiedPubFiniteSubIsIncompatible) {
+  auto pub = base();
+  pub.liveliness_lease_duration = {0, 0};
+  auto sub = base();
+  sub.liveliness_lease_duration = {0, 100000000};  // 100ms
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, LeaseBothInfiniteIsCompatible) {
+  auto pub = base();
+  pub.liveliness_lease_duration = RMW_DURATION_INFINITE;
+  auto sub = base();
+  sub.liveliness_lease_duration = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, LeaseUnspecifiedSubIsCompatibleRegardlessOfPub) {
+  auto pub = base();
+  pub.liveliness_lease_duration = {0, 200000000};  // 200ms, finite
+  auto sub = base();
+  sub.liveliness_lease_duration = {0, 0};  // unspecified
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, LeaseInfiniteSubIsCompatible) {
+  auto pub = base();
+  pub.liveliness_lease_duration = {0, 200000000};  // 200ms, finite
+  auto sub = base();
+  sub.liveliness_lease_duration = RMW_DURATION_INFINITE;
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, LeaseFinitePubLessEqualSubIsCompatible) {
+  auto pub = base();
+  pub.liveliness_lease_duration = {0, 50000000};  // 50ms
+  auto sub = base();
+  sub.liveliness_lease_duration = {0, 100000000};  // 100ms
+  EXPECT_TRUE(qos_incompatibility(pub, sub).empty());
+}
+TEST(QosPolicy, LeaseFinitePubExceedsSubIsIncompatible) {
+  auto pub = base();
+  pub.liveliness_lease_duration = {0, 200000000};  // 200ms
+  auto sub = base();
+  sub.liveliness_lease_duration = {0, 100000000};  // 100ms
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+
+// rmw_time_t::sec is uint64_t, so sec * 1e9 can overflow. Wrapping would turn an absurdly
+// long duration into a SMALL nanosecond value - i.e. a tighter deadline than the operator
+// asked for - and flip the RxO verdict. Saturation keeps it on the permissive side.
+TEST(QosPolicy, HugeButFiniteDurationSaturatesInsteadOfWrapping) {
+  constexpr uint64_t kMaxU64 = std::numeric_limits<uint64_t>::max();
+  const rmw_time_t huge{kMaxU64 / 2, 0};  // finite, but sec * 1e9 overflows
+  EXPECT_EQ(qos_duration_ns(huge), kMaxU64);
+
+  const rmw_time_t nsec_carry{kMaxU64 / 1000000000ull, kMaxU64};  // overflows on the +nsec
+  EXPECT_EQ(qos_duration_ns(nsec_carry), kMaxU64);
+
+  // A sane value is untouched.
+  EXPECT_EQ(qos_duration_ns(rmw_time_t{2, 500000000}), 2500000000ull);
+}
+
+// The saturated value must behave like the longest possible duration in a real comparison:
+// a publisher offering it against a normal subscriber deadline is incompatible, never
+// silently "compatible" via a wrapped small number.
+TEST(QosPolicy, SaturatedPubDeadlineStaysIncompatibleAgainstFiniteSub) {
+  auto pub = base();
+  pub.deadline = {std::numeric_limits<uint64_t>::max() / 2, 0};
+  auto sub = base();
+  sub.deadline = {0, 100000000};  // 100ms
+  EXPECT_FALSE(qos_incompatibility(pub, sub).empty());
+}
+}  // namespace

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_reliability_gate.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_reliability_gate.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/detector.hpp"  // reliability_allows() free function
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+using ros2_medkit_gateway::App;
+using ros2_medkit_gateway::IntrospectionInput;
+using ros2_medkit_graph_watchdog::reliability_allows;
+using ros2_medkit_graph_watchdog::ReliabilityGate;
+
+class ReliabilityGateTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    node_ = std::make_shared<rclcpp::Node>("reliability_gate_test_node");
+  }
+  void TearDown() override {
+    node_.reset();
+  }
+  static IntrospectionInput snap(std::vector<std::string> app_ids) {
+    IntrospectionInput in;
+    for (auto & id : app_ids) {
+      App a;
+      a.id = id;
+      in.apps.push_back(a);
+    }
+    return in;
+  }
+  rclcpp::Node::SharedPtr node_;
+  std::mutex mtx_;
+};
+
+TEST_F(ReliabilityGateTest, SuppressedUntilArmed) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/a"}), 5);
+  EXPECT_FALSE(g.allows_raise("/a"));  // tick 5, first_seen 5
+  g.update(snap({"/a"}), 8);           // 3 elapsed
+  EXPECT_TRUE(g.allows_raise("/a"));
+}
+
+TEST_F(ReliabilityGateTest, UnknownSourceFallsBackToGlobalWarmup) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/a"}), 1);                    // graph first non-empty at tick 1
+  EXPECT_FALSE(g.allows_raise("/some/topic"));  // unknown, 0 elapsed globally
+  g.update(snap({"/a"}), 4);
+  EXPECT_TRUE(g.allows_raise("/some/topic"));  // 3 elapsed globally
+}
+
+TEST_F(ReliabilityGateTest, StatusJsonShape) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/a"}), 1);
+  g.update(snap({"/a"}), 10);
+  const auto j = g.status_json();
+  ASSERT_TRUE(j.contains("x-medkit-watchdog"));
+  const auto & body = j["x-medkit-watchdog"];
+  EXPECT_TRUE(body.contains("entities"));
+  EXPECT_EQ(body["warmup_cycles"], 3);
+}
+
+// The gate composes warmup AND lifecycle: an armed entity whose managed lifecycle is
+// non-active must still be suppressed, and reported "warming_up" in status_json. Without
+// this the `&& node_ok` conjunct in allows_raise() is unreachable from a gate-level test
+// (every other test builds Apps with no services, so nothing is lifecycle-tracked and
+// node_ok is always true - dropping the conjunct would leave the suite green).
+TEST_F(ReliabilityGateTest, ArmedButLifecycleInactiveIsSuppressed) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/a"}), 5);
+  g.update(snap({"/a"}), 8);          // 3 elapsed -> armed
+  EXPECT_TRUE(g.allows_raise("/a"));  // armed, nothing lifecycle-tracked -> allowed
+
+  g.set_lifecycle_state_for_test("/a", "inactive");
+  EXPECT_FALSE(g.allows_raise("/a"));  // armed but lifecycle non-active -> suppressed
+
+  const auto j = g.status_json();
+  bool found = false;
+  for (const auto & e : j["x-medkit-watchdog"]["entities"]) {
+    if (e["id"] == "/a") {
+      found = true;
+      EXPECT_EQ(e["state"], "warming_up");  // suppressed by lifecycle, though armed
+      EXPECT_EQ(e["lifecycle"], "inactive");
+      EXPECT_EQ(e["armed"], true);
+    }
+  }
+  EXPECT_TRUE(found);
+
+  // Once the node reports active, the same armed entity is allowed.
+  g.set_lifecycle_state_for_test("/a", "active");
+  EXPECT_TRUE(g.allows_raise("/a"));
+}
+
+// A null gate (not yet wired by the plugin) must never suppress a raise.
+TEST(ReliabilityAllows, NullGateAlwaysAllows) {
+  EXPECT_TRUE(reliability_allows(nullptr, "x"));
+}
+
+// The free function must mirror ReliabilityGate::allows_raise for a real gate:
+// suppressed while warming up, allowed once armed.
+TEST_F(ReliabilityGateTest, MirrorsGateArmedState) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/a"}), 5);
+  EXPECT_FALSE(reliability_allows(&g, "/a"));  // not armed yet (0 elapsed)
+  g.update(snap({"/a"}), 8);                   // 3 elapsed -> armed
+  EXPECT_TRUE(reliability_allows(&g, "/a"));
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_warmup_tracker.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_warmup_tracker.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "ros2_medkit_graph_watchdog/warmup_tracker.hpp"
+
+using ros2_medkit_graph_watchdog::WarmupTracker;
+
+TEST(WarmupTracker, UnknownUntilSeen) {
+  WarmupTracker w(3);
+  EXPECT_FALSE(w.is_known("/a"));
+  EXPECT_FALSE(w.is_armed("/a", 10));
+}
+
+TEST(WarmupTracker, ArmsAfterNCycles) {
+  WarmupTracker w(3);
+  w.update({"/a"}, 5);  // first seen at tick 5
+  EXPECT_TRUE(w.is_known("/a"));
+  EXPECT_FALSE(w.is_armed("/a", 5));  // 0 elapsed
+  EXPECT_FALSE(w.is_armed("/a", 7));  // 2 elapsed
+  EXPECT_TRUE(w.is_armed("/a", 8));   // 3 elapsed >= 3
+}
+
+TEST(WarmupTracker, ZeroCyclesArmsImmediately) {
+  WarmupTracker w(0);
+  w.update({"/a"}, 5);
+  EXPECT_TRUE(w.is_armed("/a", 5));
+}
+
+TEST(WarmupTracker, ReappearingEntityRewarms) {
+  WarmupTracker w(3);
+  w.update({"/a"}, 1);
+  EXPECT_TRUE(w.is_armed("/a", 10));   // armed
+  w.update({}, 11);                    // /a gone: 11 - last_seen(1) = 10 > grace(2) -> forgotten
+  w.update({"/a"}, 12);                // reappears -> fresh first_seen at 12
+  EXPECT_FALSE(w.is_armed("/a", 13));  // 1 elapsed since reappearance
+  EXPECT_TRUE(w.is_armed("/a", 15));   // 3 elapsed
+}
+
+// A transient one-tick discovery gap (DDS churn, not a real restart) must NOT re-warm an
+// already-armed entity: gaps recurring faster than the warmup window would otherwise
+// suppress it forever. The forget grace absorbs short gaps.
+TEST(WarmupTracker, TransientGapWithinGraceDoesNotRewarm) {
+  WarmupTracker w(3);  // default forget grace = 2 ticks
+  w.update({"/a"}, 1);
+  w.update({"/a"}, 2);
+  w.update({"/a"}, 3);
+  EXPECT_TRUE(w.is_armed("/a", 4));  // armed (>= 3 elapsed since first_seen 1)
+  w.update({}, 5);                   // one-tick gap: 5 - last_seen(3) = 2, not > grace(2) -> kept
+  w.update({"/a"}, 6);               // back within grace: original first_seen(1) preserved
+  EXPECT_TRUE(w.is_armed("/a", 6));  // still armed - not re-warmed
+}
+
+// A gap longer than the forget grace is a real restart and DOES re-warm.
+TEST(WarmupTracker, GapBeyondGraceRewarms) {
+  WarmupTracker w(3);  // default forget grace = 2 ticks
+  w.update({"/a"}, 1);
+  EXPECT_TRUE(w.is_armed("/a", 5));
+  w.update({}, 6);                    // 6 - last_seen(1) = 5 > grace(2) -> forgotten
+  w.update({"/a"}, 7);                // reappears -> re-warmed from tick 7
+  EXPECT_FALSE(w.is_armed("/a", 9));  // 2 elapsed since reappearance
+  EXPECT_TRUE(w.is_armed("/a", 10));  // 3 elapsed
+}
+
+// Custom (zero) forget grace: any single missed tick forgets immediately.
+TEST(WarmupTracker, ZeroForgetGraceForgetsOnFirstMiss) {
+  WarmupTracker w(3, /*forget_grace=*/0);
+  w.update({"/a"}, 1);
+  w.update({}, 2);  // 2 - last_seen(1) = 1 > grace(0) -> forgotten
+  EXPECT_FALSE(w.is_known("/a"));
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_watchdog_clock.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_watchdog_clock.cpp
@@ -1,0 +1,95 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rosgraph_msgs/msg/clock.hpp>
+
+#include "ros2_medkit_graph_watchdog/watchdog_clock.hpp"
+
+class WatchdogClockTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    node_ = std::make_shared<rclcpp::Node>("watchdog_clock_test_node");
+  }
+  void TearDown() override {
+    node_.reset();
+  }
+  rclcpp::Node::SharedPtr node_;
+};
+
+TEST_F(WatchdogClockTest, IsMonotonicNonDecreasing) {
+  ros2_medkit_graph_watchdog::WatchdogClock clock(node_.get());
+  const rclcpp::Time t1 = clock.now();
+  const rclcpp::Time t2 = clock.now();
+  EXPECT_GE(t2.nanoseconds(), t1.nanoseconds());
+}
+
+// Exercises that WatchdogClock actually honors use_sim_time (rather than just
+// asserting the clock type matches the node's own clock, which is true by
+// construction and proves nothing about sim-time wiring). Publishes on /clock
+// and asserts now() reports the published sim time, not wall-clock time.
+TEST_F(WatchdogClockTest, HonorsSimTime) {
+  auto sim_node = std::make_shared<rclcpp::Node>(
+      "watchdog_clock_sim_node", rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("use_sim_time", true)}));
+  auto clock_pub = sim_node->create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::ClockQoS());
+  ros2_medkit_graph_watchdog::WatchdogClock wclock(sim_node.get());
+
+  rosgraph_msgs::msg::Clock msg;
+  msg.clock = rclcpp::Time(12345, 678000000, RCL_ROS_TIME);
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(sim_node);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  double t = 0.0;
+  while (std::chrono::steady_clock::now() < deadline) {
+    clock_pub->publish(msg);
+    exec.spin_some();
+    t = wclock.now().seconds();
+    if (t > 12000.0 && t < 13000.0) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  EXPECT_GT(t, 12000.0);  // sim time ~12345s, not wall-clock ~1.7e9s
+  EXPECT_LT(t, 13000.0);
+}
+
+TEST_F(WatchdogClockTest, SystemTimeAlwaysValid) {
+  ros2_medkit_graph_watchdog::WatchdogClock clock(node_.get());  // use_sim_time not set -> false
+  clock.mark_tick();
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  clock.mark_tick();
+  EXPECT_TRUE(clock.time_is_valid());
+}
+
+TEST_F(WatchdogClockTest, StalledSimClockIsInvalid) {
+  auto sim_node = std::make_shared<rclcpp::Node>(
+      "watchdog_clock_stall_node",
+      rclcpp::NodeOptions().parameter_overrides({rclcpp::Parameter("use_sim_time", true)}));
+  // No /clock ever published -> sim time stays at 0 while wall time advances.
+  ros2_medkit_graph_watchdog::WatchdogClock clock(sim_node.get());
+  clock.mark_tick();
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  clock.mark_tick();
+  EXPECT_FALSE(clock.time_is_valid());  // sim time did not advance while wall time did
+}


### PR DESCRIPTION
## Summary

Adds `ros2_medkit_graph_watchdog`, a `GatewayPlugin` for failures where every node is up, nothing logs an error, and the robot is still broken.

This is the first of seven changes. It carries the plugin scaffolding and one detector, so the seam is proven end to end before the rest arrive. Each remaining silent-fault class lands separately against its own issue; their codes are already reserved in the frozen `GRAPH_*` namespace so the contract does not churn.

**Scaffolding**

- detector interface, self-registering registry, nested per-detector config
- unknown config keys and unknown detector ids are warned about at startup, so a typo cannot silently do nothing
- a central reliability gate holding every raise until an entity has been continuously present for `warmup_cycles` ticks, so bringup churn does not read as failure
- `AggregatedFault`: one graph-level fault per code, level-triggered, because fault_manager identifies a fault by `fault_code` alone
- one synthetic App published through `IntrospectionProvider`, so `GRAPH_*` faults resolve to a real entity and roll up to the host component
- a dedicated tick thread, never the gateway executor, since detectors do blocking reads

**`qos_mismatch` (`GRAPH_QOS_MISMATCH`)**

Applies the RxO rule to every publisher x subscriber pair on every topic. Reliability, durability, deadline and liveliness lease are checked; duration comparisons saturate instead of wrapping.

Two levels, because they mean different things to an operator:

- **starved** (ERROR): incompatible with every publisher, so it receives nothing
- **partial** (WARN): incompatible with some publisher, so it still gets data while one producer is silently discarded

The fault names the affected subscriber FQNs. A persistence threshold absorbs non-atomic endpoint discovery, where a subscriber can be visible before a publisher QoS is.

---

## Issue

- closes #572

Part of #570.

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

18 tests, all green locally on Jazzy: 12 gtest targets (policy units plus integration tests driving real `rclcpp` nodes and real DDS), 1 launch test running a full e2e against a real gateway process, real fault_manager and a real ROS graph, and 5 linters.

Test domains 75-89 are carved out of the gateway range, which shrinks to 30-74 and keeps 12 free slots (it consumes 33 today). Each gtest that creates live ROS nodes gets its own domain; launch tests share one under a `RESOURCE_LOCK`. Sharing a domain between gtests let a publisher outlive its test and change the next one.s result.

    colcon build --packages-select ros2_medkit_graph_watchdog
    colcon test --packages-select ros2_medkit_graph_watchdog && colcon test-result --verbose

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed

Two things worth flagging rather than leaving to be found:

- The plugin compiles three gateway sources by path (`lifecycle_status_helpers.cpp`, `ros2_lifecycle_state_reader.cpp`, `ros2_parameter_transport.cpp`) because `ros2_medkit_gateway` exports include dirs but installs no library target. Fine in a workspace build, but it would not survive a released source package, so it needs resolving before this is ever bloom-released.
- `flake8` and `pep257` are excluded, matching every other package here: nothing in this repo lints Python today, including the package holding all the other launch tests. `copyright`, `clang_format`, `cppcheck`, `lint_cmake` and `xmllint` are on.