### PR TITLE
Stop PASSED events re-dating a fault, and count real SSE loss

### DIFF
--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -31,8 +31,12 @@ Core fault data model representing an aggregated fault condition.
    # Timestamp when this fault was first reported
    builtin_interfaces/Time first_occurred
 
-   # Timestamp when this fault was last reported
+   # Timestamp when this fault last occurred (FAILED events only; a PASSED
+   # event is the fault ending, not occurring, and does not touch this field)
    builtin_interfaces/Time last_occurred
+
+   # Timestamp of the last PASSED event reported for this fault (zero = never)
+   builtin_interfaces/Time last_passed
 
    # Total number of FAILED events aggregated across all sources
    uint32 occurrence_count
@@ -128,7 +132,9 @@ prefix (for example ``/robot1/fault_manager/events``).
    * - ``fault_confirmed``
      - Fault transitioned from PREFAILED to CONFIRMED
    * - ``fault_cleared``
-     - Fault cleared via ClearFault service
+     - Fault ended: cleared via the ClearFault service, or healed when PASSED
+       events crossed the healing threshold (``fault.status`` distinguishes
+       ``CLEARED`` from ``HEALED``)
    * - ``fault_updated``
      - Fault data changed without status transition (e.g., new occurrence)
 

--- a/postman/collections/ros2-medkit-gateway.postman_collection.json
+++ b/postman/collections/ros2-medkit-gateway.postman_collection.json
@@ -1080,7 +1080,7 @@
                 "stream"
               ]
             },
-            "description": "Server-Sent Events (SSE) stream for real-time fault notifications.\n\nEvents:\n- fault_confirmed: Fault transitioned to CONFIRMED status\n- fault_cleared: Fault was manually cleared\n- fault_updated: Fault data changed (occurrence_count, sources)\n\nSSE Format:\n```\nevent: fault_confirmed\ndata: {\"event_type\":\"fault_confirmed\",\"fault\":{...},\"timestamp\":1234567890.123}\n```\n\nNote: Postman has limited SSE support. For testing, use:\n- Browser: `new EventSource('http://localhost:8080/api/v1/faults/stream')`\n- curl: `curl -N {{base_url}}/faults/stream`\n\nFeatures:\n- Keepalive every 30 seconds\n- Reconnection support via Last-Event-ID header\n- Multiple simultaneous clients supported"
+            "description": "Server-Sent Events (SSE) stream for real-time fault notifications.\n\nEvents:\n- fault_confirmed: Fault transitioned to CONFIRMED status\n- fault_cleared: Fault ended (manually cleared, or auto-healed; check fault.status for CLEARED vs HEALED)\n- fault_updated: Fault data changed (occurrence_count, sources)\n\nSSE Format:\n```\nevent: fault_confirmed\ndata: {\"event_type\":\"fault_confirmed\",\"fault\":{...},\"timestamp\":1234567890.123}\n```\n\nNote: Postman has limited SSE support. For testing, use:\n- Browser: `new EventSource('http://localhost:8080/api/v1/faults/stream')`\n- curl: `curl -N {{base_url}}/faults/stream`\n\nFeatures:\n- Keepalive every 30 seconds\n- Reconnection support via Last-Event-ID header\n- Multiple simultaneous clients supported"
           },
           "response": []
         },

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -672,6 +672,14 @@ void FaultManagerNode::handle_report_fault(
     const bool just_healed = !is_new && status_before != ros2_medkit_msgs::msg::Fault::STATUS_HEALED &&
                              fault_after->status == ros2_medkit_msgs::msg::Fault::STATUS_HEALED;
 
+    // The end of a fault must reach the event stream too, or an SSE consumer keeps
+    // showing a fault that is over. EVENT_CLEARED (not a new event name) so existing
+    // consumers act on it; the payload's status = HEALED distinguishes auto-heal from
+    // an acknowledged clear.
+    if (just_healed) {
+      publish_fault_event(ros2_medkit_msgs::msg::FaultEvent::EVENT_CLEARED, *fault_after);
+    }
+
     // Append tamper-evident audit records for the transitions that just happened.
     // Recorded regardless of correlation muting: muting affects display, not the
     // fact that the state transition occurred.

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -76,6 +76,7 @@ ros2_medkit_msgs::msg::Fault FaultState::to_msg() const {
   msg.description = description;
   msg.first_occurred = first_occurred;
   msg.last_occurred = last_occurred;
+  msg.last_passed = last_passed_time;
   msg.occurrence_count = occurrence_count;
   msg.status = status;
 

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -175,9 +175,11 @@ bool InMemoryFaultStorage::report_fault_event(const std::string & fault_code, ui
     return true;  // Reactivation treated as new occurrence for event publishing
   }
 
-  state.last_occurred = timestamp;
-
   if (is_failed) {
+    // last_occurred tracks occurrences only. A PASSED event is the fault ENDING, not
+    // occurring; bumping it there makes a long-stale CONFIRMED fault look freshly
+    // active to operators. The PASSED instant is kept in last_passed_time.
+    state.last_occurred = timestamp;
     state.last_failed_time = timestamp;
 
     // occurrence_count is NOT bumped here: this is a still-active fault being

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -191,6 +191,19 @@ void SqliteFaultStorage::initialize_schema() {
     }
   }
 
+  // Migration: releases that advanced last_occurred_ns on PASSED events left
+  // inflated rows behind, and a latched CONFIRMED fault that only ever heals
+  // would keep the wrong timestamp forever. last_failed_ns holds the true
+  // last occurrence; last_occurred_ns can only exceed it via that old bug.
+  if (sqlite3_exec(db_,
+                   "UPDATE faults SET last_occurred_ns = last_failed_ns "
+                   "WHERE last_failed_ns > 0 AND last_occurred_ns > last_failed_ns",
+                   nullptr, nullptr, &err_msg) != SQLITE_OK) {
+    std::string error = err_msg ? err_msg : "Unknown error";
+    sqlite3_free(err_msg);
+    throw std::runtime_error("Failed to repair last_occurred_ns rows: " + error);
+  }
+
   // Create snapshots table for storing topic data captured when faults are confirmed
   const char * create_snapshots_table_sql = R"(
     CREATE TABLE IF NOT EXISTS snapshots (

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -608,7 +608,7 @@ SqliteFaultStorage::list_faults(bool filter_by_severity, uint8_t severity,
   // Build query
   std::string sql =
       "SELECT fault_code, severity, description, first_occurred_ns, last_occurred_ns, "
-      "occurrence_count, status, reporting_sources FROM faults WHERE status IN (";
+      "occurrence_count, status, reporting_sources, last_passed_ns FROM faults WHERE status IN (";
   for (size_t i = 0; i < status_filter.size(); ++i) {
     if (i > 0) {
       sql += ", ";
@@ -646,6 +646,7 @@ SqliteFaultStorage::list_faults(bool filter_by_severity, uint8_t severity,
     fault.occurrence_count = static_cast<uint32_t>(stmt.column_int64(5));
     fault.status = stmt.column_text(6);
     fault.reporting_sources = parse_json_array(stmt.column_text(7));
+    fault.last_passed = rclcpp::Time(stmt.column_int64(8), RCL_SYSTEM_TIME);
 
     result.push_back(fault);
   }
@@ -658,7 +659,7 @@ std::optional<ros2_medkit_msgs::msg::Fault> SqliteFaultStorage::get_fault(const 
 
   SqliteStatement stmt(db_,
                        "SELECT fault_code, severity, description, first_occurred_ns, last_occurred_ns, "
-                       "occurrence_count, status, reporting_sources FROM faults WHERE fault_code = ?");
+                       "occurrence_count, status, reporting_sources, last_passed_ns FROM faults WHERE fault_code = ?");
   stmt.bind_text(1, fault_code);
 
   if (stmt.step() != SQLITE_ROW) {
@@ -678,6 +679,7 @@ std::optional<ros2_medkit_msgs::msg::Fault> SqliteFaultStorage::get_fault(const 
   fault.occurrence_count = static_cast<uint32_t>(stmt.column_int64(5));
   fault.status = stmt.column_text(6);
   fault.reporting_sources = parse_json_array(stmt.column_text(7));
+  fault.last_passed = rclcpp::Time(stmt.column_int64(8), RCL_SYSTEM_TIME);
 
   return fault;
 }
@@ -1178,7 +1180,7 @@ std::vector<ros2_medkit_msgs::msg::Fault> SqliteFaultStorage::get_all_faults() c
 
   SqliteStatement stmt(db_,
                        "SELECT fault_code, severity, description, first_occurred_ns, last_occurred_ns, "
-                       "occurrence_count, status, reporting_sources FROM faults");
+                       "occurrence_count, status, reporting_sources, last_passed_ns FROM faults");
 
   std::vector<ros2_medkit_msgs::msg::Fault> result;
   while (stmt.step() == SQLITE_ROW) {
@@ -1195,6 +1197,7 @@ std::vector<ros2_medkit_msgs::msg::Fault> SqliteFaultStorage::get_all_faults() c
     fault.occurrence_count = static_cast<uint32_t>(stmt.column_int64(5));
     fault.status = stmt.column_text(6);
     fault.reporting_sources = parse_json_array(stmt.column_text(7));
+    fault.last_passed = rclcpp::Time(stmt.column_int64(8), RCL_SYSTEM_TIME);
 
     result.push_back(fault);
   }

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -510,16 +510,15 @@ bool SqliteFaultStorage::report_fault_event(const std::string & fault_code, uint
 
       std::string new_status = compute_debounce_status(debounce_counter, current_status, config);
 
+      // last_occurred_ns is deliberately NOT touched: a PASSED event is the fault
+      // ENDING, not occurring. Bumping it made a long-stale CONFIRMED fault look
+      // freshly active. The PASSED instant is recorded in last_passed_ns.
       SqliteStatement update_stmt(
-          db_,
-          "UPDATE faults SET last_occurred_ns = ?, last_passed_ns = ?, status = ?, debounce_counter "
-          "= ? WHERE "
-          "fault_code = ?");
+          db_, "UPDATE faults SET last_passed_ns = ?, status = ?, debounce_counter = ? WHERE fault_code = ?");
       update_stmt.bind_int64(1, timestamp_ns);
-      update_stmt.bind_int64(2, timestamp_ns);
-      update_stmt.bind_text(3, new_status);
-      update_stmt.bind_int(4, debounce_counter);
-      update_stmt.bind_text(5, fault_code);
+      update_stmt.bind_text(2, new_status);
+      update_stmt.bind_int(3, debounce_counter);
+      update_stmt.bind_text(4, fault_code);
 
       if (update_stmt.step() != SQLITE_DONE) {
         throw std::runtime_error(std::string("Failed to update fault: ") + sqlite3_errmsg(db_));

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -509,6 +509,25 @@ TEST_F(FaultStorageTest, PassedEventIncrementsCounter) {
   EXPECT_EQ(fault->status, Fault::STATUS_PREPASSED);  // Counter > 0
 }
 
+TEST_F(FaultStorageTest, PassedEventDoesNotAdvanceLastOccurred) {
+  // Observed on a live box: a plugin sent one PASSED on reconnect, healing was
+  // disabled so the fault stayed CONFIRMED (by design), but last_occurred jumped
+  // to the PASSED instant - a fault that had not occurred for hours read as if it
+  // had just happened. last_occurred belongs to occurrences (FAILED) only.
+  const rclcpp::Time failed_at(1000, 0, RCL_SYSTEM_TIME);
+  const rclcpp::Time passed_at(9000, 0, RCL_SYSTEM_TIME);
+
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                              failed_at, default_config());
+  storage_.report_fault_event("FAULT_1", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", passed_at,
+                              default_config());
+
+  auto fault = storage_.get_fault("FAULT_1");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // healing disabled: latched, by design
+  EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
+}
+
 TEST_F(FaultStorageTest, HealingDisabledByDefault) {
   rclcpp::Clock clock;
 
@@ -1056,6 +1075,19 @@ class FaultEventPublishingTest : public ::testing::Test {
     return future.get()->accepted;
   }
 
+  bool call_report_passed(const std::string & fault_code, const std::string & source_id) {
+    auto request = std::make_shared<ReportFault::Request>();
+    request->fault_code = fault_code;
+    request->event_type = ReportFault::Request::EVENT_PASSED;
+    request->source_id = source_id;
+
+    auto future = report_fault_client_->async_send_request(request);
+    if (!spin_until_future_ready(future)) {
+      return false;
+    }
+    return future.get()->accepted;
+  }
+
   bool call_clear_fault(const std::string & fault_code) {
     auto request = std::make_shared<ClearFault::Request>();
     request->fault_code = fault_code;
@@ -1160,6 +1192,51 @@ TEST_F(FaultEventPublishingTest, ClearFaultPublishesClearedEvent) {
   EXPECT_EQ(received_events_[0].event_type, FaultEvent::EVENT_CLEARED);
   EXPECT_EQ(received_events_[0].fault.fault_code, "TEST_FAULT_3");
   EXPECT_EQ(received_events_[0].fault.status, Fault::STATUS_CLEARED);
+}
+
+/// Healing on, threshold 1: FAILED confirms (counter -1), the first PASSED lands on
+/// 0 (latched CONFIRMED), the second reaches 1 and heals.
+class HealingFaultEventPublishingTest : public FaultEventPublishingTest {
+ protected:
+  std::vector<rclcpp::Parameter> fault_manager_overrides() override {
+    return {
+        rclcpp::Parameter("storage_type", "memory"),
+        rclcpp::Parameter("confirmation_threshold", -1),
+        rclcpp::Parameter("healing_enabled", true),
+        rclcpp::Parameter("healing_threshold", 1),
+    };
+  }
+};
+
+TEST_F(HealingFaultEventPublishingTest, HealPublishesClearedEventSoStreamConsumersSeeTheEnd) {
+  ASSERT_TRUE(call_report_fault("HEAL_ME", Fault::SEVERITY_ERROR, "/test_node"));
+  ASSERT_TRUE(spin_until([this]() {
+    return received_events_.size() >= 1;
+  }));
+  received_events_.clear();
+
+  ASSERT_TRUE(call_report_passed("HEAL_ME", "/test_node"));
+  ASSERT_TRUE(call_report_passed("HEAL_ME", "/test_node"));
+
+  // The heal is the fault's end; without an event the SSE stream keeps every
+  // consumer showing a fault that is over.
+  auto find_end_event = [this]() -> const FaultEvent * {
+    for (const auto & event : received_events_) {
+      if (event.event_type == FaultEvent::EVENT_CLEARED) {
+        return &event;
+      }
+    }
+    return nullptr;
+  };
+
+  ASSERT_TRUE(spin_until([&]() {
+    return find_end_event() != nullptr;
+  })) << "no event published for the CONFIRMED -> HEALED transition";
+
+  const FaultEvent * event = find_end_event();
+  ASSERT_NE(event, nullptr);
+  EXPECT_EQ(event->fault.fault_code, "HEAL_ME");
+  EXPECT_EQ(event->fault.status, Fault::STATUS_HEALED);
 }
 
 TEST_F(FaultEventPublishingTest, ClearNonExistentFaultNoEvent) {

--- a/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_fault_manager.cpp
@@ -526,6 +526,8 @@ TEST_F(FaultStorageTest, PassedEventDoesNotAdvanceLastOccurred) {
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // healing disabled: latched, by design
   EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
+  // The PASSED instant is not lost: it rides on the wire as last_passed.
+  EXPECT_EQ(rclcpp::Time(fault->last_passed).nanoseconds(), passed_at.nanoseconds());
 }
 
 TEST_F(FaultStorageTest, HealingDisabledByDefault) {

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -14,6 +14,8 @@
 
 #include <gtest/gtest.h>
 
+#include <sqlite3.h>
+
 #include <cstdio>
 #include <filesystem>
 #include <memory>
@@ -208,6 +210,31 @@ TEST_F(SqliteFaultStorageTest, PassedEventDoesNotAdvanceLastOccurred) {
   auto fault = storage_->get_fault("FAULT_LO");
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // healing disabled: latched, by design
+  EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
+}
+
+TEST_F(SqliteFaultStorageTest, ReopenRepairsLastOccurredInflatedByOldPassedBug) {
+  // Databases written by releases that advanced last_occurred_ns on PASSED
+  // events hold inflated rows, and a latched CONFIRMED fault that never fails
+  // again would keep the wrong timestamp forever. Opening the storage must
+  // repair them from last_failed_ns.
+  const rclcpp::Time failed_at(1000, 0, RCL_SYSTEM_TIME);
+  storage_->report_fault_event("FAULT_MIG", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               failed_at, default_config());
+  storage_.reset();
+
+  // Simulate the old bug: a PASSED event at t=9000s re-dated the row.
+  sqlite3 * db = nullptr;
+  ASSERT_EQ(sqlite3_open(temp_db_path_.c_str(), &db), SQLITE_OK);
+  ASSERT_EQ(sqlite3_exec(db, "UPDATE faults SET last_occurred_ns = 9000000000000 WHERE fault_code = 'FAULT_MIG'",
+                         nullptr, nullptr, nullptr),
+            SQLITE_OK);
+  sqlite3_close(db);
+
+  storage_ = std::make_unique<SqliteFaultStorage>(temp_db_path_.string());
+
+  auto fault = storage_->get_fault("FAULT_MIG");
+  ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
 }
 

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -193,6 +193,24 @@ TEST_F(SqliteFaultStorageTest, ClearNonExistentFault) {
   EXPECT_FALSE(cleared);
 }
 
+TEST_F(SqliteFaultStorageTest, PassedEventDoesNotAdvanceLastOccurred) {
+  // Same contract as the in-memory backend: a PASSED event ends a fault, it does
+  // not re-date it. Guards against a stale CONFIRMED fault reading as freshly
+  // active in /faults and in the SSE payload.
+  const rclcpp::Time failed_at(1000, 0, RCL_SYSTEM_TIME);
+  const rclcpp::Time passed_at(9000, 0, RCL_SYSTEM_TIME);
+
+  storage_->report_fault_event("FAULT_LO", ReportFault::Request::EVENT_FAILED, Fault::SEVERITY_ERROR, "Test", "/node1",
+                               failed_at, default_config());
+  storage_->report_fault_event("FAULT_LO", ReportFault::Request::EVENT_PASSED, 0, "", "/node1", passed_at,
+                               default_config());
+
+  auto fault = storage_->get_fault("FAULT_LO");
+  ASSERT_TRUE(fault.has_value());
+  EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // healing disabled: latched, by design
+  EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
+}
+
 TEST_F(SqliteFaultStorageTest, GetClearedFaults) {
   rclcpp::Clock clock;
   auto timestamp = clock.now();

--- a/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_sqlite_storage.cpp
@@ -211,6 +211,8 @@ TEST_F(SqliteFaultStorageTest, PassedEventDoesNotAdvanceLastOccurred) {
   ASSERT_TRUE(fault.has_value());
   EXPECT_EQ(fault->status, Fault::STATUS_CONFIRMED);  // healing disabled: latched, by design
   EXPECT_EQ(rclcpp::Time(fault->last_occurred).nanoseconds(), failed_at.nanoseconds());
+  // The PASSED instant is not lost: it rides on the wire as last_passed.
+  EXPECT_EQ(rclcpp::Time(fault->last_passed).nanoseconds(), passed_at.nanoseconds());
 }
 
 TEST_F(SqliteFaultStorageTest, ReopenRepairsLastOccurredInflatedByOldPassedBug) {

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -793,8 +793,9 @@ Real-time fault event stream using Server-Sent Events (SSE). Clients receive ins
 - **Real-time notifications**: Events pushed instantly when fault state changes
 - **Automatic reconnection**: Supports `Last-Event-ID` header for seamless reconnection
 - **Keepalive**: Sends `:keepalive` comment every 30 seconds to prevent timeouts
-- **Event buffer**: Buffers up to 100 recent events for reconnecting clients. Under overflow the buffer drops entries every live client has already received, then entries superseded by a newer event for the same fault code, so a lagging client still converges on the current state of every fault
+- **Event buffer**: Buffers up to 100 recent events for reconnecting clients. Under overflow the buffer evicts entries every live client has already received, then `fault_updated` entries superseded by a newer event for the same fault code - a lagging client still converges on the current state of every fault and loses no status transition. Anything beyond that (a superseded transition, or an event with no newer sibling) is genuinely lost for lagging clients: those losses are counted and logged as drops, and an affected client should refetch `GET /api/v1/faults` to resynchronize
 - **Entity context (SOVD payload extension)**: When the gateway can resolve the fault's first reporting source back to an entity, the payload carries an `x-medkit` object with `entity_type` and `entity_id` fields so consumers can hit `/{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}` directly without enumerating entities
+- **Correlation payload**: when a root-cause event auto-clears correlated symptom faults, the payload carries their codes in `auto_cleared_codes` (omitted when empty); those symptoms get no event of their own
 
 **Event Types:**
 - `fault_confirmed` - Fault transitioned to CONFIRMED status
@@ -833,7 +834,7 @@ data: {"event_type":"fault_cleared","fault":{"fault_code":"MOTOR_OVERHEAT",...},
 curl -N -H "Last-Event-ID: 5" http://localhost:8080/api/v1/faults/stream
 ```
 
-This replays any buffered events with ID > 5, then continues streaming new events.
+This replays any buffered events with ID > 5, then continues streaming new events. Replayed `id` sequences may contain holes (e.g. 41, 43, 44) where buffer eviction removed superseded events; ids are monotonically increasing but never guaranteed contiguous. A `Last-Event-ID` beyond the newest issued id is treated as "caught up": the client receives only events published after it connected.
 
 #### GET /api/v1/components/{component_id}/faults
 

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -793,13 +793,13 @@ Real-time fault event stream using Server-Sent Events (SSE). Clients receive ins
 - **Real-time notifications**: Events pushed instantly when fault state changes
 - **Automatic reconnection**: Supports `Last-Event-ID` header for seamless reconnection
 - **Keepalive**: Sends `:keepalive` comment every 30 seconds to prevent timeouts
-- **Event buffer**: Buffers up to 100 recent events for reconnecting clients
+- **Event buffer**: Buffers up to 100 recent events for reconnecting clients. Under overflow the buffer drops entries every live client has already received, then entries superseded by a newer event for the same fault code, so a lagging client still converges on the current state of every fault
 - **Entity context (SOVD payload extension)**: When the gateway can resolve the fault's first reporting source back to an entity, the payload carries an `x-medkit` object with `entity_type` and `entity_id` fields so consumers can hit `/{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}` directly without enumerating entities
 
 **Event Types:**
 - `fault_confirmed` - Fault transitioned to CONFIRMED status
 - `fault_updated` - Fault data changed (occurrence_count, sources, etc.)
-- `fault_cleared` - Fault was cleared via ClearFault service
+- `fault_cleared` - Fault ended: cleared via ClearFault service, or auto-healed by PASSED events (check `fault.status` for `CLEARED` vs `HEALED`)
 
 **Example:**
 ```bash

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -42,7 +42,8 @@ namespace dto {
 //
 // Wire keys (exact, from fault_msg_conversions.cpp):
 //   fault_code, severity, description, first_occurred, last_occurred,
-//   occurrence_count, status, reporting_sources, severity_label
+//   last_passed (absent = never passed), occurrence_count, status,
+//   reporting_sources, severity_label
 // =============================================================================
 struct FaultListItem {
   std::string fault_code;
@@ -50,6 +51,7 @@ struct FaultListItem {
   std::optional<std::string> description;
   std::optional<double> first_occurred;
   std::optional<double> last_occurred;
+  std::optional<double> last_passed;
   std::optional<int64_t> occurrence_count;
   std::string status;
   std::optional<std::vector<std::string>> reporting_sources;
@@ -60,8 +62,9 @@ template <>
 inline constexpr auto dto_fields<FaultListItem> = std::make_tuple(
     field("fault_code", &FaultListItem::fault_code), field("severity", &FaultListItem::severity),
     field("description", &FaultListItem::description), field("first_occurred", &FaultListItem::first_occurred),
-    field("last_occurred", &FaultListItem::last_occurred), field("occurrence_count", &FaultListItem::occurrence_count),
-    field("status", &FaultListItem::status), field("reporting_sources", &FaultListItem::reporting_sources),
+    field("last_occurred", &FaultListItem::last_occurred), field("last_passed", &FaultListItem::last_passed),
+    field("occurrence_count", &FaultListItem::occurrence_count), field("status", &FaultListItem::status),
+    field("reporting_sources", &FaultListItem::reporting_sources),
     field_enum("severity_label", &FaultListItem::severity_label, kFaultSeverityLabelValues));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -82,7 +82,11 @@ class SSEFaultHandler {
   SSEFaultHandler(HandlerContext & ctx, std::shared_ptr<SSEClientTracker> client_tracker,
                   std::chrono::milliseconds keepalive_interval);
 
-  /// Destructor - cleanup subscription
+  /// Destructor. Signals shutdown, then blocks until every stream closure has
+  /// been destroyed: the per-stream unregister deleter locks queue_mutex_ and
+  /// touches clients_, so no closure may outlive the handler. The HTTP server
+  /// must already be stopping (request_shutdown() makes every loop return
+  /// false on its next wakeup) or destruction will wait for it.
   ~SSEFaultHandler();
 
   // Disable copy/move

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -53,15 +52,18 @@ namespace handlers {
  * Features:
  * - Multi-client support (multiple browsers can connect simultaneously)
  * - Keepalive every 30 seconds to prevent connection timeout
- * - Automatic reconnection support via Last-Event-ID header
- * - Replay buffer of up to 100 events. Eviction is state-convergent rather
- *   than plain FIFO: entries every live client has already been sent go
- *   first, then entries superseded by a newer event for the same fault code
- *   (a lagging client still converges on the correct current state of every
- *   fault). Only when neither applies is an event genuinely lost, and only
- *   that case is counted and logged as a drop.
- * - Clients that make no progress for 3 keepalive intervals are treated as
- *   dead, reaped, and excluded from the backpressure accounting.
+ * - Automatic reconnection support via Last-Event-ID header (values above the
+ *   newest issued id are clamped to it, so a bogus header cannot starve the
+ *   stream or alias the delivery accounting)
+ * - Replay buffer of up to 100 events. Eviction order under overflow:
+ *   1. entries every live client has already been sent (free),
+ *   2. fault_updated entries superseded by a newer event for the same fault
+ *      code (coalesced - a lagging client still converges on the correct
+ *      current state, and no status transition is erased),
+ *   3. transition entries (confirmed / cleared) superseded by a newer event
+ *      for the same code - the current state survives but the transition
+ *      history is lost, so this IS counted and logged as a drop,
+ *   4. the oldest entry, owed and not superseded - counted and logged too.
  */
 class SSEFaultHandler {
  public:
@@ -127,24 +129,21 @@ class SSEFaultHandler {
   size_t connected_clients() const;
 
   /**
-   * @brief Events genuinely lost: evicted while still owed to a live client and
-   * not superseded by a newer event for the same fault code.
+   * @brief Events genuinely lost: evicted while still owed to a live client,
+   * except fault_updated entries a newer same-code event supersedes. Includes
+   * superseded transitions - their history is gone even though the current
+   * state survives.
    *
    * Rotation of the replay buffer with no client attached is NOT a drop.
    */
   std::size_t dropped_events() const;
 
   /**
-   * @brief Events evicted because a newer event for the same fault code was
-   * already buffered. Lagging clients still converge on the correct state.
+   * @brief fault_updated events evicted because a newer event for the same
+   * fault code was already buffered. Lagging clients still converge on the
+   * correct state and lose no transition, so this is not a loss.
    */
   std::size_t coalesced_events() const;
-
-  /**
-   * @brief Clients declared dead (no delivery progress for 3 keepalive
-   * intervals) and reaped while making room in the replay buffer.
-   */
-  std::size_t reaped_clients() const;
 
   /**
    * @brief Total number of fault events received and processed so far.
@@ -200,34 +199,28 @@ class SSEFaultHandler {
   /// is no longer reported as client backpressure.
   struct ClientCursor {
     uint64_t last_delivered{0};
-    std::chrono::steady_clock::time_point last_progress{};
-    bool stalled{false};
   };
 
   /// Outcome of one eviction pass, reported outside the queue lock.
   struct EvictionStats {
     std::size_t dropped{0};
     std::size_t coalesced{0};
-    std::size_t reaped{0};
     std::size_t slow_clients{0};
   };
 
   /// Trim the buffer back to kMaxBufferedEvents. Caller holds queue_mutex_.
   EvictionStats evict_to_capacity_locked();
 
-  /// Highest event id already delivered to every live client; kNothingOwed when
-  /// no live client is attached. Caller holds queue_mutex_.
-  uint64_t delivered_watermark_locked() const;
+  /// Highest event id already delivered to every live client; empty when no
+  /// live client is attached. Caller holds queue_mutex_.
+  std::optional<uint64_t> delivered_watermark_locked() const;
 
-  /// Oldest buffered entry whose fault code appears again later in the buffer,
-  /// i.e. one whose state a later entry already supersedes. Entries carrying
-  /// auto_cleared_codes are never chosen: that correlation payload exists
-  /// nowhere else. Caller holds queue_mutex_.
-  std::deque<QueuedEvent>::iterator find_superseded_locked();
-
-  /// Mark cursors with no delivery progress for kStallIntervals keepalives as
-  /// dead so their stream loop exits. Caller holds queue_mutex_.
-  std::size_t reap_stalled_clients_locked(std::chrono::steady_clock::time_point now);
+  /// Oldest buffered entry whose state a later same-code entry supersedes.
+  /// With `updates_only` set, only fault_updated entries qualify (erasing them
+  /// cannot erase a status transition). Entries carrying auto_cleared_codes
+  /// are never chosen: that correlation payload exists nowhere else. Caller
+  /// holds queue_mutex_.
+  std::deque<QueuedEvent>::iterator find_superseded_locked(bool updates_only);
 
   /// Record a successful write for this client. Caller holds queue_mutex_.
   void note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id);
@@ -264,18 +257,16 @@ class SSEFaultHandler {
   /// Live delivery cursors, one per streaming connection. Guarded by queue_mutex_.
   std::vector<std::shared_ptr<ClientCursor>> clients_;
 
-  /// Total events genuinely lost (owed to a live client, nothing newer for the
-  /// same fault code). Surfaced via WARN logs at a fixed cadence
-  /// (kDropLogEveryN) so operators notice client lag without flooding the
-  /// logger.
+  /// Total events genuinely lost while owed to a live client (superseded
+  /// transitions included). Surfaced via WARN logs on the first loss and then
+  /// at a fixed cadence (kDropLogEveryN) so operators notice client lag
+  /// without flooding the logger.
   std::atomic<std::size_t> dropped_events_{0};
 
-  /// Total events evicted because a newer event for the same fault code was
-  /// buffered. Not a loss: the client still converges on the right state.
+  /// Total fault_updated events evicted because a newer event for the same
+  /// fault code was buffered. Not a loss: the client still converges on the
+  /// right state and no transition is erased.
   std::atomic<std::size_t> coalesced_events_{0};
-
-  /// Total clients reaped as dead while making room in the buffer.
-  std::atomic<std::size_t> reaped_clients_{0};
 
   /// Keepalive interval used by the streaming loop
   std::chrono::milliseconds keepalive_interval_;
@@ -289,13 +280,6 @@ class SSEFaultHandler {
 
   /// Keepalive interval in seconds
   static constexpr int kKeepaliveIntervalSec = 30;
-
-  /// A client that has not completed a write (event or keepalive) for this many
-  /// keepalive intervals is dead, not slow.
-  static constexpr int kStallIntervals = 3;
-
-  /// Watermark meaning "no live client is owed anything in the buffer".
-  static constexpr uint64_t kNothingOwed = std::numeric_limits<uint64_t>::max();
 };
 
 }  // namespace handlers

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -222,6 +222,10 @@ class SSEFaultHandler {
   /// holds queue_mutex_.
   std::deque<QueuedEvent>::iterator find_superseded_locked(bool updates_only);
 
+  /// True when the buffer holds an event newer than last_event_id. Caller
+  /// holds queue_mutex_.
+  bool has_pending_locked(uint64_t last_event_id) const;
+
   /// Record a successful write for this client. Caller holds queue_mutex_.
   void note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id);
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -20,10 +20,12 @@
 #include <cstdint>
 #include <deque>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -45,16 +47,21 @@ namespace handlers {
  *
  * Events streamed:
  * - fault_confirmed: When a fault transitions to CONFIRMED status
- * - fault_cleared: When a fault is manually cleared
+ * - fault_cleared: When a fault ends (acknowledged clear, or auto-heal)
  * - fault_updated: When fault data changes (occurrence_count, sources)
  *
  * Features:
  * - Multi-client support (multiple browsers can connect simultaneously)
  * - Keepalive every 30 seconds to prevent connection timeout
  * - Automatic reconnection support via Last-Event-ID header
- * - Replay buffer of up to 100 most recent events for reconnecting clients;
- *   when the buffer is full, older events are discarded (FIFO), so clients
- *   that are disconnected for long periods may miss some events
+ * - Replay buffer of up to 100 events. Eviction is state-convergent rather
+ *   than plain FIFO: entries every live client has already been sent go
+ *   first, then entries superseded by a newer event for the same fault code
+ *   (a lagging client still converges on the correct current state of every
+ *   fault). Only when neither applies is an event genuinely lost, and only
+ *   that case is counted and logged as a drop.
+ * - Clients that make no progress for 3 keepalive intervals are treated as
+ *   dead, reaped, and excluded from the backpressure accounting.
  */
 class SSEFaultHandler {
  public:
@@ -120,6 +127,26 @@ class SSEFaultHandler {
   size_t connected_clients() const;
 
   /**
+   * @brief Events genuinely lost: evicted while still owed to a live client and
+   * not superseded by a newer event for the same fault code.
+   *
+   * Rotation of the replay buffer with no client attached is NOT a drop.
+   */
+  std::size_t dropped_events() const;
+
+  /**
+   * @brief Events evicted because a newer event for the same fault code was
+   * already buffered. Lagging clients still converge on the correct state.
+   */
+  std::size_t coalesced_events() const;
+
+  /**
+   * @brief Clients declared dead (no delivery progress for 3 keepalive
+   * intervals) and reaped while making room in the replay buffer.
+   */
+  std::size_t reaped_clients() const;
+
+  /**
    * @brief Total number of fault events received and processed so far.
    *
    * Monotonically increasing (it never resets, even when the replay buffer
@@ -168,6 +195,43 @@ class SSEFaultHandler {
     std::optional<EntityContext> entity;
   };
 
+  /// Per-connection delivery cursor. Lets the buffer tell "nobody is owed this
+  /// event" from "a live client has not read it yet", so ring-buffer rotation
+  /// is no longer reported as client backpressure.
+  struct ClientCursor {
+    uint64_t last_delivered{0};
+    std::chrono::steady_clock::time_point last_progress{};
+    bool stalled{false};
+  };
+
+  /// Outcome of one eviction pass, reported outside the queue lock.
+  struct EvictionStats {
+    std::size_t dropped{0};
+    std::size_t coalesced{0};
+    std::size_t reaped{0};
+    std::size_t slow_clients{0};
+  };
+
+  /// Trim the buffer back to kMaxBufferedEvents. Caller holds queue_mutex_.
+  EvictionStats evict_to_capacity_locked();
+
+  /// Highest event id already delivered to every live client; kNothingOwed when
+  /// no live client is attached. Caller holds queue_mutex_.
+  uint64_t delivered_watermark_locked() const;
+
+  /// Oldest buffered entry whose fault code appears again later in the buffer,
+  /// i.e. one whose state a later entry already supersedes. Entries carrying
+  /// auto_cleared_codes are never chosen: that correlation payload exists
+  /// nowhere else. Caller holds queue_mutex_.
+  std::deque<QueuedEvent>::iterator find_superseded_locked();
+
+  /// Mark cursors with no delivery progress for kStallIntervals keepalives as
+  /// dead so their stream loop exits. Caller holds queue_mutex_.
+  std::size_t reap_stalled_clients_locked(std::chrono::steady_clock::time_point now);
+
+  /// Record a successful write for this client. Caller holds queue_mutex_.
+  void note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id);
+
   /// Format a fault event as SSE message
   static std::string format_sse_event(const QueuedEvent & queued);
 
@@ -197,11 +261,21 @@ class SSEFaultHandler {
   /// Shutdown flag for clean termination
   std::atomic<bool> shutdown_flag_{false};
 
-  /// Total number of buffered fault events dropped because the buffer was at
-  /// kMaxBufferedEvents and a new event arrived. Surfaced via WARN logs at a
-  /// fixed cadence (kDropLogEveryN) so operators notice client lag without
-  /// flooding the logger.
+  /// Live delivery cursors, one per streaming connection. Guarded by queue_mutex_.
+  std::vector<std::shared_ptr<ClientCursor>> clients_;
+
+  /// Total events genuinely lost (owed to a live client, nothing newer for the
+  /// same fault code). Surfaced via WARN logs at a fixed cadence
+  /// (kDropLogEveryN) so operators notice client lag without flooding the
+  /// logger.
   std::atomic<std::size_t> dropped_events_{0};
+
+  /// Total events evicted because a newer event for the same fault code was
+  /// buffered. Not a loss: the client still converges on the right state.
+  std::atomic<std::size_t> coalesced_events_{0};
+
+  /// Total clients reaped as dead while making room in the buffer.
+  std::atomic<std::size_t> reaped_clients_{0};
 
   /// Keepalive interval used by the streaming loop
   std::chrono::milliseconds keepalive_interval_;
@@ -215,6 +289,13 @@ class SSEFaultHandler {
 
   /// Keepalive interval in seconds
   static constexpr int kKeepaliveIntervalSec = 30;
+
+  /// A client that has not completed a write (event or keepalive) for this many
+  /// keepalive intervals is dead, not slow.
+  static constexpr int kStallIntervals = 3;
+
+  /// Watermark meaning "no live client is owed anything in the buffer".
+  static constexpr uint64_t kNothingOwed = std::numeric_limits<uint64_t>::max();
 };
 
 }  // namespace handlers

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -92,46 +92,34 @@ void SSEFaultHandler::request_shutdown() {
   queue_cv_.notify_all();
 }
 
-uint64_t SSEFaultHandler::delivered_watermark_locked() const {
-  uint64_t watermark = kNothingOwed;
+std::optional<uint64_t> SSEFaultHandler::delivered_watermark_locked() const {
+  std::optional<uint64_t> watermark;
   for (const auto & cursor : clients_) {
-    if (cursor->stalled) {
-      continue;  // dead client: its backlog is not backpressure
-    }
-    watermark = std::min(watermark, cursor->last_delivered);
+    watermark = watermark ? std::min(*watermark, cursor->last_delivered) : cursor->last_delivered;
   }
   return watermark;
 }
 
-std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superseded_locked() {
+std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superseded_locked(bool updates_only) {
   std::unordered_map<std::string, std::size_t> newest_index;
   for (std::size_t i = 0; i < event_queue_.size(); ++i) {
     newest_index[event_queue_[i].event.fault.fault_code] = i;
   }
   for (std::size_t i = 0; i < event_queue_.size(); ++i) {
+    const auto & entry = event_queue_[i].event;
     // An auto-clear cascade lists its symptoms only here; those codes get no
     // event of their own, so this entry is never redundant.
-    if (!event_queue_[i].event.auto_cleared_codes.empty()) {
+    if (!entry.auto_cleared_codes.empty()) {
       continue;
     }
-    if (newest_index[event_queue_[i].event.fault.fault_code] != i) {
+    if (updates_only && entry.event_type != ros2_medkit_msgs::msg::FaultEvent::EVENT_UPDATED) {
+      continue;
+    }
+    if (newest_index[entry.fault.fault_code] != i) {
       return event_queue_.begin() + static_cast<std::ptrdiff_t>(i);
     }
   }
   return event_queue_.end();
-}
-
-std::size_t SSEFaultHandler::reap_stalled_clients_locked(std::chrono::steady_clock::time_point now) {
-  const auto stall_timeout = keepalive_interval_ * kStallIntervals;
-  std::size_t reaped = 0;
-  for (const auto & cursor : clients_) {
-    if (cursor->stalled || (now - cursor->last_progress) <= stall_timeout) {
-      continue;
-    }
-    cursor->stalled = true;  // the stream loop returns false on its next wakeup
-    ++reaped;
-  }
-  return reaped;
 }
 
 SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
@@ -140,28 +128,37 @@ SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
     return stats;
   }
 
-  stats.reaped = reap_stalled_clients_locked(std::chrono::steady_clock::now());
-  const uint64_t watermark = delivered_watermark_locked();
+  const auto watermark = delivered_watermark_locked();
+  uint64_t newest_lost = 0;
 
   while (event_queue_.size() > kMaxBufferedEvents) {
-    if (event_queue_.front().id <= watermark) {
-      event_queue_.pop_front();  // every live client already has it
+    if (!watermark || event_queue_.front().id <= *watermark) {
+      event_queue_.pop_front();  // nobody attached, or every live client already has it
       continue;
     }
-    auto superseded = find_superseded_locked();
+    auto superseded = find_superseded_locked(/*updates_only=*/true);
     if (superseded != event_queue_.end()) {
-      event_queue_.erase(superseded);  // newer state for that fault code survives
+      event_queue_.erase(superseded);  // newer state survives, no transition erased
       ++stats.coalesced;
       continue;
     }
-    event_queue_.pop_front();  // distinct fault codes only: this one is lost
+    // Something a live client is owed has to go. Prefer an entry a newer
+    // same-code event supersedes: the current state still reaches the client
+    // even though the transition history does not. Either way it is a real,
+    // counted loss.
+    auto victim = find_superseded_locked(/*updates_only=*/false);
+    if (victim == event_queue_.end()) {
+      victim = event_queue_.begin();
+    }
+    newest_lost = std::max(newest_lost, victim->id);
+    event_queue_.erase(victim);
     ++stats.dropped;
   }
 
   if (stats.dropped > 0) {
     for (const auto & cursor : clients_) {
-      if (!cursor->stalled && cursor->last_delivered < event_queue_.back().id) {
-        ++stats.slow_clients;
+      if (cursor->last_delivered < newest_lost) {
+        ++stats.slow_clients;  // this client was owed at least one lost event
       }
     }
   }
@@ -185,13 +182,6 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
     stats = evict_to_capacity_locked();
   }
 
-  if (stats.reaped > 0) {
-    reaped_clients_.fetch_add(stats.reaped);
-    RCLCPP_WARN(HandlerContext::logger(),
-                "SSE fault stream: %zu client(s) made no progress for %" PRId64
-                "ms; treating them as disconnected and reaping",
-                stats.reaped, (keepalive_interval_ * kStallIntervals).count());
-  }
   if (stats.coalesced > 0) {
     coalesced_events_.fetch_add(stats.coalesced);
   }
@@ -205,8 +195,8 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
     if (previous == 0 || (total / kDropLogEveryN) > (previous / kDropLogEveryN)) {
       RCLCPP_WARN(HandlerContext::logger(),
                   "SSE fault event lost: %zu event(s) dropped total for %zu slow client(s) "
-                  "(buffer cap=%zu, %zu coalesced so far, %zu client(s) reaped as dead)",
-                  total, stats.slow_clients, kMaxBufferedEvents, coalesced_events_.load(), reaped_clients_.load());
+                  "(buffer cap=%zu, %zu coalesced so far)",
+                  total, stats.slow_clients, kMaxBufferedEvents, coalesced_events_.load());
     }
   }
 
@@ -220,15 +210,16 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
 namespace {
 
 /// Parse the Last-Event-ID header; absent / malformed values map to 0 so the
-/// client receives every buffered event on connect.
+/// client receives every buffered event on connect. Digits only: std::stoull
+/// alone would accept "-1" and wrap it to UINT64_MAX.
 uint64_t parse_last_event_id(std::string_view value) {
-  if (value.empty()) {
+  if (value.empty() || value.find_first_not_of("0123456789") != std::string_view::npos) {
     return 0;
   }
   try {
     return std::stoull(std::string(value));
   } catch (...) {
-    return 0;
+    return 0;  // out of range
   }
 }
 
@@ -236,13 +227,18 @@ uint64_t parse_last_event_id(std::string_view value) {
 
 void SSEFaultHandler::note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id) {
   cursor->last_delivered = std::max(cursor->last_delivered, delivered_id);
-  cursor->last_progress = std::chrono::steady_clock::now();
 }
 
 std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint64_t initial_last_event_id) {
+  // Clamp to the newest id issued so far: a Last-Event-ID above it (any bogus
+  // value, e.g. "18446744073709551615") would otherwise leave collect_pending
+  // permanently empty (blind stream, no keepalives under steady traffic) and
+  // seed the delivery watermark with an id nobody was ever sent, evicting the
+  // whole buffer as "already delivered".
+  initial_last_event_id = std::min(initial_last_event_id, next_event_id_.load() - 1);
+
   auto cursor = std::make_shared<ClientCursor>();
   cursor->last_delivered = initial_last_event_id;
-  cursor->last_progress = std::chrono::steady_clock::now();
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
     clients_.push_back(cursor);
@@ -310,9 +306,6 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
 
         if (shutdown_flag_.load()) {
           return false;  // Handler is shutting down
-        }
-        if (cursor->stalled) {
-          return false;  // Reaped as dead while the buffer was under pressure
         }
 
         pending = collect_pending();
@@ -437,10 +430,6 @@ std::size_t SSEFaultHandler::dropped_events() const {
 
 std::size_t SSEFaultHandler::coalesced_events() const {
   return coalesced_events_.load();
-}
-
-std::size_t SSEFaultHandler::reaped_clients() const {
-  return reaped_clients_.load();
 }
 
 uint64_t SSEFaultHandler::events_received() const {

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -466,6 +466,13 @@ std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) {
       static_cast<double>(queued.event.timestamp.sec) + static_cast<double>(queued.event.timestamp.nanosec) * 1e-9;
   json_event["timestamp"] = timestamp_sec;
 
+  // Correlation payload: symptom codes auto-cleared with this event's root
+  // cause. These codes get no event of their own, so this is the only place
+  // a stream consumer learns about the cascade. Omitted when empty.
+  if (!queued.event.auto_cleared_codes.empty()) {
+    json_event["auto_cleared_codes"] = queued.event.auto_cleared_codes;
+  }
+
   // SOVD payload extension: nest ``entity_type`` / ``entity_id`` under the
   // ``x-medkit`` response-extension object so global-stream consumers can
   // hit ``/{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}``

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -21,8 +21,11 @@
 #include <functional>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <string_view>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/models/error_info.hpp"
@@ -89,6 +92,82 @@ void SSEFaultHandler::request_shutdown() {
   queue_cv_.notify_all();
 }
 
+uint64_t SSEFaultHandler::delivered_watermark_locked() const {
+  uint64_t watermark = kNothingOwed;
+  for (const auto & cursor : clients_) {
+    if (cursor->stalled) {
+      continue;  // dead client: its backlog is not backpressure
+    }
+    watermark = std::min(watermark, cursor->last_delivered);
+  }
+  return watermark;
+}
+
+std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superseded_locked() {
+  std::unordered_map<std::string, std::size_t> newest_index;
+  for (std::size_t i = 0; i < event_queue_.size(); ++i) {
+    newest_index[event_queue_[i].event.fault.fault_code] = i;
+  }
+  for (std::size_t i = 0; i < event_queue_.size(); ++i) {
+    // An auto-clear cascade lists its symptoms only here; those codes get no
+    // event of their own, so this entry is never redundant.
+    if (!event_queue_[i].event.auto_cleared_codes.empty()) {
+      continue;
+    }
+    if (newest_index[event_queue_[i].event.fault.fault_code] != i) {
+      return event_queue_.begin() + static_cast<std::ptrdiff_t>(i);
+    }
+  }
+  return event_queue_.end();
+}
+
+std::size_t SSEFaultHandler::reap_stalled_clients_locked(std::chrono::steady_clock::time_point now) {
+  const auto stall_timeout = keepalive_interval_ * kStallIntervals;
+  std::size_t reaped = 0;
+  for (const auto & cursor : clients_) {
+    if (cursor->stalled || (now - cursor->last_progress) <= stall_timeout) {
+      continue;
+    }
+    cursor->stalled = true;  // the stream loop returns false on its next wakeup
+    ++reaped;
+  }
+  return reaped;
+}
+
+SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
+  EvictionStats stats;
+  if (event_queue_.size() <= kMaxBufferedEvents) {
+    return stats;
+  }
+
+  stats.reaped = reap_stalled_clients_locked(std::chrono::steady_clock::now());
+  const uint64_t watermark = delivered_watermark_locked();
+
+  while (event_queue_.size() > kMaxBufferedEvents) {
+    if (event_queue_.front().id <= watermark) {
+      event_queue_.pop_front();  // every live client already has it
+      continue;
+    }
+    auto superseded = find_superseded_locked();
+    if (superseded != event_queue_.end()) {
+      event_queue_.erase(superseded);  // newer state for that fault code survives
+      ++stats.coalesced;
+      continue;
+    }
+    event_queue_.pop_front();  // distinct fault codes only: this one is lost
+    ++stats.dropped;
+  }
+
+  if (stats.dropped > 0) {
+    for (const auto & cursor : clients_) {
+      if (!cursor->stalled && cursor->last_delivered < event_queue_.back().id) {
+        ++stats.slow_clients;
+      }
+    }
+  }
+  return stats;
+}
+
 void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr & msg) {
   uint64_t event_id = next_event_id_.fetch_add(1);
 
@@ -97,30 +176,36 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
   // lock-free with respect to the cache.
   auto entity = resolve_entity_context(msg->fault);
 
-  std::size_t dropped_this_call = 0;
+  EvictionStats stats;
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
     // Add event to queue with resolved entity context
     event_queue_.push_back(QueuedEvent{event_id, *msg, std::move(entity)});
-
-    // Trim old events if buffer is full
-    while (event_queue_.size() > kMaxBufferedEvents) {
-      event_queue_.pop_front();
-      ++dropped_this_call;
-    }
+    stats = evict_to_capacity_locked();
   }
 
-  // Surface SSE backpressure without spamming the log: every kDropLogEveryN
-  // drops emit one WARN with the running total. dropped_events_ remains
-  // queryable for tests / future metrics endpoints.
-  if (dropped_this_call > 0) {
-    const auto total = dropped_events_.fetch_add(dropped_this_call) + dropped_this_call;
-    if ((total / kDropLogEveryN) > ((total - dropped_this_call) / kDropLogEveryN)) {
+  if (stats.reaped > 0) {
+    reaped_clients_.fetch_add(stats.reaped);
+    RCLCPP_WARN(HandlerContext::logger(),
+                "SSE fault stream: %zu client(s) made no progress for %" PRId64
+                "ms; treating them as disconnected and reaping",
+                stats.reaped, (keepalive_interval_ * kStallIntervals).count());
+  }
+  if (stats.coalesced > 0) {
+    coalesced_events_.fetch_add(stats.coalesced);
+  }
+
+  // Surface real SSE backpressure without spamming the log: every kDropLogEveryN
+  // losses emit one WARN with the running total. Buffer rotation with no client
+  // waiting on the evicted event is not counted at all.
+  if (stats.dropped > 0) {
+    const auto total = dropped_events_.fetch_add(stats.dropped) + stats.dropped;
+    if ((total / kDropLogEveryN) > ((total - stats.dropped) / kDropLogEveryN)) {
       RCLCPP_WARN(HandlerContext::logger(),
-                  "SSE fault event buffer overflow: %zu events dropped total "
-                  "(buffer cap=%zu, slow or disconnected clients)",
-                  total, kMaxBufferedEvents);
+                  "SSE fault event lost: %zu event(s) dropped total for %zu slow client(s) "
+                  "(buffer cap=%zu, %zu coalesced so far, %zu client(s) reaped as dead)",
+                  total, stats.slow_clients, kMaxBufferedEvents, coalesced_events_.load(), reaped_clients_.load());
     }
   }
 
@@ -148,69 +233,108 @@ uint64_t parse_last_event_id(std::string_view value) {
 
 }  // namespace
 
+void SSEFaultHandler::note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id) {
+  cursor->last_delivered = std::max(cursor->last_delivered, delivered_id);
+  cursor->last_progress = std::chrono::steady_clock::now();
+}
+
 std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint64_t initial_last_event_id) {
-  return [this, last_event_id = initial_last_event_id](httplib::DataSink & sink) mutable -> bool {
-    // First, send any buffered events the client missed (for reconnection)
-    {
-      std::lock_guard<std::mutex> lock(queue_mutex_);
+  auto cursor = std::make_shared<ClientCursor>();
+  cursor->last_delivered = initial_last_event_id;
+  cursor->last_progress = std::chrono::steady_clock::now();
+  {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    clients_.push_back(cursor);
+  }
+
+  // Deregisters when the content provider (and with it this closure) is
+  // destroyed, which is the only point at which the connection is certainly
+  // gone for both the typed and the legacy entry.
+  auto unregister = std::shared_ptr<void>(nullptr, [this, cursor](void *) {
+    std::lock_guard<std::mutex> lock(queue_mutex_);
+    clients_.erase(std::remove(clients_.begin(), clients_.end(), cursor), clients_.end());
+  });
+
+  return [this, cursor, unregister, last_event_id = initial_last_event_id](httplib::DataSink & sink) mutable -> bool {
+    // Formatting happens under the lock, writing does not: the buffer now
+    // erases from the middle to coalesce, so holding an iterator across a
+    // write would be a use-after-free.
+    auto collect_pending = [this, &last_event_id]() {
+      std::vector<std::pair<uint64_t, std::string>> pending;
       for (const auto & queued : event_queue_) {
         if (queued.id > last_event_id) {
-          std::string sse_msg = format_sse_event(queued);
-          if (!sink.write(sse_msg.data(), sse_msg.size())) {
-            return false;  // Client disconnected
-          }
-          last_event_id = queued.id;
+          pending.emplace_back(queued.id, format_sse_event(queued));
         }
+      }
+      return pending;
+    };
+
+    auto flush = [this, &sink, &cursor, &last_event_id](const std::vector<std::pair<uint64_t, std::string>> & pending) {
+      for (const auto & [id, sse_msg] : pending) {
+        if (!sink.write(sse_msg.data(), sse_msg.size())) {
+          return false;  // Client disconnected
+        }
+        last_event_id = id;
+      }
+      std::lock_guard<std::mutex> lock(queue_mutex_);
+      note_progress_locked(cursor, last_event_id);
+      return true;
+    };
+
+    // First, send any buffered events the client missed (for reconnection)
+    {
+      std::vector<std::pair<uint64_t, std::string>> pending;
+      {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        pending = collect_pending();
+      }
+      if (!pending.empty() && !flush(pending)) {
+        return false;
       }
     }
 
     // Wait for new events or keepalive timeout
-    auto timeout = keepalive_interval_;
-    std::unique_lock<std::mutex> lock(queue_mutex_);
+    const auto timeout = keepalive_interval_;
 
     while (true) {
-      // Check for shutdown
-      if (shutdown_flag_.load()) {
-        return false;  // Handler is shutting down
+      std::vector<std::pair<uint64_t, std::string>> pending;
+      bool keepalive_due = false;
+      {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (shutdown_flag_.load()) {
+          return false;  // Handler is shutting down
+        }
+
+        const auto status = queue_cv_.wait_for(lock, timeout);
+
+        if (shutdown_flag_.load()) {
+          return false;  // Handler is shutting down
+        }
+        if (cursor->stalled) {
+          return false;  // Reaped as dead while the buffer was under pressure
+        }
+
+        pending = collect_pending();
+        keepalive_due = pending.empty() && status == std::cv_status::timeout;
       }
 
-      // Wait for new event or timeout
-      auto status = queue_cv_.wait_for(lock, timeout);
-
-      // Check for shutdown after wakeup
-      if (shutdown_flag_.load()) {
-        return false;  // Handler is shutting down
-      }
-
-      if (status == std::cv_status::timeout) {
-        // Send keepalive comment
+      if (keepalive_due) {
         const char * keepalive = ":keepalive\n\n";
-        lock.unlock();
         if (!sink.write(keepalive, strlen(keepalive))) {
           return false;  // Client disconnected
         }
-        lock.lock();
+        // A completed keepalive write is proof the connection is alive even
+        // when there is nothing to deliver.
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        note_progress_locked(cursor, last_event_id);
         continue;
       }
 
-      // Check for new events
-      bool found_new = false;
-      for (const auto & queued : event_queue_) {
-        if (queued.id > last_event_id) {
-          std::string sse_msg = format_sse_event(queued);
-          lock.unlock();
-          if (!sink.write(sse_msg.data(), sse_msg.size())) {
-            return false;  // Client disconnected
-          }
-          lock.lock();
-          last_event_id = queued.id;
-          found_new = true;
-        }
+      if (pending.empty()) {
+        continue;  // Spurious wakeup
       }
-
-      if (!found_new) {
-        // Spurious wakeup, continue waiting
-        continue;
+      if (!flush(pending)) {
+        return false;
       }
     }
 
@@ -304,6 +428,18 @@ void SSEFaultHandler::handle_stream(const httplib::Request & req, httplib::Respo
 
 size_t SSEFaultHandler::connected_clients() const {
   return client_tracker_->connected_clients();
+}
+
+std::size_t SSEFaultHandler::dropped_events() const {
+  return dropped_events_.load();
+}
+
+std::size_t SSEFaultHandler::coalesced_events() const {
+  return coalesced_events_.load();
+}
+
+std::size_t SSEFaultHandler::reaped_clients() const {
+  return reaped_clients_.load();
 }
 
 uint64_t SSEFaultHandler::events_received() const {

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -82,6 +82,15 @@ SSEFaultHandler::~SSEFaultHandler() {
   // Signal shutdown and wake up any waiting clients
   request_shutdown();
   subscription_.reset();
+
+  // The per-stream unregister deleter dereferences this handler (it locks
+  // queue_mutex_ and erases from clients_) and runs whenever the framework
+  // destroys the content provider. Hold destruction until every closure is
+  // gone so that deleter can never run on a dead handler.
+  std::unique_lock<std::mutex> lock(queue_mutex_);
+  queue_cv_.wait(lock, [this] {
+    return clients_.empty();
+  });
 }
 
 void SSEFaultHandler::request_shutdown() {
@@ -254,6 +263,7 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
   auto unregister = std::shared_ptr<void>(nullptr, [this, cursor](void *) {
     std::lock_guard<std::mutex> lock(queue_mutex_);
     clients_.erase(std::remove(clients_.begin(), clients_.end(), cursor), clients_.end());
+    queue_cv_.notify_all();  // ~SSEFaultHandler may be waiting for the last closure
   });
 
   return [this, cursor, unregister, last_event_id = initial_last_event_id](httplib::DataSink & sink) mutable -> bool {

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -196,12 +196,13 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
     coalesced_events_.fetch_add(stats.coalesced);
   }
 
-  // Surface real SSE backpressure without spamming the log: every kDropLogEveryN
-  // losses emit one WARN with the running total. Buffer rotation with no client
-  // waiting on the evicted event is not counted at all.
+  // Surface real SSE backpressure without spamming the log: the first loss, then
+  // one WARN per kDropLogEveryN. Buffer rotation with no client waiting on the
+  // evicted event is not counted at all.
   if (stats.dropped > 0) {
-    const auto total = dropped_events_.fetch_add(stats.dropped) + stats.dropped;
-    if ((total / kDropLogEveryN) > ((total - stats.dropped) / kDropLogEveryN)) {
+    const auto previous = dropped_events_.fetch_add(stats.dropped);
+    const auto total = previous + stats.dropped;
+    if (previous == 0 || (total / kDropLogEveryN) > (previous / kDropLogEveryN)) {
       RCLCPP_WARN(HandlerContext::logger(),
                   "SSE fault event lost: %zu event(s) dropped total for %zu slow client(s) "
                   "(buffer cap=%zu, %zu coalesced so far, %zu client(s) reaped as dead)",

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -122,6 +122,10 @@ std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superse
   return event_queue_.end();
 }
 
+bool SSEFaultHandler::has_pending_locked(uint64_t last_event_id) const {
+  return !event_queue_.empty() && event_queue_.back().id > last_event_id;
+}
+
 SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
   EvictionStats stats;
   if (event_queue_.size() <= kMaxBufferedEvents) {
@@ -298,18 +302,20 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
       bool keepalive_due = false;
       {
         std::unique_lock<std::mutex> lock(queue_mutex_);
-        if (shutdown_flag_.load()) {
-          return false;  // Handler is shutting down
-        }
 
-        const auto status = queue_cv_.wait_for(lock, timeout);
+        // Predicate form: an event enqueued between the last flush and this
+        // wait already spent its notify_all while nobody was waiting; a plain
+        // wait_for would sleep the full keepalive interval on top of it.
+        const bool woke = queue_cv_.wait_for(lock, timeout, [this, &last_event_id] {
+          return shutdown_flag_.load() || has_pending_locked(last_event_id);
+        });
 
         if (shutdown_flag_.load()) {
           return false;  // Handler is shutting down
         }
 
         pending = collect_pending();
-        keepalive_due = pending.empty() && status == std::cv_status::timeout;
+        keepalive_due = !woke && pending.empty();
       }
 
       if (keepalive_due) {

--- a/src/ros2_medkit_gateway/src/ros2/conversions/fault_msg_conversions.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/conversions/fault_msg_conversions.cpp
@@ -35,6 +35,10 @@ nlohmann::json fault_to_json(const ros2_medkit_msgs::msg::Fault & fault) {
   j["description"] = fault.description;
   j["first_occurred"] = to_seconds(fault.first_occurred);
   j["last_occurred"] = to_seconds(fault.last_occurred);
+  // Omitted while zero: the fault never reported a PASSED event.
+  if (fault.last_passed.sec != 0 || fault.last_passed.nanosec != 0u) {
+    j["last_passed"] = to_seconds(fault.last_passed);
+  }
   j["occurrence_count"] = fault.occurrence_count;
   j["status"] = fault.status;
   j["reporting_sources"] = fault.reporting_sources;

--- a/src/ros2_medkit_gateway/src/trigger_fault_subscriber.cpp
+++ b/src/ros2_medkit_gateway/src/trigger_fault_subscriber.cpp
@@ -64,7 +64,10 @@ void TriggerFaultSubscriber::on_fault_event(const ros2_medkit_msgs::msg::FaultEv
     }
   }
 
-  // Map event_type to ChangeType
+  // Map event_type to ChangeType. fault_cleared covers the manual clear AND
+  // the auto-heal; both remove the fault from the active set, so both are
+  // DELETED. Consumers needing the distinction read the payload's "status"
+  // (CLEARED vs HEALED) - change_type itself has no reader today.
   ChangeType change_type = ChangeType::UPDATED;
   if (msg->event_type == "fault_confirmed") {
     change_type = ChangeType::CREATED;

--- a/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
@@ -617,6 +617,7 @@ TEST(FaultListItemSchema, FaultToJsonConformsAndRoundTrips) {
   fault.occurrence_count = 3;
   fault.status = "active";
   fault.reporting_sources = {"brake_ecu", "abs_node"};
+  fault.last_passed.sec = 1200;  // absent-when-zero covered separately below
 
   const json wire = conversions::fault_to_json(fault);
 
@@ -625,6 +626,20 @@ TEST(FaultListItemSchema, FaultToJsonConformsAndRoundTrips) {
   ASSERT_TRUE(parsed.has_value()) << "fault_to_json output does not conform to FaultListItem";
   // ... and round-trip back to identical wire (no field added or dropped).
   EXPECT_EQ(dto::JsonWriter<dto::FaultListItem>::write(parsed.value()), wire);
+}
+
+TEST(FaultListItemSchema, LastPassedOmittedWhenNeverPassed) {
+  // last_passed carries the last PASSED instant; zero means the fault never
+  // reported PASSED, and the wire says that by omitting the key entirely.
+  ros2_medkit_msgs::msg::Fault fault;
+  fault.fault_code = "NEVER_PASSED";
+  fault.status = "active";
+
+  EXPECT_FALSE(conversions::fault_to_json(fault).contains("last_passed"));
+
+  fault.last_passed.sec = 1200;
+  fault.last_passed.nanosec = 500000000;
+  EXPECT_DOUBLE_EQ(conversions::fault_to_json(fault)["last_passed"].get<double>(), 1200.5);
 }
 
 TEST(FaultListItemSchema, UnknownSeverityLabelIsAcceptedByEnum) {

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -415,8 +415,10 @@ TEST_F(SSEFaultHandlerTest, BufferRotationWithNoClientsIsNotADrop) {
 TEST_F(SSEFaultHandlerTest, LaggingClientKeepsRareFaultWhenFlapFillsBuffer) {
   // A PLC alarm flapping on a few-second cycle used to push every other fault
   // out of the 100-entry buffer, so a client behind by more than the buffer
-  // never learned the standing fault was active. Superseded flap events are
-  // evicted first now: the client converges on the current state of every code.
+  // never learned the standing fault was active. Superseded flap transitions
+  // are evicted before the unique standing fault - but a transition is
+  // history a lagging client can never recover, so every one of those
+  // evictions is honest, counted loss, never "coalesced".
   auto req = make_stream_request("127.0.0.1");
   httplib::Response res;
   handler_->handle_stream(req, res);  // registers a cursor; never drained below
@@ -427,8 +429,8 @@ TEST_F(SSEFaultHandlerTest, LaggingClientKeepsRareFaultWhenFlapFillsBuffer) {
     enqueue_event(make_fault_event(type, "TC3_ALARM_FLAP", 100 + i));
   }
 
-  EXPECT_EQ(handler_->dropped_events(), 0u);
-  EXPECT_GT(handler_->coalesced_events(), 0u);
+  EXPECT_EQ(handler_->dropped_events(), 51u);   // 151 events, 100 kept, all losses counted
+  EXPECT_EQ(handler_->coalesced_events(), 0u);  // transitions are never "no-loss" evictions
 
   auto output = read_stream_once(res, 1);
   EXPECT_EQ(parse_sse_payload(output)["fault"]["fault_code"], "PLC_COMMS_LOST");
@@ -436,22 +438,32 @@ TEST_F(SSEFaultHandlerTest, LaggingClientKeepsRareFaultWhenFlapFillsBuffer) {
   release_stream(res);
 }
 
-TEST_F(SSEFaultHandlerTest, CoalescedReplayEndsOnTheCurrentStateOfEachFault) {
-  // Convergence contract: whatever is dropped for capacity, the last event a
-  // client receives for a fault code must be that fault's latest state.
-  for (int i = 0; i < 150; ++i) {
-    const auto type = (i % 2 == 0) ? FaultEvent::EVENT_CONFIRMED : FaultEvent::EVENT_CLEARED;
-    enqueue_event(make_fault_event(type, "FLAPPER", 200 + i));
+TEST_F(SSEFaultHandlerTest, CoalescedReplayKeepsTransitionsAndEndsOnCurrentState) {
+  // Convergence contract for genuine coalescing: only fault_updated entries
+  // may be silently superseded. An update storm must not push out the fault's
+  // confirmation, and the last replayed frame must be the latest state.
+  auto req = make_stream_request("127.0.0.1");
+  httplib::Response res;
+  handler_->handle_stream(req, res);  // cursor open while the buffer is trimmed
+
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "FLAPPER", 200));
+  for (int i = 1; i <= 149; ++i) {
+    enqueue_event(make_fault_event(FaultEvent::EVENT_UPDATED, "FLAPPER", 200 + i));
   }
   enqueue_event(make_fault_event(FaultEvent::EVENT_CLEARED, "FLAPPER", 999));
 
-  auto req = make_stream_request("127.0.0.1");
-  httplib::Response res;
-  handler_->handle_stream(req, res);
+  EXPECT_GT(handler_->coalesced_events(), 0u);
+  EXPECT_EQ(handler_->dropped_events(), 0u);
 
   // The buffer holds exactly its cap after the overflow; disconnect on the last
   // replayed frame so the loop never reaches the keepalive wait.
   auto output = read_stream_once(res, 100);
+
+  const auto first_frame = output.find("event: ");
+  ASSERT_NE(first_frame, std::string::npos);
+  auto first = parse_sse_payload(output.substr(first_frame));
+  EXPECT_EQ(first["event_type"], "fault_confirmed");  // the transition survived the storm
+
   const auto last_frame = output.rfind("event: ");
   ASSERT_NE(last_frame, std::string::npos);
   auto payload = parse_sse_payload(output.substr(last_frame));
@@ -462,34 +474,61 @@ TEST_F(SSEFaultHandlerTest, CoalescedReplayEndsOnTheCurrentStateOfEachFault) {
   release_stream(res);
 }
 
-TEST_F(SSEFaultHandlerTest, StalledClientIsReapedInsteadOfCountedAsBackpressure) {
-  // A client that stops making progress is dead, not slow. It must be reaped
-  // and dropped from the backpressure accounting, and said so in the log.
-  auto fast_tracker = std::make_shared<SSEClientTracker>(1);
-  SSEFaultHandler fast_handler(*ctx_, fast_tracker, 10ms);  // stall budget = 30ms
-
+TEST_F(SSEFaultHandlerTest, OwedDistinctEventsLostUnderPressureAreCountedAndLogged) {
+  // The counter this PR is about: a live client is owed events, the buffer
+  // overflows with distinct fault codes (nothing to coalesce), so events are
+  // genuinely lost - counted, attributed to the one slow client, and WARNed
+  // starting from the very first loss.
   auto req = make_stream_request("127.0.0.1");
   httplib::Response res;
-  fast_handler.handle_stream(req, res);  // cursor registered, provider never driven
-  std::this_thread::sleep_for(100ms);
+  handler_->handle_stream(req, res);  // cursor registered; never drained
 
   testing::internal::CaptureStderr();
-  // Fill past capacity with distinct codes so nothing can be coalesced: only
-  // the reaping decision keeps these evictions from counting as loss.
   for (int i = 1; i <= 150; ++i) {
-    auto event = make_fault_event(FaultEvent::EVENT_CONFIRMED, "STALL_" + std::to_string(i), i);
-    publisher_->publish(event);
-    const uint64_t before = fast_handler.events_received();
-    for (int spin = 0; spin < 500 && fast_handler.events_received() == before; ++spin) {
-      executor_->spin_some();
-      std::this_thread::sleep_for(1ms);
-    }
+    enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "DISTINCT_" + std::to_string(i), i));
   }
   auto logs = testing::internal::GetCapturedStderr();
 
-  EXPECT_EQ(fast_handler.reaped_clients(), 1u);
-  EXPECT_EQ(fast_handler.dropped_events(), 0u);
-  EXPECT_NE(logs.find("made no progress"), std::string::npos) << logs;
+  EXPECT_EQ(handler_->dropped_events(), 50u);
+  EXPECT_EQ(handler_->coalesced_events(), 0u);
+  EXPECT_NE(logs.find("SSE fault event lost: 1 event(s) dropped total for 1 slow client(s)"), std::string::npos)
+      << logs;
+
+  release_stream(res);
+}
+
+TEST_F(SSEFaultHandlerTest, HugeLastEventIdIsClampedToNewestIssuedId) {
+  // Last-Event-ID above the newest issued id (here: UINT64_MAX) used to make
+  // the stream permanently blind and alias the delivery watermark. It must be
+  // treated as "caught up": new events still flow.
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "FAULT_OLD", 100));
+
+  auto req = make_stream_request("127.0.0.1", "18446744073709551615");
+  httplib::Response res;
+  handler_->handle_stream(req, res);
+
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "FAULT_NEW", 101));
+
+  auto output = read_stream_once(res, 1);
+  EXPECT_NE(output.find("id: 2\n"), std::string::npos);
+  EXPECT_EQ(parse_sse_payload(output)["fault"]["fault_code"], "FAULT_NEW");
+
+  release_stream(res);
+}
+
+TEST_F(SSEFaultHandlerTest, NegativeLastEventIdFallsBackToFullReplay) {
+  // std::stoull accepts "-1" and wraps it to UINT64_MAX; the parser must
+  // reject it as malformed so the client gets the full replay instead of a
+  // blind stream.
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "FAULT_NEG", 300));
+
+  auto req = make_stream_request("127.0.0.1", "-1");
+  httplib::Response res;
+  handler_->handle_stream(req, res);
+
+  auto output = read_stream_once(res, 1);
+  EXPECT_NE(output.find("id: 1\n"), std::string::npos);
+  EXPECT_EQ(parse_sse_payload(output)["fault"]["fault_code"], "FAULT_NEG");
 
   release_stream(res);
 }

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -399,6 +399,101 @@ TEST_F(SSEFaultHandlerTest, BufferEvictsOldestEventWhenFull) {
   release_stream(res);
 }
 
+TEST_F(SSEFaultHandlerTest, BufferRotationWithNoClientsIsNotADrop) {
+  // Observed on a live diagnostic box: 19,000+ "events dropped ... slow or
+  // disconnected clients" with zero SSE clients ever connected. Rotating a
+  // replay buffer nobody is reading loses nothing and must not be reported as
+  // backpressure.
+  for (int i = 1; i <= 150; ++i) {
+    enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "FAULT_" + std::to_string(i), i));
+  }
+
+  EXPECT_EQ(handler_->connected_clients(), 0u);
+  EXPECT_EQ(handler_->dropped_events(), 0u);
+}
+
+TEST_F(SSEFaultHandlerTest, LaggingClientKeepsRareFaultWhenFlapFillsBuffer) {
+  // A PLC alarm flapping on a few-second cycle used to push every other fault
+  // out of the 100-entry buffer, so a client behind by more than the buffer
+  // never learned the standing fault was active. Superseded flap events are
+  // evicted first now: the client converges on the current state of every code.
+  auto req = make_stream_request("127.0.0.1");
+  httplib::Response res;
+  handler_->handle_stream(req, res);  // registers a cursor; never drained below
+
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "PLC_COMMS_LOST", 1));
+  for (int i = 0; i < 150; ++i) {
+    const auto type = (i % 2 == 0) ? FaultEvent::EVENT_CLEARED : FaultEvent::EVENT_CONFIRMED;
+    enqueue_event(make_fault_event(type, "TC3_ALARM_FLAP", 100 + i));
+  }
+
+  EXPECT_EQ(handler_->dropped_events(), 0u);
+  EXPECT_GT(handler_->coalesced_events(), 0u);
+
+  auto output = read_stream_once(res, 1);
+  EXPECT_EQ(parse_sse_payload(output)["fault"]["fault_code"], "PLC_COMMS_LOST");
+
+  release_stream(res);
+}
+
+TEST_F(SSEFaultHandlerTest, CoalescedReplayEndsOnTheCurrentStateOfEachFault) {
+  // Convergence contract: whatever is dropped for capacity, the last event a
+  // client receives for a fault code must be that fault's latest state.
+  for (int i = 0; i < 150; ++i) {
+    const auto type = (i % 2 == 0) ? FaultEvent::EVENT_CONFIRMED : FaultEvent::EVENT_CLEARED;
+    enqueue_event(make_fault_event(type, "FLAPPER", 200 + i));
+  }
+  enqueue_event(make_fault_event(FaultEvent::EVENT_CLEARED, "FLAPPER", 999));
+
+  auto req = make_stream_request("127.0.0.1");
+  httplib::Response res;
+  handler_->handle_stream(req, res);
+
+  // The buffer holds exactly its cap after the overflow; disconnect on the last
+  // replayed frame so the loop never reaches the keepalive wait.
+  auto output = read_stream_once(res, 100);
+  const auto last_frame = output.rfind("event: ");
+  ASSERT_NE(last_frame, std::string::npos);
+  auto payload = parse_sse_payload(output.substr(last_frame));
+  EXPECT_EQ(payload["fault"]["fault_code"], "FLAPPER");
+  EXPECT_EQ(payload["event_type"], "fault_cleared");
+  EXPECT_DOUBLE_EQ(payload["timestamp"].get<double>(), 999.0);
+
+  release_stream(res);
+}
+
+TEST_F(SSEFaultHandlerTest, StalledClientIsReapedInsteadOfCountedAsBackpressure) {
+  // A client that stops making progress is dead, not slow. It must be reaped
+  // and dropped from the backpressure accounting, and said so in the log.
+  auto fast_tracker = std::make_shared<SSEClientTracker>(1);
+  SSEFaultHandler fast_handler(*ctx_, fast_tracker, 10ms);  // stall budget = 30ms
+
+  auto req = make_stream_request("127.0.0.1");
+  httplib::Response res;
+  fast_handler.handle_stream(req, res);  // cursor registered, provider never driven
+  std::this_thread::sleep_for(100ms);
+
+  testing::internal::CaptureStderr();
+  // Fill past capacity with distinct codes so nothing can be coalesced: only
+  // the reaping decision keeps these evictions from counting as loss.
+  for (int i = 1; i <= 150; ++i) {
+    auto event = make_fault_event(FaultEvent::EVENT_CONFIRMED, "STALL_" + std::to_string(i), i);
+    publisher_->publish(event);
+    const uint64_t before = fast_handler.events_received();
+    for (int spin = 0; spin < 500 && fast_handler.events_received() == before; ++spin) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(1ms);
+    }
+  }
+  auto logs = testing::internal::GetCapturedStderr();
+
+  EXPECT_EQ(fast_handler.reaped_clients(), 1u);
+  EXPECT_EQ(fast_handler.dropped_events(), 0u);
+  EXPECT_NE(logs.find("made no progress"), std::string::npos) << logs;
+
+  release_stream(res);
+}
+
 TEST_F(SSEFaultHandlerTest, StreamSanitizesNewlinesInEventType) {
   enqueue_event(make_fault_event("fault_confirmed\nretry: 0\r\nevent: injected", "FAULT_SANITIZED", 300));
 

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -320,6 +320,28 @@ TEST_F(SSEFaultHandlerTest, StreamReplaysBufferedEventsUsingSseFormat) {
   EXPECT_EQ(payload["fault"]["fault_code"], "TEMP_HIGH");
   EXPECT_EQ(payload["fault"]["severity_label"], "ERROR");
   EXPECT_DOUBLE_EQ(payload["timestamp"].get<double>(), 123.456);
+  EXPECT_FALSE(payload.contains("auto_cleared_codes"));  // omitted when empty
+
+  release_stream(res);
+}
+
+TEST_F(SSEFaultHandlerTest, StreamCarriesAutoClearedCodes) {
+  // A correlation cascade lists its auto-cleared symptoms only on the root
+  // cause's event; the stream payload must carry them or SSE consumers never
+  // learn about the cascade.
+  auto event = make_fault_event(FaultEvent::EVENT_CLEARED, "ROOT_CAUSE", 80);
+  event.auto_cleared_codes = {"SYMPTOM_A", "SYMPTOM_B"};
+  enqueue_event(event);
+
+  auto req = make_stream_request("127.0.0.1");
+  httplib::Response res;
+  handler_->handle_stream(req, res);
+
+  auto output = read_stream_once(res, 1);
+  auto payload = parse_sse_payload(output);
+
+  ASSERT_TRUE(payload.contains("auto_cleared_codes")) << payload.dump();
+  EXPECT_EQ(payload["auto_cleared_codes"], (json::array({"SYMPTOM_A", "SYMPTOM_B"})));
 
   release_stream(res);
 }

--- a/src/ros2_medkit_integration_tests/test/features/test_sse_fault_stream.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_sse_fault_stream.test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end test for the SSE fault stream with a real fault manager.
+
+Drives a fault through ReportFault (FAILED -> confirm, PASSED x2 -> heal)
+and asserts both transitions arrive at an HTTP client on /faults/stream:
+fault_confirmed with status CONFIRMED, then fault_cleared with status
+HEALED. This is the full pipeline: service -> fault manager -> events
+topic -> gateway SSE handler -> HTTP.
+"""
+
+import json
+import threading
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ReportFault
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, FAULT_TIMEOUT
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+
+FAULT_CODE = 'SSE_E2E_HEAL_ME'
+SOURCE_ID = '/powertrain/engine/temp_sensor'
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor'],
+        fault_manager=True,
+        fault_manager_params={
+            'storage_type': 'memory',
+            # One FAILED confirms (counter -1 <= -1); two PASSED heal
+            # (counter -1 -> 0 -> 1 >= 1).
+            'confirmation_threshold': -1,
+            'healing_enabled': True,
+            'healing_threshold': 1,
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+
+class TestSseFaultStreamE2E(GatewayTestCase):
+    """Fault confirm + heal must reach an HTTP SSE client."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {'temp_sensor'}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        rclpy.init()
+        cls._reporter = Node('sse_fault_stream_reporter')
+        cls._report_client = cls._reporter.create_client(
+            ReportFault, '/fault_manager/report_fault'
+        )
+        assert cls._report_client.wait_for_service(timeout_sec=15.0), \
+            'report_fault service not available'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    def _report(self, event_type):
+        req = ReportFault.Request()
+        req.fault_code = FAULT_CODE
+        req.event_type = event_type
+        req.severity = Fault.SEVERITY_ERROR
+        req.description = 'SSE E2E test fault'
+        req.source_id = SOURCE_ID
+        future = self._report_client.call_async(req)
+        deadline = time.monotonic() + 5.0
+        while not future.done() and time.monotonic() < deadline:
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+        self.assertTrue(future.done(), 'report_fault call timed out')
+        self.assertTrue(future.result().accepted)
+
+    @staticmethod
+    def _pump_stream(response, frames, stop_event):
+        """Collect SSE frames as dicts of field -> value."""
+        current = {}
+        try:
+            for line in response.iter_lines(decode_unicode=True):
+                if stop_event.is_set():
+                    break
+                if line is None:
+                    continue
+                if line == '':
+                    if current:
+                        frames.append(current)
+                        current = {}
+                    continue
+                if line.startswith(':'):
+                    continue  # keepalive comment
+                key, _, value = line.partition(':')
+                current[key.strip()] = value.strip()
+        except Exception:  # noqa: BLE001 - closed socket on test teardown
+            pass
+
+    def _wait_for_event(self, frames, event_type, deadline):
+        while time.monotonic() < deadline:
+            for frame in list(frames):
+                if frame.get('event') != event_type or 'data' not in frame:
+                    continue
+                payload = json.loads(frame['data'])
+                if payload['fault']['fault_code'] == FAULT_CODE:
+                    return payload
+            time.sleep(0.2)
+        raise AssertionError(
+            f'no {event_type} for {FAULT_CODE} on /faults/stream within '
+            f'{FAULT_TIMEOUT}s; frames seen: {list(frames)}'
+        )
+
+    def test_confirm_and_heal_reach_http_client(self):
+        frames = []
+        stop_event = threading.Event()
+        response = requests.get(
+            f'{self.BASE_URL}/faults/stream', stream=True, timeout=(5, 60)
+        )
+        self.assertEqual(response.status_code, 200)
+        pump = threading.Thread(
+            target=self._pump_stream, args=(response, frames, stop_event),
+            daemon=True,
+        )
+        pump.start()
+        try:
+            self._report(ReportFault.Request.EVENT_FAILED)
+            confirmed = self._wait_for_event(
+                frames, 'fault_confirmed', time.monotonic() + FAULT_TIMEOUT
+            )
+            self.assertEqual(confirmed['fault']['status'], 'CONFIRMED')
+
+            self._report(ReportFault.Request.EVENT_PASSED)
+            self._report(ReportFault.Request.EVENT_PASSED)
+            cleared = self._wait_for_event(
+                frames, 'fault_cleared', time.monotonic() + FAULT_TIMEOUT
+            )
+            # The heal is the fault's end; status distinguishes it from a
+            # manual clear.
+            self.assertEqual(cleared['fault']['status'], 'HEALED')
+            self.assertIn('last_passed', cleared['fault'])
+        finally:
+            stop_event.set()
+            response.close()
+            pump.join(timeout=5)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """All processes exited cleanly (SIGTERM allowed for SSE teardown)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_sse_fault_stream.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_sse_fault_stream.test.py
@@ -41,6 +41,7 @@ from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
 
 FAULT_CODE = 'SSE_E2E_HEAL_ME'
+PRIME_CODE = 'SSE_E2E_PRIME'
 SOURCE_ID = '/powertrain/engine/temp_sensor'
 
 
@@ -82,9 +83,9 @@ class TestSseFaultStreamE2E(GatewayTestCase):
         cls._reporter.destroy_node()
         rclpy.shutdown()
 
-    def _report(self, event_type):
+    def _report(self, event_type, fault_code=FAULT_CODE):
         req = ReportFault.Request()
-        req.fault_code = FAULT_CODE
+        req.fault_code = fault_code
         req.event_type = event_type
         req.severity = Fault.SEVERITY_ERROR
         req.description = 'SSE E2E test fault'
@@ -118,6 +119,35 @@ class TestSseFaultStreamE2E(GatewayTestCase):
         except Exception:  # noqa: BLE001 - closed socket on test teardown
             pass
 
+    def _prime_stream(self, frames):
+        """Block until the fault event pipeline demonstrably reaches the stream.
+
+        /fault_manager/events is reliable but volatile: an event published
+        before the gateway's subscription has matched the fault manager's
+        publisher is lost outright, and under sanitizer load that matching can
+        finish after the first report (ASan CI lost the one-shot confirm to
+        exactly this race). Every accepted report publishes an event, so
+        repeating a sacrificial fault until one of its frames arrives proves
+        service -> fault manager -> events topic -> SSE end to end.
+        """
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            self._report(ReportFault.Request.EVENT_FAILED, fault_code=PRIME_CODE)
+            settle = min(time.monotonic() + 1.0, deadline)
+            while time.monotonic() < settle:
+                for frame in list(frames):
+                    data = frame.get('data')
+                    if data is None:
+                        continue
+                    payload = json.loads(data)
+                    if payload.get('fault', {}).get('fault_code') == PRIME_CODE:
+                        return
+                time.sleep(0.1)
+        raise AssertionError(
+            f'no event for priming fault {PRIME_CODE} on /faults/stream '
+            f'within {FAULT_TIMEOUT}s; events pipeline never went live'
+        )
+
     def _wait_for_event(self, frames, event_type, deadline):
         while time.monotonic() < deadline:
             for frame in list(frames):
@@ -145,6 +175,7 @@ class TestSseFaultStreamE2E(GatewayTestCase):
         )
         pump.start()
         try:
+            self._prime_stream(frames)
             self._report(ReportFault.Request.EVENT_FAILED)
             confirmed = self._wait_for_event(
                 frames, 'fault_confirmed', time.monotonic() + FAULT_TIMEOUT

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -22,7 +22,8 @@ Core fault data model representing an aggregated fault condition with AUTOSAR DE
 | `severity` | uint8 | Severity level (use SEVERITY_* constants) |
 | `description` | string | Human-readable description |
 | `first_occurred` | builtin_interfaces/Time | When fault was first reported |
-| `last_occurred` | builtin_interfaces/Time | When fault was last reported (FAILED or PASSED) |
+| `last_occurred` | builtin_interfaces/Time | When fault last occurred (FAILED events only) |
+| `last_passed` | builtin_interfaces/Time | When fault last reported PASSED (zero = never) |
 | `occurrence_count` | uint32 | Total FAILED events aggregated across all sources |
 | `status` | string | Current status (see STATUS_* constants) |
 | `reporting_sources` | string[] | List of source identifiers that reported this fault |
@@ -63,12 +64,13 @@ Real-time fault event notification for SSE streaming (published on `/fault_manag
 | `event_type` | string | Event type (see constants below) |
 | `fault` | Fault | The fault data (state after event) |
 | `timestamp` | builtin_interfaces/Time | When the event occurred |
+| `auto_cleared_codes` | string[] | Symptom codes auto-cleared with the root cause (correlation) |
 
 **Event Types:**
 | Constant | Trigger |
 |----------|---------|
 | `EVENT_CONFIRMED` | Fault transitions PREFAILED → CONFIRMED |
-| `EVENT_CLEARED` | Fault transitions to CLEARED |
+| `EVENT_CLEARED` | Fault ends: CLEARED via ClearFault, or HEALED by PASSED events (`fault.status` tells which) |
 | `EVENT_UPDATED` | Fault data changes without status transition |
 
 ## Services

--- a/src/ros2_medkit_msgs/msg/Fault.msg
+++ b/src/ros2_medkit_msgs/msg/Fault.msg
@@ -35,8 +35,12 @@ string description
 # Timestamp when this fault was first reported
 builtin_interfaces/Time first_occurred
 
-# Timestamp when this fault was last reported (FAILED or PASSED event)
+# Timestamp when this fault last occurred (FAILED events only; a PASSED
+# event is the fault ending, not occurring, and does not touch this field)
 builtin_interfaces/Time last_occurred
+
+# Timestamp of the last PASSED event reported for this fault (zero = never)
+builtin_interfaces/Time last_passed
 
 # Total number of FAILED events aggregated across all sources
 uint32 occurrence_count

--- a/src/ros2_medkit_msgs/msg/FaultEvent.msg
+++ b/src/ros2_medkit_msgs/msg/FaultEvent.msg
@@ -30,7 +30,9 @@ builtin_interfaces/Time timestamp
 # Emitted when a fault transitions from PREFAILED to CONFIRMED status
 # (e.g., after debounce counter reaches confirmation threshold).
 string EVENT_CONFIRMED = "fault_confirmed"
-# Emitted when a fault transitions to CLEARED status via ClearFault service.
+# Emitted when a fault ends: CLEARED via the ClearFault service, or HEALED when
+# PASSED events drive it past the healing threshold. Check fault.status to tell
+# the two apart.
 string EVENT_CLEARED = "fault_cleared"
 # Emitted when fault data changes without status transition
 # (e.g., occurrence_count incremented, new source added to reporting_sources).


### PR DESCRIPTION
Two defects found on a live diagnostic box, plus the fix for each.

## A stale fault reads as freshly active

`PLC_COMMS_LOST` on the Beckhoff ADS instance sat `CONFIRMED` for hours while the link was
demonstrably alive, and its `last_occurred` matched the plugin's clear log to the millisecond.

The `CONFIRMED` latch itself is **not** a bug: `compute_debounce_status` only returns `HEALED` when
healing is enabled, the box runs `healing=disabled`, and that is the documented default. What is a
bug is that PASSED events advanced `last_occurred`, so a fault cleared three hours ago presented as
current. The clear instant already has its own field, `last_passed_ns`; `last_occurred` is now
written only on FAILED.

Found next to it and fixed here too: no event was published on the `CONFIRMED -> HEALED`
transition. The shipped `bringup_params.yaml` sets `healing_enabled: true`, so on the default stack
a healed fault stayed on every SSE consumer's screen indefinitely. It now publishes `EVENT_CLEARED`
with `status: HEALED` - deliberately the existing event name, since a new one would be silently
dropped by any UI not listening for it.

## The SSE drop counter measured the wrong thing

The handler trimmed a shared 100-entry replay buffer FIFO and counted every eviction as a
client-visible drop, with no notion of clients at all. On the box the counter passed 20,000 while
`SSE fault client connected` appeared zero times in the log - nothing had ever been lost, the ring
was simply rotating, and the "slow or disconnected clients" text was fiction.

Eviction is now cursor-aware. Entries every live client has already received go first and cost
nothing. Entries superseded by a newer event for the same fault code go next, so a lagging client
still converges on the current state of every fault; entries carrying `auto_cleared_codes` are
exempt, because those symptom codes appear nowhere else. Only what neither rule covers is counted
and logged as an actual loss, with the slow-client, coalesced and reaped counts in the message.
A client with no completed write for three keepalive intervals is reaped and excluded from the
accounting rather than inflating backpressure forever.

Because coalescing erases mid-deque, the stream loop now formats under the lock and writes outside
it; the previous code held a `deque` iterator across `sink.write`.

## Verification

Built and tested in the CI image (Jazzy, CycloneDDS). Gateway 3959 tests, fault_manager 527 tests,
zero failures. `clang-format-18` run deliberately rather than left to be skipped: 438 files in the
gateway, 36 in fault_manager, clean.

Each fix has a test that fails when it is reverted:

- `FaultStorageTest.PassedEventDoesNotAdvanceLastOccurred` and the sqlite equivalent
- `HealingFaultEventPublishingTest` - "no event published for the CONFIRMED -> HEALED transition"
- `BufferRotationWithNoClientsIsNotADrop`, `LaggingClientKeepsRareFaultWhenFlapFillsBuffer`,
  `StalledClientIsReapedInsteadOfCountedAsBackpressure`

`test_graph_provider_{sse,greenwave,stale}` in `ros2_medkit_integration_tests` fail in this
container, and also fail on an unmodified `origin/main` build with the same signature
(`rclcpp::graph_listener::NodeNotFoundError` aborting the gateway). Pre-existing, not from this
change.
