### PR TITLE
feat(graph_watchdog): orphan detector (GRAPH_ORPHAN)

### DIFF
--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -190,6 +190,9 @@ if(BUILD_TESTING)
   # LifecycleShutdownSuppressor: needs a REAL ReliabilityGate (departed_lifecycle_state_of()
   # reads live from ctx.gate) - same real-Node/ROS_DOMAIN_ID rationale as test_reliability_gate
   # above, unlike test_allowlist_suppressor (pure interface, no gate needed).
+  ament_add_gtest(test_orphan_policy test/test_orphan_policy.cpp)
+  target_include_directories(test_orphan_policy PRIVATE include)
+
   ament_add_gtest(test_qos_policy test/test_qos_policy.cpp)
   target_include_directories(test_qos_policy PRIVATE include)
   medkit_target_dependencies(test_qos_policy rmw)   # rmw is transitively found via rclcpp; no find_package needed
@@ -214,7 +217,20 @@ if(BUILD_TESTING)
     ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs std_msgs)
   target_link_libraries(test_qos_mismatch_integration nlohmann_json::nlohmann_json)
   medkit_set_test_domain(test_qos_mismatch_integration)
-  set_tests_properties(test_qos_mismatch_integration PROPERTIES TIMEOUT 120 RESOURCE_LOCK graph_watchdog_integration_domain)
+
+  ament_add_gtest(test_orphan_integration
+    test/test_orphan_integration.cpp
+    src/detectors/orphan_detector.cpp
+    src/detector_registry.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_orphan_integration PRIVATE include)
+  medkit_target_dependencies(test_orphan_integration
+    ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs std_msgs sensor_msgs)
+  target_link_libraries(test_orphan_integration nlohmann_json::nlohmann_json)
+  medkit_set_test_domain(test_orphan_integration)
+  set_tests_properties(test_orphan_integration PROPERTIES TIMEOUT 120 RESOURCE_LOCK graph_watchdog_integration_domain)
 
   # === QoS-mismatch e2e (launch_testing) ===
   #
@@ -232,6 +248,13 @@ if(BUILD_TESTING)
     LABELS "integration;e2e"
     # Shares the e2e domain and its lock rather than consuming another slot.
     ENVIRONMENT "GATEWAY_TEST_PORT=19120;ROS_DOMAIN_ID=89;GRAPH_WATCHDOG_PLUGIN_PATH=${_WATCHDOG_E2E_SO}"
+    RESOURCE_LOCK graph_watchdog_e2e_domain)
+
+  add_launch_test(test/e2e/test_orphan_e2e.test.py TIMEOUT 180)
+  set_tests_properties(test_e2e_test_orphan_e2e.test.py PROPERTIES
+    LABELS "integration;e2e"
+    # Shares the e2e domain and its lock rather than consuming another slot.
+    ENVIRONMENT "GATEWAY_TEST_PORT=19130;ROS_DOMAIN_ID=89;GRAPH_WATCHDOG_PLUGIN_PATH=${_WATCHDOG_E2E_SO}"
     RESOURCE_LOCK graph_watchdog_e2e_domain)
 
   ros2_medkit_relax_vendor_warnings()

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -7,7 +7,7 @@ Detectors read the graph and raise faults through a `ReportFault` service client
 gateway node; the faults surface via FaultManager on the gateway `/faults` API.
 
 This package carries the plugin skeleton, the central reliability gate that holds raises
-until the graph has quiesced, and the first detector, `qos_mismatch`. The remaining
+until the graph has quiesced, and two detectors, `qos_mismatch` and `orphan`. The remaining
 silent-fault classes land in follow-up changes, each against its own issue; their fault
 codes are already reserved in the frozen `GRAPH_*` namespace (see "Fault codes").
 
@@ -42,6 +42,35 @@ delivers them to the plugin as a nested object. A bare `off` is a YAML 1.1 boole
 read produces one startup warning naming the key and listing the ones that exist, so a
 typo like `allow_list:` for `allowlist:` cannot silently do nothing. A typo in the detector
 id itself is warned about the same way, with the registered ids listed.
+
+### `orphan` keys
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `mode` | string | `raise` | As above. |
+| `grace` | int | `10` | Consecutive sweeps a candidate pair must hold before it is reported. A staged bringup or a restart makes one side missing for a short time, which looks exactly like a typo until the other side appears. |
+| `max_edit_distance` | int | `1` | How many character edits the LEAF (the part after the last `/`) may differ by and still count as the same intended name. Values outside 1..8 keep the default: past a few edits a "near miss" starts matching unrelated topics. |
+| `namespace_edit_distance` | int | `0` | The same budget for the namespace, spent separately. `0` means the namespace must match to the character, which is what makes `/robot1/scan` and `/robot2/scan` two robots rather than a typo. Raise it to catch a misspelled namespace, and read the warning under the table first. Values outside 0..8 keep the default. |
+| `allowlist` | string[] | `[]` | Topic names never reported. Exact match only, never a prefix, so allowlisting `/r1/scan` does not also silence `/r2/scan`. |
+
+**What this detector will not catch, on purpose.** A pair whose names match once every run of
+digits is collapsed is treated as an enumeration of sensors, not a typo: `/lidar_1` next to
+`/lidar_2`, each one-sided, is an ordinary state on a multi-sensor robot and reporting it would
+be a false alarm on every such machine. Collapsing runs rather than comparing character
+positions is what also covers `/lidar_9` next to `/lidar_10`. The cost is that a typo which
+*is* a digit stops being reported. An appended digit is not that case: `/scan1` collapses to
+`/scan#`, which is not `/scan`, so it is still reported.
+
+**A misspelled namespace is opt-in, and it can be expensive.** `/robott/scan` against
+`/robot/scan` is one edit, but in the namespace, so by default it is not reported. Setting
+`namespace_edit_distance: 1` reports it. Check the naming scheme before doing that: on a fleet
+named with letters, `/amr_a` and `/amr_b` are also one edit apart, and every robot in the
+fleet will be reported as a typo. A numbered fleet is safe, since `/robot1` against `/robot2`
+differs only in its numeric field and the rule above already spares it.
+
+**What it cannot catch at all.** A namespace added or dropped by mistake, `/scan` against
+`/robot/scan`, is six edits apart, so no budget that is still specific will reach it. Do not
+rely on this detector for that class.
 
 ### `qos_mismatch` keys
 
@@ -182,6 +211,133 @@ with their own QoS conventions, not useful signal here).
    reaches a SOVD fault through the real tick timer against a reliability mismatch
    (raise + clear round trip), a deadline mismatch, and a liveliness-lease-duration
    mismatch (the description names each policy).
+
+#### `orphan` (GRAPH_ORPHAN)
+
+Watches every topic's publisher/subscriber counts and raises `GRAPH_ORPHAN` when a
+one-sided endpoint (a topic with publishers but no subscribers, or vice versa) has a
+same-type, same-namespace near-miss counterpart carrying the complementary side - the
+signature of a remap / topic-name typo (e.g. a node publishes on `/scann` while every
+would-be subscriber listens on `/scan`; neither side ever notices, and no `/diagnostics`
+or `/rosout` signal fires). "Near-miss" is a small Levenshtein edit distance, default `1`
+(config-overridable via `max_edit_distance`), which catches single-character typos. Numeric
+siblings are spared by a separate rule, described under "Digit guard" below, because raising
+the distance is not what separates them from a typo.
+
+**Names both sides, suggests neither.** A finding's `reason` names BOTH the pub-only and
+sub-only topic; the detector deliberately gives no directional rename recommendation -
+it cannot know which of the two names is the canonical one, so the operator decides. Each
+unordered near-miss pair is reported exactly once, not once per side.
+
+**A candidate, not a verdict - and it has to hold.** The pub-only/sub-only shape is not
+unique to a typo. Any node that publishes one name and subscribes a near-identical one of
+the same type - a CAN/serial bridge on `/can_rx` + `/can_tx`, any relay that republishes a
+one-character variant - produces exactly this shape the moment its peer exits, whether that
+is a crash, a supervisor restart, or staged bringup. So the fault is worded as a candidate
+("either a remap typo or a departed counterpart"), and a pair must hold for `grace`
+consecutive ticks before it is reported at all.
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `mode` | string \| bool | `raise` | `raise` / `advisory` / `off` (framework seam). |
+| `max_edit_distance` | int | `1` | Levenshtein distance that still counts as a near miss (1..8). |
+| `grace` | int | `10` | Consecutive ticks a candidate pair must hold before it is reported. |
+| `namespace_edit_distance` | int | `0` | Edit budget for the namespace, spent separately from the leaf (0..8). |
+| `allowlist` | string[] | `[]` | Topic names never reported, matched exactly and never by prefix. |
+
+`grace` costs no meaningful detection latency, because a real name typo is static and still
+there N ticks later. The reliability gate does not cover this case: `graph_watchdog` is the
+plugin's own entity, not the app being restarted, so `allows_raise()` is already armed and
+gives a restarting node no settle window. At the 1s default tick the default outlives a
+supervisor restart; it does NOT outlive a slow staged bringup, which is why the wording
+stays a candidate rather than an instruction to rename something.
+
+**Same-namespace guard.** The leaf and the namespace get separate edit budgets, and the
+namespace budget defaults to `0`, so by default both topics must share the same parent
+namespace (everything up to the final `/`). `/scann` vs `/scan` (same namespace, leaf edit
+distance 1) matches; `/robot1/scan` vs `/robot2/scan` (different namespaces, also edit
+distance 1) does not - that is a fleet layout, not a typo.
+
+`namespace_edit_distance` opts out of that. At `1`, `/robott/scan` vs `/robot/scan` is
+reported - a real remap mistake that is invisible by default. The budgets stay independent, so
+spending the namespace one does not buy extra leaf edits, and the numeric-field guard still applies
+to the whole name, which keeps a numbered fleet quiet even here. What it does NOT keep quiet is a
+fleet named with letters: `/amr_a` and `/amr_b` are one edit apart, so every robot pairs with
+its neighbour. Set this only if the namespaces on the robot are not near-misses of each
+other.
+
+**Numeric-field guard.** A pair whose names are equal once every run of digits collapses to a
+single placeholder is an enumeration, not a typo:
+`/lidar_1` next to `/lidar_2`, each one-sided, is the ordinary state of a multi-sensor
+machine, and reporting it would fire on every such machine. Collapsing runs rather than
+comparing character positions also covers `/lidar_9` vs `/lidar_10`, where the index changes
+length. This is checked independently of `max_edit_distance`, so lowering the distance does not
+help and raising it does not hurt here. The price is that a typo which is itself a digit stops being reported. That is a
+deliberate trade: a fleet-wide false alarm is worse than one missed class of typo.
+
+**What this detector cannot see at all** is a namespace added or dropped by accident.
+`/scan` against `/robot/scan` is 6 edits apart, far beyond any distance that would still be
+specific, so do not rely on this detector for that class.
+
+**When it is still wrong, allowlist the topic.** Any node that publishes one name and
+subscribes a near-identical one of the same type produces the orphan shape permanently once
+its peer is gone for good, and no threshold separates that from a typo. Name either side of
+the pair; matching is exact, so allowlisting `/r1/scan` does not also silence `/r2/scan`.
+
+```yaml
+plugins:
+  graph_watchdog:
+    detectors:
+      orphan:
+        grace: 10
+        max_edit_distance: 1
+        namespace_edit_distance: 0   # 1 also catches /robto/scan vs /robot/scan; see above
+        allowlist: ["/can_rx"]       # a bridge whose peer is intentionally absent
+```
+
+**Aggregated fault, not per-pair**, via the same `AggregatedFault` helper `qos_mismatch`
+uses - the fault_manager identifies a fault by `fault_code` alone, so one `GRAPH_ORPHAN`
+per near-miss pair would collide into a single record under the shared code. One
+graph-level fault enumerates every currently-orphaned pair, keyed by the canonical
+`<publisher_topic> <-> <subscriber_topic>` string; it clears (`EVENT_PASSED`) on every
+tick where nothing is orphaned, subject to the same `healing_enabled` requirement
+described in "Closing the loop" above to actually reach HEALED.
+
+**Exhaustive, not budgeted**, the same rationale as `qos_mismatch`: no external service is
+read - `get_topic_names_and_types()` and `count_publishers()`/`count_subscribers()` are
+local graph-cache queries, so every topic is checked every tick. `/rosout` and
+`/parameter_events` are skipped.
+
+**Test tiers:**
+
+1. **Unit** (`test/test_orphan_policy.cpp`): pure `find_orphans()` logic against
+   hand-built `TopicEndpointCounts` - the typo pair reported once naming both sides, a
+   lone topic with no counterpart, a near-miss pair of DIFFERENT types, a fully-connected
+   topic, the default-vs-opt-in edit-distance boundary (`/scan` vs `/scan_1`), the
+   same-namespace guard (`/robot1/scan` vs `/robot2/scan`), and the numeric-field guard - what
+   it spares (`/lidar_1` vs `/lidar_2`, and `/lidar_9` vs `/lidar_10`), what it knowingly
+   drops (a typo in a digit), and the appended digit it still reports (`/scan1` vs `/scan`),
+   with a letter difference of the same shape still reported to keep the guard honest. The
+   namespace budget is pinned on both sides of its default and at the bound above it, along
+   with the two properties that make it safe to ship: it does not widen the leaf budget, and
+   it does not defeat the digit guard.
+2. **Integration** (`test/test_orphan_integration.cpp`): a real publisher on a topic-name
+   typo and a real subscriber on the intended target, both `sensor_msgs/msg/LaserScan`
+   over real DDS, read through the actual `get_topic_names_and_types()` +
+   `count_publishers()`/`count_subscribers()` API against a fake `ReportFault` service. A
+   concurrent lone pub-only topic proves the detector does not over-fire on "any one-sided
+   topic". Clearing destroys the typo publisher - adding a publisher on the target topic
+   instead would leave the typo topic permanently orphaned. A third case allowlists a topic
+   and drives 12 ticks past `grace` to prove it is never reported.
+3. **E2e** (`test/e2e/test_orphan_e2e.test.py`): the acceptance gate - a
+   real gateway process with the plugin `.so` loaded, a real fault_manager, and the
+   operator-visible `GET /api/v1/faults` surface, proving the whole raise/clear story
+   reaches a SOVD fault through the real tick timer. It runs a second, allowlisted near-miss
+   pair alongside the reported one, plus a namespace-typo pair that is reported ONLY because
+   the launch raises `namespace_edit_distance`. Together they are the only place a string array
+   and an integer are proven to survive the YAML -> ROS parameter -> nested-config path into
+   `configure()`; both C++ tiers hand `configure()` a JSON object directly.
+
 
 ## Reliability (bringup-quiesce)
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -89,10 +89,10 @@ Reliability core
 
 Detectors
 ---------
-``qos_mismatch`` is the detector this package ships first. The remaining silent-fault
-classes land in follow-up changes, each against its own issue.
+``qos_mismatch`` and ``orphan`` are the detectors this package ships so far. The
+remaining silent-fault classes land in follow-up changes, each against its own issue.
 
-``qos_mismatch`` is the second detector and raises ``GRAPH_QOS_MISMATCH``. It
+``qos_mismatch`` raises ``GRAPH_QOS_MISMATCH``. It
 watches every topic's publisher/subscriber QoS pairs rather than parameter values: each
 tick it enumerates every topic via ``get_topic_names_and_types()`` and, for each one,
 every currently-connected publisher and subscriber (``get_publishers_info_by_topic`` /
@@ -177,9 +177,53 @@ overlapping:
    ``tick()`` called directly.
 
 
+
+``orphan`` raises ``GRAPH_ORPHAN``. It looks for the mistake no ROS 2 tool
+reports: a topic that exists but has no counterpart, because one side was spelled
+slightly differently. Each tick it counts publishers and subscribers per topic, keeps
+the one-sided ones, and pairs a publisher-only topic with a subscriber-only topic when
+their names are within ``max_edit_distance`` Levenshtein edits of each other. Only a
+pair is reported, never a lone one-sided topic: a publisher with no subscriber is
+normal on almost every robot, so it carries no signal on its own.
+
+**Three guards keep this from crying wolf.**
+
+- Names must sit in the same parent namespace. ``/a/scan`` and ``/b/scan`` differ by one
+  character but belong to two different robots, and pairing them would be nonsense. The
+  leaf and the namespace carry separate edit budgets and the namespace one defaults to
+  zero, so this is an exact match unless an operator raises
+  ``namespace_edit_distance``. Raising it is what makes a misspelled namespace
+  (``/robott/scan`` against ``/robot/scan``) visible at all, at the price of reporting
+  every robot of a fleet whose namespaces are themselves near-misses, which is why it is
+  opt-in rather than tuned.
+- A pair that matches once every run of digits collapses to one placeholder is an
+  enumeration, not a typo. ``/lidar_1`` next to ``/lidar_2``, each one-sided, is the
+  ordinary state of a multi-sensor machine, and reporting it would fire on every such
+  machine. Collapsing runs rather than comparing character positions also covers
+  ``/lidar_9`` next to ``/lidar_10``, where the index changes length. The price is a real
+  typo in a digit going unreported, which is a deliberate trade.
+- ``grace`` consecutive sweeps must agree before anything is raised. During bringup one
+  side of a healthy pair is routinely missing for a moment, which looks exactly like a
+  typo until the other side appears.
+
+An operator who still gets a false alarm puts the topic in ``allowlist``. What this
+detector cannot see at all is a namespace added or dropped by accident: ``/scan``
+against ``/robot/scan`` is far past any sensible edit distance.
+
+**Test tiers.** ``test_orphan_policy.cpp`` pins the pure matching rules, including each
+guard and the cases it deliberately lets through. ``test_orphan_integration.cpp`` drives
+the detector over a real ``rclcpp`` graph and a fake ``ReportFault`` service, covering
+the grace counter, the clear on repair, and the allowlist. ``test/e2e/test_orphan_e2e.test.py``
+is the acceptance gate: a real gateway with the plugin loaded, a real fault_manager, and
+the fault read back from ``GET /api/v1/faults``. It carries three pairs at once - one
+reported, one allowlisted, one visible only under a raised ``namespace_edit_distance`` -
+so it also proves a string array and an integer survive the parameter path into
+``configure()``, which no C++ tier can show.
+
+
 Status
 ---------------
-The plugin loads, ticks the graph, and shuts down cleanly. The reliability core is
-real and already ticking, and all six silent-fault detector classes are live and
-raising through it. The remaining silent-fault classes land in follow-up changes,
-each against its own issue.
+The plugin loads, ticks the graph, and shuts down cleanly. The reliability core is real
+and already ticking. Two silent-fault detector classes raise through it today,
+``qos_mismatch`` and ``orphan``. The remaining classes land in follow-up changes, each
+against its own issue.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/orphan_policy.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/orphan_policy.hpp
@@ -1,0 +1,208 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace ros2_medkit_graph_watchdog {
+
+struct TopicEndpointCounts {
+  std::string name;
+  std::string type;
+  std::size_t publishers = 0;
+  std::size_t subscribers = 0;
+};
+
+/// A near-miss pair of one-sided endpoints. We name both ends and deliberately do
+/// NOT recommend which to rename - the canonical name is the operator's call.
+struct OrphanFinding {
+  std::string publisher_topic;   // the pub-only side of the pair
+  std::string subscriber_topic;  // the sub-only side of the pair
+  std::string reason;
+};
+
+inline int levenshtein(const std::string & a, const std::string & b) {
+  std::vector<int> prev(b.size() + 1), cur(b.size() + 1);
+  for (std::size_t j = 0; j <= b.size(); ++j) {
+    prev[j] = static_cast<int>(j);
+  }
+  for (std::size_t i = 1; i <= a.size(); ++i) {
+    cur[0] = static_cast<int>(i);
+    for (std::size_t j = 1; j <= b.size(); ++j) {
+      const int cost = (a[i - 1] == b[j - 1]) ? 0 : 1;
+      cur[j] = std::min({prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + cost});
+    }
+    std::swap(prev, cur);
+  }
+  return prev[b.size()];
+}
+
+/// ROS 2 system topics, skipped because they have their own lifecycle and pairing them
+/// would be noise. Both names are ABSOLUTE and global - a node in a namespace still
+/// publishes to /rosout and /parameter_events - so an exact match is the whole set. A
+/// prefix match would additionally swallow user topics that merely start with the same
+/// text (/parameter_events_debug), silently exempting them from orphan detection. Same
+/// exact-match rule as qos_mismatch_detector.cpp.
+inline bool is_system_topic(const std::string & name) {
+  return name == "/rosout" || name == "/parameter_events";
+}
+
+/// Everything up to and including the final '/'. "/ns/scan" -> "/ns/", "/scan" -> "/".
+inline std::string parent_namespace(const std::string & topic) {
+  const auto slash = topic.rfind('/');
+  return slash == std::string::npos ? std::string() : topic.substr(0, slash + 1);
+}
+
+/// A name with every RUN of digits collapsed to a single '#'. "/lidar_1" and "/lidar_10"
+/// both become "/lidar_#"; "/scan" is unchanged.
+inline std::string collapse_digit_runs(const std::string & name) {
+  std::string out;
+  out.reserve(name.size());
+  bool in_digits = false;
+  for (const char c : name) {
+    const bool digit = c >= '0' && c <= '9';
+    if (digit) {
+      if (!in_digits) {
+        out.push_back('#');
+      }
+    } else {
+      out.push_back(c);
+    }
+    in_digits = digit;
+  }
+  return out;
+}
+
+/// True when two names differ only in their numeric fields. `/lidar_1` vs `/lidar_2`,
+/// `/image1` vs `/image2`, `/cameras/image1` vs `/cameras/image2`, and also `/lidar_9` vs
+/// `/lidar_10`, where the index crosses a digit-count boundary. A difference confined to a
+/// numeric field is a sibling index, not a typo: two independently one-sided members of such a
+/// family is an ordinary state on a multi-sensor robot, where nothing is recording `/lidar_1`
+/// while `/lidar_2`'s driver is down.
+///
+/// The same-namespace guard does not catch these, because it only helps when the differing
+/// character sits in a namespace segment; here it sits in the leaf and both names share a
+/// parent. Reporting them names two unrelated topics as a possible mismatch, at ERROR.
+///
+/// Comparing collapsed names rather than character positions is what covers the
+/// digit-count boundary: `/lidar_9` and `/lidar_10` are not even the same length, yet they
+/// are the ninth and tenth sensor of one family.
+///
+/// Known cost, accepted deliberately: a typo that IS a digit (a remap writing `/lidar_2`
+/// where `/lidar_1` was meant) stops being reported. A false ERROR on every multi-sensor
+/// robot is worse than that miss, and this detector's whole premise is staying silent on a
+/// graph nobody configured. An appended digit is NOT this case: `/scan1` collapses to
+/// `/scan#`, which is not `/scan`, so it is still reported.
+inline bool differs_only_in_numeric_fields(const std::string & a, const std::string & b) {
+  return a != b && collapse_digit_runs(a) == collapse_digit_runs(b);
+}
+
+/// Everything after the final '/'. "/ns/scan" -> "scan", "/scan" -> "scan".
+inline std::string leaf_name(const std::string & topic) {
+  const auto slash = topic.rfind('/');
+  return slash == std::string::npos ? topic : topic.substr(slash + 1);
+}
+
+/// A one-sided endpoint (pub-only or sub-only) plus a near-miss topic of the SAME
+/// message type carrying the complementary side is the signature of a remap / name
+/// typo. Each such pair is reported ONCE (deduped by the unordered name pair). The
+/// type + distance gate stops legitimate lone debug topics from false-positiving.
+///
+/// `max_edit_distance` budgets the LEAF, `namespace_edit_distance` budgets the parent
+/// namespace, and the two are independent. The default namespace budget is 0, i.e. the
+/// namespace must match to the character, which is the only safe default: on a fleet named
+/// with letters (/amr_a, /amr_b) every robot's topic is one edit from its neighbour's, so any
+/// namespace budget above 0 reports the whole fleet as typos. The numeric-field rule saves
+/// a NUMBERED fleet (/robot1, /robot2) but nothing saves a lettered one, which is why this is
+/// opt-in rather than a tuned default.
+inline std::vector<OrphanFinding> find_orphans(const std::vector<TopicEndpointCounts> & topics, int max_edit_distance,
+                                               int namespace_edit_distance = 0) {
+  std::vector<OrphanFinding> out;
+  std::set<std::string> paired;  // canonical "min\nmax" keys already reported
+  for (const auto & t : topics) {
+    if (is_system_topic(t.name)) {
+      continue;
+    }
+    const bool pub_only = t.publishers > 0 && t.subscribers == 0;
+    const bool sub_only = t.subscribers > 0 && t.publishers == 0;
+    if (!pub_only && !sub_only) {
+      continue;
+    }
+    // Admission is the two budgets above; this only picks the CLOSEST admitted candidate and
+    // supplies the "differ by N char(s)" figure. The bound is the sum of both budgets because
+    // a whole-name distance never exceeds the namespace distance plus the leaf distance.
+    int best = max_edit_distance + namespace_edit_distance + 1;
+    const TopicEndpointCounts * match = nullptr;
+    for (const auto & u : topics) {
+      if (&u == &t || is_system_topic(u.name) || u.type != t.type) {
+        continue;
+      }
+      // Budget the namespace and the leaf separately. At the default namespace budget of 0
+      // this is an exact-namespace guard: a leaf typo (/scann vs /scan) matches, while
+      // distinct per-robot topics (/robot1/scan vs /robot2/scan, also distance 1) do not -
+      // that is a fleet layout, not a typo. Raising the namespace budget is what lets a
+      // misspelled namespace (/robto/scan vs /robot/scan) pair at all.
+      if (levenshtein(parent_namespace(t.name), parent_namespace(u.name)) > namespace_edit_distance) {
+        continue;
+      }
+      if (levenshtein(leaf_name(t.name), leaf_name(u.name)) > max_edit_distance) {
+        continue;
+      }
+      // An enumeration of sensors, not a typo - see differs_only_in_numeric_fields().
+      if (differs_only_in_numeric_fields(t.name, u.name)) {
+        continue;
+      }
+      // The counterpart must be strictly one-sided in the COMPLEMENTARY direction: a typo means
+      // the publisher meant the subscriber-only topic (which is starved) and vice-versa. A fully
+      // connected sibling (a healthy /lidar_2 next to a one-sided /lidar_1) is NOT a typo, so it
+      // must NOT pair - otherwise every digit-substitution sensor sibling would false-positive.
+      const bool complements =
+          pub_only ? (u.subscribers > 0 && u.publishers == 0) : (u.publishers > 0 && u.subscribers == 0);
+      if (!complements) {
+        continue;
+      }
+      const int d = levenshtein(t.name, u.name);
+      if (d >= 1 && d < best) {
+        best = d;
+        match = &u;
+      }
+    }
+    if (match == nullptr) {
+      continue;
+    }
+    const std::string key = t.name < match->name ? t.name + "\n" + match->name : match->name + "\n" + t.name;
+    if (!paired.insert(key).second) {
+      continue;  // this unordered pair already reported (from the other side)
+    }
+    const std::string & pub_side = pub_only ? t.name : match->name;
+    const std::string & sub_side = pub_only ? match->name : t.name;
+    // Deliberately a CANDIDATE, not a conclusion. The pub-only/sub-only shape is not unique
+    // to a typo: any node that publishes one name and subscribes a near-identical one of the
+    // same type - a CAN/serial bridge on /can_rx + /can_tx, any relay that republishes a
+    // one-character variant - leaves exactly this shape the moment its peer exits. Telling an
+    // operator to "reconcile the two names" in that case hands them a wrong remediation on
+    // top of whatever actually died.
+    out.push_back({pub_side, sub_side,
+                   "possible topic-name mismatch: publisher-only '" + pub_side + "' and subscriber-only '" + sub_side +
+                       "' share type " + t.type + " and differ by " + std::to_string(best) +
+                       " char(s) - either a remap typo or a departed counterpart; check both before renaming"});
+  }
+  return out;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/orphan_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/orphan_detector.cpp
@@ -1,0 +1,218 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <cstdint>
+#include <iterator>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/msg/fault.hpp>
+
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+#include "ros2_medkit_graph_watchdog/orphan_policy.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+namespace {
+// Fault severity scale: SEVERITY_WARN=1, SEVERITY_ERROR=2 (ros2_medkit_msgs/msg/Fault.msg).
+// A pub-only/sub-only near-miss pair means data silently never arrives at its intended
+// destination - as severe as QoS starvation.
+constexpr std::uint8_t kOrphanSeverity = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
+// Catches single-char typos, e.g. /scann vs /scan. Numeric siblings such as /lidar_1 vs
+// /lidar_2 are within this distance but are spared by differs_only_in_numeric_fields().
+// Config-overridable via "max_edit_distance".
+constexpr int kDefaultMaxEditDistance = 1;
+// Upper bound on the configurable edit distance: beyond a few edits a "near miss" matches
+// unrelated topics, and an unbounded value would overflow `best` in find_orphans. A value
+// outside (0, kMaxEditDistance] keeps the default.
+constexpr int kMaxEditDistance = 8;
+// The namespace must match to the character unless an operator opts out. A fleet named with
+// letters (/amr_a, /amr_b) puts every robot one edit from its neighbour, so any budget above 0
+// reports the entire fleet as typos - the numeric-field rule spares a NUMBERED fleet, but
+// nothing spares a lettered one. Raising it is how a misspelled namespace (/robto/scan vs
+// /robot/scan) becomes visible at all, which is a real remap mistake this detector otherwise
+// cannot see. That trade belongs to whoever knows the naming scheme, so it is opt-in.
+// A value outside [0, kMaxEditDistance] keeps the default.
+constexpr int kDefaultNamespaceEditDistance = 0;
+
+/// Consecutive ticks a candidate pair must hold before it is reported.
+///
+/// Without this one sweep raises, and the shipped fault_manager config carries
+/// `confirmation_threshold: -1`, so that single tick becomes a CONFIRMED ERROR and - with
+/// `snapshots.rosbag.enabled` - burns a black-box capture. The pub-only/sub-only shape this
+/// detector looks for is exactly what a restart produces: a node that publishes one name and
+/// subscribes a near-identical one of the same type (a CAN bridge on /can_rx + /can_tx) makes
+/// its peer's topics look one-sided for as long as that peer is down, and staged bringup does
+/// the same before the second half starts.
+///
+/// The reliability gate does not cover it: graph_source_id() is not an app id, so
+/// allows_raise() takes the unknown-source branch and is permanently armed once the graph has
+/// been non-empty for warmup_cycles ticks. Anything restarted after that gets no settle window
+/// at all.
+///
+/// A real name typo is static - still there N ticks later - so this costs no meaningful
+/// detection latency. The default outlives a supervisor restart at the 1s default tick; it
+/// does NOT outlive a slow staged bringup, which is why the description stays a candidate.
+constexpr int kDefaultGrace = 10;
+}  // namespace
+
+/// Watches every topic for a one-sided endpoint (pub-only or sub-only) with a near-miss,
+/// same-type counterpart in the same namespace carrying the complementary side - the signature of
+/// a remap / topic-name typo. See orphan_policy.hpp for the pure matching core (dedup,
+/// system-topic skip, same-namespace guard) and design doc / [[project_graph_watchdog_zero_config]].
+class OrphanDetector : public Detector {
+ public:
+  std::string id() const override {
+    return "orphan";
+  }
+
+  void configure(const nlohmann::json & config) override {
+    std::vector<std::string> warnings;
+    if (config.contains("max_edit_distance")) {
+      const auto & value = config["max_edit_distance"];
+      if (value.is_number_integer() && value.get<int>() > 0 && value.get<int>() <= kMaxEditDistance) {
+        max_edit_distance_ = value.get<int>();
+      } else {
+        warnings.push_back("'max_edit_distance' must be an integer in 1.." + std::to_string(kMaxEditDistance) +
+                           "; keeping the default (" + std::to_string(kDefaultMaxEditDistance) + ")");
+      }
+    }
+    if (config.contains("namespace_edit_distance")) {
+      const auto & value = config["namespace_edit_distance"];
+      if (value.is_number_integer() && value.get<int>() >= 0 && value.get<int>() <= kMaxEditDistance) {
+        namespace_edit_distance_ = value.get<int>();
+      } else {
+        warnings.push_back("'namespace_edit_distance' must be an integer in 0.." + std::to_string(kMaxEditDistance) +
+                           "; keeping the default (" + std::to_string(kDefaultNamespaceEditDistance) + ")");
+      }
+    }
+    if (config.contains("grace")) {
+      const auto & value = config["grace"];
+      if (value.is_number_integer() && value.get<int>() >= 0) {
+        grace_ = value.get<int>();
+      } else {
+        warnings.push_back("'grace' must be a non-negative integer; keeping the default (" +
+                           std::to_string(kDefaultGrace) + ")");
+      }
+    }
+    // Same escape hatch every other detector offers: a heuristic over topic NAMES cannot be
+    // right for every graph, and without this an operator whose layout trips it has no option
+    // but to turn the whole detector off. Exact match only, never a prefix, so allowlisting
+    // /r1/scan cannot silently also silence /r2/scan.
+    allowlist_.clear();
+    if (config.contains("allowlist")) {
+      const auto & value = config["allowlist"];
+      if (value.is_array()) {
+        for (const auto & entry : value) {
+          if (entry.is_string() && !entry.get<std::string>().empty()) {
+            allowlist_.insert(entry.get<std::string>());
+          }
+        }
+      } else {
+        warnings.push_back("'allowlist' must be an array of topic names; ignoring it");
+      }
+    }
+    collect_unknown_detector_keys(config, known_keys(), warnings);
+    warnings_ = std::move(warnings);
+    streak_.clear();
+  }
+
+  void tick(DetectorContext & ctx) override {
+    if (!ctx.gateway_node) {
+      return;
+    }
+    log_warnings_once(ctx);
+
+    std::vector<TopicEndpointCounts> topics;
+    const auto names_and_types = ctx.gateway_node->get_topic_names_and_types();
+    topics.reserve(names_and_types.size());
+    for (const auto & [name, types] : names_and_types) {
+      if (ctx.cancelled && ctx.cancelled->load()) {
+        return;  // shutting down: do not emit a clear built from a partial sweep
+      }
+      TopicEndpointCounts t;
+      t.name = name;
+      t.type = types.empty() ? std::string() : types.front();
+      t.publishers = ctx.gateway_node->count_publishers(name);
+      t.subscribers = ctx.gateway_node->count_subscribers(name);
+      topics.push_back(std::move(t));
+    }
+
+    std::map<std::string, std::string> affected;  // "pub <-> sub" -> reason
+    std::vector<std::string> newly_affected;      // crossed the gate this tick -> named first
+    std::set<std::string> seen_pairs;
+    for (const auto & finding : find_orphans(topics, max_edit_distance_, namespace_edit_distance_)) {
+      const std::string key = finding.publisher_topic + " <-> " + finding.subscriber_topic;
+      seen_pairs.insert(key);
+      // Persistence gate, per pair so one flapping pair never delays another.
+      // A pair crossing the gate on THIS tick is the new information. Each orphan reason is
+      // long, so two entries fill the description cap; without this a newly detected pair
+      // sorting later changes nothing an operator can see.
+      if (allowlist_.count(finding.publisher_topic) != 0 || allowlist_.count(finding.subscriber_topic) != 0) {
+        streak_.erase(key);
+        continue;
+      }
+      if (++streak_[key] == grace_ + 1) {
+        newly_affected.push_back(key);
+      }
+      if (streak_[key] <= grace_) {
+        continue;
+      }
+      affected[key] = finding.reason;
+    }
+    // Drop streaks for pairs that stopped matching, so a pair has to hold CONSECUTIVE ticks
+    // and the map cannot grow without bound on a graph that churns topic names.
+    for (auto it = streak_.begin(); it != streak_.end();) {
+      it = seen_pairs.count(it->first) == 0 ? streak_.erase(it) : std::next(it);
+    }
+
+    aggregated_.emit_ordered(ctx, affected, newly_affected);
+  }
+
+ private:
+  static const std::set<std::string> & known_keys() {
+    static const std::set<std::string> keys{"allowlist", "grace", "max_edit_distance", "namespace_edit_distance"};
+    return keys;
+  }
+
+  void log_warnings_once(const DetectorContext & ctx) {
+    if (warnings_.empty() || warnings_logged_ || !ctx.gateway_node) {
+      return;
+    }
+    for (const auto & warning : warnings_) {
+      RCLCPP_WARN(ctx.gateway_node->get_logger(), "graph_watchdog orphan: %s", warning.c_str());
+    }
+    warnings_logged_ = true;
+  }
+
+  int max_edit_distance_ = kDefaultMaxEditDistance;
+  int namespace_edit_distance_ = kDefaultNamespaceEditDistance;
+  int grace_ = kDefaultGrace;
+  std::set<std::string> allowlist_;    // topic names never reported
+  std::map<std::string, int> streak_;  ///< pair key -> consecutive matching ticks
+  std::vector<std::string> warnings_;
+  bool warnings_logged_ = false;
+  AggregatedFault aggregated_{graph_fault_codes::kOrphan, kOrphanSeverity};
+};
+
+REGISTER_DETECTOR(OrphanDetector, "orphan")
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Orphan / topic-name-mismatch e2e: proves GRAPH_ORPHAN raises and clears through the
+REAL gateway + orphan_detector + fault_manager stack. This is the acceptance gate for
+its design issue.
+
+Unlike test_orphan_integration.cpp (which drives the detector directly against a fake
+ReportFault service and a bare rclcpp::Node), this launches the REAL gateway process with
+the graph_watchdog plugin (.so) loaded and a real fault_manager, and polls the
+operator-visible ``GET /api/v1/faults`` surface - the only way to prove the detector's
+raise/clear actually reaches a SOVD fault through the real tick timer and config-delivery
+path (see harness.py's module docstring for why a C++ test alone cannot give this proof).
+
+Two real rclpy nodes are created directly in this test process (mirrors the pattern in
+test_qos_e2e.test.py and ros2_medkit_integration_tests'
+test_external_component_fault_rollup.test.py):
+
+- a publisher on ``/scam`` (LaserScan) - the typo, pub-only, never changes until removed.
+- a publisher on ``/robott/odom`` and a subscriber on ``/robot/odom`` - the same mistake made
+  in the namespace instead of the leaf, reported only because this launch opts into
+  ``namespace_edit_distance``. Both typo publishers sit on the same node, so destroying it
+  leaves nothing orphaned and the clear story below still holds.
+- a subscriber on ``/scan`` (LaserScan) - the intended target, sub-only. It never matches
+  the typo publisher (different topic name), so no data ever flows between the two nodes
+  even though both are alive - the silent failure signature this detector exists to catch.
+
+Endpoint discovery (participant/publication/subscription builtin-topic data) is populated
+by DDS's own background discovery, independent of executor spinning - the same rationale
+as test_orphan_integration.cpp - so these nodes are never spun; they only need to stay
+alive so their advertised pub/sub counts remain visible to the gateway.
+"""
+
+import os
+import sys
+import unittest
+
+import launch_testing
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+from sensor_msgs.msg import LaserScan
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from harness import create_watchdog_test_launch, poll_cleared, poll_faults  # noqa: E402
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+
+PORT = get_test_port()
+
+# Fast tick cadence + short warmup so the whole story (gateway/fault_manager startup, real
+# DDS endpoint discovery, per-app arm, global bringup grace) comfortably fits inside the
+# poll_faults()/poll_cleared() timeouts below without a hand-tuned pre-sleep - see the
+# identical rationale in test_qos_e2e.test.py.
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+
+TYPO_TOPIC = '/scam'
+TARGET_TOPIC = '/scan'
+FAULT_CODE = 'GRAPH_ORPHAN'
+
+# A second near-miss pair, identical in shape to the one above (same parent namespace, edit
+# distance 1, same type, one-sided on each side) and only distinguished by being allowlisted.
+# It is the negative control for the allowlist: the detector must report the first pair and
+# stay silent about this one, which is also the only proof that a string ARRAY survives the
+# YAML -> ROS parameter -> nested-config delivery path into configure(). No C++ test can give
+# that proof - both the unit and the integration test hand configure() a JSON object directly.
+ALLOWLISTED_TYPO_TOPIC = '/hokuyo_scam'
+ALLOWLISTED_TARGET_TOPIC = '/hokuyo_scan'
+
+# A misspelled NAMESPACE with an identical leaf. At the default namespace_edit_distance of 0
+# this pair is invisible, so seeing it reported is what proves an integer key also survives
+# the parameter path - and it is the mistake the exact-namespace guard otherwise hides.
+NS_TYPO_TOPIC = '/robott/odom'
+NS_TARGET_TOPIC = '/robot/odom'
+NAMESPACE_EDIT_DISTANCE = 1
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+        'plugins.graph_watchdog.detectors.orphan.allowlist': [ALLOWLISTED_TYPO_TOPIC],
+        'plugins.graph_watchdog.detectors.orphan.namespace_edit_distance': NAMESPACE_EDIT_DISTANCE,
+    }
+    return create_watchdog_test_launch(
+        detector_params=detector_params,
+        demo_nodes=None,
+        port=PORT,
+        # Clearing GRAPH_ORPHAN after the typo publisher is removed must reach HEALED
+        # (absent from the default active-fault query) - see harness.py's healing_enabled
+        # doc.
+        healing_enabled=True,
+    )
+
+
+class TestOrphanE2e(unittest.TestCase):
+    """GRAPH_ORPHAN raises on a real pub-only/sub-only topic-name near-miss pair, clears
+    once the typo publisher is destroyed."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._pub_node = Node('orphan_e2e_typo_pub')
+        cls._pub = cls._pub_node.create_publisher(LaserScan, TYPO_TOPIC, QoSProfile(depth=10))
+        cls._ns_pub = cls._pub_node.create_publisher(LaserScan, NS_TYPO_TOPIC, QoSProfile(depth=10))
+
+        cls._sub_node = Node('orphan_e2e_target_sub')
+        cls._sub = cls._sub_node.create_subscription(
+            LaserScan, TARGET_TOPIC, lambda _msg: None, QoSProfile(depth=10))
+        cls._ns_sub = cls._sub_node.create_subscription(
+            LaserScan, NS_TARGET_TOPIC, lambda _msg: None, QoSProfile(depth=10))
+
+        cls._allowed_node = Node('orphan_e2e_allowlisted')
+        cls._allowed_pub = cls._allowed_node.create_publisher(
+            LaserScan, ALLOWLISTED_TYPO_TOPIC, QoSProfile(depth=10))
+        cls._allowed_sub = cls._allowed_node.create_subscription(
+            LaserScan, ALLOWLISTED_TARGET_TOPIC, lambda _msg: None, QoSProfile(depth=10))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._allowed_node.destroy_node()
+        cls._sub_node.destroy_node()
+        if cls._pub_node is not None:
+            cls._pub_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_01_typo_pair_raises_naming_both(self):
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        self.assertIsNotNone(
+            fault,
+            f'{FAULT_CODE} never raised for a pub-only {TYPO_TOPIC} / sub-only '
+            f'{TARGET_TOPIC} near-miss pair',
+        )
+        description = fault.get('description', '')
+        self.assertIn(TYPO_TOPIC, description)
+        self.assertIn(TARGET_TOPIC, description)
+
+    def test_01a_namespace_typo_pair_is_reported_too(self):
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} is no longer raised')
+        description = fault.get('description', '')
+        self.assertIn(
+            NS_TYPO_TOPIC,
+            description,
+            f'{NS_TYPO_TOPIC} / {NS_TARGET_TOPIC} differ only in the namespace, so they are '
+            f'reported only if namespace_edit_distance={NAMESPACE_EDIT_DISTANCE} reached the '
+            f'detector: {description}',
+        )
+
+    def test_01b_allowlisted_pair_is_absent_from_the_same_fault(self):
+        # The aggregated fault enumerates every orphaned pair, so an allowlist that never
+        # reached the detector would show up here as a second pair in the same description.
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} is no longer raised')
+        description = fault.get('description', '')
+        self.assertNotIn(
+            ALLOWLISTED_TYPO_TOPIC,
+            description,
+            f'{ALLOWLISTED_TYPO_TOPIC} is allowlisted in the gateway parameters but was '
+            f'still reported: {description}',
+        )
+
+    def test_02_removing_typo_publisher_clears(self):
+        # Clear: DESTROY the typo publisher (not "add a publisher on /scan" - that would
+        # leave /scam permanently orphaned) - same rationale as
+        # test_orphan_integration.cpp.
+        type(self)._pub_node.destroy_node()
+        type(self)._pub_node = None
+        type(self)._pub = None
+
+        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0)
+        self.assertTrue(
+            cleared,
+            f'{FAULT_CODE} did not clear after the typo publishers {TYPO_TOPIC} and '
+            f'{NS_TYPO_TOPIC} were removed',
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_orphan_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_orphan_integration.cpp
@@ -1,0 +1,313 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Drives the REAL mechanism: a real publisher on a topic-name typo and a real subscriber
+// on the intended target topic, both LaserScan, over real DDS - and the detector reads the
+// live endpoint counts via gateway_node->get_topic_names_and_types() +
+// count_publishers()/count_subscribers() - never hand-built TopicEndpointCounts (that is
+// test_orphan_policy.cpp's job) - and raises/clears through a real ReportFault service
+// round-trip to a fake fault_manager. NOT a full-gateway e2e (that is
+// test/e2e/test_orphan_e2e.test.py); this proves the detector end to end within its own
+// scope.
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+
+using ros2_medkit_gateway::IntrospectionInput;
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::DetectorMode;
+using ros2_medkit_graph_watchdog::graph_fault_codes::kOrphan;
+using ReportFault = ros2_medkit_msgs::srv::ReportFault;
+using LaserScan = sensor_msgs::msg::LaserScan;
+using namespace std::chrono_literals;
+
+namespace {
+// The detector class is file-local in orphan_detector.cpp but self-registers via
+// REGISTER_DETECTOR, which runs when that .cpp is linked into this test. Pull an
+// instance from the registry (no production factory needed).
+std::unique_ptr<ros2_medkit_graph_watchdog::Detector> make_orphan() {
+  for (auto & d : ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all()) {
+    if (d->id() == "orphan") {
+      return std::move(d);
+    }
+  }
+  return nullptr;
+}
+// Aggregated fault source: no Component in the test snapshot, so graph_source_id()
+// falls back to this literal (see aggregated_fault.hpp).
+constexpr const char * kGraphSource = "graph_watchdog";
+}  // namespace
+
+class OrphanIntegrationTest : public ::testing::Test {
+ protected:
+  // Must run before the FIRST test's fixture is constructed - see the identical
+  // rationale in test_qos_mismatch_integration.cpp.
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  void SetUp() override {
+    gateway_ = std::make_shared<rclcpp::Node>("orphan_it_gateway");
+    sink_ = std::make_shared<rclcpp::Node>("orphan_it_sink");
+    srv_ = sink_->create_service<ReportFault>(
+        "/fault_manager/report_fault",
+        [this](const std::shared_ptr<ReportFault::Request> req, std::shared_ptr<ReportFault::Response> resp) {
+          {
+            std::lock_guard<std::mutex> lk(mtx_);
+            received_.push_back(*req);
+          }
+          resp->accepted = true;  // ReportFault.srv response field is `bool accepted`
+        });
+    client_ = gateway_->create_client<ReportFault>("/fault_manager/report_fault");
+    exec_.add_node(gateway_);
+    exec_.add_node(sink_);
+    spin_ = std::thread([this]() {
+      exec_.spin();
+    });
+    ASSERT_TRUE(client_->wait_for_service(5s));
+  }
+
+  void TearDown() override {
+    exec_.cancel();
+    if (spin_.joinable()) {
+      spin_.join();
+    }
+    exec_.remove_node(gateway_);
+    exec_.remove_node(sink_);
+    client_.reset();
+    srv_.reset();
+    sink_.reset();
+    typo_pub_.reset();
+    target_sub_.reset();
+    debug_pub_.reset();
+    typo_pub_node_.reset();
+    target_sub_node_.reset();
+    debug_pub_node_.reset();
+    peer_sub_.reset();
+    peer_sub_node_.reset();
+    gateway_.reset();
+  }
+
+  DetectorContext make_ctx(DetectorMode mode) {
+    DetectorContext ctx;
+    ctx.gateway_node = gateway_.get();
+    ctx.node_mutex = &node_mutex_;
+    ctx.mode = mode;
+    ctx.gate = nullptr;  // ungated
+    ctx.fault_client = client_;
+    ctx.snapshot = &snapshot_;  // empty -> aggregated source falls back to kGraphSource
+    return ctx;
+  }
+
+  // Endpoint discovery (rmw participant builtin-topic data) is populated by the
+  // middleware's own background discovery, not by executor spinning - so these helper
+  // nodes are never added to exec_. They just need to stay alive for the DDS entities to
+  // remain visible to the gateway node.
+  static rclcpp::Publisher<LaserScan>::SharedPtr
+  make_publisher(rclcpp::Node::SharedPtr & node_out, const std::string & node_name, const std::string & topic) {
+    node_out = std::make_shared<rclcpp::Node>(node_name);
+    return node_out->create_publisher<LaserScan>(topic, rclcpp::QoS(10));
+  }
+
+  static rclcpp::Subscription<LaserScan>::SharedPtr
+  make_subscription(rclcpp::Node::SharedPtr & node_out, const std::string & node_name, const std::string & topic) {
+    node_out = std::make_shared<rclcpp::Node>(node_name);
+    return node_out->create_subscription<LaserScan>(topic, rclcpp::QoS(10), [](LaserScan::UniquePtr) {});
+  }
+
+  // How many matching faults are currently in the log (for absence checks + snapshots).
+  std::size_t count_faults(const std::string & source_id, uint8_t event_type) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    std::size_t n = 0;
+    for (const auto & r : received_) {
+      if (r.source_id == source_id && r.fault_code == kOrphan && r.event_type == event_type) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+  // True if any recorded FAILED for `source_id` carries a description containing EVERY needle.
+  bool any_failed_desc_contains(const std::string & source_id, const std::vector<std::string> & needles) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    for (const auto & r : received_) {
+      if (r.source_id != source_id || r.fault_code != kOrphan || r.event_type != ReportFault::Request::EVENT_FAILED) {
+        continue;
+      }
+      bool all = true;
+      for (const auto & needle : needles) {
+        if (r.description.find(needle) == std::string::npos) {
+          all = false;
+          break;
+        }
+      }
+      if (all) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Tick until a NEW matching fault appears beyond `baseline_count` (arrived AFTER the
+  // trigger), or timeout. 130 iterations at 100ms is a 13s window, comfortably over the
+  // >=5s real DDS endpoint-discovery window pub/sub visibility needs.
+  bool poll_for_new(const std::string & source_id, uint8_t event_type, std::size_t baseline_count,
+                    ros2_medkit_graph_watchdog::Detector & det, DetectorContext & ctx) {
+    for (int i = 0; i < 130; ++i) {
+      det.tick(ctx);
+      std::this_thread::sleep_for(100ms);
+      if (count_faults(source_id, event_type) > baseline_count) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  rclcpp::Node::SharedPtr gateway_, sink_;
+  rclcpp::Service<ReportFault>::SharedPtr srv_;
+  rclcpp::Client<ReportFault>::SharedPtr client_;
+  rclcpp::executors::MultiThreadedExecutor exec_;
+  std::thread spin_;
+  std::mutex mtx_, node_mutex_;
+  std::vector<ReportFault::Request> received_;
+  IntrospectionInput snapshot_;  // owned, empty entity snapshot (no Component -> literal source)
+
+  rclcpp::Node::SharedPtr typo_pub_node_, target_sub_node_, debug_pub_node_, peer_sub_node_;
+  rclcpp::Publisher<LaserScan>::SharedPtr typo_pub_, debug_pub_;
+  rclcpp::Subscription<LaserScan>::SharedPtr target_sub_, peer_sub_;
+};
+
+// The full story in one test: a pub-only typo (/scam) + sub-only intended target (/scan),
+// same LaserScan type, raises the aggregate naming BOTH endpoints; a concurrent lone
+// pub-only /debug topic (no counterpart at all) never appears in any raised description
+// (positive control - proves the detector discriminates a real near-miss pair from "just
+// some topic with only one side"); destroying the typo publisher (never "add a publisher
+// on /scan" - that would leave /scam orphaned forever) clears the aggregate.
+TEST_F(OrphanIntegrationTest, TypoPairRaisesNamesBothDebugNeverNamedThenClearsOnRemoval) {
+  typo_pub_ = make_publisher(typo_pub_node_, "orphan_it_typo_pub", "/scam");
+  target_sub_ = make_subscription(target_sub_node_, "orphan_it_target_sub", "/scan");
+  debug_pub_ = make_publisher(debug_pub_node_, "orphan_it_debug_pub", "/debug");
+
+  auto det = make_orphan();
+  ASSERT_TRUE(det) << "orphan did not self-register - REGISTER_DETECTOR did not run";
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  EXPECT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before, *det, ctx));
+
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/scam"}));
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/scan"}));
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"/debug"}))
+      << "/debug (a lone topic with no counterpart) must never be named in an aggregated raise";
+
+  // Clear: DESTROY the /scam typo publisher (not "add a publisher on /scan" - that would
+  // leave /scam permanently orphaned). Once /scam is gone, the near-miss pair vanishes.
+  typo_pub_.reset();
+  typo_pub_node_.reset();
+
+  const auto passed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED);
+  EXPECT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_PASSED, passed_before, *det, ctx));
+}
+
+// A restart is not a typo. Any node that publishes one name and subscribes a near-identical
+// one of the same type - a CAN/serial bridge on /can_rx + /can_tx, any relay that
+// republishes a one-character variant - leaves EXACTLY the pub-only/sub-only shape this
+// detector matches, for as long as its peer is down. Before the persistence gate that was a
+// CONFIRMED ERROR on the first sweep (fault_manager ships confirmation_threshold -1), with a
+// "reconcile the two names" instruction attached to something that is not misnamed at all.
+TEST_F(OrphanIntegrationTest, PeerRestartWindowDoesNotRaise) {
+  // Bridge side only: publishes /can_rx, subscribes /can_tx. Its peer is down.
+  typo_pub_ = make_publisher(typo_pub_node_, "orphan_it_bridge_pub", "/can_rx");
+  target_sub_ = make_subscription(target_sub_node_, "orphan_it_bridge_sub", "/can_tx");
+
+  auto det = make_orphan();
+  ASSERT_TRUE(det);
+  det->configure({{"grace", 10}});  // the shipped default, stated explicitly
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  for (int i = 0; i < 6; ++i) {  // peer down, but for fewer ticks than grace
+    det->tick(ctx);
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "a peer that is merely restarting must not be reported as a name typo";
+
+  // Peer returns: both topics are two-sided again, so the near-miss pair stops matching.
+  debug_pub_ = make_publisher(debug_pub_node_, "orphan_it_peer_pub", "/can_tx");
+  peer_sub_ = make_subscription(peer_sub_node_, "orphan_it_peer_sub", "/can_rx");
+  for (int i = 0; i < 25; ++i) {
+    det->tick(ctx);
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "the streak must reset when the pair stops matching, never accumulate across the gap";
+}
+
+// The persistence gate must not cost detection: a genuine typo is static, so it is still
+// there N ticks later and still gets reported.
+TEST_F(OrphanIntegrationTest, StaticTypoStillRaisesOnceGraceElapses) {
+  typo_pub_ = make_publisher(typo_pub_node_, "orphan_it_static_pub", "/scam2");
+  target_sub_ = make_subscription(target_sub_node_, "orphan_it_static_sub", "/scan2");
+
+  auto det = make_orphan();
+  ASSERT_TRUE(det);
+  det->configure({{"grace", 2}});
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, before, *det, ctx));
+  // Worded as a candidate, not a conclusion: the same shape is produced by a departed peer,
+  // so telling the operator to rename one of the two would be a wrong remediation.
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"possible topic-name mismatch"}));
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"likely a remap typo"}));
+}
+
+// A heuristic over topic names cannot be right for every graph, so an operator needs a way to
+// silence one finding without turning the detector off. Same escape hatch the other detectors
+// offer. Exact match only: allowlisting one name must not silence a similarly-named topic.
+TEST_F(OrphanIntegrationTest, AllowlistedTopicIsNeverReported) {
+  typo_pub_ = make_publisher(typo_pub_node_, "orphan_it_allow_pub", "/scam3");
+  target_sub_ = make_subscription(target_sub_node_, "orphan_it_allow_sub", "/scan3");
+
+  auto det = make_orphan();
+  ASSERT_TRUE(det);
+  det->configure({{"grace", 0}, {"allowlist", {"/scam3"}}});
+  auto ctx = make_ctx(DetectorMode::Raise);
+
+  const auto before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  for (int i = 0; i < 12; ++i) {
+    det->tick(ctx);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), before)
+      << "an allowlisted topic must never be reported, however long the pair holds";
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_orphan_policy.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_orphan_policy.cpp
@@ -1,0 +1,229 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "ros2_medkit_graph_watchdog/orphan_policy.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+using ros2_medkit_graph_watchdog::find_orphans;
+using ros2_medkit_graph_watchdog::TopicEndpointCounts;
+
+TEST(OrphanPolicy, TypoPairReportedOnceNamingBothSides) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/scann", "sensor_msgs/msg/LaserScan", 1, 0},  // typo: pub-only
+      {"/scan", "sensor_msgs/msg/LaserScan", 0, 1},   // intended target: sub-only
+  };
+  auto out = find_orphans(topics, 1);
+  ASSERT_EQ(out.size(), 1u);  // ONE finding, not two
+  EXPECT_EQ(out[0].publisher_topic, "/scann");
+  EXPECT_EQ(out[0].subscriber_topic, "/scan");
+  EXPECT_NE(out[0].reason.find("/scann"), std::string::npos);
+  EXPECT_NE(out[0].reason.find("/scan"), std::string::npos);  // names both, suggests neither
+}
+TEST(OrphanPolicy, LoneDebugTopicWithNoCounterpartIsNotOrphan) {
+  std::vector<TopicEndpointCounts> topics = {{"/debug_markers", "visualization_msgs/msg/Marker", 1, 0}};
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+TEST(OrphanPolicy, NearMissButDifferentTypeIsNotOrphan) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/scann", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/scan", "sensor_msgs/msg/PointCloud2", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+TEST(OrphanPolicy, FullyConnectedTopicIsNotOrphan) {
+  std::vector<TopicEndpointCounts> topics = {{"/scan", "sensor_msgs/msg/LaserScan", 1, 1}};
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+TEST(OrphanPolicy, NumericSuffixWithinDistance2ButNotDefaultDistance) {
+  // /scan vs /scan_1 is Levenshtein 2 (two trailing inserts); at the detector default
+  // (max_edit_distance=1) this legitimate sibling topic must NOT be flagged.
+  std::vector<TopicEndpointCounts> topics = {
+      {"/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/scan_1", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+  EXPECT_FALSE(find_orphans(topics, 2).empty());  // only fires if an operator opts into distance 2
+}
+TEST(OrphanPolicy, PerRobotTopicsInDifferentNamespacesAreNotOrphans) {
+  // /robot1/scan vs /robot2/scan is distance 1 but a fleet layout, not a typo.
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robot1/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot2/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+
+// The case above is now rejected by the numeric-field rule as well, so on its own it no
+// longer proves the same-namespace guard does anything. A fleet is not always numbered:
+// these two namespaces differ by a letter, and the pair must still be rejected because the
+// difference sits in the namespace, not in the leaf.
+TEST(OrphanPolicy, ALetterDifferenceInTheNamespaceIsStillNotAnOrphan) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/left/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/lift/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+TEST(OrphanPolicy, OneSidedNextToHealthyConnectedSiblingIsNotOrphan) {
+  // /lidar_1 is pub-only; /lidar_2 is fully connected and HEALTHY (same type, distance 1,
+  // same namespace). /lidar_2 is not waiting for /lidar_1's data, so this is a normal
+  // multi-sensor layout, not a typo - the counterpart must be strictly one-sided to pair.
+  std::vector<TopicEndpointCounts> topics = {
+      {"/lidar_1", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/lidar_2", "sensor_msgs/msg/LaserScan", 1, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+TEST(OrphanPolicy, SystemTopicsAreSkippedButOnlyByExactName) {
+  // /rosout and /parameter_events are absolute and global: exactly two names, never a prefix
+  // class. A user topic that merely starts with the same text must stay under detection - a
+  // prefix match would silently exempt it and hide a real typo.
+  std::vector<TopicEndpointCounts> system_pair = {
+      {"/parameter_eventt", "rcl_interfaces/msg/ParameterEvent", 1, 0},
+      {"/parameter_events", "rcl_interfaces/msg/ParameterEvent", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(system_pair, 1).empty());  // the real system topic is skipped
+
+  std::vector<TopicEndpointCounts> user_pair = {
+      {"/parameter_events_debugg", "rcl_interfaces/msg/ParameterEvent", 1, 0},
+      {"/parameter_events_debug", "rcl_interfaces/msg/ParameterEvent", 0, 1},
+  };
+  auto out = find_orphans(user_pair, 1);
+  ASSERT_EQ(out.size(), 1u) << "a user topic starting with /parameter_events must still be checked";
+  EXPECT_EQ(out[0].publisher_topic, "/parameter_events_debugg");
+  EXPECT_EQ(out[0].subscriber_topic, "/parameter_events_debug");
+}
+// Two independently one-sided members of a sensor enumeration is an ordinary state on a
+// multi-sensor robot: nothing is recording /lidar_1 while /lidar_2's driver is down. Naming
+// them as a possible typo, at ERROR, is exactly the false positive this detector must not
+// produce. The same-namespace guard does not catch these, because it only helps when the
+// differing character sits in a namespace segment; in all of these it sits in the leaf.
+TEST(OrphanPolicy, ANumericFieldDifferenceIsAnEnumerationNotATypo) {
+  struct Case {
+    const char * pub;
+    const char * sub;
+  };
+  const Case cases[] = {
+      {"/lidar_1", "/lidar_2"},
+      {"/image1", "/image2"},
+      {"/cameras/image1", "/cameras/image2"},
+      {"/camera1/image", "/camera2/image"},
+  };
+  for (const auto & c : cases) {
+    std::vector<TopicEndpointCounts> topics = {
+        {c.pub, "sensor_msgs/msg/Image", 1, 0},
+        {c.sub, "sensor_msgs/msg/Image", 0, 1},
+    };
+    EXPECT_TRUE(find_orphans(topics, 1).empty()) << c.pub << " + " << c.sub << " is an enumeration, not a typo";
+  }
+}
+
+// The cost of the rule above, stated as a test so it cannot be forgotten: a typo that IS a
+// digit is no longer reported. Accepted deliberately - a false ERROR on every multi-sensor
+// robot is worse than this miss.
+TEST(OrphanPolicy, ADigitTypoIsKnowinglyNotReported) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/lidar_1", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/lidar_2", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+
+// A letter difference is still a typo and must keep firing, otherwise the rule above has
+// swallowed the whole detector.
+TEST(OrphanPolicy, LetterDifferenceIsStillReported) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/scan_raw", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/scan_row", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  auto out = find_orphans(topics, 1);
+  ASSERT_EQ(out.size(), 1u);
+  EXPECT_EQ(out[0].publisher_topic, "/scan_raw");
+}
+
+// A name that differs by adding or removing characters is not a digit substitution, even when
+// the changed characters are digits, so it must stay under detection.
+// The tenth sensor of a family is two edits from the ninth, so this pair only becomes a
+// candidate at max_edit_distance 2 - and there the numeric-field rule is the only thing left
+// that spares it. Comparing character positions instead of collapsed names would report it.
+TEST(OrphanPolicy, ANumericFieldDifferenceIsSparedWhenTheIndexChangesLength) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/lidar_9", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/lidar_10", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 2).empty());
+}
+
+// An appended digit is a different name, not another member of a family: "/scan1"
+// collapses to "/scan#", which is not "/scan".
+TEST(OrphanPolicy, AnAppendedDigitIsStillReported) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/scan1", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_EQ(find_orphans(topics, 1).size(), 1u);
+}
+}  // namespace
+
+// A misspelled namespace is the one remap mistake the exact-namespace guard hides, so the
+// budget that reveals it needs its own coverage on both sides of the default.
+TEST(OrphanPolicy, AMisspelledNamespaceIsInvisibleAtTheDefaultBudget) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robott/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1).empty());
+}
+
+TEST(OrphanPolicy, AMisspelledNamespaceIsReportedOnceTheNamespaceBudgetAllowsIt) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robott/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  const auto found = find_orphans(topics, 1, 1);
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found[0].publisher_topic, "/robott/scan");
+  EXPECT_EQ(found[0].subscriber_topic, "/robot/scan");
+}
+
+// A transposition costs two edits, so the namespace budget is a real bound and not a
+// yes/no switch: the same pair stays hidden at 1 and appears at 2.
+TEST(OrphanPolicy, TheNamespaceBudgetIsABoundNotASwitch) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robto/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1, 1).empty());
+  EXPECT_EQ(find_orphans(topics, 1, 2).size(), 1u);
+}
+
+// The digit guard outranks the namespace budget: a numbered fleet must stay quiet even for
+// an operator who opted into namespace matching.
+TEST(OrphanPolicy, ANumberedFleetIsStillSparedUnderANamespaceBudget) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robot1/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot2/scan", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1, 1).empty());
+}
+
+// The two budgets are independent: spending the namespace one does not buy extra leaf edits.
+TEST(OrphanPolicy, TheLeafBudgetIsNotWidenedByTheNamespaceBudget) {
+  std::vector<TopicEndpointCounts> topics = {
+      {"/robott/scan", "sensor_msgs/msg/LaserScan", 1, 0},
+      {"/robot/odometry", "sensor_msgs/msg/LaserScan", 0, 1},
+  };
+  EXPECT_TRUE(find_orphans(topics, 1, 1).empty());
+}


### PR DESCRIPTION
## Summary

Second of the seven silent-fault detectors. Raises `GRAPH_ORPHAN` for a topic with publishers but no subscribers, or the reverse, when a topic with the complementary shape exists nearby: same namespace, same message type, name within a very small edit distance.

That is what a remap typo looks like from the graph. One node publishes `/scan_raw`, another subscribes `/scan_row`, both are healthy, and neither is talking to the other.

Two deliberate choices:

**The fault names both sides and calls it a candidate.** Nothing in the graph can tell a typo from a counterpart that has just exited or has not started yet, so the description says both and asks the operator to check before renaming.

**A pair must hold for more than `grace` sweeps, default 10.** During a staged bringup one side legitimately exists without the other, which is indistinguishable from a typo until the second node appears. Reporting on a single sweep would fire on every launch.

---

## Issue

- closes #577

Part of #570.

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

21 tests green locally on Jazzy, up from 18. New: a policy unit test for the near-miss matching and the edit distance, an integration test driving real publishers and subscribers over real DDS, and an e2e against a real gateway asserting over `/faults`.

    colcon build --packages-select ros2_medkit_graph_watchdog
    colcon test --packages-select ros2_medkit_graph_watchdog && colcon test-result --verbose

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed