### PR TITLE
Data triggers on plugin entities: resolve from declared topics, fail loud on bad names

### DIFF
--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -574,7 +574,13 @@ policy is set).
 
 If the plugin publishes ROS 2 topics that back an entity's data points (the
 PLC-bridge pattern: values mirrored to ``/plc/...`` topics), declare them on
-the entity via ``App::topics`` / ``Component::topics``:
+the entity via ``App::topics`` / ``Component::topics``. This works for
+entities the plugin itself adds in ``new_entities``. It does NOT work as an
+enrichment of an app that runtime discovery already found: for live-data
+fields the runtime layer is authoritative and the plugin layer is enrichment,
+so a ``topics`` list declared on a shadow of a runtime-discovered app is
+dropped by the merge. If you need extra topics on a runtime-discovered app,
+bind them through a manifest instead:
 
 .. code-block:: cpp
 

--- a/docs/tutorials/plugin-system.rst
+++ b/docs/tutorials/plugin-system.rst
@@ -572,6 +572,23 @@ New entities in ``new_entities`` only appear in responses when
 ``allow_new_entities`` is true in the plugin configuration (or an equivalent
 policy is set).
 
+If the plugin publishes ROS 2 topics that back an entity's data points (the
+PLC-bridge pattern: values mirrored to ``/plc/...`` topics), declare them on
+the entity via ``App::topics`` / ``Component::topics``:
+
+.. code-block:: cpp
+
+   App app;
+   app.id = "my_device";
+   app.topics.publishes.push_back("/plc/main/counter");
+
+Runtime graph discovery attributes a topic to the ROS node that publishes it -
+for plugin-published topics that is the gateway's own node, not the plugin
+entity. Without the declaration, entity-scoped topic lookups on the plugin
+entity return nothing, and in particular data triggers
+(``POST /apps/<id>/triggers`` with a ``data/...`` resource) can never resolve
+and never fire. Declare only topics that actually get a publisher.
+
 ScriptProvider Example
 ----------------------
 

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1047,6 +1047,10 @@ if(BUILD_TESTING)
   ament_add_gtest(test_fault_trigger_engine test/test_fault_trigger_engine.cpp)
   target_link_libraries(test_fault_trigger_engine gateway_core)
 
+  # Data-point suggestion helpers (issue #584): header-only, ROS-neutral.
+  ament_add_gtest(test_data_point_suggest test/test_data_point_suggest.cpp)
+  target_link_libraries(test_data_point_suggest gateway_core)
+
   # Peer client tests (aggregation module)
   ament_add_gtest(test_peer_client test/test_peer_client.cpp)
   target_link_libraries(test_peer_client gateway_ros2)

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/data_point_suggest.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/data_point_suggest.hpp
@@ -1,0 +1,116 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_
+#define ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_
+
+// Suggestion helpers for "data point does not exist" errors. PLC plugins
+// register symbols under a sanitized leaf name (MAIN.counter -> counter), so
+// an operator typing the source notation gets no hit; these helpers recover
+// the intended name instead of dumping an alphabetical prefix of ~200 symbols.
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+
+inline size_t edit_distance(const std::string & a, const std::string & b) {
+  std::vector<size_t> prev(b.size() + 1), cur(b.size() + 1);
+  for (size_t j = 0; j <= b.size(); ++j) {
+    prev[j] = j;
+  }
+  for (size_t i = 1; i <= a.size(); ++i) {
+    cur[0] = i;
+    for (size_t j = 1; j <= b.size(); ++j) {
+      const size_t sub = prev[j - 1] + (a[i - 1] == b[j - 1] ? 0 : 1);
+      cur[j] = std::min({prev[j] + 1, cur[j - 1] + 1, sub});
+    }
+    std::swap(prev, cur);
+  }
+  return prev[b.size()];
+}
+
+/// MAIN.counter -> counter: leaf after the last '.' or '/', lowercased with
+/// non-alphanumerics mapped to '_' - the same shape the PLC bridges produce
+/// when they sanitize a symbol into a data point id.
+inline std::string sanitized_leaf(const std::string & input) {
+  const auto pos = input.find_last_of("./");
+  std::string leaf = (pos == std::string::npos) ? input : input.substr(pos + 1);
+  std::string out;
+  out.reserve(leaf.size());
+  for (char c : leaf) {
+    if (std::isalnum(static_cast<unsigned char>(c))) {
+      out += static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    } else if (c == '_' || c == '-') {
+      out += c;
+    } else {
+      out += '_';
+    }
+  }
+  return out;
+}
+
+/// Best existing name for a miss, or empty when nothing is close. The
+/// sanitized leaf wins exactly (the deterministic mapping); otherwise the
+/// closest name within an input-length-scaled edit distance budget.
+inline std::string suggest_data_point(const std::string & input, const std::vector<std::string> & names) {
+  const std::string leaf = sanitized_leaf(input);
+  if (!leaf.empty() && std::find(names.begin(), names.end(), leaf) != names.end()) {
+    return leaf;
+  }
+  const size_t budget = std::max<size_t>(2, input.size() / 4);
+  size_t best_dist = budget + 1;
+  std::string best;
+  for (const auto & name : names) {
+    size_t d = edit_distance(input, name);
+    if (!leaf.empty()) {
+      d = std::min(d, edit_distance(leaf, name));
+    }
+    if (d < best_dist || (d == best_dist && name < best)) {
+      best_dist = d;
+      best = name;
+    }
+  }
+  return best_dist <= budget ? best : std::string{};
+}
+
+/// Up to n names ordered by edit distance to the input (ties alphabetical),
+/// so a truncated "available:" list shows the relevant neighborhood instead
+/// of an alphabetical prefix.
+inline std::vector<std::string> closest_data_points(const std::string & input, const std::vector<std::string> & names,
+                                                    size_t n) {
+  const std::string leaf = sanitized_leaf(input);
+  std::vector<std::pair<size_t, std::string>> ranked;
+  ranked.reserve(names.size());
+  for (const auto & name : names) {
+    size_t d = edit_distance(input, name);
+    if (!leaf.empty()) {
+      d = std::min(d, edit_distance(leaf, name));
+    }
+    ranked.emplace_back(d, name);
+  }
+  std::sort(ranked.begin(), ranked.end());
+  std::vector<std::string> out;
+  out.reserve(std::min(n, ranked.size()));
+  for (size_t i = 0; i < ranked.size() && i < n; ++i) {
+    out.push_back(ranked[i].second);
+  }
+  return out;
+}
+
+}  // namespace ros2_medkit_gateway
+
+#endif  // ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/data_point_suggest.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/data_point_suggest.hpp
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_
-#define ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_
+#pragma once
 
 // Suggestion helpers for "data point does not exist" errors. PLC plugins
 // register symbols under a sanitized leaf name (MAIN.counter -> counter), so
@@ -22,6 +21,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -71,20 +71,29 @@ inline std::string suggest_data_point(const std::string & input, const std::vect
   if (!leaf.empty() && std::find(names.begin(), names.end(), leaf) != names.end()) {
     return leaf;
   }
-  const size_t budget = std::max<size_t>(2, input.size() / 4);
-  size_t best_dist = budget + 1;
+  // Each candidate distance gets the budget of the string it was measured
+  // against: a long namespace prefix must not buy a short leaf a huge budget
+  // (MAIN.Very.Long.Prefix.rpm would otherwise "suggest" whatever is nearest
+  // to a three-letter leaf).
+  const size_t input_budget = std::max<size_t>(2, input.size() / 4);
+  const size_t leaf_budget = std::max<size_t>(2, leaf.size() / 4);
+  size_t best_score = SIZE_MAX;
   std::string best;
   for (const auto & name : names) {
-    size_t d = edit_distance(input, name);
+    const size_t d_input = edit_distance(input, name);
+    size_t score = d_input <= input_budget ? d_input : SIZE_MAX;
     if (!leaf.empty()) {
-      d = std::min(d, edit_distance(leaf, name));
+      const size_t d_leaf = edit_distance(leaf, name);
+      if (d_leaf <= leaf_budget && d_leaf < score) {
+        score = d_leaf;
+      }
     }
-    if (d < best_dist || (d == best_dist && name < best)) {
-      best_dist = d;
+    if (score < best_score || (score == best_score && score != SIZE_MAX && name < best)) {
+      best_score = score;
       best = name;
     }
   }
-  return best_dist <= budget ? best : std::string{};
+  return best_score != SIZE_MAX ? best : std::string{};
 }
 
 /// Up to n names ordered by edit distance to the input (ties alphabetical),
@@ -112,5 +121,3 @@ inline std::vector<std::string> closest_data_points(const std::string & input, c
 }
 
 }  // namespace ros2_medkit_gateway
-
-#endif  // ROS2_MEDKIT_GATEWAY__CORE__DATA_POINT_SUGGEST_HPP_

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/trigger_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/trigger_manager.hpp
@@ -164,6 +164,15 @@ class TriggerManager {
   /// Set the topic name resolver. Called by GatewayNode after cache is available.
   void set_resolve_topic_fn(ResolveTopicFn fn);
 
+  /// Operator-facing warning sink (transport-agnostic; GatewayNode wires it to
+  /// the ROS logger). Used when deferred resolution gives up on a trigger.
+  using WarnLogFn = std::function<void(const std::string & message)>;
+  void set_warn_log_fn(WarnLogFn fn);
+
+  /// How long deferred resolution keeps retrying before giving up.
+  /// Default 60 s; tests shrink it to exercise the expiry path.
+  void set_unresolved_timeout(std::chrono::seconds timeout);
+
   /// Retry resolving data triggers whose topic names were unknown at creation.
   /// Called periodically (today: from the rclcpp adapter's retry tick) so
   /// that triggers stuck without a topic name get a chance to subscribe.
@@ -293,7 +302,8 @@ class TriggerManager {
   };
   std::vector<UnresolvedTrigger> unresolved_data_triggers_;  // guarded by triggers_mutex_
   ResolveTopicFn resolve_topic_fn_;                          // guarded by triggers_mutex_
-  static constexpr int kUnresolvedTimeoutSec = 60;
+  WarnLogFn warn_log_fn_;                                    // guarded by triggers_mutex_
+  std::chrono::seconds unresolved_timeout_{60};              // guarded by triggers_mutex_
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
@@ -226,10 +226,14 @@ class PluginManager : public LogProviderRegistry {
    * thread-safe (already the contract across concurrent HTTP workers; this
    * entry point just adds one more caller).
    *
+   * @param item optional data point name; when non-empty the single-item
+   *        route (x-plc-data/<item>) is dispatched instead of the list.
+   *
    * @return Parsed JSON body on a 200 response; nullopt when the entity is
    *         not plugin-owned, no route matches, or the handler fails.
    */
-  std::optional<nlohmann::json> fetch_entity_data_via_route(const std::string & entity_id);
+  std::optional<nlohmann::json> fetch_entity_data_via_route(const std::string & entity_id,
+                                                            const std::string & item = "");
 
   /// Check if an entity is owned by a plugin
   /// @return Plugin name if owned, nullopt otherwise

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/plugins/plugin_manager.hpp
@@ -235,6 +235,12 @@ class PluginManager : public LogProviderRegistry {
   std::optional<nlohmann::json> fetch_entity_data_via_route(const std::string & entity_id,
                                                             const std::string & item = "");
 
+  /// Whether the entity's owning plugin registered a GET data route
+  /// (x-plc-data) that fetch_entity_data_via_route() could dispatch. Cheap
+  /// route-table check, no handler invocation - capability advertising uses
+  /// it so /data is only announced where a read can actually be served.
+  bool has_entity_data_route(const std::string & entity_id);
+
   /// Check if an entity is owned by a plugin
   /// @return Plugin name if owned, nullopt otherwise
   std::optional<std::string> get_entity_owner(const std::string & entity_id) const;

--- a/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/src/core/fault_trigger_engine.cpp
@@ -21,6 +21,8 @@
 #include <fstream>
 #include <utility>
 
+#include "ros2_medkit_gateway/core/data_point_suggest.hpp"
+
 namespace ros2_medkit_gateway {
 
 namespace {
@@ -150,17 +152,26 @@ tl::expected<FaultTriggerRule, std::pair<int, std::string>> FaultTriggerEngine::
   if (data_point_names_) {
     const auto names = data_point_names_(rule.app_id);
     if (names.has_value() && std::find(names->begin(), names->end(), rule.data_name) == names->end()) {
-      std::string available;
+      // ~200 PLC symbols make an alphabetical prefix useless: rank by edit
+      // distance so the neighborhood of the typo is what gets listed, and
+      // resolve the deterministic MAIN.counter -> counter mapping outright.
       constexpr size_t kMaxListed = 20;
-      for (size_t i = 0; i < names->size() && i < kMaxListed; ++i) {
-        available += (i == 0 ? "" : ", ") + (*names)[i];
+      const auto listed = closest_data_points(rule.data_name, *names, kMaxListed);
+      std::string available;
+      for (size_t i = 0; i < listed.size(); ++i) {
+        available += (i == 0 ? "" : ", ") + listed[i];
       }
-      if (names->size() > kMaxListed) {
-        available += ", ...";
+      std::string msg = "data point '" + rule.data_name + "' does not exist on app '" + rule.app_id + "'";
+      const std::string suggestion = suggest_data_point(rule.data_name, *names);
+      if (!suggestion.empty()) {
+        msg += " - did you mean '" + suggestion + "'?";
       }
-      return tl::make_unexpected(
-          std::make_pair(400, "data point '" + rule.data_name + "' does not exist on app '" + rule.app_id + "'" +
-                                  (available.empty() ? std::string{} : " (available: " + available + ")")));
+      if (!available.empty()) {
+        msg += names->size() > kMaxListed ? " (" + std::to_string(names->size()) + " available, closest " +
+                                                std::to_string(listed.size()) + ": " + available + ")"
+                                          : " (available: " + available + ")";
+      }
+      return tl::make_unexpected(std::make_pair(400, std::move(msg)));
     }
   }
 

--- a/src/ros2_medkit_gateway/src/core/managers/trigger_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/trigger_manager.cpp
@@ -122,6 +122,16 @@ void TriggerManager::set_resolve_topic_fn(ResolveTopicFn fn) {
   resolve_topic_fn_ = std::move(fn);
 }
 
+void TriggerManager::set_warn_log_fn(WarnLogFn fn) {
+  std::lock_guard<std::mutex> lock(triggers_mutex_);
+  warn_log_fn_ = std::move(fn);
+}
+
+void TriggerManager::set_unresolved_timeout(std::chrono::seconds timeout) {
+  std::lock_guard<std::mutex> lock(triggers_mutex_);
+  unresolved_timeout_ = timeout;
+}
+
 void TriggerManager::retry_unresolved_triggers() {
   if (shutdown_flag_.load()) {
     return;
@@ -140,8 +150,17 @@ void TriggerManager::retry_unresolved_triggers() {
   for (size_t i = 0; i < unresolved_data_triggers_.size(); ++i) {
     auto & entry = unresolved_data_triggers_[i];
 
-    if (now - entry.created_at > std::chrono::seconds(kUnresolvedTimeoutSec)) {
+    if (now - entry.created_at > unresolved_timeout_) {
+      // Give up loudly: the trigger stays registered and ACTIVE, but with no
+      // subscription it will never fire. Silence here is a dead alarm the
+      // operator believes in.
       expired_indices.push_back(i);
+      if (warn_log_fn_) {
+        warn_log_fn_("trigger '" + entry.trigger_id + "': gave up resolving resource_path '" + entry.resource_path +
+                     "' to a topic for entity '" + entry.entity_id + "' after " +
+                     std::to_string(unresolved_timeout_.count()) +
+                     " s. The trigger stays active but cannot fire; delete it and recreate it once the topic exists.");
+      }
       continue;
     }
 

--- a/src/ros2_medkit_gateway/src/core/managers/trigger_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/trigger_manager.cpp
@@ -137,71 +137,83 @@ void TriggerManager::retry_unresolved_triggers() {
     return;
   }
 
-  std::lock_guard<std::mutex> lock(triggers_mutex_);
+  // Collected under the lock, emitted after release: warn_log_fn_ is an
+  // arbitrary external callback and must not run under triggers_mutex_.
+  std::vector<std::string> warnings;
+  WarnLogFn warn_fn;
+  {
+    std::lock_guard<std::mutex> lock(triggers_mutex_);
 
-  if (unresolved_data_triggers_.empty() || !resolve_topic_fn_ || !topic_transport_) {
-    return;
-  }
-
-  auto now = std::chrono::steady_clock::now();
-  std::vector<size_t> resolved_indices;
-  std::vector<size_t> expired_indices;
-
-  for (size_t i = 0; i < unresolved_data_triggers_.size(); ++i) {
-    auto & entry = unresolved_data_triggers_[i];
-
-    if (now - entry.created_at > unresolved_timeout_) {
-      // Give up loudly: the trigger stays registered and ACTIVE, but with no
-      // subscription it will never fire. Silence here is a dead alarm the
-      // operator believes in.
-      expired_indices.push_back(i);
-      if (warn_log_fn_) {
-        warn_log_fn_("trigger '" + entry.trigger_id + "': gave up resolving resource_path '" + entry.resource_path +
-                     "' to a topic for entity '" + entry.entity_id + "' after " +
-                     std::to_string(unresolved_timeout_.count()) +
-                     " s. The trigger stays active but cannot fire; delete it and recreate it once the topic exists.");
-      }
-      continue;
+    if (unresolved_data_triggers_.empty() || !resolve_topic_fn_ || !topic_transport_) {
+      return;
     }
 
-    std::string topic_name = resolve_topic_fn_(entry.entity_id, entry.resource_path);
-    if (!topic_name.empty()) {
-      // Update the trigger's resolved_topic_name + register a transport
-      // handle whose lifetime is tied to the trigger entry (cleared on
-      // remove()/cleanup_expired_trigger()).
-      auto it = triggers_.find(entry.trigger_id);
-      if (it != triggers_.end()) {
-        std::lock_guard<std::mutex> state_lock(it->second->mtx);
-        it->second->info.resolved_topic_name = topic_name;
+    auto now = std::chrono::steady_clock::now();
+    std::vector<size_t> resolved_indices;
+    std::vector<size_t> expired_indices;
+
+    for (size_t i = 0; i < unresolved_data_triggers_.size(); ++i) {
+      auto & entry = unresolved_data_triggers_[i];
+
+      if (now - entry.created_at > unresolved_timeout_) {
+        // Give up loudly: the trigger stays registered and ACTIVE, but with no
+        // subscription it will never fire. Silence here is a dead alarm the
+        // operator believes in.
+        expired_indices.push_back(i);
+        warnings.push_back("trigger '" + entry.trigger_id + "': gave up resolving resource_path '" +
+                           entry.resource_path + "' to a topic for entity '" + entry.entity_id + "' after " +
+                           std::to_string(unresolved_timeout_.count()) +
+                           " s. The trigger stays active but cannot fire; delete it and recreate it once the topic "
+                           "exists.");
+        continue;
       }
-      const std::string trigger_id = entry.trigger_id;
-      const std::string entity_id = entry.entity_id;
-      const std::string resource_path = entry.resource_path;
-      auto handle = topic_transport_->subscribe(
-          topic_name, /*msg_type=*/"", [this, entity_id, resource_path](const nlohmann::json & sample) {
-            notifier_.notify("data", entity_id, resource_path, sample, ChangeType::UPDATED);
-          });
-      if (handle) {
-        topic_handles_[trigger_id] = std::move(handle);
-        resolved_indices.push_back(i);
-      } else {
-        // Subscribe failed (rclcpp threw inside TriggerTopicSubscriber).
-        // Keep the trigger on the pending list so the next retry tick can
-        // try again; the subscriber has already logged the root cause.
-        // Without this guard the trigger would be marked resolved but
-        // never deliver samples.
-        // Index intentionally NOT added to resolved_indices.
+
+      std::string topic_name = resolve_topic_fn_(entry.entity_id, entry.resource_path);
+      if (!topic_name.empty()) {
+        // Update the trigger's resolved_topic_name + register a transport
+        // handle whose lifetime is tied to the trigger entry (cleared on
+        // remove()/cleanup_expired_trigger()).
+        auto it = triggers_.find(entry.trigger_id);
+        if (it != triggers_.end()) {
+          std::lock_guard<std::mutex> state_lock(it->second->mtx);
+          it->second->info.resolved_topic_name = topic_name;
+        }
+        const std::string trigger_id = entry.trigger_id;
+        const std::string entity_id = entry.entity_id;
+        const std::string resource_path = entry.resource_path;
+        auto handle = topic_transport_->subscribe(
+            topic_name, /*msg_type=*/"", [this, entity_id, resource_path](const nlohmann::json & sample) {
+              notifier_.notify("data", entity_id, resource_path, sample, ChangeType::UPDATED);
+            });
+        if (handle) {
+          topic_handles_[trigger_id] = std::move(handle);
+          resolved_indices.push_back(i);
+        } else {
+          // Subscribe failed (rclcpp threw inside TriggerTopicSubscriber).
+          // Keep the trigger on the pending list so the next retry tick can
+          // try again; the subscriber has already logged the root cause.
+          // Without this guard the trigger would be marked resolved but
+          // never deliver samples.
+          // Index intentionally NOT added to resolved_indices.
+        }
       }
     }
+
+    // Remove resolved and expired entries (reverse order to maintain indices)
+    std::vector<size_t> to_remove;
+    to_remove.insert(to_remove.end(), resolved_indices.begin(), resolved_indices.end());
+    to_remove.insert(to_remove.end(), expired_indices.begin(), expired_indices.end());
+    std::sort(to_remove.rbegin(), to_remove.rend());
+    for (size_t idx : to_remove) {
+      unresolved_data_triggers_.erase(unresolved_data_triggers_.begin() + static_cast<std::ptrdiff_t>(idx));
+    }
+    warn_fn = warn_log_fn_;
   }
 
-  // Remove resolved and expired entries (reverse order to maintain indices)
-  std::vector<size_t> to_remove;
-  to_remove.insert(to_remove.end(), resolved_indices.begin(), resolved_indices.end());
-  to_remove.insert(to_remove.end(), expired_indices.begin(), expired_indices.end());
-  std::sort(to_remove.rbegin(), to_remove.rend());
-  for (size_t idx : to_remove) {
-    unresolved_data_triggers_.erase(unresolved_data_triggers_.begin() + static_cast<std::ptrdiff_t>(idx));
+  if (warn_fn) {
+    for (const auto & w : warnings) {
+      warn_fn(w);
+    }
   }
 }
 

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -981,6 +981,9 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
       }
       return "";
     });
+    trigger_mgr_->set_warn_log_fn([this](const std::string & message) {
+      RCLCPP_WARN(get_logger(), "%s", message.c_str());
+    });
     trigger_topic_subscriber_->set_retry_callback([this]() {
       trigger_mgr_->retry_unresolved_triggers();
     });

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -984,6 +984,14 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     trigger_mgr_->set_warn_log_fn([this](const std::string & message) {
       RCLCPP_WARN(get_logger(), "%s", message.c_str());
     });
+    // The deferred-resolution budget must outlive at least one full discovery
+    // refresh: plugin-declared topics only reach the entity cache on a refresh
+    // pass, and refresh_interval_ms is configurable up to 60 s - equal to the
+    // old fixed budget, which made "resolves on a later tick" false at the
+    // extreme. Two refresh cycles keeps the reasoning true for every allowed
+    // configuration.
+    trigger_mgr_->set_unresolved_timeout(
+        std::max(std::chrono::seconds(60), std::chrono::seconds(2 * refresh_interval_ms_ / 1000)));
     trigger_topic_subscriber_->set_retry_callback([this]() {
       trigger_mgr_->retry_unresolved_triggers();
     });

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -221,8 +221,25 @@ http::Result<dto::DataListResult> DataHandlers::list_data(const http::TypedReque
     if (data_prov == nullptr) {
       // PLC bridges serve live values through their own x-plc-data route
       // instead of a DataProvider - dispatch it in-process (same path the
-      // freeze-frame capture uses) so /data works for them too.
+      // freeze-frame capture uses) so /data works for them too. The vendor
+      // shape differs from the DataProvider one (name = data name, no id, no
+      // category), and SOVD requires id on every item - normalize here so
+      // /data items always carry id/name/category regardless of which plugin
+      // path produced them; vendor extras pass through untouched.
       if (auto via_route = pmgr ? pmgr->fetch_entity_data_via_route(entity_id) : std::nullopt) {
+        if (via_route->contains("items") && (*via_route)["items"].is_array()) {
+          for (auto & item : (*via_route)["items"]) {
+            if (!item.is_object()) {
+              continue;
+            }
+            if (!item.contains("id") && item.contains("name")) {
+              item["id"] = item["name"];
+            }
+            if (!item.contains("category")) {
+              item["category"] = "currentData";
+            }
+          }
+        }
         return dto::DataListResult{std::move(*via_route)};
       }
       return tl::make_unexpected(

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -219,6 +219,12 @@ http::Result<dto::DataListResult> DataHandlers::list_data(const http::TypedReque
     auto * pmgr = ctx_.node()->get_plugin_manager();
     auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
     if (data_prov == nullptr) {
+      // PLC bridges serve live values through their own x-plc-data route
+      // instead of a DataProvider - dispatch it in-process (same path the
+      // freeze-frame capture uses) so /data works for them too.
+      if (auto via_route = pmgr ? pmgr->fetch_entity_data_via_route(entity_id) : std::nullopt) {
+        return dto::DataListResult{std::move(*via_route)};
+      }
       return tl::make_unexpected(
           make_error(404, ERR_RESOURCE_NOT_FOUND, "No data provider for plugin entity '" + entity_id + "'"));
     }
@@ -334,6 +340,10 @@ http::Result<dto::DataValue> DataHandlers::get_data_item(const http::TypedReques
     auto * pmgr = ctx_.node()->get_plugin_manager();
     auto * data_prov = pmgr ? pmgr->get_data_provider_for_entity(entity_id) : nullptr;
     if (data_prov == nullptr) {
+      // Same x-plc-data route fallback as list_data above, single-item form.
+      if (auto via_route = pmgr ? pmgr->fetch_entity_data_via_route(entity_id, topic_name) : std::nullopt) {
+        return dto::DataValue{std::move(*via_route)};
+      }
       return tl::make_unexpected(
           make_error(404, ERR_RESOURCE_NOT_FOUND, "No data provider for plugin entity '" + entity_id + "'"));
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/discovery_handlers.cpp
@@ -119,7 +119,10 @@ void prune_plugin_unserved_capabilities(std::vector<CapabilityBuilder::Capabilit
   auto drop = [&caps](CapabilityBuilder::Capability cap) {
     caps.erase(std::remove(caps.begin(), caps.end(), cap), caps.end());
   };
-  if (!pmgr->get_data_provider_for_entity(entity_id)) {
+  if (!pmgr->get_data_provider_for_entity(entity_id) && !pmgr->has_entity_data_route(entity_id)) {
+    // Only prune when NEITHER serving path exists: data_handlers now falls
+    // back to the plugin's own x-plc-data route, so an entity with that route
+    // serves /data even without a DataProvider.
     drop(CapabilityBuilder::Capability::DATA);
   }
   if (!pmgr->get_operation_provider_for_entity(entity_id)) {

--- a/src/ros2_medkit_gateway/src/http/handlers/trigger_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/trigger_handlers.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <optional>
 #include <regex>
 #include <string>
 #include <unordered_set>
@@ -31,6 +32,7 @@
 #include "ros2_medkit_gateway/core/http/http_utils.hpp"
 #include "ros2_medkit_gateway/core/models/entity_types.hpp"
 #include "ros2_medkit_gateway/core/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/core/providers/data_provider.hpp"
 #include "ros2_medkit_gateway/entity_freeze_frame_capture.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_support.hpp"
@@ -230,17 +232,37 @@ TriggerHandlers::post_trigger(const http::TypedRequest & req, dto::TriggerCreate
     if (resolved_topic_name.empty() && entity_result->is_plugin) {
       // Plugin data points are enumerable right now, so a name the plugin does
       // not have can be rejected outright with a suggestion - parking it would
-      // create a permanently ACTIVE trigger that never fires. Same enumeration
-      // as the fault-trigger engine, so "exists" means "the in-process data
-      // route can read it"; nullopt (plugin busy/unreadable) falls through to
-      // the late-binding path below. An EXISTING point that merely failed to
-      // resolve also falls through: the entity cache lags the plugin's live
-      // node map by up to one refresh cycle (<= 60 s, inside the retry
-      // budget), so a point merged at runtime resolves on a later tick, and a
+      // create a permanently ACTIVE trigger that never fires. DataProvider
+      // first (covers plugin Components and DataProvider-only plugins), the
+      // apps-scoped x-plc-data route as the fallback - the same order
+      // data_handlers uses. Enumeration failure (plugin busy, link down, no
+      // provider and no route) falls through to the late-binding path below,
+      // as does an EXISTING point that merely failed to resolve: the entity
+      // cache lags the plugin's live node map by up to one refresh cycle
+      // (the retry budget is sized against it in gateway_node), and a
       // genuinely topic-less point surfaces through the retry-expiry warning.
       auto * pmgr = ctx_.node()->get_plugin_manager();
-      auto content = pmgr ? pmgr->fetch_entity_data_via_route(entity_id) : std::nullopt;
-      if (content) {
+      std::optional<nlohmann::json> content;
+      if (pmgr != nullptr) {
+        if (auto * data_prov = pmgr->get_data_provider_for_entity(entity_id)) {
+          try {
+            if (auto result = data_prov->list_data(entity_id)) {
+              content = result->content;
+            }
+          } catch (...) {
+            // Enumeration is advisory here - a throwing provider must not
+            // break trigger creation, it just skips the strict check.
+          }
+        }
+        if (!content) {
+          content = pmgr->fetch_entity_data_via_route(entity_id);
+        }
+      }
+      // Same liveness guard as the fault-trigger enumeration in gateway_node:
+      // a bridge with a dead PLC link answers 200 with connected=false and an
+      // empty list, which must read as "unreadable right now", never as "this
+      // entity has zero data points".
+      if (content && EntityFreezeFrameCapture::content_has_live_data(*content)) {
         const auto values = EntityFreezeFrameCapture::values_from_list_content(*content);
         if (values.is_object()) {
           std::vector<std::string> names;

--- a/src/ros2_medkit_gateway/src/http/handlers/trigger_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/trigger_handlers.cpp
@@ -14,6 +14,7 @@
 
 #include "ros2_medkit_gateway/core/http/handlers/trigger_handlers.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstddef>
 #include <regex>
@@ -21,12 +22,16 @@
 #include <unordered_set>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <rclcpp/rclcpp.hpp>
 
+#include "ros2_medkit_gateway/core/data_point_suggest.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/http/http_utils.hpp"
 #include "ros2_medkit_gateway/core/models/entity_types.hpp"
+#include "ros2_medkit_gateway/core/plugins/plugin_manager.hpp"
+#include "ros2_medkit_gateway/entity_freeze_frame_capture.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_support.hpp"
 
@@ -220,6 +225,43 @@ TriggerHandlers::post_trigger(const http::TypedRequest & req, dto::TriggerCreate
                               parsed->resource_path) == 0)) {
         resolved_topic_name = topic.name;
         break;
+      }
+    }
+    if (resolved_topic_name.empty() && entity_result->is_plugin) {
+      // Plugin data points are enumerable right now, so a name the plugin does
+      // not have can be rejected outright with a suggestion - parking it would
+      // create a permanently ACTIVE trigger that never fires. Same enumeration
+      // as the fault-trigger engine, so "exists" means "the in-process data
+      // route can read it"; nullopt (plugin busy/unreadable) falls through to
+      // the late-binding path below. An EXISTING point that merely failed to
+      // resolve also falls through: the entity cache lags the plugin's live
+      // node map by up to one refresh cycle (<= 60 s, inside the retry
+      // budget), so a point merged at runtime resolves on a later tick, and a
+      // genuinely topic-less point surfaces through the retry-expiry warning.
+      auto * pmgr = ctx_.node()->get_plugin_manager();
+      auto content = pmgr ? pmgr->fetch_entity_data_via_route(entity_id) : std::nullopt;
+      if (content) {
+        const auto values = EntityFreezeFrameCapture::values_from_list_content(*content);
+        if (values.is_object()) {
+          std::vector<std::string> names;
+          names.reserve(values.size());
+          for (auto it = values.begin(); it != values.end(); ++it) {
+            names.push_back(it.key());
+          }
+          const std::string data_name = parsed->resource_path.substr(1);
+          if (std::find(names.begin(), names.end(), data_name) == names.end()) {
+            std::string msg = "data point '" + data_name + "' does not exist on entity '" + entity_id + "'";
+            json params{
+                {"parameter", "resource"}, {"resource_path", parsed->resource_path}, {"available_count", names.size()}};
+            const std::string suggestion = suggest_data_point(data_name, names);
+            if (!suggestion.empty()) {
+              msg += " - did you mean '" + suggestion + "'?";
+              params["did_you_mean"] = suggestion;
+            }
+            params["closest"] = closest_data_points(data_name, names, 20);
+            return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, msg, params));
+          }
+        }
       }
     }
     if (resolved_topic_name.empty()) {

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -384,6 +384,37 @@ void PluginManager::register_routes(httplib::Server & server, const std::string 
   }
 }
 
+bool PluginManager::has_entity_data_route(const std::string & entity_id) {
+  const std::string full_path = std::string(API_BASE_PATH) + "/apps/" + entity_id + "/x-plc-data";
+  std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
+  auto own_it = entity_ownership_.find(entity_id);
+  if (own_it == entity_ownership_.end()) {
+    return false;
+  }
+  for (auto & lp : plugins_) {
+    if (!lp.load_result.plugin || lp.load_result.plugin->name() != own_it->second) {
+      continue;
+    }
+    if (!cache_routes_locked(lp)) {
+      return false;
+    }
+    for (const auto & route : lp.routes) {
+      if (route.method != "GET") {
+        continue;
+      }
+      try {
+        if (std::regex_match(full_path, std::regex(API_BASE_PATH + ("/" + route.pattern)))) {
+          return true;
+        }
+      } catch (const std::regex_error &) {
+        continue;
+      }
+    }
+    break;
+  }
+  return false;
+}
+
 std::optional<nlohmann::json> PluginManager::fetch_entity_data_via_route(const std::string & entity_id,
                                                                          const std::string & item) {
   const std::string full_path =

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -384,8 +384,10 @@ void PluginManager::register_routes(httplib::Server & server, const std::string 
   }
 }
 
-std::optional<nlohmann::json> PluginManager::fetch_entity_data_via_route(const std::string & entity_id) {
-  const std::string full_path = std::string(API_BASE_PATH) + "/apps/" + entity_id + "/x-plc-data";
+std::optional<nlohmann::json> PluginManager::fetch_entity_data_via_route(const std::string & entity_id,
+                                                                         const std::string & item) {
+  const std::string full_path =
+      std::string(API_BASE_PATH) + "/apps/" + entity_id + "/x-plc-data" + (item.empty() ? "" : "/" + item);
 
   // Copy the owning plugin's matching GET handler out under the lock and
   // invoke it after release: handlers run arbitrary plugin code that may call

--- a/src/ros2_medkit_gateway/test/test_data_point_suggest.cpp
+++ b/src/ros2_medkit_gateway/test/test_data_point_suggest.cpp
@@ -1,0 +1,94 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/data_point_suggest.hpp"
+
+using ros2_medkit_gateway::closest_data_points;
+using ros2_medkit_gateway::edit_distance;
+using ros2_medkit_gateway::sanitized_leaf;
+using ros2_medkit_gateway::suggest_data_point;
+
+TEST(EditDistanceTest, Basics) {
+  EXPECT_EQ(edit_distance("", ""), 0u);
+  EXPECT_EQ(edit_distance("abc", "abc"), 0u);
+  EXPECT_EQ(edit_distance("abc", ""), 3u);
+  EXPECT_EQ(edit_distance("", "abc"), 3u);
+  EXPECT_EQ(edit_distance("counter", "countr"), 1u);
+  EXPECT_EQ(edit_distance("kitten", "sitting"), 3u);
+}
+
+TEST(SanitizedLeafTest, StripsNamespaceAndSanitizes) {
+  EXPECT_EQ(sanitized_leaf("MAIN.counter"), "counter");
+  EXPECT_EQ(sanitized_leaf("MAIN.Counter"), "counter");
+  EXPECT_EQ(sanitized_leaf("GVL.Motor Speed"), "motor_speed");
+  EXPECT_EQ(sanitized_leaf("counter"), "counter");
+  EXPECT_EQ(sanitized_leaf("ns1.ns2.leaf"), "leaf");
+  EXPECT_EQ(sanitized_leaf("/plc/main/counter"), "counter");
+  EXPECT_EQ(sanitized_leaf(""), "");
+}
+
+TEST(SuggestDataPointTest, DeterministicLeafMappingWinsExactly) {
+  const std::vector<std::string> names{"counter", "level", "adsigrp_sym_uploadinfo"};
+  EXPECT_EQ(suggest_data_point("MAIN.counter", names), "counter");
+  EXPECT_EQ(suggest_data_point("GVL.Level", names), "level");
+}
+
+TEST(SuggestDataPointTest, CloseTypoSuggested) {
+  const std::vector<std::string> names{"counter", "level"};
+  EXPECT_EQ(suggest_data_point("countr", names), "counter");
+  EXPECT_EQ(suggest_data_point("MAIN.countr", names), "counter");
+}
+
+TEST(SuggestDataPointTest, NothingCloseReturnsEmpty) {
+  const std::vector<std::string> names{"counter", "level"};
+  EXPECT_EQ(suggest_data_point("hydraulic_pressure", names), "");
+  EXPECT_EQ(suggest_data_point("xyz", names), "");
+}
+
+TEST(SuggestDataPointTest, EmptyNamesReturnsEmpty) {
+  EXPECT_EQ(suggest_data_point("counter", {}), "");
+}
+
+TEST(ClosestDataPointsTest, RanksByDistanceThenName) {
+  const std::vector<std::string> names{"zeta", "counter", "counters", "level"};
+  const auto ranked = closest_data_points("counter", names, 3);
+  ASSERT_EQ(ranked.size(), 3u);
+  EXPECT_EQ(ranked[0], "counter");
+  EXPECT_EQ(ranked[1], "counters");
+}
+
+TEST(ClosestDataPointsTest, TruncatesToN) {
+  std::vector<std::string> names;
+  for (int i = 0; i < 50; ++i) {
+    names.push_back("sym_" + std::to_string(i));
+  }
+  EXPECT_EQ(closest_data_points("sym_1", names, 20).size(), 20u);
+  EXPECT_EQ(closest_data_points("sym_1", names, 100).size(), 50u);
+}
+
+TEST(ClosestDataPointsTest, LeafOfNamespacedInputDrivesRanking) {
+  std::vector<std::string> names;
+  for (int i = 10; i < 40; ++i) {
+    names.push_back("adsigrp_sym_" + std::to_string(i));
+  }
+  names.push_back("counter");
+  const auto ranked = closest_data_points("MAIN.counter", names, 20);
+  ASSERT_FALSE(ranked.empty());
+  EXPECT_EQ(ranked[0], "counter") << "sanitized leaf must outrank the alphabetical prefix";
+}

--- a/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_trigger_engine.cpp
@@ -104,11 +104,39 @@ TEST(FaultTriggerEngineTest, CreateRejectsNonexistentDataPoint) {
   EXPECT_NE(bogus.error().second.find("level"), std::string::npos) << "message should list the available points";
   EXPECT_TRUE(engine.list("tank").empty());
 
+  // Source-notation symbol: the deterministic sanitized-leaf mapping is
+  // suggested outright (MAIN.Level -> level).
+  auto namespaced = engine.create("tank", make_body("MAIN.Level", ">", 10.0, "F", "ERROR"));
+  ASSERT_FALSE(namespaced);
+  EXPECT_NE(namespaced.error().second.find("did you mean 'level'?"), std::string::npos) << namespaced.error().second;
+
   // Existing point passes.
   EXPECT_TRUE(engine.create("tank", make_body("level", ">", 50.0, "F", "ERROR")));
 
   // Points not enumerable right now (nullopt): creation must not be blocked.
   EXPECT_TRUE(engine.create("other_app", make_body("anything", ">", 1.0, "F2", "ERROR")));
+}
+
+TEST(FaultTriggerEngineTest, NonexistentDataPointListsClosestNamesNotAlphabeticalPrefix) {
+  // Regression for the field report in #584: ~25 system symbols sorted before
+  // the name the operator needed, and the alphabetical 20-entry cut dropped
+  // it. The truncated list must be ranked by distance to the input.
+  auto names = [](const std::string &) -> std::optional<std::vector<std::string>> {
+    std::vector<std::string> v;
+    for (int i = 10; i < 40; ++i) {
+      v.push_back("adsigrp_sym_" + std::to_string(i));
+    }
+    v.push_back("counter");
+    return v;
+  };
+  FaultTriggerEngine engine("", nullptr, nullptr, nullptr, nullptr, names);
+
+  auto miss = engine.create("plc", make_body("MAIN.counter", ">", 1.0, "F", "ERROR"));
+  ASSERT_FALSE(miss);
+  const auto & msg = miss.error().second;
+  EXPECT_NE(msg.find("did you mean 'counter'?"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("31 available, closest 20: counter"), std::string::npos)
+      << "ranked list should surface the near-match first: " << msg;
 }
 
 TEST(FaultTriggerEngineTest, CreateWithoutEnumeratorSkipsExistenceCheck) {

--- a/src/ros2_medkit_gateway/test/test_plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_manager.cpp
@@ -538,6 +538,17 @@ TEST(PluginManagerTest, FetchEntityDataViaRouteDispatchesOwningPluginHandler) {
   EXPECT_EQ(raw->last_path_, "/api/v1/apps/plc_app/x-plc-data");
 }
 
+TEST(PluginManagerTest, FetchEntityDataViaRouteSingleItemDispatchesItemRoute) {
+  PluginManager mgr;
+  mgr.add_plugin(std::make_unique<MockPlcRoutePlugin>());
+  mgr.configure_plugins();
+  mgr.register_entity_ownership("mock_plc", {"plc_app"});
+
+  auto body = mgr.fetch_entity_data_via_route("plc_app", "level");
+  ASSERT_TRUE(body.has_value());
+  EXPECT_EQ((*body)["single"], true);
+}
+
 TEST(PluginManagerTest, FetchEntityDataViaRouteUnownedEntityReturnsNullopt) {
   PluginManager mgr;
   mgr.add_plugin(std::make_unique<MockPlcRoutePlugin>());

--- a/src/ros2_medkit_gateway/test/test_plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_manager.cpp
@@ -187,7 +187,8 @@ class MockPlcRoutePlugin : public GatewayPlugin {
          }},
         // Longer sibling pattern must not shadow the exact match above.
         {"GET", R"(apps/([^/]+)/x-plc-data/([^/]+))",
-         [](const PluginRequest & /*req*/, PluginResponse & res) {
+         [this](const PluginRequest & req, PluginResponse & res) {
+           last_path_ = req.path();
            res.send_json({{"single", true}});
          }},
     };
@@ -540,13 +541,18 @@ TEST(PluginManagerTest, FetchEntityDataViaRouteDispatchesOwningPluginHandler) {
 
 TEST(PluginManagerTest, FetchEntityDataViaRouteSingleItemDispatchesItemRoute) {
   PluginManager mgr;
-  mgr.add_plugin(std::make_unique<MockPlcRoutePlugin>());
+  auto plugin = std::make_unique<MockPlcRoutePlugin>();
+  auto * raw = plugin.get();
+  mgr.add_plugin(std::move(plugin));
   mgr.configure_plugins();
   mgr.register_entity_ownership("mock_plc", {"plc_app"});
 
   auto body = mgr.fetch_entity_data_via_route("plc_app", "level");
   ASSERT_TRUE(body.has_value());
   EXPECT_EQ((*body)["single"], true);
+  // The item must actually reach the dispatched path - a regression to the
+  // list route would still answer 200 here.
+  EXPECT_EQ(raw->last_path_, "/api/v1/apps/plc_app/x-plc-data/level");
 }
 
 TEST(PluginManagerTest, FetchEntityDataViaRouteUnownedEntityReturnsNullopt) {

--- a/src/ros2_medkit_gateway/test/test_trigger_manager_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_trigger_manager_routing.cpp
@@ -423,10 +423,15 @@ TEST_F(TriggerManagerRoutingTest, UnresolvedTriggerExpiryWarnsAndStopsRetrying) 
   EXPECT_NE(warnings[0].find("/counter"), std::string::npos) << warnings[0];
 
   // The entry is gone: later ticks are silent, and the trigger itself is
-  // still registered (the expiry only stops the resolution retries).
+  // still registered and ACTIVE - with no subscription behind it, exactly the
+  // silently-dead state the warning is there to expose.
   manager_->retry_unresolved_triggers();
   EXPECT_EQ(warnings.size(), 1u);
-  EXPECT_EQ(manager_->list("plc_app").size(), 1u);
+  auto listed = manager_->list("plc_app");
+  ASSERT_EQ(listed.size(), 1u);
+  EXPECT_EQ(listed[0].status, TriggerStatus::ACTIVE);
+  EXPECT_TRUE(listed[0].resolved_topic_name.empty());
+  EXPECT_EQ(transport_->total_subscribes(), 0u) << "giving up must not leave a live subscription behind";
 }
 
 TEST_F(TriggerManagerRoutingTest, NonDataTriggerDoesNotSubscribe) {

--- a/src/ros2_medkit_gateway/test/test_trigger_manager_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_trigger_manager_routing.cpp
@@ -396,6 +396,39 @@ TEST_F(TriggerManagerRoutingTest, RestoreQueuesPersistentTriggerOnSubscribeFailu
   restored_mgr->shutdown();
 }
 
+TEST_F(TriggerManagerRoutingTest, UnresolvedTriggerExpiryWarnsAndStopsRetrying) {
+  // #584: an unresolved data trigger used to be dropped from the retry list
+  // after the timeout with no trace, leaving a permanently ACTIVE trigger
+  // that can never fire. The expiry must be loud.
+  std::vector<std::string> warnings;
+  manager_->set_warn_log_fn([&warnings](const std::string & m) {
+    warnings.push_back(m);
+  });
+  manager_->set_resolve_topic_fn([](const std::string &, const std::string &) {
+    return std::string{};
+  });
+
+  auto created = manager_->create(make_data_request("plc_app", /*resolved_topic=*/"", "/counter"));
+  ASSERT_TRUE(created.has_value()) << created.error().message;
+
+  // Within the timeout: retry ticks stay silent.
+  manager_->retry_unresolved_triggers();
+  EXPECT_TRUE(warnings.empty());
+
+  // Shrink the timeout so the next tick expires the entry.
+  manager_->set_unresolved_timeout(std::chrono::seconds(0));
+  manager_->retry_unresolved_triggers();
+  ASSERT_EQ(warnings.size(), 1u);
+  EXPECT_NE(warnings[0].find(created->id), std::string::npos) << warnings[0];
+  EXPECT_NE(warnings[0].find("/counter"), std::string::npos) << warnings[0];
+
+  // The entry is gone: later ticks are silent, and the trigger itself is
+  // still registered (the expiry only stops the resolution retries).
+  manager_->retry_unresolved_triggers();
+  EXPECT_EQ(warnings.size(), 1u);
+  EXPECT_EQ(manager_->list("plc_app").size(), 1u);
+}
+
 TEST_F(TriggerManagerRoutingTest, NonDataTriggerDoesNotSubscribe) {
   // Faults / configurations / etc. don't go through the topic transport.
   TriggerCreateRequest req;

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(example_interfaces REQUIRED)
 find_package(ros2_medkit_msgs REQUIRED)
 find_package(diagnostic_msgs REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(ros2_medkit_gateway REQUIRED)
 
 # === Demo node executables ===
 
@@ -122,6 +123,15 @@ ament_python_install_package(ros2_medkit_test_utils)
 install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/launch)
 
 # === Integration tests ===
+
+# Topic-backed test plugin for the issue #584 integration test: dlopen-loaded
+# by the gateway under test, so it mirrors the production plugin link model
+# (MODULE, unresolved symbols provided by the host process).
+add_library(topics_test_plugin MODULE test_plugins/topics_test_plugin.cpp)
+medkit_target_dependencies(topics_test_plugin ros2_medkit_gateway rclcpp std_msgs)
+target_link_options(topics_test_plugin PRIVATE -Wl,--unresolved-symbols=ignore-all)
+set_target_properties(topics_test_plugin PROPERTIES OUTPUT_NAME "topics_test_plugin")
+install(TARGETS topics_test_plugin LIBRARY DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(launch_testing_ament_cmake REQUIRED)

--- a/src/ros2_medkit_integration_tests/test/features/test_triggers_plugin_entity.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_triggers_plugin_entity.test.py
@@ -1,0 +1,171 @@
+# Copyright 2026 mfaferek93
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end regression tests for issue #584.
+
+A data trigger on a plugin-provided entity used to pass validation, return
+201 ACTIVE, and never fire: topic resolution consulted the ROS-graph topic
+list, which attributes plugin-published topics to the gateway node. With the
+plugin declaring its value-bridge topics on the owning entity (App::topics),
+the trigger must resolve, subscribe, and deliver SSE events. A wrong data
+point name must be rejected at create time with a suggestion, and GET /data
+must serve the plugin's enumeration route when there is no DataProvider.
+"""
+
+import json
+import threading
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ament_index_python.packages import get_package_prefix
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, API_BASE_PATH
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+import os
+
+
+def _get_plugin_path():
+    pkg_prefix = get_package_prefix('ros2_medkit_integration_tests')
+    return os.path.join(
+        pkg_prefix, 'lib', 'ros2_medkit_integration_tests',
+        'libtopics_test_plugin.so',
+    )
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=[],
+        fault_manager=False,
+        gateway_params={
+            'plugins': ['topics_test'],
+            'plugins.topics_test.path': _get_plugin_path(),
+        },
+    )
+
+
+class TestTriggersPluginEntity(GatewayTestCase):
+    """Data triggers on a plugin entity with declared topics (issue #584)."""
+
+    MIN_EXPECTED_APPS = 0
+
+    app_id = 'plugin_dev'
+
+    def _wait_for_plugin_entity(self, timeout=30.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            resp = requests.get(f'{self.BASE_URL}/apps', timeout=5)
+            if resp.status_code == 200:
+                ids = [item.get('id') for item in resp.json().get('items', [])]
+                if self.app_id in ids:
+                    return
+            time.sleep(1.0)
+        self.fail(f'plugin entity {self.app_id!r} never appeared in /apps')
+
+    def test_01_trigger_on_plugin_entity_resolves_and_fires(self):
+        """The headline regression: create resolves via declared topics and SSE events flow."""
+        self._wait_for_plugin_entity()
+
+        resp = requests.post(
+            f'{self.BASE_URL}/apps/{self.app_id}/triggers',
+            json={
+                'resource': f'{API_BASE_PATH}/apps/{self.app_id}/data/value',
+                'trigger_condition': {'condition_type': 'OnChange'},
+                'multishot': True,
+            },
+            timeout=5,
+        )
+        self.assertEqual(resp.status_code, 201, resp.text)
+        trigger = resp.json()
+        self.assertEqual(trigger['status'], 'active')
+        trigger_id = trigger['id']
+
+        events = []
+        done = threading.Event()
+
+        def consume():
+            try:
+                with requests.get(
+                    f'{self.BASE_URL}/apps/{self.app_id}/triggers/{trigger_id}/events',
+                    stream=True, timeout=30,
+                ) as stream:
+                    for line in stream.iter_lines():
+                        if line and line.startswith(b'data:'):
+                            events.append(json.loads(line[5:].decode()))
+                            if len(events) >= 2:
+                                done.set()
+                                return
+            except requests.RequestException:
+                pass
+
+        worker = threading.Thread(target=consume, daemon=True)
+        worker.start()
+        # The plugin publishes an incrementing value at 5 Hz, so two OnChange
+        # events must arrive well inside this window.
+        self.assertTrue(done.wait(timeout=25.0),
+                        f'expected >=2 SSE events, got {len(events)}')
+
+        requests.delete(
+            f'{self.BASE_URL}/apps/{self.app_id}/triggers/{trigger_id}',
+            timeout=5,
+        )
+
+    def test_02_wrong_data_point_rejected_with_suggestion(self):
+        """A typo is a 400 with did_you_mean at create time, not a dead ACTIVE trigger."""
+        self._wait_for_plugin_entity()
+
+        resp = requests.post(
+            f'{self.BASE_URL}/apps/{self.app_id}/triggers',
+            json={
+                'resource': f'{API_BASE_PATH}/apps/{self.app_id}/data/valu',
+                'trigger_condition': {'condition_type': 'OnChange'},
+                'multishot': True,
+            },
+            timeout=5,
+        )
+        self.assertEqual(resp.status_code, 400, resp.text)
+        body = resp.json()
+        params = body.get('parameters', body.get('params', {}))
+        self.assertEqual(params.get('did_you_mean'), 'value', body)
+
+    def test_03_data_route_fallback_serves_and_normalizes(self):
+        """GET /data works without a DataProvider and items carry SOVD ids."""
+        self._wait_for_plugin_entity()
+
+        resp = requests.get(
+            f'{self.BASE_URL}/apps/{self.app_id}/data', timeout=5,
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        items = resp.json().get('items', [])
+        self.assertTrue(items, 'expected the plugin route content')
+        ids = [item.get('id') for item in items]
+        self.assertIn('value', ids, f'normalized id missing: {items}')
+        self.assertEqual(items[0].get('category'), 'currentData', items[0])
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check all processes exited cleanly (SIGTERM allowed)."""
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}'
+            )

--- a/src/ros2_medkit_integration_tests/test_plugins/topics_test_plugin.cpp
+++ b/src/ros2_medkit_integration_tests/test_plugins/topics_test_plugin.cpp
@@ -1,0 +1,143 @@
+// Copyright 2026 mfaferek93
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Minimal topic-backed test plugin for the issue #584 integration test.
+// Registers one entity whose data point is backed by a topic the plugin
+// itself publishes (the PLC-bridge pattern in miniature): entity
+// `plugin_dev`, data point `value`, topic `/plugin_dev/value` declared via
+// App::topics and published at 5 Hz with an incrementing value. Serves the
+// enumeration route (x-plc-data) the gateway uses for create-time trigger
+// validation and the /data fallback.
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_gateway/core/plugins/gateway_plugin.hpp>
+#include <ros2_medkit_gateway/core/providers/introspection_provider.hpp>
+#include <ros2_medkit_gateway/plugins/ros_plugin_context.hpp>
+#include <std_msgs/msg/float64.hpp>
+
+namespace ros2_medkit_integration_tests {
+
+using namespace ros2_medkit_gateway;
+
+class TopicsTestPlugin : public GatewayPlugin, public IntrospectionProvider {
+ public:
+  ~TopicsTestPlugin() override {
+    stop();
+  }
+
+  std::string name() const override {
+    return "topics_test";
+  }
+
+  void configure(const nlohmann::json & /*config*/) override {
+  }
+
+  void set_context(PluginContext & context) override {
+    auto * ctx = as_ros_plugin_context(context);
+    auto * node = ctx != nullptr ? ctx->node() : nullptr;
+    if (node == nullptr) {
+      return;
+    }
+    publisher_ = node->create_publisher<std_msgs::msg::Float64>("/plugin_dev/value", rclcpp::SensorDataQoS());
+    running_.store(true);
+    publish_thread_ = std::thread([this] {
+      while (running_.load()) {
+        std_msgs::msg::Float64 msg;
+        msg.data = static_cast<double>(counter_.fetch_add(1));
+        publisher_->publish(msg);
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+      }
+    });
+  }
+
+  std::vector<PluginRoute> get_routes() override {
+    return {
+        {"GET", R"(apps/([^/]+)/x-plc-data)",
+         [this](const PluginRequest & /*req*/, PluginResponse & res) {
+           res.send_json({{"connected", true},
+                          {"items", nlohmann::json::array(
+                                        {{{"name", "value"}, {"value", static_cast<double>(counter_.load())}}})}});
+         }},
+    };
+  }
+
+  IntrospectionResult introspect(const IntrospectionInput & /*input*/) override {
+    IntrospectionResult result;
+
+    Area area;
+    area.id = "test_plugin_area";
+    area.name = "Test Plugin Area";
+    result.new_entities.areas.push_back(std::move(area));
+
+    Component comp;
+    comp.id = "test_plugin_comp";
+    comp.name = "Test Plugin Component";
+    comp.area = "test_plugin_area";
+    comp.external = true;
+    result.new_entities.components.push_back(std::move(comp));
+
+    App app;
+    app.id = "plugin_dev";
+    app.name = "Plugin Device";
+    app.component_id = "test_plugin_comp";
+    app.external = true;
+    app.is_online = true;
+    app.source = "plugin";
+    // The point of this plugin: the data point's backing topic is declared on
+    // the owning entity, so entity-scoped topic lookup (trigger resolution)
+    // can see it (issue #584).
+    app.topics.publishes.push_back("/plugin_dev/value");
+    result.new_entities.apps.push_back(std::move(app));
+
+    return result;
+  }
+
+  void shutdown() override {
+    stop();
+  }
+
+ private:
+  void stop() {
+    if (running_.exchange(false) && publish_thread_.joinable()) {
+      publish_thread_.join();
+    }
+  }
+
+  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr publisher_;
+  std::thread publish_thread_;
+  std::atomic<bool> running_{false};
+  std::atomic<uint64_t> counter_{0};
+};
+
+}  // namespace ros2_medkit_integration_tests
+
+extern "C" GATEWAY_PLUGIN_EXPORT int plugin_api_version() {
+  return ros2_medkit_gateway::PLUGIN_API_VERSION;
+}
+
+extern "C" GATEWAY_PLUGIN_EXPORT ros2_medkit_gateway::GatewayPlugin * create_plugin() {
+  return new ros2_medkit_integration_tests::TopicsTestPlugin();
+}
+
+extern "C" GATEWAY_PLUGIN_EXPORT ros2_medkit_gateway::IntrospectionProvider *
+get_introspection_provider(ros2_medkit_gateway::GatewayPlugin * plugin) {
+  return static_cast<ros2_medkit_integration_tests::TopicsTestPlugin *>(plugin);
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/include/ros2_medkit_opcua/node_map.hpp
@@ -277,6 +277,15 @@ struct PlcEntityDef {
 };
 
 /// Manages the OPC-UA NodeId to SOVD entity mapping, loaded from YAML
+/// Single source of truth for "does this entry get a ROS 2 value publisher":
+/// create_value_publishers() creates one exactly for these entries, and
+/// introspect() declares exactly these topics on the owning entity - the two
+/// must never drift apart or triggers bind to forever-idle topics (medkit
+/// issue #584).
+inline bool entry_has_value_publisher(const NodeMapEntry & entry) {
+  return entry.data_type != "string" && !entry.ros2_topic.empty();
+}
+
 class NodeMap {
  public:
   NodeMap() = default;

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -778,13 +778,13 @@ IntrospectionResult OpcuaPlugin::introspect(const IntrospectionInput & /*input*/
     // Graph discovery attributes them to the gateway node (their publisher),
     // so without this the entity-scoped topic lookup - what resolves a data
     // trigger's resource_path - comes up empty and the trigger never fires
-    // (issue #584). Mirrors create_value_publishers(): string-typed entries
-    // get no publisher, so they are not declared either.
+    // (issue #584). entry_has_value_publisher is the same predicate
+    // create_value_publishers() uses, so declaration and publication cannot
+    // drift apart.
     for (const auto * entry : node_map_.entries_for_entity(def.id)) {
-      if (entry->data_type == "string" || entry->ros2_topic.empty()) {
-        continue;
+      if (entry_has_value_publisher(*entry)) {
+        app.topics.publishes.push_back(entry->ros2_topic);
       }
-      app.topics.publishes.push_back(entry->ros2_topic);
     }
     result.new_entities.apps.push_back(std::move(app));
 
@@ -1308,7 +1308,7 @@ void OpcuaPlugin::create_value_publishers() {
     if (publishers_.count(entry.node_id_str) > 0) {
       continue;  // already created (e.g. a previous call before a reconnect)
     }
-    if (entry.data_type == "string") {
+    if (!entry_has_value_publisher(entry)) {
       log_info("PLC bridge: skipping non-numeric " + entry.node_id_str + " (data_type=" + entry.data_type + ")");
       continue;
     }

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/src/opcua_plugin.cpp
@@ -774,6 +774,18 @@ IntrospectionResult OpcuaPlugin::introspect(const IntrospectionInput & /*input*/
     app.is_online = client_->is_connected();
     app.source = "plugin";
     app.description = "PLC application with " + std::to_string(def.data_names.size()) + " data points";
+    // Declare the value-bridge topics on the entity that owns the data points.
+    // Graph discovery attributes them to the gateway node (their publisher),
+    // so without this the entity-scoped topic lookup - what resolves a data
+    // trigger's resource_path - comes up empty and the trigger never fires
+    // (issue #584). Mirrors create_value_publishers(): string-typed entries
+    // get no publisher, so they are not declared either.
+    for (const auto * entry : node_map_.entries_for_entity(def.id)) {
+      if (entry->data_type == "string" || entry->ros2_topic.empty()) {
+        continue;
+      }
+      app.topics.publishes.push_back(entry->ros2_topic);
+    }
     result.new_entities.apps.push_back(std::move(app));
 
     // Register capabilities per entity (never type-level): only PLC-backed

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -22,6 +22,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdio>
@@ -223,6 +224,44 @@ TEST_F(OpcuaPluginTest, ListDataReturnsItems) {
   EXPECT_EQ(result->content["items"].size(), 2u);
   EXPECT_EQ(result->content["items"][0]["id"], "level");
   EXPECT_EQ(result->content["items"][1]["id"], "pressure");
+}
+
+TEST(OpcuaPluginIntrospectTopics, DeclaresValueBridgeTopicsOnOwningEntity) {
+  // #584: graph discovery attributes /plc/* topics to the gateway node (their
+  // publisher), so the plugin must declare them on the entity that owns the
+  // data points or entity-scoped topic lookup (data trigger resolution) stays
+  // empty. String-typed entries get no publisher and must not be declared.
+  const std::string yaml_path = "/tmp/test_opcua_introspect_topics.yaml";
+  {
+    std::ofstream f(yaml_path);
+    f << R"(
+area_id: test_plc
+component_id: test_runtime
+nodes:
+  - node_id: "ns=2;i=1"
+    entity_id: tank
+    data_name: level
+    data_type: float
+  - node_id: "ns=2;i=2"
+    entity_id: tank
+    data_name: label
+    data_type: string
+)";
+  }
+  OpcuaPlugin plugin;
+  nlohmann::json config;
+  config["node_map_path"] = yaml_path;
+  config["endpoint_url"] = "opc.tcp://127.0.0.1:1";
+  plugin.configure(config);
+
+  auto result = plugin.introspect({});
+  const auto it = std::find_if(result.new_entities.apps.begin(), result.new_entities.apps.end(), [](const App & a) {
+    return a.id == "tank";
+  });
+  ASSERT_NE(it, result.new_entities.apps.end());
+  ASSERT_EQ(it->topics.publishes.size(), 1u) << "only the float entry has a publisher";
+  EXPECT_EQ(it->topics.publishes[0], "/plc/tank/level");
+  EXPECT_TRUE(it->topics.subscribes.empty());
 }
 
 TEST_F(OpcuaPluginTest, ListDataEntityNotFound) {

--- a/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_opcua/test/test_opcua_plugin.cpp
@@ -262,6 +262,19 @@ nodes:
   ASSERT_EQ(it->topics.publishes.size(), 1u) << "only the float entry has a publisher";
   EXPECT_EQ(it->topics.publishes[0], "/plc/tank/level");
   EXPECT_TRUE(it->topics.subscribes.empty());
+  // Both call sites (create_value_publishers and the declaration above) share
+  // entry_has_value_publisher(), so the predicate itself must classify these
+  // two fixture entries the way the declaration did - if either call site
+  // stops using the predicate, review must catch it here.
+  NodeMap map;
+  ASSERT_TRUE(map.load(yaml_path));
+  std::vector<std::string> predicate_topics;
+  for (const auto & e : map.entries()) {
+    if (entry_has_value_publisher(e)) {
+      predicate_topics.push_back(e.ros2_topic);
+    }
+  }
+  EXPECT_EQ(it->topics.publishes, predicate_topics);
 }
 
 TEST_F(OpcuaPluginTest, ListDataEntityNotFound) {


### PR DESCRIPTION
Fixes #584.

A data trigger on a plugin-provided entity passed validation, returned 201 ACTIVE, and never fired. Topic resolution reads the entity's topic list from the discovery cache, and that list is built from the ROS graph, which attributes plugin-published `/plc/*` topics to the gateway node - so plugin entities always resolved to nothing. The deferred-resolution retry ran the same empty lookup every 5 s and silently dropped the entry after 60 s, leaving the trigger permanently active and permanently dead.

What changed:

- `App::topics` was already part of the plugin introspection API and flows through both entity-injection paths; the opcua plugin now declares each non-string entry's value-bridge topic on the entity that owns it, which makes the existing resolution and firing path just work. Documented in the plugin tutorial as the pattern for topic-backed data points.
- Creating a data trigger on a plugin entity whose data points are enumerable now rejects an unknown data point with 400, a "did you mean 'counter'?" suggestion (PLC symbols register under sanitized leaf names, so `MAIN.counter` resolves deterministically), and the closest names in `params`. An existing point that merely failed to resolve keeps the deferred path - the cache lags the live node map by at most one refresh cycle, which is inside the retry budget.
- Deferred resolution now warns when it gives up on a trigger instead of dropping the retry entry with no trace.
- `GET /apps/<id>/data` (list and single item) falls back to the plugin's own `x-plc-data` route when there is no DataProvider - the same in-process dispatch freeze-frame already uses - instead of 404ing on entities whose values other parts of the gateway happily read.
- The fault-trigger 400 for a bad data point now ranks the truncated available-list by edit distance and reports the total count; before, ~25 system symbols alphabetically ahead of the intended name pushed it out of the list.

Verified: full gateway + opcua unit suites in the jazzy container (129 + 16 green; `test_opcua_secured` fails in that local container on unmodified main as well, so CI here is the arbiter), and end to end against a live Beckhoff target through a protocol plugin that declares its topics - trigger create resolves and subscribes to the declared `/plc/...` topic, and OnChange stays correctly silent for a constant value.