### PR TITLE
build: instrument every C++ package for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,9 +334,12 @@ jobs:
             exit 1
           fi
 
+          # $PWD, not pwd -P: gcov records the path the compiler was given, which
+          # is the logical one. Resolving symlinks here would stop matching.
+          WS="${PWD}"
           lcov --extract coverage.raw.info \
-            '*/ros2_medkit/src/*/src/*' \
-            '*/ros2_medkit/src/*/include/*' \
+            "${WS}/src/*/src/*" \
+            "${WS}/src/*/include/*" \
             --output-file coverage.extracted.info \
             --ignore-errors unused,empty
 
@@ -352,6 +355,15 @@ jobs:
 
           lcov --list coverage.info
           genhtml coverage.info --output-directory coverage_html --ignore-errors source
+
+      # A package that never gets --coverage emits no .gcda and drops out of the
+      # report entirely - out of the numerator and the denominator both, so the
+      # percentage silently stops describing the workspace. Assert the report
+      # still covers every package the source tree says holds production C++.
+      - name: Verify every C++ package reached the coverage report
+        run: |
+          ./scripts/check_coverage_packages.sh coverage.info \
+            --skip ros2_medkit_opcua
 
       - name: Upload coverage HTML report as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Source-tree half of the coverage-scope gate. Reads only CMakeLists.txt,
+      # needs neither ROS nor a build, so it sits directly after checkout: a
+      # package that compiles C++ without opting into coverage instrumentation
+      # fails here in under a second instead of at the end of the coverage job.
+      - name: Every C++ package opts into coverage instrumentation
+        run: ./scripts/check_coverage_packages.sh --static-only
+
       - name: Pre-install ROS 2 apt source
         uses: ./.github/actions/ros-apt-source
 
@@ -347,9 +354,9 @@ jobs:
       # fit the container overlay on small GitHub runners, so build on /mnt.
       volumes:
         - "/mnt:/mnt"
-    # A full TSan run is ~40 min, leaving only ~5 min of headroom at 45; bump to
-    # 60 so a slow runner does not cancel the job mid-run (see sanitizer-asan).
-    timeout-minutes: 60
+    # Successful runs reach 59 min, and a timeout here reads as "TSan found
+    # something" rather than "the job ran out of clock". Keep the headroom.
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,8 @@ cover/
 *.gcno
 *.gcov
 coverage.info
+coverage.raw.info
+coverage.extracted.info
 coverage_html/
 
 # Translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,15 +95,60 @@ On push: incremental clang-tidy on changed `.cpp` files.
 
 #### Code Coverage
 
+Run from the workspace root. This mirrors the measurement pipeline of the CI
+coverage job (same lcov capture, filters and flags), so the local percentage is
+comparable to the published one. The job additionally builds with
+`--symlink-install`, installs `ros-jazzy-test-msgs` via rosdep, and prints
+`lcov --list`; see `.github/workflows/ci.yml` for the authoritative version.
+
 ```bash
-colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
-./scripts/test.sh              # run tests
-lcov --capture --directory build --output-file coverage.raw.info --ignore-errors mismatch,negative
-lcov --extract coverage.raw.info '*/ros2_medkit/src/*/src/*' '*/ros2_medkit/src/*/include/*' --output-file coverage.info
-genhtml coverage.info --output-directory coverage_html
+WS="${PWD}"   # gcov records the path the compiler was given, not the resolved one
+
+colcon build --packages-skip ros2_medkit_opcua \
+  --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+colcon test --packages-skip ros2_medkit_opcua --ctest-args -LE linter
+
+lcov --capture --directory build --output-file coverage.raw.info \
+  --ignore-errors mismatch,negative,empty,gcov
+lcov --extract coverage.raw.info "${WS}/src/*/src/*" "${WS}/src/*/include/*" \
+  --output-file coverage.extracted.info --ignore-errors unused,empty
+lcov --remove coverage.extracted.info '*/vendored/*' \
+  --output-file coverage.info --ignore-errors unused,empty
+genhtml coverage.info --output-directory coverage_html --ignore-errors source
+
+./scripts/check_coverage_packages.sh coverage.info --skip ros2_medkit_opcua
 ```
 
 Open `coverage_html/index.html` in your browser.
+
+`ros2_medkit_opcua` is skipped because it pulls `open62541pp` over the network
+via `FetchContent`, which costs every matrix run time for a plugin unrelated to
+it; CI skips it in the same jobs and builds it separately in
+`.github/workflows/opcua-plugin.yml`. Dropping the `--remove` step leaves
+vendored third-party code in the report and your number will not match CI's.
+
+#### Coverage scope
+
+`ENABLE_COVERAGE` is handled by the shared `ROS2MedkitCoverage` module, not by
+per-package CMake code. **Every package that compiles production C++ must
+`include(ROS2MedkitCoverage)` before it declares its first target** - the flags
+apply at directory scope, so a target created before the include is not
+instrumented. Packages that compile only test scaffolding are exempt and are
+listed in `EXCLUDED_PACKAGES` in the gate script, each with a reason;
+`ros2_medkit_integration_tests` is the current entry.
+
+A package that misses this does not fail the build. It emits no `.gcda`, lcov
+never sees it, and it drops out of both the numerator and the denominator - the
+reported percentage then silently describes a subset of the workspace.
+
+`scripts/check_coverage_packages.sh` guards against that. It derives the set of
+packages that *must* appear from the source tree (anything holding hand-written
+C++ under `src/` or `include/`), never from the presence of the include - a set
+derived from the include could not detect a package that never added it, or one
+where the line was deleted. It runs twice in CI: `--static-only` in the Quality
+workflow, so a missing include fails in seconds, and against the real report in
+the coverage job. Pass `--skip <package>` for a package the current job does not
+build.
 
 #### CI/CD
 

--- a/docs/tutorials/devcontainer.rst
+++ b/docs/tutorials/devcontainer.rst
@@ -152,9 +152,30 @@ Generating Coverage
 
 .. code-block:: bash
 
-   colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
-   colcon test
-   # Coverage report in build/ros2_medkit_gateway/coverage/
+   cd ~/workspace
+   WS="${PWD}"
+
+   colcon build --packages-skip ros2_medkit_opcua \
+     --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+   colcon test --packages-skip ros2_medkit_opcua --ctest-args -LE linter
+
+   lcov --capture --directory build --output-file coverage.raw.info \
+     --ignore-errors mismatch,negative,empty,gcov
+   lcov --extract coverage.raw.info "${WS}/src/*/src/*" \
+     "${WS}/src/*/include/*" \
+     --output-file coverage.extracted.info --ignore-errors unused,empty
+   lcov --remove coverage.extracted.info '*/vendored/*' \
+     --output-file coverage.info --ignore-errors unused,empty
+   genhtml coverage.info --output-directory coverage_html --ignore-errors source
+
+   # Assert no package silently dropped out of the report
+   ./scripts/check_coverage_packages.sh coverage.info --skip ros2_medkit_opcua
+
+Open ``coverage_html/index.html`` in a browser. This mirrors the measurement
+pipeline of the CI coverage job, so the number is comparable to the published
+one; ``.github/workflows/ci.yml`` is the authoritative version. See
+``CONTRIBUTING.md`` for why the last step exists and why ``ros2_medkit_opcua``
+is skipped.
 
 Customization
 -------------

--- a/scripts/check_coverage_packages.sh
+++ b/scripts/check_coverage_packages.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-loud gate against silently shrinking coverage scope.
+#
+# A package that never applies --coverage produces no .gcda, so lcov never sees
+# it and it disappears from the report entirely - out of the numerator AND the
+# denominator. The workspace percentage then describes only the instrumented
+# subset while looking like it describes everything. That is how nine C++
+# packages sat outside the reported number without any job turning red.
+#
+# The expected package set is derived from the SOURCE TREE - any package holding
+# hand-written C++ outside test/ and vendored/ - and never from the presence of
+# include(ROS2MedkitCoverage). Deriving it from the include would be circular:
+# deleting that one line would remove the package from the report and from the
+# assertion about it in the same edit, and a newly added package that never
+# opts in would never be expected in the first place. Both are exactly the
+# regression this gate exists to catch.
+#
+# Two checks:
+#   static  - every expected package includes ROS2MedkitCoverage
+#   report  - every expected package reached the lcov report, contributing a
+#             record for one of its own implementation files (not merely a
+#             header, which a consumer's translation unit would supply anyway)
+#
+# WHAT THIS DOES NOT CATCH, stated so nobody mistakes it for more:
+#   * per-file loss. The report check is per package: a package that loses
+#     instrumentation on all but one of its .cpp files still passes. Closing
+#     that needs a committed per-package file-count baseline, which is churn
+#     on every legitimate source addition.
+#   * include placed after a target. The flags apply at directory scope, so a
+#     target declared before the include is not instrumented. Asserting the
+#     include's line number against the first add_library/add_executable is not
+#     workable: such a grep fails legal CMake (targets inside function() bodies,
+#     if(FALSE) blocks, INTERFACE libraries that compile nothing) while missing
+#     real ones (ament_auto_add_library, uppercase commands, add_subdirectory).
+#     A misplaced include still shows up here whenever it costs the package
+#     every .cpp record; a partial slip does not.
+#
+# Usage:
+#   ./scripts/check_coverage_packages.sh <coverage.info> [--skip <package>]...
+#   ./scripts/check_coverage_packages.sh --static-only [--skip <package>]...
+#
+# --static-only runs the source-tree half without a coverage build, for the
+# lint job, where it costs a fraction of a second.
+#
+# --skip marks a package deliberately not built in the current job (e.g.
+# ros2_medkit_opcua, excluded from the coverage build). Skips are echoed, and a
+# --skip naming a package that is not expected is an error rather than a silent
+# no-op, so the flag cannot rot after a rename.
+#
+# Exit codes:
+#   0  every expected package passes every applicable check
+#   1  at least one expected package failed a check
+#   2  gate misconfiguration (bad arguments, missing files, empty expected set)
+
+set -euo pipefail
+
+# Packages that hold C++ but are deliberately outside the coverage report.
+# Every entry needs a reason. Entries are validated against the source tree, so
+# one that no longer names a real package is an error rather than dead weight.
+EXCLUDED_PACKAGES=(
+  # Everything it compiles is test scaffolding - demo_nodes/ fixtures driven by
+  # the launch_testing suites - not production code under measurement.
+  "ros2_medkit_integration_tests"
+)
+
+COVERAGE_FILE=""
+STATIC_ONLY=""
+SKIPPED=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --static-only)
+      STATIC_ONLY="yes"
+      shift
+      ;;
+    --skip)
+      if [[ $# -lt 2 ]]; then
+        echo "FAIL: --skip requires a package name." >&2
+        exit 2
+      fi
+      SKIPPED+=("$2")
+      shift 2
+      ;;
+    -*)
+      echo "FAIL: unknown argument '$1'." >&2
+      exit 2
+      ;;
+    *)
+      if [[ -n "${COVERAGE_FILE}" ]]; then
+        echo "FAIL: unexpected extra argument '$1'." >&2
+        exit 2
+      fi
+      COVERAGE_FILE="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${STATIC_ONLY}" && -z "${COVERAGE_FILE}" ]]; then
+  echo "FAIL: usage: $(basename "$0") <coverage.info> [--skip <package>]..." >&2
+  echo "              $(basename "$0") --static-only [--skip <package>]..." >&2
+  exit 2
+fi
+
+if [[ -n "${COVERAGE_FILE}" && ! -s "${COVERAGE_FILE}" ]]; then
+  echo "FAIL: coverage file '${COVERAGE_FILE}' is missing or empty." >&2
+  exit 2
+fi
+
+if [[ ! -d src ]]; then
+  echo "FAIL: 'src' not found. Run this script from the colcon workspace root." >&2
+  exit 2
+fi
+
+# Expected set: package directories holding hand-written C++ under src/ or
+# include/. -L follows a symlinked src (a plain `find src` refuses to descend
+# into one and would silently yield an empty set). The manifest list is
+# materialised first so a find failure is fatal instead of being swallowed by a
+# process substitution, which `set -o pipefail` does not cover.
+manifests=""
+if ! manifests=$(find -L src -name package.xml -print 2>/dev/null | sort); then
+  echo "FAIL: could not enumerate packages under 'src'." >&2
+  exit 2
+fi
+if [[ -z "${manifests}" ]]; then
+  echo "FAIL: no package.xml found under 'src' - the gate would pass vacuously." >&2
+  exit 2
+fi
+
+# Every extension GCC will compile as C++ and gcov will therefore record. A
+# narrower list would make a package invisible purely by naming its files .cc.
+CXX_FIND_EXPR=(
+  -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' -o -name '*.c++'
+  -o -name '*.hpp' -o -name '*.hh' -o -name '*.hxx' -o -name '*.h'
+)
+CXX_IMPL_RE='\.(cpp|cc|cxx|c\+\+)$'
+
+expected=()
+seen_names=""
+declare -A pkg_dir_of=()
+declare -A has_impl_sources=()
+declare -A package_exists=()
+while IFS= read -r manifest; do
+  [[ -n "${manifest}" ]] || continue
+  pkg_dir="$(dirname "${manifest}")"
+  pkg="$(basename "${pkg_dir}")"
+  package_exists["${pkg}"]="${pkg_dir}"
+
+  # Two package directories sharing a basename would collapse into one entry in
+  # the associative arrays below, leaving the first silently unchecked. Refuse
+  # rather than half-check.
+  if [[ "${seen_names}" == *"|${pkg}|"* ]]; then
+    echo "FAIL: two packages share the directory name '${pkg}'." >&2
+    echo "This gate keys packages by name; rename one or teach it full paths." >&2
+    exit 2
+  fi
+  seen_names="${seen_names}|${pkg}|"
+
+  excluded=""
+  for e in "${EXCLUDED_PACKAGES[@]}"; do
+    if [[ "${pkg}" == "${e}" ]]; then
+      excluded="yes"
+      break
+    fi
+  done
+  if [[ -n "${excluded}" ]]; then
+    echo "EXCLUDED: ${pkg} (see EXCLUDED_PACKAGES in $(basename "$0"))"
+    continue
+  fi
+
+  # Search the whole package, not just src/ and include/: a package keeping its
+  # sources in nodes/ or lib/ is just as much production code. test/ and
+  # vendored/ are the only things measurement legitimately ignores.
+  # No `head` in this pipeline: it would close the pipe early, SIGPIPE the
+  # producer, and `set -o pipefail` would then kill the gate with no output.
+  sources=$(find -L "${pkg_dir}" -type f \( "${CXX_FIND_EXPR[@]}" \) 2>/dev/null \
+            | grep -vE "^${pkg_dir}/(test|vendored)/|/vendored/" || true)
+  [[ -n "${sources}" ]] || continue
+
+  expected+=("${pkg}")
+  pkg_dir_of["${pkg}"]="${pkg_dir}"
+  # Header-only packages (INTERFACE libraries) legitimately reach the report
+  # only through a consumer's translation unit; packages shipping an
+  # implementation file must show one of their own.
+  if printf '%s\n' "${sources}" | grep -qE "${CXX_IMPL_RE}"; then
+    has_impl_sources["${pkg}"]="yes"
+  fi
+done <<< "${manifests}"
+
+if [[ ${#expected[@]} -eq 0 ]]; then
+  echo "FAIL: no package under 'src' holds C++ sources - the gate would pass vacuously." >&2
+  echo "This is not the ros2_medkit workspace, or the layout changed." >&2
+  exit 2
+fi
+
+# An EXCLUDED_PACKAGES entry naming nothing is a rotted exemption. Unlike a
+# rotted --skip it would never surface, because exclusion happens before any
+# check runs - so validate it explicitly.
+for e in "${EXCLUDED_PACKAGES[@]}"; do
+  if [[ -z "${package_exists[${e}]:-}" ]]; then
+    echo "FAIL: EXCLUDED_PACKAGES names '${e}', which is not a package under 'src'." >&2
+    echo "It was renamed or removed. Drop the entry or correct it." >&2
+    exit 2
+  fi
+done
+
+# A --skip that matches nothing is a rotted flag, not a no-op.
+for s in ${SKIPPED[@]+"${SKIPPED[@]}"}; do
+  found=""
+  for pkg in "${expected[@]}"; do
+    if [[ "${pkg}" == "${s}" ]]; then
+      found="yes"
+      break
+    fi
+  done
+  if [[ -z "${found}" ]]; then
+    echo "FAIL: --skip '${s}' matches no expected package." >&2
+    echo "It was renamed, moved, or no longer holds C++. Update the caller." >&2
+    exit 2
+  fi
+done
+
+failed=()
+
+# --- static check: the include is present -------------------------------------
+# Case-insensitive and tolerant of whitespace before the paren, because CMake
+# commands are case-insensitive and `include (X)` is legal. A stricter matcher
+# would fail correct code.
+for pkg in "${expected[@]}"; do
+  cmakelists="${pkg_dir_of[${pkg}]}/CMakeLists.txt"
+  if [[ ! -f "${cmakelists}" ]]; then
+    failed+=("${pkg} (has C++ sources but no CMakeLists.txt)")
+    continue
+  fi
+
+  if ! grep -qiE '^[[:space:]]*include[[:space:]]*\([[:space:]]*ROS2MedkitCoverage[[:space:]]*\)' \
+         "${cmakelists}"; then
+    failed+=("${pkg} (missing include(ROS2MedkitCoverage))")
+  fi
+done
+
+# --- report check: the package actually reached the lcov output ---------------
+checked=0
+if [[ -z "${STATIC_ONLY}" ]]; then
+  for pkg in "${expected[@]}"; do
+    skip=""
+    for s in ${SKIPPED[@]+"${SKIPPED[@]}"}; do
+      if [[ "${pkg}" == "${s}" ]]; then
+        skip="yes"
+        break
+      fi
+    done
+    if [[ -n "${skip}" ]]; then
+      echo "SKIP: ${pkg} (not built in this job)"
+      continue
+    fi
+
+    checked=$((checked + 1))
+    # Anchor on the package directory as it sits under the workspace, so build/
+    # and install/ copies cannot stand in as proof that a package's production
+    # code was measured. Vendored records are excluded here too: CI strips them
+    # with lcov --remove, but this gate must not depend on the caller doing so.
+    # shellcheck disable=SC2016
+    # Single quotes are deliberate: `&` is sed's "the whole match" backreference
+    # and must reach sed literally, not be expanded by the shell.
+    esc='s/[][\.*^$(){}?+|/]/\\&/g'
+    dir_re=$(printf '%s' "${pkg_dir_of[${pkg}]}" | sed "${esc}")
+    files=$(grep -E "^SF:.*/${dir_re}/" "${COVERAGE_FILE}" \
+            | grep -vc '/vendored/' || true)
+    if [[ "${files}" -eq 0 ]]; then
+      failed+=("${pkg} (no files in ${COVERAGE_FILE})")
+      continue
+    fi
+
+    # Headers alone do not prove the package was instrumented. A consumer's
+    # instrumented translation unit attributes coverage to every header it
+    # includes, so a package could lose instrumentation on all of its own
+    # implementation files and still appear "present". Demand a record for one
+    # of its own .cpp/.cc/.cxx whenever it ships any.
+    if [[ -n "${has_impl_sources[${pkg}]:-}" ]]; then
+      impl=$(grep -E "^SF:.*/${dir_re}/" "${COVERAGE_FILE}" \
+             | grep -v '/vendored/' | grep -cE "${CXX_IMPL_RE}" || true)
+      if [[ "${impl}" -eq 0 ]]; then
+        failed+=("${pkg} (only headers in ${COVERAGE_FILE}, no implementation file of its own)")
+        continue
+      fi
+    fi
+
+    printf 'OK:   %-42s %s file(s)\n' "${pkg}" "${files}"
+  done
+fi
+
+# Reported before the "everything was skipped" bail-out below, so a real static
+# failure is never swallowed by a misconfigured caller.
+if [[ ${#failed[@]} -gt 0 ]]; then
+  echo >&2
+  echo "FAIL: coverage scope is smaller than the source tree:" >&2
+  for f in "${failed[@]}"; do
+    echo "  - ${f}" >&2
+  done
+  echo >&2
+  echo "Every package holding production C++ must include the shared" >&2
+  echo "ROS2MedkitCoverage module, before its first target, and must appear in" >&2
+  echo "the report. A package that does neither still builds and still runs its" >&2
+  echo "tests; it just leaves the reported percentage describing a subset. Fix by:" >&2
+  echo "  * adding include(ROS2MedkitCoverage) above the first target, or" >&2
+  echo "  * passing --skip <package> if this job deliberately does not build it, or" >&2
+  echo "  * adding it to EXCLUDED_PACKAGES with a reason if it is not production code" >&2
+  exit 1
+fi
+
+if [[ -z "${STATIC_ONLY}" && ${checked} -eq 0 ]]; then
+  echo "FAIL: every expected package was skipped - nothing was verified." >&2
+  exit 2
+fi
+
+if [[ -n "${STATIC_ONLY}" ]]; then
+  echo "OK: all ${#expected[@]} C++ package(s) include ROS2MedkitCoverage."
+else
+  echo
+  echo "OK: all ${checked} checked C++ package(s) include ROS2MedkitCoverage and reached ${COVERAGE_FILE}."
+fi

--- a/src/ros2_medkit_action_status_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_action_status_bridge/CMakeLists.txt
@@ -22,15 +22,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 find_package(ament_cmake REQUIRED)
 
@@ -101,11 +95,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_action_status_bridge action_status_bridge_lib)
   medkit_target_dependencies(test_action_status_bridge rclcpp action_msgs ros2_medkit_msgs)
   medkit_set_test_domain(test_action_status_bridge)
-
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_action_status_bridge PRIVATE --coverage -O0 -g)
-    target_link_options(test_action_status_bridge PRIVATE --coverage)
-  endif()
 
   # Integration test (launch_testing): fault_manager + bridge + synthetic status
   install(DIRECTORY test

--- a/src/ros2_medkit_cmake/CMakeLists.txt
+++ b/src/ros2_medkit_cmake/CMakeLists.txt
@@ -23,6 +23,7 @@ install(
   FILES
     cmake/ROS2MedkitCompat.cmake
     cmake/ROS2MedkitCcache.cmake
+    cmake/ROS2MedkitCoverage.cmake
     cmake/ROS2MedkitLinting.cmake
     cmake/ROS2MedkitSanitizers.cmake
     cmake/ROS2MedkitTestDomain.cmake

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -8,8 +8,12 @@ build acceleration, and centralized linting configuration across all packages.
 | Module | Description |
 |--------|-------------|
 | `ROS2MedkitCcache.cmake` | Auto-detect and configure ccache with PCH-aware sloppiness settings |
-| `ROS2MedkitLinting.cmake` | Centralized clang-tidy configuration (opt-in locally, mandatory in CI) |
 | `ROS2MedkitCompat.cmake` | Multi-distro compatibility shims for ROS 2 Humble, Jazzy, and Lyrical |
+| `ROS2MedkitCoverage.cmake` | gcov/lcov instrumentation behind `-DENABLE_COVERAGE=ON` |
+| `ROS2MedkitLinting.cmake` | Centralized clang-tidy configuration (opt-in locally, mandatory in CI) |
+| `ROS2MedkitSanitizers.cmake` | ASan / TSan / UBSan behind `-DSANITIZER=asan,ubsan` |
+| `ROS2MedkitTestDomain.cmake` | Per-package `ROS_DOMAIN_ID` allocation for test isolation |
+| `ROS2MedkitWarnings.cmake` | Shared warning flags and vendored-code relaxations |
 
 ### ROS2MedkitCompat
 
@@ -20,15 +24,43 @@ Resolves dependency differences across ROS 2 distributions:
 - `medkit_target_dependencies()` - Drop-in replacement for `ament_target_dependencies` (removed on Lyrical)
 - `medkit_detect_compat_defs()` / `medkit_apply_compat_defs()` - Compile definitions for version-specific APIs
 
+### ROS2MedkitCoverage
+
+Adds `--coverage -O0 -g` when built with `-DENABLE_COVERAGE=ON`, and is a no-op
+otherwise. The flags are applied at directory scope, so every target declared
+after the `include()` is instrumented - libraries, executables and test binaries
+alike.
+
+Every package that compiles production C++ must include this module, and must
+include it **before its first target**. Packages that compile only test
+scaffolding are exempt; they are listed in `EXCLUDED_PACKAGES` in the gate
+script, each with a reason.
+
+Skipping it does not break the build: the package emits no `.gcda`, lcov never
+sees it, and it silently leaves both the numerator and the denominator of the
+reported coverage percentage. `scripts/check_coverage_packages.sh` guards
+against that, deriving the packages that must appear from the source tree rather
+than from this include. It runs `--static-only` in the Quality workflow and
+against the generated report in the CI coverage job.
+
+The gate checks that the include is present, not where it sits, because no
+reliable line-based check survives legal CMake (targets inside `function()`
+bodies, `if(FALSE)` blocks, `INTERFACE` libraries that compile nothing). An
+include placed after a target still shows up whenever it costs the package all
+of its records; a partial slip does not. Put it above the first target.
+
 ## Usage
 
-In your package's `CMakeLists.txt`:
+In your package's `CMakeLists.txt`, before the first target:
 
 ```cmake
 find_package(ros2_medkit_cmake REQUIRED)
-include(ROS2MedkitCcache)
-include(ROS2MedkitLinting)
 include(ROS2MedkitCompat)
+include(ROS2MedkitCcache)
+include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
+include(ROS2MedkitLinting)
+include(ROS2MedkitWarnings)
 ```
 
 Add to `package.xml`:

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitCoverage.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitCoverage.cmake
@@ -1,0 +1,54 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard(GLOBAL)
+
+# Code coverage support for ros2_medkit packages.
+# Include this module early in CMakeLists.txt, before the first target is
+# declared (alongside ROS2MedkitCcache and ROS2MedkitSanitizers).
+#
+# Activate from the command line:
+#   colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
+#
+# When ENABLE_COVERAGE is OFF (the default), this module is a no-op.
+#
+# The flags are applied at directory scope, so every target declared after the
+# include() is instrumented: libraries, executables and test binaries alike.
+# There is no per-target opt-in, which is deliberate - a package that forgets
+# to instrument a target does not fail the build, it silently drops out of the
+# coverage report, leaving both the numerator and the denominator. Whether that
+# moves the workspace percentage up or down depends on how well the vanished
+# package was covered, which is exactly why it must not be left to chance.
+#
+# Every package that compiles production C++ must include this module; packages
+# that compile only test scaffolding are exempt and are named, with a reason, in
+# EXCLUDED_PACKAGES in scripts/check_coverage_packages.sh. That script is the
+# guard: it derives the packages that must be instrumented from the source tree,
+# not from this include, so a package that never opts in is still caught. It
+# runs in the Quality workflow (--static-only) and in the CI coverage job.
+
+option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
+
+if(NOT ENABLE_COVERAGE)
+  return()
+endif()
+
+# -O0 keeps the line mapping faithful to the source: inlining and other
+# optimisations make gcov attribute lines to the wrong place. -g is not required
+# by gcov (the line map lives in the .gcno) but keeps the build debuggable, and
+# coverage builds are debug builds.
+add_compile_options(--coverage -O0 -g)
+add_link_options(--coverage)
+
+message(STATUS "Code coverage enabled for ${PROJECT_NAME}")

--- a/src/ros2_medkit_cmake/cmake/ros2_medkit_cmake-extras.cmake
+++ b/src/ros2_medkit_cmake/cmake/ros2_medkit_cmake-extras.cmake
@@ -15,8 +15,8 @@
 # Automatically sourced by ament after find_package(ros2_medkit_cmake).
 # Adds the installed cmake module directory to CMAKE_MODULE_PATH so that
 # include(ROS2MedkitCompat), include(ROS2MedkitCcache),
-# include(ROS2MedkitLinting), include(ROS2MedkitSanitizers),
-# include(ROS2MedkitTestDomain), and include(ROS2MedkitWarnings)
-# work transparently.
+# include(ROS2MedkitCoverage), include(ROS2MedkitLinting),
+# include(ROS2MedkitSanitizers), include(ROS2MedkitTestDomain),
+# and include(ROS2MedkitWarnings) work transparently.
 
 list(APPEND CMAKE_MODULE_PATH "${ros2_medkit_cmake_DIR}")

--- a/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
@@ -22,16 +22,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-# Code coverage option
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 find_package(ament_cmake REQUIRED)
 
@@ -111,11 +104,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_diagnostic_bridge diagnostic_bridge_lib)
   medkit_target_dependencies(test_diagnostic_bridge rclcpp diagnostic_msgs ros2_medkit_msgs)
   medkit_set_test_domain(test_diagnostic_bridge)
-
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_diagnostic_bridge PRIVATE --coverage -O0 -g)
-    target_link_options(test_diagnostic_bridge PRIVATE --coverage)
-  endif()
 
   # Integration tests
   install(DIRECTORY test

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_beacon_common/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_param_beacon/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CMakeLists.txt
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_topic_beacon/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_fault_detection/CMakeLists.txt
+++ b/src/ros2_medkit_fault_detection/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(ros2_medkit_cmake REQUIRED)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -24,16 +24,9 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-# Code coverage option
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -89,20 +82,9 @@ target_link_libraries(fault_manager_lib PUBLIC
 
 medkit_apply_compat_defs(fault_manager_lib)
 
-if(ENABLE_COVERAGE)
-  target_compile_options(fault_manager_lib PRIVATE --coverage -O0 -g)
-  target_link_options(fault_manager_lib PRIVATE --coverage)
-endif()
-
 # Executable target
 add_executable(fault_manager_node src/main.cpp)
 target_link_libraries(fault_manager_node fault_manager_lib)
-
-# Apply coverage flags to executable
-if(ENABLE_COVERAGE)
-  target_compile_options(fault_manager_node PRIVATE --coverage -O0 -g)
-  target_link_options(fault_manager_node PRIVATE --coverage)
-endif()
 
 # Install targets
 install(TARGETS fault_manager_node
@@ -181,26 +163,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_entity_thresholds fault_manager_lib)
   medkit_target_dependencies(test_entity_thresholds rclcpp ros2_medkit_msgs)
   medkit_set_test_domain(test_entity_thresholds)
-
-  # Apply coverage flags to test targets
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_fault_manager PRIVATE --coverage -O0 -g)
-    target_link_options(test_fault_manager PRIVATE --coverage)
-    target_compile_options(test_sqlite_storage PRIVATE --coverage -O0 -g)
-    target_link_options(test_sqlite_storage PRIVATE --coverage)
-    target_compile_options(test_snapshot_capture PRIVATE --coverage -O0 -g)
-    target_link_options(test_snapshot_capture PRIVATE --coverage)
-    target_compile_options(test_rosbag_capture PRIVATE --coverage -O0 -g)
-    target_link_options(test_rosbag_capture PRIVATE --coverage)
-    target_compile_options(test_correlation_config_parser PRIVATE --coverage -O0 -g)
-    target_link_options(test_correlation_config_parser PRIVATE --coverage)
-    target_compile_options(test_pattern_matcher PRIVATE --coverage -O0 -g)
-    target_link_options(test_pattern_matcher PRIVATE --coverage)
-    target_compile_options(test_correlation_engine PRIVATE --coverage -O0 -g)
-    target_link_options(test_correlation_engine PRIVATE --coverage)
-    target_compile_options(test_entity_thresholds PRIVATE --coverage -O0 -g)
-    target_link_options(test_entity_thresholds PRIVATE --coverage)
-  endif()
 
   # Integration tests
   install(DIRECTORY test

--- a/src/ros2_medkit_fault_reporter/CMakeLists.txt
+++ b/src/ros2_medkit_fault_reporter/CMakeLists.txt
@@ -22,16 +22,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-# Code coverage option
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 find_package(ament_cmake REQUIRED)
 
@@ -57,11 +50,6 @@ medkit_target_dependencies(fault_reporter_lib
   rclcpp_lifecycle
   ros2_medkit_msgs
 )
-
-if(ENABLE_COVERAGE)
-  target_compile_options(fault_reporter_lib PRIVATE --coverage -O0 -g)
-  target_link_options(fault_reporter_lib PRIVATE --coverage)
-endif()
 
 # Install library
 install(TARGETS fault_reporter_lib
@@ -100,20 +88,10 @@ if(BUILD_TESTING)
   target_link_libraries(test_local_filter fault_reporter_lib)
   medkit_target_dependencies(test_local_filter rclcpp rclcpp_lifecycle ros2_medkit_msgs)
 
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_local_filter PRIVATE --coverage -O0 -g)
-    target_link_options(test_local_filter PRIVATE --coverage)
-  endif()
-
   ament_add_gtest(test_fault_reporter_construction test/test_fault_reporter_construction.cpp)
   target_link_libraries(test_fault_reporter_construction fault_reporter_lib)
   medkit_target_dependencies(test_fault_reporter_construction rclcpp rclcpp_lifecycle ros2_medkit_msgs)
   medkit_set_test_domain(test_fault_reporter_construction)
-
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_fault_reporter_construction PRIVATE --coverage -O0 -g)
-    target_link_options(test_fault_reporter_construction PRIVATE --coverage)
-  endif()
 
   # Integration tests
   install(DIRECTORY test

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -10,16 +10,9 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-# Code coverage option
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 # Swagger UI embedding option
 option(ENABLE_SWAGGER_UI "Embed Swagger UI assets in gateway binary" OFF)
@@ -257,14 +250,6 @@ if(ENABLE_SWAGGER_UI)
   target_compile_definitions(gateway_node PRIVATE ENABLE_SWAGGER_UI)
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SwaggerUI.cmake)
   target_compile_definitions(gateway_ros2 PRIVATE SWAGGER_UI_VERSION="${SWAGGER_UI_VERSION}")
-endif()
-
-# Apply coverage flags to main targets
-if(ENABLE_COVERAGE)
-  foreach(_target gateway_ros2 gateway_node)
-    target_compile_options(${_target} PRIVATE --coverage -O0 -g)
-    target_link_options(${_target} PRIVATE --coverage)
-  endforeach()
 endif()
 
 # Install
@@ -1102,106 +1087,7 @@ if(BUILD_TESTING)
   # No medkit_set_test_domain - this is ROS-free (gateway_core only).
   ament_add_gtest(test_entity_cache_alloc test/test_entity_cache_alloc.cpp)
   target_link_libraries(test_entity_cache_alloc gateway_core)
-  # NOTE: test_entity_cache_alloc is intentionally excluded from _test_targets below.
-  # Its global operator new/delete override corrupts lcov allocation counters in other TUs.
 
-  # Apply coverage flags to test targets
-  if(ENABLE_COVERAGE)
-    set(_test_targets
-      test_gateway_node
-      test_auth_manager
-      test_generic_client_compat
-      test_operation_manager
-      test_configuration_manager
-      test_ros2_parameter_transport
-      test_ros2_parameter_transport_shutdown
-      test_discovery_manager
-      test_runtime_discovery
-      test_tls_config
-      test_fault_manager
-      test_error_info
-      test_parameter_error_precedence
-      test_lifecycle_status_helpers
-      test_ros2_lifecycle_state_reader
-      test_ros2_subscription_executor
-      test_ros2_subscription_slot
-      test_topic_data_provider_interface
-      test_ros2_topic_data_provider
-      test_trigger_topic_subscriber
-      test_ros2_log_source
-      test_discovery_models
-      test_host_info_provider
-      test_discovery_handlers
-      test_manifest_parser
-      test_manifest_validator
-      test_manifest_manager
-      test_capability_builder
-      test_handler_context
-      test_rate_limiter
-      test_auth_config
-      test_data_access_manager
-      test_entity_resource_model
-      test_function_resource_collections
-      test_entity_path_utils
-      test_fault_handlers
-      test_bulk_data_store
-      test_bulkdata_handlers
-      test_subscription_manager
-      test_resource_sampler_registry
-      test_transport_registry
-      test_cyclic_subscription_handlers
-      test_sse_transport_provider
-      test_sse_fault_handler
-      test_entity_freeze_frame_capture
-      test_update_manager
-      test_script_manager
-      test_default_script_provider
-      test_script_handlers
-      test_data_handlers
-      test_auth_handlers
-      test_health_handlers
-      test_operation_handlers
-      test_plugin_loader
-      test_plugin_manager
-      test_plugin_http_types
-      test_plugin_abi_conformance
-      test_log_manager
-      test_log_handlers
-      test_log_scope
-      test_merge_pipeline
-      test_runtime_linker
-      test_route_descriptions
-      test_schema_builder
-      test_path_builder
-      test_openapi_spec_builder
-      test_path_resolver
-      test_capability_generator
-      test_route_registry
-      test_typed_route_registry
-      test_docs_handlers
-      test_lock_manager
-      test_lock_handlers
-      test_condition_evaluator
-      test_resource_change_notifier
-      test_trigger_store
-      test_trigger_manager
-      test_trigger_handlers
-      test_fault_trigger_engine
-      test_peer_client
-      test_entity_merger
-      test_fan_out_helpers
-      test_aggregation_manager
-      test_aggregation_classification
-      test_stream_proxy
-      test_mdns_discovery
-      test_network_utils
-      test_plugin_context_aggregation
-    )
-    foreach(_target ${_test_targets})
-      target_compile_options(${_target} PRIVATE --coverage -O0 -g)
-      target_link_options(${_target} PRIVATE --coverage)
-    endforeach()
-  endif()
   ros2_medkit_relax_vendor_warnings()
 endif()
 

--- a/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/test/test_ros2_parameter_transport.cpp
@@ -530,12 +530,19 @@ class TestRos2ParameterTransportListRespondsGetSetStuck : public ::testing::Test
   }
 
   void TearDown() override {
+    // Both halves of this order are load-bearing.
+    // Join before cancel(): cancel() while the spin thread is inside
+    // spin_some() races the executor's notify-waitable
+    // (ExecutorNotifyWaitable::is_ready() against trigger_entity_recollect()).
+    // Keep cancel(): it releases the executor's node references. Without it the
+    // previous test's service outlives its fixture and answers the next test's
+    // request, turning an expected timeout into a success.
     release_all_ = true;  // unstick any blocked callback first
-    executor_->cancel();
     spin_thread_running_ = false;
     if (spin_thread_.joinable()) {
       spin_thread_.join();
     }
+    executor_->cancel();
     executor_->remove_node(node_);
     executor_.reset();
     list_parameters_service_.reset();

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -11,6 +11,17 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitWarnings)
 
+# The shared coverage module is deliberately NOT included here: everything this
+# package compiles is test scaffolding - the demo_nodes/ fixtures driven by the
+# launch_testing suites - not production code, so it stays out of the coverage
+# report by design rather than by oversight.
+#
+# What keeps it out is the EXCLUDED_PACKAGES array in
+# scripts/check_coverage_packages.sh, NOT the absence of the include. That gate
+# derives the packages it expects from the source tree precisely so that a
+# missing include cannot excuse itself. Delete the array entry and this package
+# starts failing the gate.
+
 find_package(ament_cmake_python REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)

--- a/src/ros2_medkit_log_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_log_bridge/CMakeLists.txt
@@ -22,15 +22,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 find_package(ament_cmake REQUIRED)
 
@@ -103,11 +97,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_log_bridge log_bridge_lib)
   medkit_target_dependencies(test_log_bridge rclcpp rcl_interfaces ros2_medkit_msgs)
   medkit_set_test_domain(test_log_bridge)
-
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_log_bridge PRIVATE --coverage -O0 -g)
-    target_link_options(test_log_bridge PRIVATE --coverage)
-  endif()
 
   # Integration test (launch_testing): fault_manager + bridge + synthetic /rosout
   install(DIRECTORY test

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_provider/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitWarnings)
 
 find_package(ament_cmake REQUIRED)

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/fixtures/test_alarm_server/test_alarm_server.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/fixtures/test_alarm_server/test_alarm_server.cpp
@@ -826,6 +826,12 @@ int main(int argc, char ** argv) {
 
   UA_StatusCode rc = UA_Server_run(server, reinterpret_cast<volatile UA_Boolean *>(&g_running));
   g_running = false;
+  // The exit code is 1 for every bad status, so print the status itself:
+  // otherwise a server that ends on its own leaves the driving test with a
+  // closed stdin pipe and no reason anywhere.
+  if (rc != UA_STATUSCODE_GOOD) {
+    std::cout << "EXIT UA_Server_run rc=" << UA_StatusCode_name(rc) << std::endl;
+  }
   if (cli.joinable()) {
     cli.join();
   }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/integration/test_opcua_secured.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/integration/test_opcua_secured.test.py
@@ -247,6 +247,41 @@ def start_gateway(params_file, log_path, env):
     return proc
 
 
+def send_cmd(server, server_log, cmd):
+    """
+    Write one alarm-CLI command, reporting a dead server instead of EPIPE.
+
+    A bare write to an exited server raises BrokenPipeError from whichever
+    command comes next, naming neither the server nor a reason. Check first and
+    dump the server log, which carries the UA_Server_run status.
+
+    Returns True on success, False if the server is gone (caller should fail).
+    """
+    def report():
+        rc = server.returncode
+        print(f'FAIL: alarm server gone (rc={rc}) before {cmd!r}', file=sys.stderr)
+        print('server log:\n' + Path(server_log).read_text(errors='replace'),
+              file=sys.stderr)
+        return False
+
+    if server.poll() is not None:
+        return report()
+    try:
+        server.stdin.write(cmd + '\n')
+        server.stdin.flush()
+    except (BrokenPipeError, ValueError):
+        # The poll() above is a point-in-time check: the server can still exit
+        # between it and the flush. Report the same way instead of letting the
+        # exception escape, which is the failure mode this helper exists to
+        # remove. ValueError covers a stdin already closed on teardown.
+        try:
+            server.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        return report()
+    return True
+
+
 def terminate(proc):
     """Best-effort SIGTERM then SIGKILL of a child process."""
     if proc is None:
@@ -387,8 +422,8 @@ def main():
         print(f'  OK secured read: tank_level = {value}')
 
         # Secured A&C: fire an alarm over the server stdin -> CONFIRMED fault.
-        server.stdin.write('fire Overpressure 750\n')
-        server.stdin.flush()
+        if not send_cmd(server, server_log, 'fire Overpressure 750'):
+            return 1
         # Generous deadline for slow CI runners: the alarm has already fired on
         # the server, but report -> fault_manager -> REST propagation can take
         # a while under load. A longer deadline only slows the failure path.
@@ -415,8 +450,8 @@ def main():
         # while a real condition on the catch-all still faults. Reset the still-
         # active Overpressure condition first so its ConditionRefresh replay does
         # not pre-map PLC_ALARM before the sysevent is even fired.
-        server.stdin.write('clear Overpressure\n')
-        server.stdin.flush()
+        if not send_cmd(server, server_log, 'clear Overpressure'):
+            return 1
 
         catch_node_map = workdir / 'catchall_nodes.yaml'
         write_catchall_node_map(catch_node_map)
@@ -438,8 +473,8 @@ def main():
             return 1
 
         # Fire the non-condition system event; the guard must drop it.
-        server.stdin.write('sysevent\n')
-        server.stdin.flush()
+        if not send_cmd(server, server_log, 'sysevent'):
+            return 1
         leaked = wait_json(
             f'{catch_base}/faults',
             lambda j: any(i.get('fault_code') == NONCOND_CODE for i in j.get('items', [])),
@@ -455,8 +490,8 @@ def main():
 
         # A real condition on the catch-all source still faults (proves the
         # pipeline can produce PLC_ALARM, so the absence above is meaningful).
-        server.stdin.write('fire Overpressure 750\n')
-        server.stdin.flush()
+        if not send_cmd(server, server_log, 'fire Overpressure 750'):
+            return 1
         catch_faults = wait_json(
             f'{catch_base}/faults',
             lambda j: any(i.get('fault_code') == NONCOND_CODE and i.get('status') == 'CONFIRMED'

--- a/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_sovd_service_interface/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Shared cmake modules (multi-distro compat)
 find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
+include(ROS2MedkitCoverage)
 
 find_package(ament_cmake REQUIRED)
 find_package(ros2_medkit_gateway REQUIRED)

--- a/src/ros2_medkit_serialization/CMakeLists.txt
+++ b/src/ros2_medkit_serialization/CMakeLists.txt
@@ -10,16 +10,9 @@ find_package(ros2_medkit_cmake REQUIRED)
 include(ROS2MedkitCompat)
 include(ROS2MedkitCcache)
 include(ROS2MedkitSanitizers)
+include(ROS2MedkitCoverage)
 include(ROS2MedkitLinting)
 include(ROS2MedkitWarnings)
-
-# Code coverage option
-option(ENABLE_COVERAGE "Enable code coverage reporting" OFF)
-if(ENABLE_COVERAGE)
-  message(STATUS "Code coverage enabled")
-  add_compile_options(--coverage -O0 -g)
-  add_link_options(--coverage)
-endif()
 
 # Find dependencies
 find_package(ament_cmake REQUIRED)
@@ -85,12 +78,6 @@ target_link_libraries(${PROJECT_NAME}
   nlohmann_json::nlohmann_json
   yaml-cpp::yaml-cpp
 )
-
-# Apply coverage flags to library
-if(ENABLE_COVERAGE)
-  target_compile_options(${PROJECT_NAME} PRIVATE --coverage -O0 -g)
-  target_link_options(${PROJECT_NAME} PRIVATE --coverage)
-endif()
 
 # Export the library
 ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
@@ -186,17 +173,6 @@ if(BUILD_TESTING)
   target_link_libraries(test_type_introspection ${PROJECT_NAME})
   medkit_target_dependencies(test_type_introspection std_msgs std_srvs test_msgs)
 
-  # Apply coverage flags to test targets
-  if(ENABLE_COVERAGE)
-    target_compile_options(test_type_cache PRIVATE --coverage -O0 -g)
-    target_link_options(test_type_cache PRIVATE --coverage)
-    target_compile_options(test_json_serializer PRIVATE --coverage -O0 -g)
-    target_link_options(test_json_serializer PRIVATE --coverage)
-    target_compile_options(test_service_action_types PRIVATE --coverage -O0 -g)
-    target_link_options(test_service_action_types PRIVATE --coverage)
-    target_compile_options(test_type_introspection PRIVATE --coverage -O0 -g)
-    target_link_options(test_type_introspection PRIVATE --coverage)
-  endif()
   ros2_medkit_relax_vendor_warnings()
 endif()
 


### PR DESCRIPTION
## Summary

`ENABLE_COVERAGE` was declared with `option()` in each package separately, so the
nine packages that never declared it ignored `-DENABLE_COVERAGE=ON` without a
warning. They produced no `.gcda`, lcov never saw them, and they were missing
from both the numerator and the denominator of the reported percentage.

The option now lives in one shared module, `ROS2MedkitCoverage`, included by
every package that compiles production C++. The duplicated per-target flag
blocks are removed. They were already redundant, because the directory-scope
flags applied to those targets anyway. The report goes from 7 to 15 packages and
from 268 to 304 files.

The percentage barely moves: 84.17% over the old 7 packages against 84.32% over
all 15. The missing packages cover 85.90% of their lines, which is above the old
average, so their absence was pushing the number down, not up. That was luck. A
new package with poor coverage would have been invisible the same way.

`scripts/check_coverage_packages.sh` is the guard. It decides which packages must
appear by looking at the source tree, that is any package holding hand-written
C++ outside `test/` and `vendored/`. It does not look for the opt-in itself,
because that would be circular: deleting the opt-in would remove the package from
the report and from the check about it in one edit, and a new package that never
opts in would never be expected at all. The script runs in two places: right
after checkout in the Quality workflow, where it needs no build, and against the
real report in the coverage job.

Two limits of the check are written down in the script rather than hidden. It
does not assert where the include sits, because no line-based check survives
legal CMake: a target inside a `function()` body, an `if(FALSE)` block or an
`INTERFACE` library gives a false failure, while `ament_auto_add_library`,
uppercase commands and `add_subdirectory` slip past it. And it works per package,
so a package that keeps one instrumented file still passes.

The `lcov --extract` patterns are now anchored on the workspace root. The old
`*/ros2_medkit/src/*` only matched when the checkout directory happened to be
named `ros2_medkit`. The documented local commands are aligned with the job as
well: without `--ignore-errors gcov` the capture exits 1 on a stale `.gcda`, and
without the `--remove` step the local report carries 12 third-party files that CI
does not count.

Three fixes found while working on this are included:

- A data race TSan reported on main in
  `TestRos2ParameterTransportListRespondsGetSetStuck`. `cancel()` ran while the
  spin thread was still inside `spin_some()`, racing the executor's notify
  waitable. The spin thread is now joined first. `cancel()` has to stay: without
  it the executor keeps node references, the previous test's service answers the
  next test's request, and two expected timeouts come back as successes. I
  checked the other 17 teardowns that call `cancel()` before `join()`. None of
  them is affected, they all spin with a blocking `spin()` where `cancel()` is
  what unblocks the thread.
- `sanitizer-tsan` timeout raised from 60 to 90 minutes, same as
  `sanitizer-asan`. The 60 was set when a full run took about 40 minutes.
  Successful runs on main now reach 59. A timeout there looks like a TSan finding
  and sends you looking in the wrong place.
- When `test_alarm_server` exits on its own, the driving test's next stdin write
  raised `BrokenPipeError` from whatever command came next, naming no cause. The
  server captured the `UA_Server_run` status but never printed it and exited 1 for
  every status. The status is printed now, and the four stdin commands go through
  a helper that checks whether the server is alive and reports its exit code and
  log instead.

The coverage job keeps its 90 minute timeout. Successful runs top out at 55
minutes, and the eight packages added here are about 8k lines against a 72k line
gateway that was always instrumented.

---

## Issue

- closes #581

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

Full coverage build and test run on this branch: 18 packages built, 4451 tests,
lcov capture, filter and gate.

- The gate passes on the real report, all 15 built packages present, `opcua`
  skipped explicitly because the coverage job does not build it.
- Attacks against the gate, each reproduced: a package with its include deleted,
  a new C++ package that never adds it, `build/` `install/` and `test/` paths
  offered as proof, a package present only through headers a consumer pulled in,
  vendored records offered as proof, a wrong name in `--skip`, a stale
  `EXCLUDED_PACKAGES` entry, two packages sharing a directory name, sources under
  `nodes/` instead of `src/`, and `.cc` `.cxx` `.h` extensions. Each one now
  fails with the package named. Legal CMake that used to give false failures now
  passes: `INCLUDE(` in capitals, `include (` with a space, a target inside a
  `function()` body, and a target inside `if(FALSE)`.
- `test_ros2_parameter_transport`: 15 tests, 0 failures, both before and after the
  teardown change.
- The documented local command sequence was run as written and produces the same
  304 files as the job.
- opcua builds, and the new guard was exercised against an exited process: it
  returns cleanly with the exit code and the server log instead of raising.

One integration test, `test_external_app_bulk_data_uris_serve_the_captured_bag`,
fails locally. It fails the same way on `main` and is tracked in #574. The
secured opcua test also fails locally, again identically on `main`, and its own
workflow is green.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
