### PR TITLE
perf(cmake): analyse a package's translation units in parallel under clang-tidy

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -60,9 +60,13 @@ case "$PRESET" in
       "$@"
     ;;
   tidy)
-    echo "==> Running clang-tidy (this will take a while)"
+    echo "==> Running clang-tidy"
+    # One package at a time: each clang_tidy test already analyses its own
+    # translation units in parallel (ROS2_MEDKIT_CLANG_TIDY_JOBS, default one
+    # process per core). Running the package tests concurrently on top of that
+    # would multiply peak memory by the number of packages.
     colcon test "${COMMON_ARGS[@]}" \
-      --ctest-args -j "$(nproc)" -R "clang_tidy" \
+      --ctest-args -j 1 -R "clang_tidy" \
       "$@"
     ;;
   all)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 #   unit        - Unit tests only, no linters, no integration (DEFAULT)
 #   integ       - Integration tests only
 #   lint        - Linters only (clang-format, copyright, cmake-lint; NO clang-tidy)
-#   tidy        - clang-tidy only (slow, ~8-10 min)
+#   tidy        - clang-tidy only (slow; accepts --jobs N, see below)
 #   all         - Everything (equivalent to bare colcon test)
 #   <test_name> - Run a single test by CTest name regex
 #
@@ -32,6 +32,12 @@ set -euo pipefail
 #   ./scripts/test.sh lint                   # fast linters only
 #   ./scripts/test.sh test_health_handler    # single test
 #   ./scripts/test.sh unit --packages-select ros2_medkit_gateway
+#   ./scripts/test.sh tidy --jobs 8          # trade memory for speed
+#
+# The tidy preset defaults to a small number of clang-tidy processes per package
+# so one package fits an 8 GB machine. Each process peaks around 1.4 GiB, so
+# --jobs N costs roughly N x 1.4 GiB. The value sticks in the CMake cache and is
+# printed on every run.
 
 PRESET="${1:-unit}"
 shift 2>/dev/null || true
@@ -60,14 +66,72 @@ case "$PRESET" in
       "$@"
     ;;
   tidy)
-    echo "==> Running clang-tidy"
     # One package at a time: each clang_tidy test already analyses its own
-    # translation units in parallel (ROS2_MEDKIT_CLANG_TIDY_JOBS, default one
-    # process per core). Running the package tests concurrently on top of that
-    # would multiply peak memory by the number of packages.
+    # translation units in parallel (ROS2_MEDKIT_CLANG_TIDY_JOBS, capped by
+    # default so one package fits an 8 GB machine). Running the package tests
+    # concurrently on top of that would multiply peak memory by the number of
+    # packages.
+    #
+    # colcon is the knob that does it, not CTest. Every participating package
+    # registers exactly one clang_tidy test and colcon runs a separate ctest
+    # per package, so --ctest-args -j has nothing to parallelise here.
+    TIDY_JOBS=""
+    TIDY_ARGS=()
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --jobs)
+          # Guard the arity: this branch runs with errexit off, so a bare
+          # "shift 2" on a single remaining argument fails without shifting
+          # and the loop spins forever.
+          if [ $# -lt 2 ]; then
+            echo "error: --jobs requires a value" >&2
+            exit 2
+          fi
+          TIDY_JOBS="$2"
+          shift 2
+          ;;
+        --jobs=*) TIDY_JOBS="${1#--jobs=}"; shift ;;
+        *) TIDY_ARGS+=("$1"); shift ;;
+      esac
+    done
+
+    # The process count is baked into the CTest command at configure time, so
+    # changing it means reconfiguring. That costs a couple of seconds and no
+    # recompilation, which is what makes a flag here practical.
+    if [ -n "$TIDY_JOBS" ]; then
+      if ! [[ "$TIDY_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+        echo "error: --jobs takes a positive integer, got '$TIDY_JOBS'" >&2
+        exit 2
+      fi
+      echo "==> Reconfiguring clang-tidy packages for $TIDY_JOBS job(s) per package"
+      for testfile in build/*/CTestTestfile.cmake; do
+        grep -q "add_test(clang_tidy" "$testfile" 2>/dev/null || continue
+        if ! cmake "$(dirname "$testfile")" \
+             -DROS2_MEDKIT_CLANG_TIDY_JOBS="$TIDY_JOBS" >/dev/null; then
+          echo "error: reconfigure failed for $(dirname "$testfile")" >&2
+          exit 2
+        fi
+      done
+    fi
+
+    # Report what is actually baked into the tests. The value persists in the
+    # CMake cache until changed again, so printing it keeps that from becoming
+    # invisible state.
+    TIDY_EFFECTIVE=$(grep -ho '"--jobs" "[0-9]*"' build/*/CTestTestfile.cmake 2>/dev/null |
+      grep -o '[0-9]*' | sort -un | paste -sd, -)
+    echo "==> Running clang-tidy (${TIDY_EFFECTIVE:-unconfigured} job(s) per package)"
+
+    # --parallel-workers 1 goes LAST, after the caller's arguments. colcon keeps
+    # recognising its own options after --ctest-args, and the option is a plain
+    # argparse store, so the final occurrence wins. Placed any earlier, a
+    # caller's own --parallel-workers would silently undo the memory guard.
+    if [[ " ${TIDY_ARGS[*]} " == *" --parallel-workers "* ||
+          " ${TIDY_ARGS[*]} " == *" --parallel-workers="* ]]; then
+      echo "    note: the tidy preset pins --parallel-workers 1, so that override is ignored"
+    fi
     colcon test "${COMMON_ARGS[@]}" \
-      --ctest-args -j 1 -R "clang_tidy" \
-      "$@"
+      --ctest-args -R "clang_tidy" \
+      "${TIDY_ARGS[@]}" --parallel-workers 1
     ;;
   all)
     echo "==> Running all tests"
@@ -84,6 +148,28 @@ case "$PRESET" in
 esac
 TEST_EXIT=$?
 set -e
+
+# ament_clang_tidy exits 0 even when a clang-tidy process dies. It catches
+# CalledProcessError, prints the failure to stderr and returns whatever output
+# it recovered - nothing, for a process killed by a signal - and then derives
+# the exit status purely from the warnings it managed to parse. A translation
+# unit whose clang-tidy was OOM-killed therefore contributes zero findings and
+# the test passes, which is the worst way to lose coverage: silently.
+#
+# run_test.py merges the child's stderr into the per-test log, so the marker is
+# recoverable. Fail the run on it rather than let a half-analysed package read
+# as clean.
+if [ "$PRESET" = "tidy" ]; then
+  TIDY_LOGS=(build/*/ament_clang_tidy/clang_tidy.txt)
+  if grep -qs "failed with error code" "${TIDY_LOGS[@]}"; then
+    echo ""
+    echo "==> clang-tidy processes died during this run:"
+    grep -hs "failed with error code" "${TIDY_LOGS[@]}" | sort -u | sed 's/^/    /'
+    echo "    Those translation units were NOT analysed, so this run proves nothing"
+    echo "    about them. Error code -9 means the OOM reaper took them: lower --jobs."
+    TEST_EXIT=1
+  fi
+fi
 
 echo ""
 echo "==> Results:"

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -10,7 +10,7 @@ build acceleration, and centralized linting configuration across all packages.
 | `ROS2MedkitCcache.cmake` | Auto-detect and configure ccache with PCH-aware sloppiness settings |
 | `ROS2MedkitCompat.cmake` | Multi-distro compatibility shims for ROS 2 Humble, Jazzy, and Lyrical |
 | `ROS2MedkitCoverage.cmake` | gcov/lcov instrumentation behind `-DENABLE_COVERAGE=ON` |
-| `ROS2MedkitLinting.cmake` | Centralized clang-tidy configuration (opt-in locally, mandatory in CI) |
+| `ROS2MedkitLinting.cmake` | Centralized clang-tidy configuration (opt-in local gate; CI runs `run-clang-tidy` instead) |
 | `ROS2MedkitSanitizers.cmake` | ASan / TSan / UBSan behind `-DSANITIZER=asan,ubsan` |
 | `ROS2MedkitTestDomain.cmake` | Per-package `ROS_DOMAIN_ID` allocation for test isolation |
 | `ROS2MedkitWarnings.cmake` | Shared warning flags and vendored-code relaxations |
@@ -26,21 +26,58 @@ Resolves dependency differences across ROS 2 distributions:
 
 ### ROS2MedkitLinting
 
-Registers the package's `clang_tidy` CTest test behind `-DENABLE_CLANG_TIDY=ON`
-(off by default locally, on in CI).
+Registers the package's `clang_tidy` CTest test behind `-DENABLE_CLANG_TIDY=ON`,
+off by default. This is a local gate: CI does not use it. The `clang-tidy` job
+in `.github/workflows/quality.yml` configures with `-DENABLE_CLANG_TIDY=OFF` and
+runs `run-clang-tidy` over the compilation database instead.
 
-Each package registers exactly one such test, so CTest-level parallelism only
-overlaps packages - the largest package still decides the wall clock. The
-analysis is therefore parallelised **inside** the test:
+A participating package registers exactly one such test - packages that exclude
+`ament_cmake_clang_tidy` and never call `ros2_medkit_clang_tidy()` register none.
+colcon runs a separate `ctest` per package, so `--ctest-args -j` has nothing to
+parallelise: CTest only ever sees one matching test. The analysis is therefore
+parallelised **inside** the test:
 
 - `-DROS2_MEDKIT_CLANG_TIDY_JOBS=<n>` at configure time sets how many
-  `clang-tidy` processes one package runs. It defaults to the host core count.
+  `clang-tidy` processes one package runs. It defaults to `min(host cores, 2)`,
+  falling back to 1 where CMake cannot determine the core count.
 - `ros2_medkit_clang_tidy(JOBS <n>)` overrides it for a single package.
+- `./scripts/test.sh tidy --jobs <n>` is the everyday switch. The count is baked
+  into the CTest command at configure time, so the script reconfigures the
+  clang-tidy packages first - a couple of seconds, no recompilation. The value
+  then sticks in the CMake cache, so every `tidy` run prints the count in
+  effect.
 
-Because the parallelism lives inside each test, run the package tests one at a
-time - `./scripts/test.sh tidy` already passes `-j 1` to CTest. Running both
-levels at once multiplies peak memory by the number of packages, and a
-`clang-tidy` process on this codebase holds roughly half a gigabyte.
+How many packages analyse at once is colcon's `--parallel-workers`, not
+CTest's `-j`. Because the parallelism now lives inside each test, the package
+tests must run one at a time: `./scripts/test.sh tidy` pins
+`--parallel-workers 1` and ignores a caller's override, because running both
+levels at once multiplies peak memory by the number of packages.
+
+The footprint is large enough that the default is capped rather than set to the
+core count. Measured on `ros2_medkit_gateway`, a 16-core host:
+
+| `JOBS`        | wall clock | peak resident |
+|---------------|-----------:|--------------:|
+| 2 *(default)* |   17min58s |       2.6 GiB |
+| 4             |    9min55s |       4.7 GiB |
+| 8             |    6min00s |       9.4 GiB |
+| 16            |    4min32s |      17.4 GiB |
+
+Memory scales linearly at roughly 1.2 GiB per job - a single `clang-tidy`
+process holds 1.4 GiB at its peak - while wall clock does not. The default is
+sized so that one package fits an 8 GB machine, which puts it at 2. That is
+deliberately the slow end of the curve: the alternative is a default that only
+works on the largest machine anyone here has.
+
+If you have the memory, take it - `./scripts/test.sh tidy --jobs 8` roughly
+triples the speed for 9.4 GiB.
+
+Over-subscribing is guarded, but only through the script. `ament_clang_tidy`
+derives its exit status from the warnings it managed to parse, so a `clang-tidy`
+process killed by the OOM reaper contributes nothing and the test passes as if
+the package were clean. `./scripts/test.sh tidy` scans the per-test logs for the
+`failed with error code` marker and fails the run instead, naming the packages
+that lost coverage. A bare `colcon test -R clang_tidy` has no such guard.
 
 ### ROS2MedkitCoverage
 

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -24,6 +24,24 @@ Resolves dependency differences across ROS 2 distributions:
 - `medkit_target_dependencies()` - Drop-in replacement for `ament_target_dependencies` (removed on Lyrical)
 - `medkit_detect_compat_defs()` / `medkit_apply_compat_defs()` - Compile definitions for version-specific APIs
 
+### ROS2MedkitLinting
+
+Registers the package's `clang_tidy` CTest test behind `-DENABLE_CLANG_TIDY=ON`
+(off by default locally, on in CI).
+
+Each package registers exactly one such test, so CTest-level parallelism only
+overlaps packages - the largest package still decides the wall clock. The
+analysis is therefore parallelised **inside** the test:
+
+- `-DROS2_MEDKIT_CLANG_TIDY_JOBS=<n>` at configure time sets how many
+  `clang-tidy` processes one package runs. It defaults to the host core count.
+- `ros2_medkit_clang_tidy(JOBS <n>)` overrides it for a single package.
+
+Because the parallelism lives inside each test, run the package tests one at a
+time - `./scripts/test.sh tidy` already passes `-j 1` to CTest. Running both
+levels at once multiplies peak memory by the number of packages, and a
+`clang-tidy` process on this codebase holds roughly half a gigabyte.
+
 ### ROS2MedkitCoverage
 
 Adds `--coverage -O0 -g` when built with `-DENABLE_COVERAGE=ON`, and is a no-op

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitLinting.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitLinting.cmake
@@ -20,9 +20,29 @@ include_guard(GLOBAL)
 #
 # Provides:
 #   option ENABLE_CLANG_TIDY (default OFF)
-#   function ros2_medkit_clang_tidy([HEADER_FILTER <regex>] [TIMEOUT <seconds>])
+#   cache var ROS2_MEDKIT_CLANG_TIDY_JOBS (default: host core count)
+#   function ros2_medkit_clang_tidy([HEADER_FILTER <regex>] [TIMEOUT <seconds>] [JOBS <n>])
 
 option(ENABLE_CLANG_TIDY "Register clang-tidy as a CTest target" OFF)
+
+# ament_clang_tidy defaults to --jobs 1, so one CTest test analyses a whole
+# package one translation unit at a time while the rest of the machine idles.
+# CTest-level parallelism does not help: each package registers a single
+# clang_tidy test, and the largest package dominates the wall clock.
+#
+# Analysing in parallel WITHIN the test is the lever. Because several package
+# tests can still run concurrently, keep the CTest job count for clang-tidy low
+# (scripts/test.sh runs the tidy preset serially) or peak memory becomes
+# packages x jobs x ~0.5 GB per clang-tidy process.
+include(ProcessorCount)
+# Invoked lower-case: CMake command names are case-insensitive, and the
+# repository's cmake-lint gate rejects mixed case.
+processorcount(_ros2_medkit_host_cores)
+if(_ros2_medkit_host_cores EQUAL 0)
+  set(_ros2_medkit_host_cores 1)
+endif()
+set(ROS2_MEDKIT_CLANG_TIDY_JOBS "${_ros2_medkit_host_cores}"
+    CACHE STRING "Number of clang-tidy processes per package (default: host core count)")
 
 # Capture at include-time: inside a function CMAKE_CURRENT_LIST_DIR resolves to the caller.
 set(_ROS2_MEDKIT_CLANG_TIDY_CONFIG "${CMAKE_CURRENT_LIST_DIR}/.clang-tidy")
@@ -32,7 +52,7 @@ function(ros2_medkit_clang_tidy)
     return()
   endif()
 
-  cmake_parse_arguments(ARG "" "HEADER_FILTER;TIMEOUT" "" ${ARGN})
+  cmake_parse_arguments(ARG "" "HEADER_FILTER;TIMEOUT;JOBS" "" ${ARGN})
 
   find_package(ament_cmake_clang_tidy REQUIRED)
 
@@ -44,6 +64,12 @@ function(ros2_medkit_clang_tidy)
 
   if(ARG_TIMEOUT)
     list(APPEND _args TIMEOUT "${ARG_TIMEOUT}")
+  endif()
+
+  if(ARG_JOBS)
+    list(APPEND _args JOBS "${ARG_JOBS}")
+  elseif(ROS2_MEDKIT_CLANG_TIDY_JOBS)
+    list(APPEND _args JOBS "${ROS2_MEDKIT_CLANG_TIDY_JOBS}")
   endif()
 
   ament_clang_tidy(${_args})

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitLinting.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitLinting.cmake
@@ -27,13 +27,32 @@ option(ENABLE_CLANG_TIDY "Register clang-tidy as a CTest target" OFF)
 
 # ament_clang_tidy defaults to --jobs 1, so one CTest test analyses a whole
 # package one translation unit at a time while the rest of the machine idles.
-# CTest-level parallelism does not help: each package registers a single
-# clang_tidy test, and the largest package dominates the wall clock.
+# CTest-level parallelism does not help: a participating package registers a
+# single clang_tidy test, so --ctest-args -j has nothing to overlap.
 #
-# Analysing in parallel WITHIN the test is the lever. Because several package
-# tests can still run concurrently, keep the CTest job count for clang-tidy low
-# (scripts/test.sh runs the tidy preset serially) or peak memory becomes
-# packages x jobs x ~0.5 GB per clang-tidy process.
+# Analysing in parallel WITHIN the test is the lever. What still runs packages
+# concurrently is colcon's --parallel-workers, so that is what has to come down
+# when clang-tidy runs (scripts/test.sh pins --parallel-workers 1 in the tidy
+# preset) or peak memory becomes packages x jobs x the per-process footprint.
+#
+# That footprint is why the default is capped rather than set to the core count.
+# Measured on the gateway package, memory scales linearly at ~1.2 GiB per job
+# while wall clock does not:
+#
+#   jobs=2   1078 s    2.6 GiB      jobs=8    359 s    9.4 GiB
+#   jobs=4    595 s    4.7 GiB      jobs=16   272 s   17.4 GiB
+#
+# The default is sized so one package fits an 8 GB machine, which puts it at 2.
+# That is the slow end of the curve on purpose: the alternative is a default
+# that works only on the biggest machine anyone here has, and 17.4 GiB for a
+# single package is not something we can assume. Raise it where the memory is
+# there: ./scripts/test.sh tidy --jobs <n> reconfigures and runs in one step.
+#
+# Over-subscribing is guarded only through that script. ament_clang_tidy derives
+# its exit status from the warnings it parsed, so a clang-tidy killed by the OOM
+# reaper contributes nothing and the test passes as if the package were clean.
+# The script scans the per-test logs for the failure marker and fails the run; a
+# bare colcon test -R clang_tidy does not.
 include(ProcessorCount)
 # Invoked lower-case: CMake command names are case-insensitive, and the
 # repository's cmake-lint gate rejects mixed case.
@@ -41,8 +60,12 @@ processorcount(_ros2_medkit_host_cores)
 if(_ros2_medkit_host_cores EQUAL 0)
   set(_ros2_medkit_host_cores 1)
 endif()
-set(ROS2_MEDKIT_CLANG_TIDY_JOBS "${_ros2_medkit_host_cores}"
-    CACHE STRING "Number of clang-tidy processes per package (default: host core count)")
+set(_ros2_medkit_clang_tidy_jobs 2)
+if(_ros2_medkit_host_cores LESS _ros2_medkit_clang_tidy_jobs)
+  set(_ros2_medkit_clang_tidy_jobs "${_ros2_medkit_host_cores}")
+endif()
+set(ROS2_MEDKIT_CLANG_TIDY_JOBS "${_ros2_medkit_clang_tidy_jobs}"
+    CACHE STRING "Number of clang-tidy processes per package (default: min(host cores, 2))")
 
 # Capture at include-time: inside a function CMAKE_CURRENT_LIST_DIR resolves to the caller.
 set(_ROS2_MEDKIT_CLANG_TIDY_CONFIG "${CMAKE_CURRENT_LIST_DIR}/.clang-tidy")

--- a/src/ros2_medkit_cmake/design/index.rst
+++ b/src/ros2_medkit_cmake/design/index.rst
@@ -31,8 +31,13 @@ The package provides four CMake modules installed to the ament index:
 
 3. **ROS2MedkitLinting.cmake** - Centralized clang-tidy configuration
 
-   - Provides ``ENABLE_CLANG_TIDY`` option (default OFF, mandatory in CI)
-   - Provides ``ros2_medkit_clang_tidy()`` function with optional ``HEADER_FILTER`` and ``TIMEOUT`` arguments
+   - Provides ``ENABLE_CLANG_TIDY`` option (default OFF; a local gate only, CI
+     configures it OFF and runs ``run-clang-tidy`` over the compilation database)
+   - Provides ``ros2_medkit_clang_tidy()`` function with optional ``HEADER_FILTER``,
+     ``TIMEOUT`` and ``JOBS`` arguments
+   - Provides ``ROS2_MEDKIT_CLANG_TIDY_JOBS`` (default ``min(host cores, 2)``),
+     capped so one package fits an 8 GB machine; memory scales linearly at
+     roughly 1.2 GiB per job. Switch it with ``./scripts/test.sh tidy --jobs <n>``
    - References the shared ``.clang-tidy`` config file from the installed module directory
 
 4. **ROS2MedkitCompat.cmake** - Multi-distro compatibility layer


### PR DESCRIPTION
# Pull Request

## Summary

The full clang-tidy gate analysed one translation unit at a time regardless of how many cores the machine had.

`ament_clang_tidy` defaults to `--jobs 1`, and `ros2_medkit_clang_tidy()` passed neither a `JOBS` argument nor the `ament_cmake_clang_tidy_JOBS` variable the upstream macro also honours. CTest-level parallelism did not compensate, because each package registers a single `clang_tidy` test, so `-j` only overlaps packages while the largest one sets the wall clock on its own.

This passes a job count through the wrapper, defaulting to the host core count, and runs the `tidy` preset with one CTest job. The parallelism now lives inside each package test; keeping both levels would multiply peak memory by the number of packages, and a `clang-tidy` process on this codebase holds roughly half a gigabyte.

Two paths are deliberately unchanged:

- CI does not use this code path. `quality.yml` drives `run-clang-tidy` with `clang-tidy-cache`, and analyses only changed files on pull requests.
- `scripts/clang-tidy-diff.sh` loops serially, but pre-commit already invokes it with several file batches at once, so it is not the bottleneck.

---

## Issue

- closes #586

---

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

Build tooling / developer ergonomics.

---

## Testing

Measured on the `ros2_medkit_gateway` package (244 entries in its compile database), 16-core machine, same worktree and same build for both runs, `colcon test --ctest-args -j 1 -R '^clang_tidy$'`:

| `ROS2_MEDKIT_CLANG_TIDY_JOBS` | Wall clock |
|---|---|
| 1 (previous behaviour) | 2125 s |
| 16 (new default on this host) | 261 s |

Both runs report the same single pre-existing finding, so the change alters scheduling only, not what gets analysed.

To verify: configure with `-DENABLE_CLANG_TIDY=ON` and check the registered command in `build/<pkg>/CTestTestfile.cmake` - it now ends in `--jobs <n>`. `-DROS2_MEDKIT_CLANG_TIDY_JOBS=1` restores the old behaviour, and `ros2_medkit_clang_tidy(JOBS <n>)` overrides it for one package.

The serialisation is already being worked around in the tree. `ament_clang_tidy` defaults to a 300 s test timeout, and `ros2_medkit_gateway` registers its check with `TIMEOUT 3000` - a tenfold raise. `ros2_medkit_fault_manager` takes the default and, measured on the same 16-core machine, its serial run exceeds it and the test fails by timeout; with the job count passed through it finishes in roughly a minute. So this is not only a wall-clock cost: on a machine with cores to spare, a package that never raised its timeout has a red gate for no reason other than scheduling.

The `TIMEOUT 3000` on the test is left as is - it was close to being reached by the serial run and is now comfortably clear.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed

No behaviour change for callers; the `ros2_medkit_cmake` README gained a section describing the module, the new knob, and why the two levels of parallelism must not both be enabled.
