### PR TITLE
Cut PR feedback time from 56 to about 35 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,22 @@ jobs:
             log/
             build/*/test_results/
 
-  jazzy-build:
+  # Builds AND tests Jazzy. These were two jobs (jazzy-build -> jazzy-test)
+  # passing a tarred build/ + install/ tree between them. That split dates from
+  # when lint ran off the same artifact in parallel; lint has since moved to
+  # quality.yml, where format-lint and clang-tidy each do their own build, so
+  # the artifact was left with exactly one consumer and the split bought no
+  # parallelism at all. It cost 4.24 min of duplicated container bring-up and
+  # ROS setup in the second job plus 0.50 min of tar/upload in the first.
+  #
+  # The job id stays jazzy-test because notify-demos gates on it by name.
+  jazzy-test:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
+    # The more generous of the two timeouts this job replaces (build had 60,
+    # test had 45). One job now covers both phases, and a cold ccache makes the
+    # build phase the variable one, so keep the headroom rather than the sum.
     timeout-minutes: 60
     defaults:
       run:
@@ -158,7 +170,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y ros-jazzy-test-msgs
+          apt-get install -y \
+            ros-jazzy-test-msgs \
+            ros-jazzy-rmw-cyclonedds-cpp
           source /opt/ros/jazzy/setup.bash
           rosdep update
           rosdep install --from-paths src --ignore-src -y
@@ -175,61 +189,6 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
             --event-handlers console_direct+
           ccache -s
-
-      - name: Package build artifacts
-        run: tar cf /tmp/jazzy-build.tar build/ install/
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: jazzy-build
-          path: /tmp/jazzy-build.tar
-          retention-days: 1
-
-  jazzy-test:
-    needs: jazzy-build
-    runs-on: ubuntu-latest
-    container:
-      image: ubuntu:noble
-    timeout-minutes: 45
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Install Git
-        run: |
-          apt-get update
-          apt-get install -y git
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Pre-install ROS 2 apt source
-        uses: ./.github/actions/ros-apt-source
-
-      - name: Set up ROS 2 Jazzy
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
-
-      - name: Install dependencies
-        run: |
-          apt-get update
-          apt-get install -y \
-            ros-jazzy-test-msgs \
-            ros-jazzy-rmw-cyclonedds-cpp
-          source /opt/ros/jazzy/setup.bash
-          rosdep update
-          rosdep install --from-paths src --ignore-src -y
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: jazzy-build
-
-      - name: Extract build artifacts
-        run: tar xf jazzy-build.tar && rm jazzy-build.tar
 
       - name: Run unit and integration tests
         env:
@@ -258,6 +217,15 @@ jobs:
             build/*/test_results/
 
   coverage:
+    # Push to main only. This job owned CI's critical path in 79% of PR runs at
+    # ~40 min, and what a PR loses by not running it is narrow: its Codecov
+    # upload was already gated to push (see the last step), and the source-tree
+    # half of the coverage-scope gate - the half that catches a new package
+    # compiling C++ without opting into instrumentation - runs on every PR in
+    # quality.yml's format-lint job via check_coverage_packages.sh --static-only.
+    # What moves to main-only is the runtime half, which needs .gcda files and
+    # therefore needs this job's build and test run.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
@@ -319,14 +287,26 @@ jobs:
       - name: Run unit and integration tests for coverage
         run: |
           source /opt/ros/jazzy/setup.bash
-          colcon test \
+          # --return-code-on-test-failure, as in the two other colcon test
+          # invocations in this file. Without it colcon exits 0 whatever the
+          # tests did, so this job ran the full Jazzy suite under a coverage
+          # build and could not fail CI on a failure - it read as a gate
+          # without being one.
+          colcon test --return-code-on-test-failure \
             --packages-skip ros2_medkit_opcua \
             --ctest-args -LE linter \
             --event-handlers console_direct+
 
       - name: Generate coverage report
         run: |
+          # --parallel: this single lcov --capture was measured at >99% of the
+          # whole step (13.43 min of 13.50, 17.87 of 17.95) and is otherwise
+          # single-threaded, while --extract, --remove, --list and genhtml
+          # together finish in under six seconds. It forks per .gcda directory,
+          # so the output is the same records from the same gcov runs, only
+          # gathered concurrently.
           lcov --capture --directory build --output-file coverage.raw.info \
+            --parallel "$(nproc)" \
             --ignore-errors mismatch,negative,empty,gcov
 
           if [ ! -s coverage.raw.info ] || ! grep -q 'SF:' coverage.raw.info; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /root/.cache/ccache
-          key: ccache-jazzy-${{ github.sha }}
+          # ccache-jazzy-test-, not ccache-jazzy-. The shorter prefix also
+          # matches ccache-jazzy-asan-, -tsan-, -lint- and -tidy-, and
+          # restore-keys takes the most recently created match, so this job kept
+          # restoring whichever other Jazzy job finished last. It was measured
+          # loading the ASan cache: 2 GB of instrumented objects it cannot use,
+          # 10% hits, and then 219 cleanups as its own Release objects fought
+          # for the 500M ceiling on top of them.
+          key: ccache-jazzy-test-${{ github.sha }}
           restore-keys: |
-            ccache-jazzy-
+            ccache-jazzy-test-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh "${{ matrix.ros_distro }}"
 
       - name: Run unit and integration tests
         # The suite grew past the old 15-minute budget: on lyrical it was already taking
@@ -189,6 +190,7 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh jazzy-test
 
       - name: Run unit and integration tests
         env:
@@ -225,6 +227,14 @@ jobs:
     # quality.yml's format-lint job via check_coverage_packages.sh --static-only.
     # What moves to main-only is the runtime half, which needs .gcda files and
     # therefore needs this job's build and test run.
+    #
+    # This was also the only PR job building without -DNDEBUG, so on its own it
+    # would have taken every assert() out of pull request builds - the other
+    # jobs are Release or RelWithDebInfo. ROS2MedkitSanitizers.cmake now passes
+    # -UNDEBUG, which puts the asserts back in the two sanitizer jobs. Those run
+    # ctest -LE linter per package, a superset of the selection here - they do
+    # not skip ros2_medkit_opcua - so the asserts are still exercised against
+    # unit and integration tests on every PR.
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     container:
@@ -283,6 +293,7 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh coverage
 
       - name: Run unit and integration tests for coverage
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --packages-skip ros2_medkit_opcua \
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
@@ -185,6 +186,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros
         run: |
           source /opt/ros/jazzy/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --packages-skip ros2_medkit_opcua \
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
@@ -288,6 +290,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros
         run: |
           source /opt/ros/jazzy/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --packages-skip ros2_medkit_opcua \
             --cmake-args -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,5 +42,13 @@ jobs:
                   build-args: ROS_DISTRO=${{ matrix.ros_distro }}
                   tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ros2_medkit-${{ matrix.ros_distro }}:latest
                   cache-from: type=gha,scope=${{ matrix.ros_distro }}
-                  cache-to: type=gha,mode=max,scope=${{ matrix.ros_distro }}
+                  # mode=min, not max: max exports every intermediate build
+                  # stage, which for three distros held ~3.1 GB of the repo's
+                  # 10 GB Actions cache quota - about 30% of the budget, for a
+                  # job that only runs on push to main. The quota was measured
+                  # over the limit (10.54 GB active), so GitHub was evicting
+                  # LRU, and the ccache entries the build jobs depend on were
+                  # what it evicted. mode=min keeps the final-stage layers,
+                  # which is what cache-from actually reuses here.
+                  cache-to: type=gha,mode=min,scope=${{ matrix.ros_distro }}
                   platforms: linux/amd64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -48,7 +48,17 @@ jobs:
                   # job that only runs on push to main. The quota was measured
                   # over the limit (10.54 GB active), so GitHub was evicting
                   # LRU, and the ccache entries the build jobs depend on were
-                  # what it evicted. mode=min keeps the final-stage layers,
-                  # which is what cache-from actually reuses here.
+                  # what it evicted.
+                  #
+                  # This is not free. The Dockerfile is two-stage and mode=min
+                  # exports only the layers of the final image, so builder-stage
+                  # layers are no longer restored at all. What that actually
+                  # costs is smaller than it sounds: the COPY src/ layers sit
+                  # above the rosdep+colcon RUN, so any push touching src/
+                  # already invalidated the build layer under mode=max too. The
+                  # layer genuinely lost across such a push is the build-deps
+                  # apt-get. Accepted: this job is not on the pull request path,
+                  # and the quota it was holding is what every pull request
+                  # needs.
                   cache-to: type=gha,mode=min,scope=${{ matrix.ros_distro }}
                   platforms: linux/amd64

--- a/.github/workflows/pixi.yml
+++ b/.github/workflows/pixi.yml
@@ -1,10 +1,19 @@
 name: Pixi (experimental)
 
+# Push-to-main plus a nightly safety net, not per-PR. This workflow is
+# continue-on-error (see the job below), so it never gated a PR in the first
+# place, and it cost 35.3 min p50 per PR - 30.8 of that a build that could not
+# warm its own cache, because cache-write is push-to-main only. Moving it off
+# PRs loses no gate; a RoboStack packaging break is now caught on merge, or by
+# the nightly at the latest. Same shape opcua-plugin.yml uses for its filtered
+# suite: a narrowed trigger with a cron as the backstop.
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
+  schedule:
+    # Daily at 05:00 UTC. One hour after the OPC-UA nightly so the two do not
+    # contend for runners.
+    - cron: '0 5 * * *'
 
 jobs:
   pixi-build:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -298,7 +298,15 @@ jobs:
       - name: Build with ASan + UBSan
         env:
           CCACHE_DIR: /root/.cache/ccache
-          CCACHE_MAXSIZE: 500M
+          # 2G, not the 500M the other jobs use. At 500M this job's ccache was
+          # measured at 101-104% of its ceiling with 551-1019 cleanups DURING a
+          # single build - ccache evicting the objects that same build was still
+          # producing - and it never exceeded 18% hits. The instrumented object
+          # set does not fit in 500M and cannot be made to; the -g1 change in
+          # ROS2MedkitSanitizers.cmake shrinks it, this gives it somewhere to
+          # land. Sized against the repo's 10 GB Actions cache quota, which the
+          # docker-publish mode=min change frees room in.
+          CCACHE_MAXSIZE: 2G
           CCACHE_SLOPPINESS: pch_defines,time_macros
           TMPDIR: /mnt/asan/tmp
         run: |
@@ -423,7 +431,10 @@ jobs:
       - name: Build with TSan
         env:
           CCACHE_DIR: /root/.cache/ccache
-          CCACHE_MAXSIZE: 500M
+          # 1.5G - same reasoning as the ASan job, one sanitizer instead of two.
+          # Measured at 99.5-99.9% of the old 500M ceiling with 697-1017
+          # cleanups inside one build.
+          CCACHE_MAXSIZE: 1.5G
           CCACHE_SLOPPINESS: pch_defines,time_macros
           TMPDIR: /mnt/tsan/tmp
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -170,6 +170,7 @@ jobs:
               -DENABLE_CLANG_TIDY=OFF \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh jazzy-tidy
 
       - name: Merge compile databases
         run: |
@@ -233,10 +234,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-      # Bind-mount the runner's large temp disk. The ASan+UBSan build tree is
-      # ~27 GB; GitHub-hosted runners ship either a 72 GB / (only ~20 GB free,
-      # too small) or a 145 GB / disk, so the job used to pass or fail purely
-      # on which runner it landed. /mnt always has ~60+ GB free.
+      # Bind-mount the runner's large temp disk. The ASan+UBSan build tree
+      # measured ~27 GB before the sanitizer module started passing -g1; the
+      # post -g1 size has not been measured on a real run yet, so treat that
+      # figure as an upper bound. GitHub-hosted runners ship either a 72 GB /
+      # (only ~20 GB free, too small) or a 145 GB / disk, so the job used to
+      # pass or fail purely on which runner it landed. /mnt always has ~60+ GB
+      # free, which keeps that true either way.
       volumes:
         - "/mnt:/mnt"
     # Cold-cache ASan builds are ~33 min; with the test budget a full run is
@@ -286,8 +290,9 @@ jobs:
 
       - name: Redirect heavy build output to /mnt
         run: |
-          # The ASan+UBSan RelWithDebInfo build tree is ~27 GB and does not fit
-          # the container overlay on small (72 GB) GitHub runners. Point the
+          # The ASan+UBSan RelWithDebInfo build tree measured ~27 GB before -g1
+          # and does not fit the container overlay on small (72 GB) GitHub
+          # runners even at a fraction of that size. Point the
           # colcon build base and the compiler's scratch files at the large
           # /mnt temp disk (bind-mounted above). install/ stays on the overlay:
           # with --symlink-install it is only symlinks plus small setup files.
@@ -314,12 +319,14 @@ jobs:
           # RelWithDebInfo (not Debug): Debug's -O0 roughly doubles binary size
           # vs -O1, and ASan/UBSan instrumentation inflates it further. The
           # sanitizer cmake module forces -O1 regardless, so the build type only
-          # affects debug-info size. The build tree lands on /mnt (redirect step
-          # above) so the ~27 GB of instrumented objects + DWARF fit.
+          # affects debug-info size - and the module now also forces -g1, which
+          # is what cut that. The build tree lands on /mnt (redirect step above)
+          # so the instrumented objects + DWARF fit whatever the current size.
           colcon build --symlink-install \
             --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSANITIZER=asan,ubsan \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh jazzy-asan
           df -h / /mnt
 
       - name: Extend test timeouts for ASan overhead
@@ -443,6 +450,7 @@ jobs:
             --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSANITIZER=tsan \
             --event-handlers console_direct+
           ccache -s
+          ./scripts/ccache_report.sh jazzy-tsan
           df -h / /mnt
 
       - name: Extend test timeouts for TSan overhead

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -88,6 +88,9 @@ jobs:
       - name: Handlers read query params via typed query<T>() (zero-query-params regression gate)
         run: ./src/ros2_medkit_gateway/scripts/check_handlers_typed_query.sh
 
+      - name: ccache report warns on the right states
+        run: ./scripts/test_ccache_report.sh
+
       - name: Show results
         if: always()
         run: colcon test-result --verbose

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -70,9 +70,12 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros
         run: |
           source /opt/ros/jazzy/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
             --event-handlers console_direct+
+          ccache -s
+          ./scripts/ccache_report.sh jazzy-lint
 
       - name: Run format linters
         run: |
@@ -167,6 +170,7 @@ jobs:
           CCACHE_SLOPPINESS: pch_defines,time_macros
         run: |
           source /opt/ros/jazzy/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --cmake-args -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
@@ -325,6 +329,7 @@ jobs:
           # affects debug-info size - and the module now also forces -g1, which
           # is what cut that. The build tree lands on /mnt (redirect step above)
           # so the instrumented objects + DWARF fit whatever the current size.
+          ccache -z
           colcon build --symlink-install \
             --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSANITIZER=asan,ubsan \
             --event-handlers console_direct+
@@ -449,6 +454,7 @@ jobs:
           TMPDIR: /mnt/tsan/tmp
         run: |
           source /opt/ros/jazzy/setup.bash
+          ccache -z
           colcon build --symlink-install \
             --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSANITIZER=tsan \
             --event-handlers console_direct+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ build.
 
 #### CI/CD
 
-All PRs are tested on Ubuntu 24.04 (Jazzy) with parallel lint + test jobs, plus Humble and Lyrical. Coverage is uploaded to Codecov on push to main. All CI jobs use ccache.
+All PRs are tested on Ubuntu 24.04 (Jazzy), where build and tests run in a single job, plus Humble and Lyrical. Linters and clang-tidy run in the Quality workflow. Coverage is uploaded to Codecov on push to main. All CI jobs use ccache.
 
 ### Pull Request Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,9 @@ build.
 
 #### CI/CD
 
-All PRs are tested on Ubuntu 24.04 (Jazzy), where build and tests run in a single job, plus Humble and Lyrical. Linters and clang-tidy run in the Quality workflow. Coverage is uploaded to Codecov on push to main. All CI jobs use ccache.
+All PRs are tested on Ubuntu 24.04 (Jazzy), where build and tests run in a single job, plus Humble and Lyrical. Linters and clang-tidy run in the Quality workflow. Coverage is uploaded to Codecov on push to main. ccache is configured in the CI and Quality workflows and in the OPC-UA workflow's colcon jobs. The Pixi workflow and the Docker image builds compile the workspace without it, so a slow build there is expected rather than a cache problem.
+
+Every ccache-backed build step ends with `scripts/ccache_report.sh`, which writes the hit rate, cache size and cleanup count to the job summary. It raises a workflow warning in the two states that make a cache useless: cleanups above zero, meaning the cache evicted objects the same build was still producing and `CCACHE_MAXSIZE` is too small for it, and a hit rate under 50% with no cleanups, meaning the cache was never restored and the key or its `restore-keys` prefix is wrong. It never fails the step - a cold cache is a legitimate state.
 
 ### Pull Request Checklist
 

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -87,7 +87,7 @@ GitHub Copilot code review is used in addition to human review.
 All pull requests must pass CI before merging:
 
 - **Build & Test job:** Full build + unit/integration tests on Ubuntu Noble / ROS 2 Jazzy, Ubuntu Jammy / ROS 2 Humble, and Ubuntu Resolute / ROS 2 Lyrical. Linter tests on Jazzy only
-- **Coverage job:** Debug build with coverage. Reports are generated for all PRs as artifacts and uploaded to [Codecov](https://codecov.io/gh/selfpatch/ros2_medkit) on pushes to `main`
+- **Coverage job:** Debug build with coverage, run on pushes to `main`. Reports are archived as artifacts and uploaded to [Codecov](https://codecov.io/gh/selfpatch/ros2_medkit). Every pull request is gated on the static coverage-scope check in the Quality workflow, which fails if a package compiles production C++ without opting into coverage instrumentation
 - Linting enforced: `clang-format`, `clang-tidy` via `ament_lint_auto`
 
 CI configuration: [`.github/workflows/ci.yml`](.github/workflows/ci.yml)

--- a/QUALITY_DECLARATION.md
+++ b/QUALITY_DECLARATION.md
@@ -84,13 +84,26 @@ GitHub Copilot code review is used in addition to human review.
 
 ### Continuous Integration [2.iv]
 
-All pull requests must pass CI before merging:
+Every pull request runs the following, and a failure in any of them blocks
+review:
 
-- **Build & Test job:** Full build + unit/integration tests on Ubuntu Noble / ROS 2 Jazzy, Ubuntu Jammy / ROS 2 Humble, and Ubuntu Resolute / ROS 2 Lyrical. Linter tests on Jazzy only
-- **Coverage job:** Debug build with coverage, run on pushes to `main`. Reports are archived as artifacts and uploaded to [Codecov](https://codecov.io/gh/selfpatch/ros2_medkit). Every pull request is gated on the static coverage-scope check in the Quality workflow, which fails if a package compiles production C++ without opting into coverage instrumentation
-- Linting enforced: `clang-format`, `clang-tidy` via `ament_lint_auto`
+- **Build & Test:** build + unit/integration tests on Ubuntu Noble / ROS 2 Jazzy, Ubuntu Jammy / ROS 2 Humble, and Ubuntu Resolute / ROS 2 Lyrical. `ros2_medkit_opcua` is excluded here and covered by its own workflow instead
+- **Quality:** `clang-format` and the other ament linters, the static coverage-scope check, which fails if a package compiles production C++ without opting into coverage instrumentation, and two source gates (`check_no_naked_subscriptions.sh`, `check_handlers_typed_query.sh`). Jazzy only
+- **clang-tidy:** on a pull request this is incremental - it analyses the `.cpp` and `.hpp` files the branch changed, and does not run at all when the branch changes none. The full sweep over the compilation database runs on pushes to `main`
+- **Sanitizers:** the unit and integration suites again under ASan + UBSan and under TSan, on Jazzy. Only packages that include the shared sanitizer module are instrumented; `ros2_medkit_fault_detection`, `ros2_medkit_sovd_service_interface` and the integration-test fixture executables are not
+- **Documentation:** Sphinx build with `-W` plus linkcheck, on any pull request touching `docs/`, `src/` or `scripts/`
+- **OPC-UA plugin:** the OpenPLC-based integration suite, on any pull request touching the plugin, the gateway plugin/provider headers or `ros2_medkit_msgs`
 
-CI configuration: [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
+Reported on pushes to `main`, not run on pull requests:
+
+- **Coverage:** Debug build with coverage instrumentation. Reports are archived as artifacts and uploaded to [Codecov](https://codecov.io/gh/selfpatch/ros2_medkit)
+
+Merging additionally requires one approving review. Branch rules enforce the
+review requirement and a linear history; the checks above are not configured as
+required status checks, so passing them is a review expectation rather than a
+mechanical block.
+
+CI configuration: [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and [`.github/workflows/quality.yml`](.github/workflows/quality.yml)
 
 ### Documentation Policy [2.v]
 

--- a/scripts/ccache_report.sh
+++ b/scripts/ccache_report.sh
@@ -76,13 +76,31 @@ else
   hit_rate=0
 fi
 
-if [ "$max_kib" -gt 0 ]; then
+max_size=$(ccache --get-config max_size)
+
+# ccache 4.5, which is what the Humble runner's Ubuntu Jammy image ships, has no
+# max_cache_size_kibibyte in --print-stats. Without a fallback the fill would
+# read 0 there and the eviction warning could never fire on that job at all.
+# Derive it from the configured value instead, which every version prints,
+# accepting both spellings ("500.0M" and "500.0 MB"). ccache counts these in
+# powers of ten, verified against the machine-readable field: 500M reports
+# 488281 KiB and 1.5G reports 1464843.
+if [ "$max_kib" -le 0 ]; then
+  max_kib=$(awk -v s="$max_size" 'BEGIN {
+    if (match(s, /[0-9.]+/)) { n = substr(s, RSTART, RLENGTH) + 0 } else { print 0; exit }
+    unit = toupper(substr(s, RSTART + RLENGTH)); sub(/^ +/, "", unit)
+    if (unit ~ /^T/) { m = 1e12 } else if (unit ~ /^G/) { m = 1e9 }
+    else if (unit ~ /^M/) { m = 1e6 } else if (unit ~ /^K/) { m = 1e3 } else { m = 1 }
+    printf "%d", n * m / 1024
+  }')
+fi
+
+if [ "${max_kib:-0}" -gt 0 ]; then
   fill=$((size_kib * 100 / max_kib))
 else
   fill=0
 fi
 
-max_size=$(ccache --get-config max_size)
 size_gib=$(awk -v k="$size_kib" 'BEGIN { printf "%.2f", k / 1048576 }')
 
 echo "==> ccache ($LABEL): ${hit_rate}% hits (${hits}/${total}), ${size_gib} GiB of ${max_size} (${fill}% full), ${cleanups} cleanups"
@@ -108,7 +126,10 @@ fi
 # the cache was never restored - check the key and its restore-keys prefix - or
 # the branch changed something that invalidated the objects, such as a compiler
 # flag, in which case the next run recovers on its own.
-if [ "$total" -gt 0 ] && [ "$cleanups" -gt 0 ] && [ "$fill" -ge "$FULL_PCT" ]; then
+if [ "$total" -gt 0 ] && [ "$cleanups" -gt 0 ] && [ "$fill" -ge "$FULL_PCT" ] &&
+   [ "$hit_rate" -lt "$HIT_FLOOR" ]; then
+  echo "::warning title=ccache is full of another build's objects::$LABEL is ${fill}% full (${size_gib} GiB of ${max_size}) yet served only ${hit_rate}% of ${total} calls, and ran $cleanups cleanup(s) making room. A cache that is both full and useless was filled by something else: check that this job's restore-keys prefix cannot match another job's cache."
+elif [ "$total" -gt 0 ] && [ "$cleanups" -gt 0 ] && [ "$fill" -ge "$FULL_PCT" ]; then
   echo "::warning title=ccache evicted during the build::$LABEL ran $cleanups cleanup(s) while ${fill}% full (${size_gib} GiB of ${max_size}). The cache is discarding objects this same build produced, so CCACHE_MAXSIZE is too small for it or the Actions cache quota is evicting the entry."
 elif [ "$total" -gt 0 ] && [ "$hit_rate" -lt "$HIT_FLOOR" ]; then
   echo "::warning title=ccache hit rate below ${HIT_FLOOR}%::$LABEL served ${hit_rate}% of ${total} cacheable calls from cache while only ${fill}% full, so the ceiling is not the constraint. Either the cache was not restored - check the key and its restore-keys prefix - or this branch changed a compiler flag and invalidated the objects."

--- a/scripts/ccache_report.sh
+++ b/scripts/ccache_report.sh
@@ -22,6 +22,12 @@
 # `ccache -s` and nothing ever read it, so a regression back into it would have
 # been silent - the job just gets slow again.
 #
+# ccache keeps its counters inside the cache directory, and actions/cache
+# restores that directory whole, counters included. Read without preparation
+# they are therefore the running total over every job that has fed this cache
+# entry, not what the build in front of you did. Every build step that calls
+# this runs `ccache -z` first so the numbers below describe that build alone.
+#
 # Usage: scripts/ccache_report.sh <label>
 #
 # Emits a one-line table row to $GITHUB_STEP_SUMMARY when running under Actions,

--- a/scripts/ccache_report.sh
+++ b/scripts/ccache_report.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Report what ccache actually did in a CI build step, and say so loudly when it
+# thrashed.
+#
+# The build-time argument for the cache sizes in the sanitizer jobs is that a
+# cache which evicts during its own build is worse than no cache: it throws away
+# objects the same compilation is still producing. That state is visible in
+# `ccache -s` and nothing ever read it, so a regression back into it would have
+# been silent - the job just gets slow again.
+#
+# Usage: scripts/ccache_report.sh <label>
+#
+# Emits a one-line table row to $GITHUB_STEP_SUMMARY when running under Actions,
+# always prints to stdout, and raises a workflow warning when the cache filled
+# up or the hit rate collapsed. It never fails the step: a cold cache is a
+# legitimate state (a new key, a first run after a flag change) and blocking a
+# merge on a cache condition would be worse than the slow build it reports.
+
+set -euo pipefail
+
+LABEL="${1:-ccache}"
+
+# Hit-rate floor. Below this the cache is not paying for itself. The issue that
+# motivated the current sizes measured 0-49% while thrashing and 81% once the
+# cache fit, so the gap is wide and the exact threshold is not delicate.
+HIT_FLOOR=50
+
+if ! command -v ccache >/dev/null 2>&1; then
+  echo "ccache not installed, nothing to report"
+  exit 0
+fi
+
+stats=$(ccache --print-stats)
+get() { awk -v k="$1" '$1 == k { print $2; found = 1 } END { if (!found) print 0 }' <<<"$stats"; }
+
+direct=$(get direct_cache_hit)
+preprocessed=$(get preprocessed_cache_hit)
+miss=$(get cache_miss)
+cleanups=$(get cleanups_performed)
+size_kib=$(get cache_size_kibibyte)
+
+hits=$((direct + preprocessed))
+total=$((hits + miss))
+
+if [ "$total" -gt 0 ]; then
+  hit_rate=$((hits * 100 / total))
+else
+  hit_rate=0
+fi
+
+max_size=$(ccache --get-config max_size)
+size_gib=$(awk -v k="$size_kib" 'BEGIN { printf "%.2f", k / 1048576 }')
+
+echo "==> ccache ($LABEL): ${hit_rate}% hits (${hits}/${total}), ${size_gib} GiB of ${max_size}, ${cleanups} cleanups"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "| ccache | hit rate | size | max | cleanups |"
+    echo "|---|---:|---:|---:|---:|"
+    echo "| \`$LABEL\` | ${hit_rate}% | ${size_gib} GiB | ${max_size} | ${cleanups} |"
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+# Two distinct failures, reported separately because the fixes differ. Cleanups
+# mean the ceiling is too low for this build's object set: raise CCACHE_MAXSIZE,
+# or free room in the repository's Actions cache quota. A low hit rate with no
+# cleanups means the cache was not restored at all: look at the cache key and
+# its restore-keys prefix.
+if [ "$cleanups" -gt 0 ] && [ "$total" -gt 0 ]; then
+  echo "::warning title=ccache evicted during the build::$LABEL ran $cleanups cleanup(s) at ${size_gib} GiB of ${max_size}. The cache is discarding objects this same build produced, so CCACHE_MAXSIZE is too small for it or the Actions cache quota is evicting the entry."
+fi
+
+if [ "$total" -gt 0 ] && [ "$hit_rate" -lt "$HIT_FLOOR" ] && [ "$cleanups" -eq 0 ]; then
+  echo "::warning title=ccache hit rate below ${HIT_FLOOR}%::$LABEL served ${hit_rate}% of ${total} cacheable calls from cache without evicting anything, which points at a cache that was never restored rather than one that is too small. Check the cache key and its restore-keys prefix."
+fi

--- a/scripts/ccache_report.sh
+++ b/scripts/ccache_report.sh
@@ -39,6 +39,13 @@ LABEL="${1:-ccache}"
 # cache fit, so the gap is wide and the exact threshold is not delicate.
 HIT_FLOOR=50
 
+# Fill level at which cleanups mean the ceiling is the problem. A cleanup on its
+# own proves nothing: ccache trims a subdirectory when that subdirectory passes
+# max_size/16, so a cache at 14% of its ceiling can still report a handful. The
+# state worth a warning is the one that motivated the current sizes - a cache
+# pinned at its ceiling, evicting objects the same build is still producing.
+FULL_PCT=90
+
 if ! command -v ccache >/dev/null 2>&1; then
   echo "ccache not installed, nothing to report"
   exit 0
@@ -52,6 +59,7 @@ preprocessed=$(get preprocessed_cache_hit)
 miss=$(get cache_miss)
 cleanups=$(get cleanups_performed)
 size_kib=$(get cache_size_kibibyte)
+max_kib=$(get max_cache_size_kibibyte)
 
 hits=$((direct + preprocessed))
 total=$((hits + miss))
@@ -62,28 +70,40 @@ else
   hit_rate=0
 fi
 
+if [ "$max_kib" -gt 0 ]; then
+  fill=$((size_kib * 100 / max_kib))
+else
+  fill=0
+fi
+
 max_size=$(ccache --get-config max_size)
 size_gib=$(awk -v k="$size_kib" 'BEGIN { printf "%.2f", k / 1048576 }')
 
-echo "==> ccache ($LABEL): ${hit_rate}% hits (${hits}/${total}), ${size_gib} GiB of ${max_size}, ${cleanups} cleanups"
+echo "==> ccache ($LABEL): ${hit_rate}% hits (${hits}/${total}), ${size_gib} GiB of ${max_size} (${fill}% full), ${cleanups} cleanups"
 
 if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
   {
-    echo "| ccache | hit rate | size | max | cleanups |"
-    echo "|---|---:|---:|---:|---:|"
-    echo "| \`$LABEL\` | ${hit_rate}% | ${size_gib} GiB | ${max_size} | ${cleanups} |"
+    echo "| ccache | hit rate | size | max | full | cleanups |"
+    echo "|---|---:|---:|---:|---:|---:|"
+    echo "| \`$LABEL\` | ${hit_rate}% | ${size_gib} GiB | ${max_size} | ${fill}% | ${cleanups} |"
   } >> "$GITHUB_STEP_SUMMARY"
 fi
 
-# Two distinct failures, reported separately because the fixes differ. Cleanups
-# mean the ceiling is too low for this build's object set: raise CCACHE_MAXSIZE,
-# or free room in the repository's Actions cache quota. A low hit rate with no
-# cleanups means the cache was not restored at all: look at the cache key and
-# its restore-keys prefix.
-if [ "$cleanups" -gt 0 ] && [ "$total" -gt 0 ]; then
-  echo "::warning title=ccache evicted during the build::$LABEL ran $cleanups cleanup(s) at ${size_gib} GiB of ${max_size}. The cache is discarding objects this same build produced, so CCACHE_MAXSIZE is too small for it or the Actions cache quota is evicting the entry."
-fi
-
-if [ "$total" -gt 0 ] && [ "$hit_rate" -lt "$HIT_FLOOR" ] && [ "$cleanups" -eq 0 ]; then
-  echo "::warning title=ccache hit rate below ${HIT_FLOOR}%::$LABEL served ${hit_rate}% of ${total} cacheable calls from cache without evicting anything, which points at a cache that was never restored rather than one that is too small. Check the cache key and its restore-keys prefix."
+# Two distinct failures, reported separately because the fixes differ, and only
+# one of them can be true at a time.
+#
+# A cache pinned at its ceiling that is still running cleanups is discarding
+# objects the same build produced. Raise CCACHE_MAXSIZE, or free room in the
+# repository's Actions cache quota so the entry stops being evicted. Cleanups
+# below the fill threshold are not this: ccache trims per subdirectory, so a
+# nearly empty cache can report a few and it means nothing.
+#
+# A low hit rate with the ceiling nowhere in sight is the other shape. Either
+# the cache was never restored - check the key and its restore-keys prefix - or
+# the branch changed something that invalidated the objects, such as a compiler
+# flag, in which case the next run recovers on its own.
+if [ "$total" -gt 0 ] && [ "$cleanups" -gt 0 ] && [ "$fill" -ge "$FULL_PCT" ]; then
+  echo "::warning title=ccache evicted during the build::$LABEL ran $cleanups cleanup(s) while ${fill}% full (${size_gib} GiB of ${max_size}). The cache is discarding objects this same build produced, so CCACHE_MAXSIZE is too small for it or the Actions cache quota is evicting the entry."
+elif [ "$total" -gt 0 ] && [ "$hit_rate" -lt "$HIT_FLOOR" ]; then
+  echo "::warning title=ccache hit rate below ${HIT_FLOOR}%::$LABEL served ${hit_rate}% of ${total} cacheable calls from cache while only ${fill}% full, so the ceiling is not the constraint. Either the cache was not restored - check the key and its restore-keys prefix - or this branch changed a compiler flag and invalidated the objects."
 fi

--- a/scripts/test_ccache_report.sh
+++ b/scripts/test_ccache_report.sh
@@ -16,12 +16,18 @@
 # Pin what ccache_report.sh warns about.
 #
 # A warning that fires on every run carries no information, and one that never
-# fires carries none either. The rows below are the real numbers six CI jobs
-# reported, so the thresholds are checked against the states the jobs actually
-# reach rather than against invented ones. `humble` is the row that matters
-# most: four cleanups in a cache at 15% of its ceiling is ccache trimming a
-# subdirectory, not a ceiling that is too small, and an earlier version of the
-# script warned about it.
+# fires carries none either. The rows below are what CI jobs actually reported,
+# so the thresholds are checked against states the jobs reach rather than
+# invented ones. Three rows carry most of the weight:
+#
+#   humble       four cleanups in a cache at a fifth of its ceiling is ccache
+#                trimming a subdirectory, not a ceiling that is too small. An
+#                earlier threshold warned here.
+#   humble-old   the Jammy image ships ccache 4.5, which has no
+#                max_cache_size_kibibyte. Without the unit fallback the fill
+#                reads 0 and the eviction warning can never fire on that job.
+#   foreign      full and useless at once. This is what a restore-keys prefix
+#                matching another job's cache looks like from inside.
 #
 # ccache is stubbed on PATH, so the script under test runs unmodified.
 
@@ -37,12 +43,15 @@ cat > "$WORK/bin/ccache" <<'STUB'
 #!/bin/bash
 case "$1" in
   --print-stats)
-    printf 'cache_miss\t%s\n'                 "$STUB_MISS"
-    printf 'cleanups_performed\t%s\n'         "$STUB_CLEANUPS"
-    printf 'direct_cache_hit\t%s\n'           "$STUB_HITS"
+    printf 'cache_miss\t%s\n'              "$STUB_MISS"
+    printf 'cleanups_performed\t%s\n'      "$STUB_CLEANUPS"
+    printf 'direct_cache_hit\t%s\n'        "$STUB_HITS"
     printf 'preprocessed_cache_hit\t0\n'
-    printf 'cache_size_kibibyte\t%s\n'        "$STUB_SIZE_KIB"
-    printf 'max_cache_size_kibibyte\t%s\n'    "$STUB_MAX_KIB"
+    printf 'cache_size_kibibyte\t%s\n'     "$STUB_SIZE_KIB"
+    # An empty STUB_MAX_KIB stands for the older ccache that omits the field.
+    if [ -n "$STUB_MAX_KIB" ]; then
+      printf 'max_cache_size_kibibyte\t%s\n' "$STUB_MAX_KIB"
+    fi
     ;;
   --get-config) echo "$STUB_MAX_HUMAN" ;;
   *) exit 1 ;;
@@ -51,26 +60,31 @@ STUB
 chmod +x "$WORK/bin/ccache"
 export PATH="$WORK/bin:$PATH"
 
-# label|hits|miss|cleanups|size_kib|max_kib|max_human|expected
-# expected is one of: silent, evicted, hitrate
+# label|hits|miss|cleanups|size_kib|max_kib|max_human|expected|expected_fill
+# expected is one of: silent, evicted, hitrate, foreign
+# expected_fill of "-" skips the fill assertion.
 CASES=(
-  # Measured in CI. 500M resolves to 488281 KiB, 1.5G to 1464844 KiB.
-  "lyrical|788|364|0|136314|488281|500.0 MB|silent"
-  "jazzy-tidy|1166|496|0|104858|488281|500.0 MB|silent"
-  "humble|672|555|4|73400|488281|500.0 MB|silent"
-  "jazzy-tsan|501|1161|186|692061|1464844|1.5 GB|hitrate"
-  "jazzy-test|430|2185|1672|482344|488281|500.0 MB|evicted"
-  # Constructed. A full cache that is not evicting is doing its job, and a step
-  # that compiled nothing must not be reported as a 0% hit rate.
-  "full-but-clean|900|100|0|480000|488281|500.0 MB|silent"
-  "nothing-compiled|0|0|0|1000|488281|500.0 MB|silent"
-  # The ceiling wins when both shapes are true at once.
-  "pinned-and-cold|10|990|400|487000|488281|500.0 MB|evicted"
+  # Measured per build. 500M resolves to 488281 KiB, 1.5G to 1464843, 2G to 1953125.
+  "jazzy-asan|553|1|0|954204|1953125|2.0 GB|silent|48"
+  "jazzy-tsan|553|1|0|692061|1464843|1.5 GB|silent|47"
+  "jazzy-lint|553|1|0|104858|488281|500.0 MB|silent|21"
+  "lyrical|384|0|0|136314|488281|500.0 MB|silent|27"
+  "humble|272|139|2|91845|488281|500.0 MB|silent|18"
+  "foreign|42|369|219|482344|488281|500.0 MB|foreign|98"
+  # Same job, same numbers, on the ccache that omits the machine-readable max.
+  "humble-old|272|139|2|91845||500.0M|silent|18"
+  # Constructed. A full cache that is not evicting is doing its job; a step that
+  # compiled nothing must not be reported as a 0% hit rate; a cache that evicts
+  # while serving most calls simply wants a bigger ceiling.
+  "full-but-clean|900|100|0|480000|488281|500.0 MB|silent|98"
+  "nothing-compiled|0|0|0|1000|488281|500.0 MB|silent|-"
+  "pinned-but-useful|700|300|400|487000|488281|500.0 MB|evicted|99"
+  "cold|0|400|0|1000|488281|500.0 MB|hitrate|0"
 )
 
 failures=0
 for row in "${CASES[@]}"; do
-  IFS='|' read -r label hits miss cleanups size_kib max_kib max_human expected <<<"$row"
+  IFS='|' read -r label hits miss cleanups size_kib max_kib max_human expected exp_fill <<<"$row"
 
   out=$(
     STUB_HITS="$hits" STUB_MISS="$miss" STUB_CLEANUPS="$cleanups" \
@@ -78,7 +92,9 @@ for row in "${CASES[@]}"; do
     "$SCRIPT" "$label"
   )
 
-  if grep -q "title=ccache evicted during the build" <<<"$out"; then
+  if grep -q "title=ccache is full of another build" <<<"$out"; then
+    actual=foreign
+  elif grep -q "title=ccache evicted during the build" <<<"$out"; then
     actual=evicted
   elif grep -q "title=ccache hit rate below" <<<"$out"; then
     actual=hitrate
@@ -86,15 +102,12 @@ for row in "${CASES[@]}"; do
     actual=silent
   fi
 
-  # Exactly one warning, never two.
   count=$(grep -c '::warning' <<<"$out" || true)
-  if [ "$actual" = silent ] && [ "$count" -ne 0 ]; then
-    echo "FAIL $label: expected no warning, got $count"
-    failures=$((failures + 1))
-    continue
-  fi
-  if [ "$actual" != silent ] && [ "$count" -ne 1 ]; then
-    echo "FAIL $label: expected exactly one warning, got $count"
+  expected_count=0
+  [ "$expected" != silent ] && expected_count=1
+  if [ "$count" -ne "$expected_count" ]; then
+    echo "FAIL $label: expected $expected_count warning(s), got $count"
+    echo "     $out"
     failures=$((failures + 1))
     continue
   fi
@@ -103,9 +116,19 @@ for row in "${CASES[@]}"; do
     echo "FAIL $label: expected $expected, got $actual"
     echo "     $out"
     failures=$((failures + 1))
-  else
-    echo "ok   $label -> $actual"
+    continue
   fi
+
+  if [ "$exp_fill" != "-" ]; then
+    fill=$(sed -n 's/.*(\([0-9]*\)% full).*/\1/p' <<<"$out")
+    if [ "$fill" != "$exp_fill" ]; then
+      echo "FAIL $label: expected ${exp_fill}% full, reported ${fill:-none}%"
+      failures=$((failures + 1))
+      continue
+    fi
+  fi
+
+  echo "ok   $label -> $actual"
 done
 
 if [ "$failures" -gt 0 ]; then

--- a/scripts/test_ccache_report.sh
+++ b/scripts/test_ccache_report.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Pin what ccache_report.sh warns about.
+#
+# A warning that fires on every run carries no information, and one that never
+# fires carries none either. The rows below are the real numbers six CI jobs
+# reported, so the thresholds are checked against the states the jobs actually
+# reach rather than against invented ones. `humble` is the row that matters
+# most: four cleanups in a cache at 15% of its ceiling is ccache trimming a
+# subdirectory, not a ceiling that is too small, and an earlier version of the
+# script warned about it.
+#
+# ccache is stubbed on PATH, so the script under test runs unmodified.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/ccache_report.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/ccache" <<'STUB'
+#!/bin/bash
+case "$1" in
+  --print-stats)
+    printf 'cache_miss\t%s\n'                 "$STUB_MISS"
+    printf 'cleanups_performed\t%s\n'         "$STUB_CLEANUPS"
+    printf 'direct_cache_hit\t%s\n'           "$STUB_HITS"
+    printf 'preprocessed_cache_hit\t0\n'
+    printf 'cache_size_kibibyte\t%s\n'        "$STUB_SIZE_KIB"
+    printf 'max_cache_size_kibibyte\t%s\n'    "$STUB_MAX_KIB"
+    ;;
+  --get-config) echo "$STUB_MAX_HUMAN" ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$WORK/bin/ccache"
+export PATH="$WORK/bin:$PATH"
+
+# label|hits|miss|cleanups|size_kib|max_kib|max_human|expected
+# expected is one of: silent, evicted, hitrate
+CASES=(
+  # Measured in CI. 500M resolves to 488281 KiB, 1.5G to 1464844 KiB.
+  "lyrical|788|364|0|136314|488281|500.0 MB|silent"
+  "jazzy-tidy|1166|496|0|104858|488281|500.0 MB|silent"
+  "humble|672|555|4|73400|488281|500.0 MB|silent"
+  "jazzy-tsan|501|1161|186|692061|1464844|1.5 GB|hitrate"
+  "jazzy-test|430|2185|1672|482344|488281|500.0 MB|evicted"
+  # Constructed. A full cache that is not evicting is doing its job, and a step
+  # that compiled nothing must not be reported as a 0% hit rate.
+  "full-but-clean|900|100|0|480000|488281|500.0 MB|silent"
+  "nothing-compiled|0|0|0|1000|488281|500.0 MB|silent"
+  # The ceiling wins when both shapes are true at once.
+  "pinned-and-cold|10|990|400|487000|488281|500.0 MB|evicted"
+)
+
+failures=0
+for row in "${CASES[@]}"; do
+  IFS='|' read -r label hits miss cleanups size_kib max_kib max_human expected <<<"$row"
+
+  out=$(
+    STUB_HITS="$hits" STUB_MISS="$miss" STUB_CLEANUPS="$cleanups" \
+    STUB_SIZE_KIB="$size_kib" STUB_MAX_KIB="$max_kib" STUB_MAX_HUMAN="$max_human" \
+    "$SCRIPT" "$label"
+  )
+
+  if grep -q "title=ccache evicted during the build" <<<"$out"; then
+    actual=evicted
+  elif grep -q "title=ccache hit rate below" <<<"$out"; then
+    actual=hitrate
+  else
+    actual=silent
+  fi
+
+  # Exactly one warning, never two.
+  count=$(grep -c '::warning' <<<"$out" || true)
+  if [ "$actual" = silent ] && [ "$count" -ne 0 ]; then
+    echo "FAIL $label: expected no warning, got $count"
+    failures=$((failures + 1))
+    continue
+  fi
+  if [ "$actual" != silent ] && [ "$count" -ne 1 ]; then
+    echo "FAIL $label: expected exactly one warning, got $count"
+    failures=$((failures + 1))
+    continue
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL $label: expected $expected, got $actual"
+    echo "     $out"
+    failures=$((failures + 1))
+  else
+    echo "ok   $label -> $actual"
+  fi
+done
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures case(s) failed"
+  exit 1
+fi
+echo "all ${#CASES[@]} cases passed"

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -49,6 +49,37 @@ bodies, `if(FALSE)` blocks, `INTERFACE` libraries that compile nothing). An
 include placed after a target still shows up whenever it costs the package all
 of its records; a partial slip does not. Put it above the first target.
 
+### ROS2MedkitSanitizers
+
+A no-op unless `-DSANITIZER=` names at least one of `asan`, `tsan`, `ubsan`
+(comma-separated; `asan` and `tsan` cannot be combined). When it is active it
+overrides three things the build type would otherwise decide, and it does so
+through `add_compile_options`, which CMake places after
+`CMAKE_CXX_FLAGS_<CONFIG>` on the command line:
+
+- `-O1` instead of the build type's level. Sanitizers report fewer false
+  positives and run faster here than at `-O0`.
+- `-g1`: line tables plus descriptions of functions and external variables, but
+  no locals and no types. Before this was set, full DWARF took the instrumented
+  ASan tree to about 27 GB, most of it debug info, which is written by the
+  compiler, read by the linker and stored in ccache. A sanitizer report still
+  names `file:line`, and still names the overflowed variable, because that name
+  comes from the frame descriptor ASan embeds rather than from DWARF. What is
+  lost is inspecting locals in a debugger on a core file.
+- `-UNDEBUG`, so `assert()` stays live. `Release` and `RelWithDebInfo` both
+  carry `-DNDEBUG`, and the CI sanitizer jobs build `RelWithDebInfo`, so
+  without this the one build meant to abort on a broken invariant was the one
+  compiling every assert away. Note how wide this reaches: the flag is
+  directory-scoped like the others, so it enables assertions in everything
+  compiled into a participating package, not only the handful the repository
+  writes itself. `nlohmann/json` routes its `JSON_ASSERT` to `assert`, and the
+  vendored `cpp-httplib` and `dynmsg` carry their own. Those checks firing is
+  the intended behaviour of a sanitizer build, but it does mean a latent bug in
+  a header shows up as an abort in the sanitizer jobs and nowhere else.
+
+Do not move these into `CMAKE_CXX_FLAGS`, where the build type's flags would
+come last and win instead.
+
 ## Usage
 
 In your package's `CMakeLists.txt`, before the first target:

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitSanitizers.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitSanitizers.cmake
@@ -78,10 +78,24 @@ list(JOIN _FSANITIZE_FLAGS "," _FSANITIZE_VALUE)
 # ASan embeds at instrumentation time, not from DWARF, so it survives too. What
 # -g1 does drop is the ability to inspect locals in a debugger on a core file.
 #
-# Both flags come from add_compile_options, which CMake places after
+# -UNDEBUG: keep assert() live whatever build type the caller picked. Release
+# and RelWithDebInfo both carry -DNDEBUG, which compiles every assert away, and
+# the CI sanitizer jobs build RelWithDebInfo. A sanitizer build exists to abort
+# on a broken invariant, so the one build where asserts must fire was the one
+# silently compiling them out. Debug is not a substitute here: it would bring
+# -O0 with it, and -O1 above is deliberate.
+#
+# This is directory-scoped like the rest, so it also enables the assertions in
+# headers compiled into a participating package - nlohmann/json routes
+# JSON_ASSERT to assert, and the vendored cpp-httplib and dynmsg carry their
+# own. That is far more than the three assertions the repository writes itself,
+# and it is the intent: a sanitizer build should be running those checks.
+#
+# All three flags come from add_compile_options, which CMake places after
 # CMAKE_CXX_FLAGS_<CONFIG> on the command line, so these win over the build
-# type's -O2 -g. Do not move them into CMAKE_CXX_FLAGS, where they would lose.
-add_compile_options(-fsanitize=${_FSANITIZE_VALUE} -fno-omit-frame-pointer -O1 -g1)
+# type's -O2 -g -DNDEBUG. Do not move them into CMAKE_CXX_FLAGS, where they
+# would lose.
+add_compile_options(-fsanitize=${_FSANITIZE_VALUE} -fno-omit-frame-pointer -O1 -g1 -UNDEBUG)
 add_link_options(-fsanitize=${_FSANITIZE_VALUE})
 
 message(STATUS "Sanitizers enabled: ${SANITIZER} (-fsanitize=${_FSANITIZE_VALUE})")

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitSanitizers.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitSanitizers.cmake
@@ -63,7 +63,25 @@ list(JOIN _FSANITIZE_FLAGS "," _FSANITIZE_VALUE)
 
 # -O1: sanitizers produce fewer false positives and run faster than -O0.
 # This intentionally overrides Debug's -O0 for sanitizer builds.
-add_compile_options(-fsanitize=${_FSANITIZE_VALUE} -fno-omit-frame-pointer -O1)
+#
+# -g1: line tables only, no variable/type DWARF. Until this was set the module
+# overrode the build type's -O but never its -g, so RelWithDebInfo's full -g
+# stayed in force and the instrumented ASan tree reached ~27 GB, the large
+# majority of it debug info. That is not just disk: every one of those bytes is
+# written by the compiler, read by the linker, and stored in ccache, and at the
+# CI cache ceiling it meant ccache evicted the objects it was still producing.
+#
+# Nothing needed to diagnose a sanitizer finding is lost. Symbolication of the
+# stack frames in an ASan/UBSan report needs the line table, which -g1 keeps, so
+# reports still name file:line. The variable named in a stack-buffer-overflow
+# report ("in frame ... at offset N ... 'buf'") comes from the frame descriptor
+# ASan embeds at instrumentation time, not from DWARF, so it survives too. What
+# -g1 does drop is the ability to inspect locals in a debugger on a core file.
+#
+# Both flags come from add_compile_options, which CMake places after
+# CMAKE_CXX_FLAGS_<CONFIG> on the command line, so these win over the build
+# type's -O2 -g. Do not move them into CMAKE_CXX_FLAGS, where they would lose.
+add_compile_options(-fsanitize=${_FSANITIZE_VALUE} -fno-omit-frame-pointer -O1 -g1)
 add_link_options(-fsanitize=${_FSANITIZE_VALUE})
 
 message(STATUS "Sanitizers enabled: ${SANITIZER} (-fsanitize=${_FSANITIZE_VALUE})")


### PR DESCRIPTION
## Summary

Targets the 56-minute pull request feedback time measured in the issue, with an expected
result of 34 to 37 minutes. No test and no distribution is dropped from pull requests. Two
things do change and are called out below: the coverage job moves to `main`, and the image
publish job gives up its builder layer cache.

Measured on this branch. Each run changed something the caches depended on, so read them in
order:

| run | critical path | why |
|---|---|---|
| 1 | 59 min, `sanitizer-asan` | change 7 alters the sanitizer compile command line, so both sanitizer caches were invalid and built cold |
| 2 | 41 min, `jazzy-test` | sanitizers warm and at target: 99% hits, 36m55s and 34m47s. `jazzy-test` was restoring the ASan cache, see change 10 |
| 3 | 38 min, `jazzy-test` | its key prefix now matches nothing else, so it had nothing to restore and was cold by construction |

The sanitizer jobs reach the expected figure from run 2 onwards, which is what the issue
identified as 64% of the critical path. `jazzy-test` has not yet had a run with a warm cache
of its own; the next push is its first.

Ten changes, in the order they depend on each other:

1. `docker-publish.yml`: `cache-to` goes from `mode=max` to `mode=min`. It was holding about
   3.1 GB of intermediate layers in a repository cache that is already over its 10 GB limit,
   for a job that only runs on pushes to `main`. Nothing else can be fixed until this frees
   space. This costs build time in that job. The `Dockerfile` is two-stage and `mode=min`
   exports only the final image, so builder-stage layers are not restored at all. In
   practice the loss is smaller than it sounds: the `COPY src/` layers sit above the
   `rosdep` + `colcon build` layer, so any push touching `src/` already invalidated that
   layer under `mode=max` too. What such a push genuinely loses is the build-deps `apt-get`
   layer. The job is not on the pull request path, and the quota it was holding is what
   every pull request needs.
2. `ROS2MedkitSanitizers.cmake`: adds `-g1` to sanitizer builds. The module already
   overrode the build type's optimisation level but never its debug level, so
   `RelWithDebInfo` kept full debug info and the instrumented tree grew to about 27 GB,
   mostly DWARF. On one translation unit the object shrinks by 45% and its debug info by
   72%.
3. `quality.yml`: `CCACHE_MAXSIZE` goes to 2G for ASan and 1.5G for TSan. At 500M both jobs
   evicted hundreds of objects during their own build and never got above 18% hits.
4. `ci.yml`: `lcov --capture` gets `--parallel`. It was more than 99% of the 12.7-minute
   coverage report step and ran on one core.
5. `ci.yml`: `jazzy-build` is merged into `jazzy-test`. The build artifact had exactly one
   consumer, so the split paid about 4.7 minutes of repeated container and ROS setup for no
   parallel work. The job id stays `jazzy-test`, so `notify-demos` needs no change.
6. `ci.yml`: the `coverage` job runs on pushes to `main` only, and gains
   `--return-code-on-test-failure`. It was missing that flag while the two other test jobs
   have it, so a failing test there could not fail CI. The job read as a gate without being
   one.
7. `ROS2MedkitSanitizers.cmake`: adds `-UNDEBUG`. This is the compensation for change 6.
   The coverage job was the last pull request build compiling without `-DNDEBUG`, so on its
   own that change would have taken every `assert()` out of pull request builds, since the
   remaining jobs are `Release` or `RelWithDebInfo`. The two sanitizer jobs already run on
   every pull request, over a superset of the test selection the coverage job used, so
   putting the asserts there costs no CI time. Note the reach: the flag is directory-scoped,
   so it also enables assertions in headers compiled into a participating package.
   `nlohmann/json` routes `JSON_ASSERT` to `assert`, and the vendored `cpp-httplib` and
   `dynmsg` carry their own. That is the intent, but it does mean a latent bug in a header
   now shows up as an abort in the sanitizer jobs and nowhere else.
8. `pixi.yml`: runs on pushes to `main` plus a nightly cron instead of on every pull
   request. It is `continue-on-error`, so it never gated a pull request, and its cache is
   only written on `main`, so every pull request paid a 30.8-minute cold build.
9. `scripts/ccache_report.sh`: reports what ccache actually did. Changes 1 and 3 rest on the
   claim that ccache stops evicting during its own build, and nothing read the numbers that
   would show whether it worked. Every ccache-backed build step now runs `ccache -z` before
   compiling and writes hit rate, cache size, fill level and cleanup count to the job
   summary afterwards. The zeroing matters: ccache keeps its counters inside the cache
   directory and `actions/cache` restores that directory whole, so read as they come the
   numbers are the running total over every job that fed the entry rather than what this
   build did.

   It raises a workflow warning in two states. A cache at 90% of its ceiling or more that is
   still running cleanups is discarding objects the same build produced, so the ceiling is
   too small or the Actions quota is evicting the entry. A hit rate under 50% without that
   ceiling pressure means the cache was not restored, or the branch changed a compiler flag
   and invalidated the objects. Cleanups on their own prove nothing, because ccache trims a
   subdirectory when it passes `max_size/16` and a nearly empty cache reports a few. The
   script never fails the step, because a cold cache is a legitimate state.

10. `ci.yml`: `jazzy-test` gets its own ccache key prefix. It used `ccache-jazzy-`, which
    also matches `ccache-jazzy-asan-`, `-tsan-`, `-lint-` and `-tidy-`, and `restore-keys`
    takes the most recently created match. Run 2 shows it loading
    `ccache-jazzy-asan-818af7de`: 2 GB of instrumented objects it cannot use, 42 hits out of
    411 calls, then 219 cleanups as its own `Release` objects fought for the 500M ceiling on
    top of them. It was the critical path at 41m7s while the ASan job whose cache it had
    taken finished in 36m55s at 99% hits. The prefix is now `ccache-jazzy-test-`. This is
    older than this branch; it only became visible once change 9 made the numbers per-build.

Pull requests keep the static coverage scope check, which is in the Quality workflow and
fails if a package compiles production C++ without coverage instrumentation.

`QUALITY_DECLARATION.md` and `CONTRIBUTING.md` are corrected against what the workflows
actually do, including checks that were already inaccurate before this branch: the build is
not "full" (all three distro jobs skip `ros2_medkit_opcua`), clang-tidy is incremental on a
pull request, the Sphinx and OPC-UA workflows and two source gates also gate pull requests,
sanitizer instrumentation does not reach packages that omit the module, and no required
status check enforces any of it.

---

## Issue

- closes #589

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

`lcov --parallel` produces the same file as the serial run. Same md5, all 163 source file
records equal, same line and function totals. The whole downstream chain of filters and
`genhtml` runs on the parallel output.

`-g1` keeps what a sanitizer report needs. An ASan stack buffer overflow built with the new
flags still names file and line in every frame and still names the overflowed variable,
because that name comes from the frame descriptor the sanitizer embeds, not from DWARF.
What is lost is inspecting local variables in a debugger on a core file.

`-UNDEBUG` was verified by running the suite with the asserts live. The workspace was built
`RelWithDebInfo` with the config flags overridden to `-O1 -g1`, which is what the sanitizer
jobs compile with minus the instrumentation, and with no `-DNDEBUG` in any compile command.
The coverage job's test selection then ran over 18 packages: 4571 tests, and no assertion
fired anywhere. No `Assertion ... failed`, no `SIGABRT`, no core dump. One integration test
failed, `test_external_app_fault_rollup`, and it is not related: it fails at the same rate
with the asserts compiled out (2 of 10 passing either way, run alternately to keep machine
load equal), its log carries the `Buffer is empty, cannot create bag file` warning, and a
branch that fixes that empty-buffer path passes it 10 times out of 10 on the same machine.

`ccache_report.sh` has its thresholds pinned by `scripts/test_ccache_report.sh`, which runs
in `format-lint`. It stubs ccache on `PATH` so the script runs unmodified, and its rows are
the numbers six jobs reported on the first run of this branch plus three constructed cases:
a full cache that is not evicting, a step that compiled nothing, and a cache that is both
pinned and cold. Against the earlier threshold, which warned on any cleanup at all, it
fails on two of those rows, which is what makes it a test rather than a constant.

Both the threshold and the zeroing came out of that first run rather than from reading the
code. It
reported cleanups in three jobs, one of them a cache at 15% of its ceiling, which is ccache
trimming a subdirectory and not a ceiling worth raising. Chasing that down showed the
counters were cumulative, which is what change 9 now handles.

The speedup itself cannot be measured locally and is not claimed here. The `ccache` rows in
the job summaries are the thing to read, and from the second run onwards they describe a
single build: cleanups should be zero or the cache well below its ceiling, and the hit rate
well above the 50% floor. For scale, a cold full `Release` build of the workspace stores
about 101 MiB across 376 entries locally, so the 500M ceilings hold several builds' worth
of objects.

Every workflow file still parses, and every `needs:` edge and `needs.<job>.*` expression in
all seven workflows was resolved against the declared job list, with no broken references.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
