### PR TITLE
fix: report every startup parameter that is coerced or refused

### DIFF
--- a/docs/config/action-status-bridge.rst
+++ b/docs/config/action-status-bridge.rst
@@ -48,7 +48,8 @@ Parameters
    * - ``aborted_severity``
      - ``2`` (ERROR)
      - Severity reported when a goal aborts: 0 INFO, 1 WARN, 2 ERROR,
-       3 CRITICAL. Out of range is refused with a warning and ERROR is used.
+       3 CRITICAL. Out of range is refused with a warning naming the value, and
+       ERROR is used.
    * - ``canceled_is_fault``
      - ``false``
      - Report a fault when a goal is canceled. Off by default, because a cancel
@@ -81,8 +82,8 @@ Parameters
    * - ``dedup_capacity``
      - ``4096``
      - How many goal IDs are remembered to avoid reporting the same terminal
-       outcome twice. A non-positive value is refused with a warning and
-       ``4096`` is used.
+       outcome twice. A non-positive value, or one past what the counter can
+       hold, is refused with a warning naming the value, and ``4096`` is used.
 
 The bridge also declares ``fault_reporter.local_filtering.enabled`` (default
 ``false``) on its own node. See :doc:`fault-manager` for what the reporter-side

--- a/docs/config/action-status-bridge.rst
+++ b/docs/config/action-status-bridge.rst
@@ -1,0 +1,95 @@
+Action Status Bridge Configuration
+==================================
+
+The ``ros2_medkit_action_status_bridge`` node turns ROS 2 action outcomes into
+faults. An action that aborts is a discrete, authoritative failure, and without
+this bridge it is visible only to whoever was watching that action's result.
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+Overview
+--------
+
+The bridge rescans the graph for action status topics, subscribes to them, and
+reports a fault when a goal reaches a terminal state it is configured to treat
+as a failure. Terminal action states do not flap - the state model only moves on
+a net change - so the reports are not debounced the way log messages are.
+
+If the FaultManager service is not discovered yet, a report is held and retried
+on a short timer, so the freeze-frame snapshot the FaultManager takes lands as
+close to the event as discovery allows.
+
+Parameters
+----------
+
+.. code-block:: yaml
+
+   action_status_bridge:
+     ros__parameters:
+       aborted_severity: 2         # SEVERITY_ERROR
+       canceled_is_fault: false
+       heal_on_succeeded: true
+       rescan_period_sec: 2.0
+       retry_period_sec: 0.05
+       code_prefix: "ACTION"
+       exclude_actions: []
+       include_only_actions: []
+       dedup_capacity: 4096
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 12 56
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``aborted_severity``
+     - ``2`` (ERROR)
+     - Severity reported when a goal aborts: 0 INFO, 1 WARN, 2 ERROR,
+       3 CRITICAL. Out of range is refused with a warning and ERROR is used.
+   * - ``canceled_is_fault``
+     - ``false``
+     - Report a fault when a goal is canceled. Off by default, because a cancel
+       is usually a decision rather than a failure.
+   * - ``heal_on_succeeded``
+     - ``true``
+     - Report a healing event when a goal succeeds, so an earlier fault for the
+       same action clears on its own.
+   * - ``rescan_period_sec``
+     - ``2.0``
+     - How often the graph is rescanned for action status topics. A
+       non-positive value is refused with a warning and ``2.0`` is used.
+   * - ``retry_period_sec``
+     - ``0.05``
+     - Retry cadence for a report deferred because the FaultManager service was
+       not discovered. The timer is armed only while a delivery is pending. Kept
+       short so the freeze-frame lands near the event. A non-positive value is
+       refused with a warning and ``0.05`` is used.
+   * - ``code_prefix``
+     - ``ACTION``
+     - Prefix of every generated fault code. Normalized to upper snake case so
+       it cannot produce a code outside medkit's ``[A-Z0-9_]`` charset; an empty
+       result falls back to ``ACTION``.
+   * - ``exclude_actions``
+     - ``[]``
+     - Action names the bridge ignores.
+   * - ``include_only_actions``
+     - ``[]``
+     - When non-empty, only these actions are watched.
+   * - ``dedup_capacity``
+     - ``4096``
+     - How many goal IDs are remembered to avoid reporting the same terminal
+       outcome twice. A non-positive value is refused with a warning and
+       ``4096`` is used.
+
+The bridge also declares ``fault_reporter.local_filtering.enabled`` (default
+``false``) on its own node. See :doc:`fault-manager` for what the reporter-side
+filter does.
+
+See Also
+--------
+
+- :doc:`fault-manager` - where the reported faults land
+- :doc:`log-bridge` - the same idea for ``/rosout``

--- a/docs/config/aggregation.rst
+++ b/docs/config/aggregation.rst
@@ -140,7 +140,8 @@ for peer communication.
    * - ``aggregation.max_discovered_peers``
      - int
      - ``50``
-     - Maximum number of peers that can be added via mDNS discovery. Prevents
+     - Maximum number of peers that can be added via mDNS discovery. Range:
+       1-1000, clamped with a warning. Prevents
        unbounded growth of the peer list from rogue mDNS announcements on the
        local network. Static peers (configured via ``peer_urls``/``peer_names``)
        do not count against this limit. When the limit is reached, additional

--- a/docs/config/diagnostic-bridge.rst
+++ b/docs/config/diagnostic-bridge.rst
@@ -48,6 +48,7 @@ Parameters
      ros__parameters:
        diagnostics_topic: "/diagnostics"   # Topic to subscribe to
        auto_generate_codes: true           # Auto-generate fault codes from names
+       keyvalue_codes: ["fault_code"]      # Take the code from these key-value keys
 
 .. list-table::
    :header-rows: 1
@@ -63,6 +64,13 @@ Parameters
      - ``true``
      - Automatically generate fault codes from diagnostic names when no explicit
        mapping exists.
+   * - ``keyvalue_codes``
+     - ``[]``
+     - Keys to look for inside the ``DiagnosticStatus`` key-value pairs. The
+       first key in this list that the message carries supplies the fault code
+       as its value, so a publisher can name its own code instead of relying on
+       a mapping. Checked after ``name_to_code`` and before auto-generation.
+       Empty strings in the list are ignored.
 
 Custom Fault Code Mappings
 --------------------------

--- a/docs/config/discovery-options.rst
+++ b/docs/config/discovery-options.rst
@@ -132,6 +132,31 @@ This is useful when running beacon plugins as the sole enrichment source
 When a layer is disabled, its entities are not discovered and its merge
 contributions are skipped. Plugins always run regardless of these flags.
 
+Manifest Loading
+^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 8 14 44
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``discovery.manifest_strict_validation``
+     - bool
+     - ``true``
+     - Reject a manifest that fails validation instead of loading the parts of
+       it that happen to parse. Turn it off only to bring up a manifest that is
+       still being written.
+   * - ``discovery.manifest.fragments_dir``
+     - string
+     - ``""``
+     - Directory of manifest fragment YAML files. Every load and reload of the
+       manifest scans it and merges the apps, components and functions it finds
+       on top of the base manifest, so a fleet can ship one base file plus
+       per-robot fragments. Empty disables fragment loading.
+
 Field Groups
 ^^^^^^^^^^^^
 

--- a/docs/config/discovery-options.rst
+++ b/docs/config/discovery-options.rst
@@ -146,9 +146,12 @@ Manifest Loading
    * - ``discovery.manifest_strict_validation``
      - bool
      - ``true``
-     - Reject a manifest that fails validation instead of loading the parts of
-       it that happen to parse. Turn it off only to bring up a manifest that is
-       still being written.
+     - Treat manifest validation WARNINGS as fatal. Validation errors (broken
+       references, circular dependencies, duplicate bindings) always abort the
+       load whatever this is set to, and a manifest is only ever applied whole,
+       so turning this off never loads a partly-valid manifest - it only lets
+       warnings through. Turn it off to bring up a manifest that is still being
+       written.
    * - ``discovery.manifest.fragments_dir``
      - string
      - ``""``

--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -144,8 +144,9 @@ threshold overrides:
    thresholds resolved from that event's ``source_id``. This means the debounce
    behavior follows the reporting entity, not the fault.
 
-   ``auto_confirm_after_sec`` and ``critical_immediate_confirm`` are global-only and
-   cannot be overridden per-entity.
+   ``auto_confirm_after_sec`` is global-only and cannot be overridden per-entity.
+   Critical faults skip debounce and confirm on their first occurrence; that is
+   built in, not a parameter, so it can be neither disabled nor set per entity.
 
 Snapshot Configuration
 ----------------------
@@ -285,6 +286,21 @@ Capture continuous rosbag recordings around fault events.
      - In broad modes (``all``/``entity``), auto-exclude high-bandwidth sensor
        topics (image/points/depth/compressed) to bound memory. Excluded topics are
        dropped silently; ``include_topics`` re-adds any you need.
+   * - ``rosbag.include_topics``
+     - ``[]``
+     - Topics to record on top of whatever the selection mode picked. This is
+       how a topic dropped by ``exclude_sensor_topics`` is brought back.
+   * - ``rosbag.exclude_topics``
+     - ``[]``
+     - Topics to drop from whatever the selection mode picked.
+   * - ``rosbag.format``
+     - ``sqlite3``
+     - Storage format handed to rosbag2. Use ``mcap`` where the reader expects
+       it.
+   * - ``rosbag.storage_path``
+     - ``""``
+     - Directory the bag files are written to. Empty writes beside the snapshot
+       storage.
    * - ``rosbag.qos_match``
      - ``true``
      - Subscribe with each topic's publisher-offered QoS for faithful capture
@@ -389,6 +405,57 @@ arrival prunes the whole buffer by age.
 .. seealso::
 
    :doc:`/tutorials/snapshots` for detailed snapshot configuration examples.
+
+Audit Log
+---------
+
+An append-only, hash-chained record of fault state transitions, for deployments
+that have to show afterwards what the fault state was and when it changed. Off
+by default: with it off there is no table, no file and no write cost.
+
+.. code-block:: yaml
+
+   fault_manager:
+     ros__parameters:
+       audit_log:
+         enabled: false
+         transitions: "all"
+         retention_max_records: 0
+         fail_closed: false
+         database_path: ""
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 14 52
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``audit_log.enabled``
+     - ``false``
+     - Turn the audit log on.
+   * - ``audit_log.transitions``
+     - ``"all"``
+     - Which transitions are recorded: ``all`` (occurred, confirmed, cleared) or
+       ``confirmed_only``. Any other value falls back to ``all`` with a warning.
+   * - ``audit_log.retention_max_records``
+     - ``0``
+     - Seal and prune the oldest segment once the log passes this many records.
+       ``0`` disables rotation, and a negative value is refused with a warning
+       and treated as ``0``.
+   * - ``audit_log.fail_closed``
+     - ``false``
+     - Re-raise a failed audit append as a hard error instead of carrying on.
+       Note what this does and does not do: it does NOT roll back the fault
+       state change that triggered the transition, because that change has
+       already committed to the separate fault-store database and the two
+       databases cannot be made atomic. It signals a broken audit chain so an
+       operator has to act. Off by default so the audit can never block fault
+       processing.
+   * - ``audit_log.database_path``
+     - ``""``
+     - Where the audit database lives. Empty puts it beside the fault database,
+       or in memory when the fault store is itself in memory or not SQLite.
 
 Correlation Configuration
 -------------------------

--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -299,8 +299,9 @@ Capture continuous rosbag recordings around fault events.
        it.
    * - ``rosbag.storage_path``
      - ``""``
-     - Directory the bag files are written to. Empty writes beside the snapshot
-       storage.
+     - Directory the bag files are written to. Empty falls back to the system
+       temporary directory, which on most systems is cleared on reboot - set
+       this if the bags have to survive one.
    * - ``rosbag.qos_match``
      - ``true``
      - Subscribe with each topic's publisher-offered QoS for faithful capture

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -11,6 +11,8 @@ This section contains configuration references for ros2_medkit.
    manifest-schema
    fault-manager
    diagnostic-bridge
+   log-bridge
+   action-status-bridge
    graph-provider
    aggregation
 
@@ -48,6 +50,20 @@ Diagnostic Bridge
 :doc:`diagnostic-bridge`
    Diagnostic bridge configuration for converting standard ROS 2 diagnostics
    to fault events. Includes custom fault code mappings.
+
+Log Bridge
+----------
+
+:doc:`log-bridge`
+   Log bridge configuration for turning ``/rosout`` messages into faults:
+   severity floor, node filtering, and the per-node report cooldown.
+
+Action Status Bridge
+--------------------
+
+:doc:`action-status-bridge`
+   Action status bridge configuration for turning action outcomes into faults:
+   severity of an abort, cancel and success handling, and action filtering.
 
 Graph Provider
 --------------

--- a/docs/config/log-bridge.rst
+++ b/docs/config/log-bridge.rst
@@ -74,14 +74,17 @@ Parameters
    * - ``max_tracked_nodes``
      - ``512``
      - How many distinct source nodes the bridge tracks. Bounds memory when node
-       names are generated. Clamped to at least ``1``.
+       names are generated. Range: 1 to 2147483647 (the value becomes an
+       ``int``); either end is clamped with a warning.
    * - ``report_cooldown_sec``
      - ``5.0``
      - Minimum gap between two reports carrying the same generated fault code at
        the same severity. Applies to ``ERROR`` and ``FATAL`` only, because
        ``WARN`` is already debounced by the reporter-side local filter and
-       cooling it here would starve that filter's threshold counting. ``0`` or a
-       negative value disables it.
+       cooling it here would starve that filter's threshold counting. ``0``
+       disables the cooldown. Must be finite and not negative; anything else is
+       refused with a warning and ``5.0`` is used, because a non-finite value
+       would otherwise reach the duration the window is built from.
    * - ``exclude_medkit_stack``
      - ``true``
      - Ignore logs from medkit's own nodes, so the diagnostics stack does not

--- a/docs/config/log-bridge.rst
+++ b/docs/config/log-bridge.rst
@@ -1,0 +1,86 @@
+Log Bridge Configuration
+========================
+
+The ``ros2_medkit_log_bridge`` node turns ``/rosout`` messages into faults, so a
+node that only ever logged a problem still shows up in the fault list without
+being changed.
+
+.. contents:: Table of Contents
+   :local:
+   :depth: 2
+
+Overview
+--------
+
+The bridge subscribes to ``/rosout``, keeps the messages at or above a severity
+floor, derives a fault code from the logging node and the message, and reports
+it through the same ``ReportFault`` path any node would use.
+
+Two things bound the volume. Messages at ``WARN`` pass through each node's
+``FaultReporter`` local filter, which debounces on a threshold and a window;
+``ERROR`` and ``FATAL`` bypass that filter. On top of that, the bridge itself
+holds a per-node cooldown so one node in a loop cannot flood the fault store.
+
+Parameters
+----------
+
+.. code-block:: yaml
+
+   log_bridge:
+     ros__parameters:
+       rosout_topic: "/rosout"
+       severity_floor: 30          # WARN
+       code_prefix: "LOG"
+       exclude_nodes: []
+       include_only_nodes: []
+       max_tracked_nodes: 512
+       report_cooldown_sec: 5.0
+       exclude_medkit_stack: true
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 58
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``rosout_topic``
+     - ``/rosout``
+     - Topic the bridge subscribes to.
+   * - ``severity_floor``
+     - ``30`` (WARN)
+     - Lowest rcutils log level that becomes a fault: 10 DEBUG, 20 INFO,
+       30 WARN, 40 ERROR, 50 FATAL. Raise it to ``40`` on chatty or constrained
+       targets to cut volume. Out of range is clamped to ``[0, 50]`` with a
+       warning, because the value is narrowed to a byte and would otherwise wrap
+       into "let everything through".
+   * - ``code_prefix``
+     - ``LOG``
+     - Prefix of every generated fault code. Normalized to upper snake case and
+       truncated to 32 characters, so it cannot produce a code outside the
+       ``[A-Z0-9_]`` charset medkit requires. An empty result falls back to
+       ``LOG``.
+   * - ``exclude_nodes``
+     - ``[]``
+     - Node names whose logs are ignored.
+   * - ``include_only_nodes``
+     - ``[]``
+     - When non-empty, only these nodes are considered.
+   * - ``max_tracked_nodes``
+     - ``512``
+     - How many distinct nodes the bridge keeps cooldown state for. Bounds
+       memory when node names are generated. Clamped to at least ``1``.
+   * - ``report_cooldown_sec``
+     - ``5.0``
+     - Minimum gap between two reports for the same node. A negative value is
+       treated as ``0``.
+   * - ``exclude_medkit_stack``
+     - ``true``
+     - Ignore logs from medkit's own nodes, so the diagnostics stack does not
+       report on itself.
+
+See Also
+--------
+
+- :doc:`fault-manager` - where the reported faults land
+- :doc:`diagnostic-bridge` - the same idea for ``/diagnostics``

--- a/docs/config/log-bridge.rst
+++ b/docs/config/log-bridge.rst
@@ -18,8 +18,11 @@ it through the same ``ReportFault`` path any node would use.
 
 Two things bound the volume. Messages at ``WARN`` pass through each node's
 ``FaultReporter`` local filter, which debounces on a threshold and a window;
-``ERROR`` and ``FATAL`` bypass that filter. On top of that, the bridge itself
-holds a per-node cooldown so one node in a loop cannot flood the fault store.
+``ERROR`` and ``FATAL`` bypass that filter, so the bridge applies its own
+cooldown to those two levels instead. That cooldown is keyed by the generated
+fault code together with the severity, not by the node: a repeat of the same
+message is suppressed, while a different message from the same node is not, and
+an ERROR is never suppressed by an earlier WARN of the same text.
 
 Parameters
 ----------
@@ -49,11 +52,13 @@ Parameters
      - Topic the bridge subscribes to.
    * - ``severity_floor``
      - ``30`` (WARN)
-     - Lowest rcutils log level that becomes a fault: 10 DEBUG, 20 INFO,
-       30 WARN, 40 ERROR, 50 FATAL. Raise it to ``40`` on chatty or constrained
-       targets to cut volume. Out of range is clamped to ``[0, 50]`` with a
-       warning, because the value is narrowed to a byte and would otherwise wrap
-       into "let everything through".
+     - Lowest rcutils log level that becomes a fault. Useful values are ``30``
+       WARN, ``40`` ERROR and ``50`` FATAL: DEBUG and INFO never become faults
+       whatever this is set to, so ``0``, ``10`` and ``20`` all behave like
+       ``30``. Raise it to ``40`` on chatty or constrained targets to cut
+       volume. Out of range is clamped to ``[0, 50]`` with a warning, because
+       the value is narrowed to a byte and would otherwise wrap into "let
+       everything through".
    * - ``code_prefix``
      - ``LOG``
      - Prefix of every generated fault code. Normalized to upper snake case and
@@ -68,12 +73,15 @@ Parameters
      - When non-empty, only these nodes are considered.
    * - ``max_tracked_nodes``
      - ``512``
-     - How many distinct nodes the bridge keeps cooldown state for. Bounds
-       memory when node names are generated. Clamped to at least ``1``.
+     - How many distinct source nodes the bridge tracks. Bounds memory when node
+       names are generated. Clamped to at least ``1``.
    * - ``report_cooldown_sec``
      - ``5.0``
-     - Minimum gap between two reports for the same node. A negative value is
-       treated as ``0``.
+     - Minimum gap between two reports carrying the same generated fault code at
+       the same severity. Applies to ``ERROR`` and ``FATAL`` only, because
+       ``WARN`` is already debounced by the reporter-side local filter and
+       cooling it here would starve that filter's threshold counting. ``0`` or a
+       negative value disables it.
    * - ``exclude_medkit_stack``
      - ``true``
      - Ignore logs from medkit's own nodes, so the diagnostics stack does not

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -36,8 +36,9 @@ range and the gateway logs both values. This applies to the thread and pool knob
 for these, so the value is refused and the default takes its place. The warning
 names the value that was refused. This applies to ``server.port``,
 ``refresh_interval_ms``, ``discovery.refresh_debounce_ms``,
-``topic_sample_timeout_sec``, ``bulk_data.max_upload_size``,
-``sse.max_subscriptions`` and ``sse.max_duration_sec``:
+``topic_sample_timeout_sec``, ``fault_manager.service_timeout_sec``,
+``bulk_data.max_upload_size``, ``sse.max_subscriptions``,
+``sse.max_duration_sec`` and ``triggers.max_triggers``:
 
 .. code-block:: text
 
@@ -45,13 +46,19 @@ names the value that was refused. This applies to ``server.port``,
 
 **Refused at startup.** ``parameter_service_timeout_sec`` and
 ``parameter_service_negative_cache_sec`` are declared with a floating-point range
-descriptor, so rclcpp itself rejects the value and the gateway does not start:
+descriptor, so rclcpp itself rejects an out-of-range value and the gateway does
+not start:
 
 .. code-block:: text
 
    [ros2_medkit_gateway] Fatal exception in main: parameter
    'parameter_service_timeout_sec' could not be set: Parameter
    {parameter_service_timeout_sec} doesn't comply with floating point range.
+
+One value gets past that descriptor: ``.nan``. The range check compares with
+``<`` and ``>``, and every comparison against NaN is false, so rclcpp reads it as
+in-range. The gateway catches it when it reads the value, warns, and uses the
+default instead.
 
 In every case the point is the same. The config file and the running process must
 not disagree with nothing to show it, because the symptom of a mis-set value (a
@@ -352,7 +359,12 @@ Configure how the gateway connects to the fault manager services and event topic
    * - ``fault_manager.service_timeout_sec``
      - float
      - ``5.0``
-     - Timeout for fault manager service calls such as ``list_faults`` and ``get_snapshots``.
+     - Timeout for fault manager service calls such as ``list_faults`` and
+       ``get_snapshots``. Must be finite and greater than ``0``; anything else
+       is refused with a warning and ``5.0`` is used. Zero or negative would
+       make every fault call report "service not available" instead of waiting,
+       and a non-finite value would make it wait forever, holding an HTTP worker
+       for the life of the process.
    * - ``entity_freeze_frame.enabled``
      - bool
      - ``true``
@@ -664,7 +676,20 @@ Configure condition-based push notifications for resource changes.
      - int
      - ``1000``
      - Maximum number of concurrent triggers across all entities. Returns
-       HTTP 503 when this limit is reached.
+       HTTP 503 when this limit is reached. A value below ``1`` or past what an
+       ``int`` holds is refused with a warning and ``1000`` is used, because the
+       cap is compared as an unsigned count and a negative would remove it.
+   * - ``triggers.on_restart_behavior``
+     - string
+     - ``"reset"``
+     - Behavior on gateway restart for persistent triggers. ``"reset"`` clears
+       all triggers on restart. ``"restore"`` reloads persistent triggers from
+       the storage database.
+   * - ``triggers.storage.path``
+     - string
+     - ``""``
+     - Path to SQLite database for persistent trigger storage. When empty
+       (default), triggers are stored in-memory only and lost on restart.
 
 Fault-trigger rules
 ^^^^^^^^^^^^^^^^^^^
@@ -697,17 +722,6 @@ plugin is loaded; with no plugins these parameters do nothing.
      - ``""``
      - SQLite file the rules are persisted in. Empty keeps them in memory, so
        they are lost on restart.
-   * - ``triggers.on_restart_behavior``
-     - string
-     - ``"reset"``
-     - Behavior on gateway restart for persistent triggers. ``"reset"`` clears
-       all triggers on restart. ``"restore"`` reloads persistent triggers from
-       the storage database.
-   * - ``triggers.storage.path``
-     - string
-     - ``""``
-     - Path to SQLite database for persistent trigger storage. When empty
-       (default), triggers are stored in-memory only and lost on restart.
 
 Example:
 

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -25,8 +25,8 @@ range and the gateway logs both values. This applies to the thread and pool knob
 (``server.executor_threads``, ``server.http_thread_pool_size``,
 ``server.keep_alive_timeout_sec``, ``sse.max_clients``,
 ``service_call_timeout_sec``, ``logs.buffer_size``, ``entity_cache.capacity``,
-``aggregation.max_discovered_peers``) and to the ``subscription_executor.*`` and
-``data_provider.*`` knobs:
+``aggregation.max_discovered_peers``, ``fault_triggers.poll_interval_ms``) and to
+the ``subscription_executor.*`` and ``data_provider.*`` knobs:
 
 .. code-block:: text
 
@@ -70,8 +70,9 @@ If the gateway behaves as though a parameter were different from what your YAML
 says, its startup log names the parameter.
 
 Note the logger name in the message. Most of these come from
-``ros2_medkit_gateway``, but the HTTP pool and keep-alive lines come from
-``rest_server``.
+``ros2_medkit_gateway``; the three that the REST server reads for itself -
+``server.http_thread_pool_size``, ``server.keep_alive_timeout_sec`` and
+``sse.max_duration_sec`` - come from ``rest_server``.
 
 Network Settings
 ----------------
@@ -276,8 +277,10 @@ Data Access Settings
 
 .. note::
 
-   The defaults listed above match the recommended gateway configuration in
-   ``src/ros2_medkit_gateway/config/gateway_params.yaml``. If
+   The defaults listed above are the ones the code declares. Where the shipped
+   ``src/ros2_medkit_gateway/config/gateway_params.yaml`` sets a different value
+   the row says so - ``topic_sample_timeout_sec`` is the one that differs today.
+   If
    ``topic_sample_timeout_sec`` is out of range, ``DataAccessManager`` and the
    topic transport both fall back to ``1.0``.
 
@@ -592,7 +595,7 @@ configuration.
    * - ``bulk_data.max_upload_size``
      - int
      - ``104857600``
-     - Maximum upload file size in bytes (default: 100 MB). Set to 0 for unlimited.
+     - Maximum upload file size in bytes (default: 100 MB). Set to ``0`` for unlimited. A negative value is refused with a warning and the default is used: it would otherwise wrap to a huge unsigned size, which is the same "no limit" a typo should never buy silently.
    * - ``bulk_data.categories``
      - string[]
      - ``[]``
@@ -636,15 +639,15 @@ Configure limits for SSE-based streaming (fault events and cyclic subscriptions)
    * - ``sse.max_clients``
      - int
      - ``2``
-     - Maximum number of concurrent SSE connections (fault stream, cyclic subscription streams, and trigger event streams combined). Each connection pins one ``server.http_thread_pool_size`` worker for its lifetime, so this defaults at or below that pool; raise both together for more concurrent streams.
+     - Maximum number of concurrent SSE connections (fault stream, cyclic subscription streams, and trigger event streams combined). Each connection pins one ``server.http_thread_pool_size`` worker for its lifetime, so this defaults at or below that pool; raise both together for more concurrent streams. Range: 1-1024, clamped with a warning.
    * - ``sse.max_subscriptions``
      - int
      - ``100``
-     - Maximum number of active cyclic subscriptions across all entities. Returns HTTP 503 when this limit is reached.
+     - Maximum number of active cyclic subscriptions across all entities. Returns HTTP 503 when this limit is reached. Must be at least ``1``; anything lower is refused with a warning and ``100`` is used, because the cap is compared as an unsigned count and a negative would remove it.
    * - ``sse.max_duration_sec``
      - int
      - ``3600``
-     - Maximum allowed subscription duration in seconds. Requests exceeding this are rejected with HTTP 400.
+     - Maximum allowed subscription duration in seconds. Requests exceeding this are rejected with HTTP 400. Range: 1 to 2147483647 (the value becomes an ``int``); outside it the value is refused with a warning and ``3600`` is used.
 
 Example:
 
@@ -694,6 +697,19 @@ Configure condition-based push notifications for resource changes.
      - Path to SQLite database for persistent trigger storage. When empty
        (default), triggers are stored in-memory only and lost on restart.
 
+Example:
+
+.. code-block:: yaml
+
+   ros2_medkit_gateway:
+     ros__parameters:
+       triggers:
+         enabled: true
+         max_triggers: 1000
+         on_restart_behavior: "restore"
+         storage:
+           path: "/var/lib/ros2_medkit/triggers.db"
+
 Fault-trigger rules
 ^^^^^^^^^^^^^^^^^^^
 
@@ -716,28 +732,17 @@ plugin is loaded; with no plugins these parameters do nothing.
    * - ``fault_triggers.poll_interval_ms``
      - int
      - ``1000``
-     - How often the rules are evaluated. Floored at ``50`` ms so the loop
-       cannot busy-spin; a lower value is clamped with a warning. Read only when
-       the engine actually starts, so with no plugin loaded a mis-set value is
-       neither applied nor reported - it does nothing either way.
+     - How often the rules are evaluated. Range: 50 to 2147483647 ms. The floor
+       stops the loop busy-spinning; the ceiling is what an ``int`` holds, since
+       the value becomes a timer period. Either end is clamped with a warning.
+       Read only when the engine actually starts, so with no plugin loaded a
+       mis-set value is neither applied nor reported - it does nothing either
+       way.
    * - ``fault_triggers.storage.path``
      - string
      - ``""``
      - SQLite file the rules are persisted in. Empty keeps them in memory, so
        they are lost on restart.
-
-Example:
-
-.. code-block:: yaml
-
-   ros2_medkit_gateway:
-     ros__parameters:
-       triggers:
-         enabled: true
-         max_triggers: 1000
-         on_restart_behavior: "restore"
-         storage:
-           path: "/var/lib/ros2_medkit/triggers.db"
 
 Rate Limiting
 -------------

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -55,10 +55,13 @@ not start:
    'parameter_service_timeout_sec' could not be set: Parameter
    {parameter_service_timeout_sec} doesn't comply with floating point range.
 
-One value gets past that descriptor: ``.nan``. The range check compares with
-``<`` and ``>``, and every comparison against NaN is false, so rclcpp reads it as
-in-range. The gateway catches it when it reads the value, warns, and uses the
-default instead.
+``.nan`` is the one value whose handling depends on the ROS 2 distribution. The
+range check compares with ``<`` and ``>``, and every comparison against NaN is
+false, so on Jazzy rclcpp reads NaN as in-range and the gateway starts; on
+Lyrical it is refused like any other bad value and the gateway does not start.
+Where it does get through, the gateway catches it when it reads the value, warns
+and uses the default, so a NaN never reaches the code that would treat it as a
+duration.
 
 In every case the point is the same. The config file and the running process must
 not disagree with nothing to show it, because the symptom of a mis-set value (a

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -25,8 +25,8 @@ range and the gateway logs both values. This applies to the thread and pool knob
 (``server.executor_threads``, ``server.http_thread_pool_size``,
 ``server.keep_alive_timeout_sec``, ``sse.max_clients``,
 ``service_call_timeout_sec``, ``logs.buffer_size``, ``entity_cache.capacity``,
-``aggregation.max_discovered_peers``, ``fault_triggers.poll_interval_ms``) and to
-the ``subscription_executor.*`` and ``data_provider.*`` knobs:
+``aggregation.max_discovered_peers``) and to the ``subscription_executor.*`` and
+``data_provider.*`` knobs:
 
 .. code-block:: text
 
@@ -689,7 +689,9 @@ plugin is loaded; with no plugins these parameters do nothing.
      - int
      - ``1000``
      - How often the rules are evaluated. Floored at ``50`` ms so the loop
-       cannot busy-spin; a lower value is clamped with a warning.
+       cannot busy-spin; a lower value is clamped with a warning. Read only when
+       the engine actually starts, so with no plugin loaded a mis-set value is
+       neither applied nor reported - it does nothing either way.
    * - ``fault_triggers.storage.path``
      - string
      - ``""``

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -16,21 +16,52 @@ The gateway can be configured via:
 Out-of-range values
 -------------------
 
-Where a parameter below documents a valid range, that range is enforced when the
-value is read at startup. An out-of-range value neither aborts startup nor takes
-effect: it is coerced to the nearest endpoint of the range, and the gateway logs
-a warning naming both the requested and the effective value.
+Where a parameter documents a valid range, that range is enforced when the value
+is read at startup, and an out-of-range value is never accepted in silence. What
+happens next differs by parameter, in one of three ways.
+
+**Clamped to the nearest endpoint.** The value is moved to the closest end of the
+range and the gateway logs both values. This applies to the thread and pool knobs
+(``server.executor_threads``, ``server.http_thread_pool_size``,
+``server.keep_alive_timeout_sec``, ``sse.max_clients``,
+``service_call_timeout_sec``, ``logs.buffer_size``, ``entity_cache.capacity``,
+``aggregation.max_discovered_peers``) and to the ``subscription_executor.*`` and
+``data_provider.*`` knobs:
 
 .. code-block:: text
 
-   [WARN] [ros2_medkit_gateway]: server.http_thread_pool_size 0 clamped to 1
+   [WARN] [rest_server]: server.http_thread_pool_size 0 clamped to 1
 
-The coercion exists so a typo cannot break request serving - a pool of ``0``
-would queue every request forever. The warning exists because the config file
-and the running process would otherwise disagree with nothing to show it, and
-the symptom of a mis-set value (a slow or jittery gateway) surfaces far from the
-cause. If the gateway behaves as though a parameter were different from what
-your YAML says, its startup log names the parameter.
+**Rejected, and the documented default is used instead.** Clamping makes no sense
+for these, so the value is refused and the default takes its place. The warning
+names the value that was refused. This applies to ``server.port``,
+``refresh_interval_ms``, ``discovery.refresh_debounce_ms``,
+``topic_sample_timeout_sec``, ``bulk_data.max_upload_size``,
+``sse.max_subscriptions`` and ``sse.max_duration_sec``:
+
+.. code-block:: text
+
+   [ERROR] [ros2_medkit_gateway]: Invalid port 70000. Must be between 1024-65535. Using default 8080.
+
+**Refused at startup.** ``parameter_service_timeout_sec`` and
+``parameter_service_negative_cache_sec`` are declared with a floating-point range
+descriptor, so rclcpp itself rejects the value and the gateway does not start:
+
+.. code-block:: text
+
+   [ros2_medkit_gateway] Fatal exception in main: parameter
+   'parameter_service_timeout_sec' could not be set: Parameter
+   {parameter_service_timeout_sec} doesn't comply with floating point range.
+
+In every case the point is the same. The config file and the running process must
+not disagree with nothing to show it, because the symptom of a mis-set value (a
+slow or jittery gateway, a limit that never fires) surfaces far from the cause.
+If the gateway behaves as though a parameter were different from what your YAML
+says, its startup log names the parameter.
+
+Note the logger name in the message. Most of these come from
+``ros2_medkit_gateway``, but the HTTP pool and keep-alive lines come from
+``rest_server``.
 
 Network Settings
 ----------------
@@ -165,10 +196,11 @@ Data Access Settings
      - Type
      - Default
      - Description
-   * - ``max_parallel_topic_samples``
+   * - ``data_provider.max_parallel_samples``
      - int
-     - ``20``
-     - Max concurrent topic samples. Higher values use more resources. Range: 1-50.
+     - ``8``
+     - Max concurrent topic samples. Higher values use more resources. Excess
+       topics are processed in follow-up chunks. Range: 1-256.
    * - ``topic_sample_timeout_sec``
      - float
      - ``2.0``
@@ -230,9 +262,69 @@ Data Access Settings
 .. note::
 
    The defaults listed above match the recommended gateway configuration in
-   ``src/ros2_medkit_gateway/config/gateway_params.yaml``. If these parameters are
-   not provided at all, the ``DataAccessManager`` fallback defaults are
-   ``max_parallel_topic_samples = 10`` and ``topic_sample_timeout_sec = 1.0``.
+   ``src/ros2_medkit_gateway/config/gateway_params.yaml``. If
+   ``topic_sample_timeout_sec`` is out of range, ``DataAccessManager`` and the
+   topic transport both fall back to ``1.0``.
+
+Subscription Pool and Executor
+------------------------------
+
+The topic data provider keeps a pool of live subscriptions, and all subscription
+create and destroy calls are funnelled through one serial worker. These knobs
+bound both. Every value is clamped to its range on read, with a warning (see
+`Out-of-range values`_).
+
+.. list-table::
+   :header-rows: 1
+   :widths: 38 8 10 44
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``data_provider.max_pool_size``
+     - int
+     - ``256``
+     - Live per-topic subscriptions the pool keeps. At the cap, sampling a new
+       topic evicts the least recently used entry. Range: 1-4096.
+   * - ``data_provider.cold_wait_cap``
+     - int
+     - ``4``
+     - Concurrent HTTP workers allowed to block waiting for the first message on
+       a freshly subscribed topic. Further callers get 503 and back off instead
+       of saturating the request pool. Range: 0-1024.
+   * - ``data_provider.idle_safety_net_sec``
+     - int
+     - ``900``
+     - A pool entry unsampled for this long is evicted, releasing its
+       subscription. ``0`` disables idle eviction. Range: 0-86400.
+   * - ``data_provider.idle_sweep_tick_sec``
+     - int
+     - ``60``
+     - How often the idle sweep runs. ``0`` disables idle eviction.
+       Range: 0-3600.
+   * - ``subscription_executor.max_queue_depth``
+     - int
+     - ``256``
+     - Tasks queued on the serial worker before new posts are rejected with
+       backpressure. Bounds peak memory when handler threads create
+       subscriptions faster than the worker services them. Range: 16-4096.
+   * - ``subscription_executor.watchdog_threshold_ms``
+     - int
+     - ``5000``
+     - A worker task running longer than this marks the executor degraded
+       (``x-medkit-subscription-executor.degraded`` on ``/health``). The flag
+       clears when the task completes. Range: 100-60000.
+   * - ``subscription_executor.watchdog_tick_ms``
+     - int
+     - ``1000``
+     - How often the watchdog checks. Finer tick detects degradation sooner at
+       the cost of more wakeups. Range: 10-10000.
+   * - ``subscription_executor.graph_poll_tick_ms``
+     - int
+     - ``100``
+     - How often graph events are polled (publisher appear or disappear, type
+       changes). Range: 10-10000.
 
 Fault Manager Integration
 -------------------------

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -13,6 +13,25 @@ The gateway can be configured via:
 2. **Launch files**: ``parameters=[{'server.port': 9000}]``
 3. **YAML file**: See ``src/ros2_medkit_gateway/config/gateway_params.yaml``
 
+Out-of-range values
+-------------------
+
+Where a parameter below documents a valid range, that range is enforced when the
+value is read at startup. An out-of-range value neither aborts startup nor takes
+effect: it is coerced to the nearest endpoint of the range, and the gateway logs
+a warning naming both the requested and the effective value.
+
+.. code-block:: text
+
+   [WARN] [ros2_medkit_gateway]: server.http_thread_pool_size 0 clamped to 1
+
+The coercion exists so a typo cannot break request serving - a pool of ``0``
+would queue every request forever. The warning exists because the config file
+and the running process would otherwise disagree with nothing to show it, and
+the symptom of a mis-set value (a slow or jittery gateway) surfaces far from the
+cause. If the gateway behaves as though a parameter were different from what
+your YAML says, its startup log names the parameter.
+
 Network Settings
 ----------------
 
@@ -349,7 +368,9 @@ size instead of scaling with the host CPU count, so the gateway's thread
 footprint is the same on a 4-core SBC and a 64-core server. A third knob,
 ``keep_alive_timeout_sec``, bounds how long the HTTP pool keeps a worker parked
 on an idle keep-alive connection. Every value is clamped to a working minimum on
-read, so a mis-set parameter can never break request serving.
+read, so a mis-set parameter can never break request serving - and the clamp is
+reported, so it cannot quietly change what the gateway runs (see
+`Out-of-range values`_).
 
 .. list-table::
    :header-rows: 1

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -25,8 +25,8 @@ range and the gateway logs both values. This applies to the thread and pool knob
 (``server.executor_threads``, ``server.http_thread_pool_size``,
 ``server.keep_alive_timeout_sec``, ``sse.max_clients``,
 ``service_call_timeout_sec``, ``logs.buffer_size``, ``entity_cache.capacity``,
-``aggregation.max_discovered_peers``) and to the ``subscription_executor.*`` and
-``data_provider.*`` knobs:
+``aggregation.max_discovered_peers``, ``fault_triggers.poll_interval_ms``) and to
+the ``subscription_executor.*`` and ``data_provider.*`` knobs:
 
 .. code-block:: text
 
@@ -154,11 +154,13 @@ Cross-Origin Resource Sharing (CORS) settings for browser-based clients.
      - Description
    * - ``cors.allowed_origins``
      - list
-     - ``[""]``
-     - List of allowed origins. Use ``["*"]`` for all (not recommended).
+     - ``[]``
+     - List of allowed origins. Use ``["*"]`` for all (not recommended). CORS is
+       off while this is empty, so the shipped ``gateway_params.yaml`` value of
+       ``[""]`` also leaves it off: empty strings are stripped before the check.
    * - ``cors.allowed_methods``
      - list
-     - ``["GET", "PUT", "OPTIONS"]``
+     - ``["GET", "PUT", "POST", "DELETE", "OPTIONS"]``
      - Allowed HTTP methods.
    * - ``cors.allowed_headers``
      - list
@@ -203,8 +205,11 @@ Data Access Settings
        topics are processed in follow-up chunks. Range: 1-256.
    * - ``topic_sample_timeout_sec``
      - float
-     - ``2.0``
+     - ``1.0``
      - Timeout for sampling topics with active publishers. Range: 0.1-30.0.
+       The declared default is ``1.0``, which is what a bare ``ros2 run`` uses.
+       ``gateway_params.yaml`` sets ``2.0``, so a launch that loads it gets that
+       instead.
    * - ``parameter_service_timeout_sec``
      - float
      - ``2.0``
@@ -660,6 +665,36 @@ Configure condition-based push notifications for resource changes.
      - ``1000``
      - Maximum number of concurrent triggers across all entities. Returns
        HTTP 503 when this limit is reached.
+
+Fault-trigger rules
+^^^^^^^^^^^^^^^^^^^
+
+A separate engine evaluates threshold rules over plugin-provided data values and
+raises faults from them, without a rule file. It only starts when at least one
+plugin is loaded; with no plugins these parameters do nothing.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 32 8 14 46
+
+   * - Parameter
+     - Type
+     - Default
+     - Description
+   * - ``fault_triggers.enabled``
+     - bool
+     - ``true``
+     - Master switch for the rule engine.
+   * - ``fault_triggers.poll_interval_ms``
+     - int
+     - ``1000``
+     - How often the rules are evaluated. Floored at ``50`` ms so the loop
+       cannot busy-spin; a lower value is clamped with a warning.
+   * - ``fault_triggers.storage.path``
+     - string
+     - ``""``
+     - SQLite file the rules are persisted in. Empty keeps them in memory, so
+       they are lost on restart.
    * - ``triggers.on_restart_behavior``
      - string
      - ``"reset"``
@@ -913,8 +948,10 @@ Complete Example
            enabled: false
 
        refresh_interval_ms: 5000
-       max_parallel_topic_samples: 30
        topic_sample_timeout_sec: 3.0
+
+       data_provider:
+         max_parallel_samples: 30
 
        cors:
          allowed_origins: ["http://localhost:5173", "https://dashboard.example.com"]

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -237,14 +237,15 @@ Possible causes:
 
 1. **Many topics** - Response time scales with topic count
 2. **Slow publishers** - 3-second timeout per topic by default
-3. **Low parallelism** - Increase ``max_parallel_topic_samples``
+3. **Low parallelism** - Increase ``data_provider.max_parallel_samples``
 
 Optimize with:
 
 .. code-block:: yaml
 
-   max_parallel_topic_samples: 20  # Increase from default 10
-   topic_sample_timeout_sec: 0.5   # Decrease from default 1.0
+   data_provider:
+     max_parallel_samples: 32      # Increase from default 8
+   topic_sample_timeout_sec: 0.5   # Decrease from default 2.0
 
 **High CPU usage**
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -236,7 +236,8 @@ Performance Issues
 Possible causes:
 
 1. **Many topics** - Response time scales with topic count
-2. **Slow publishers** - 3-second timeout per topic by default
+2. **Slow publishers** - the per-topic timeout applies (declared default 1.0 s,
+   2.0 s with the shipped ``gateway_params.yaml``)
 3. **Low parallelism** - Increase ``data_provider.max_parallel_samples``
 
 Optimize with:

--- a/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
+++ b/src/ros2_medkit_action_status_bridge/src/action_status_bridge_node.cpp
@@ -18,8 +18,10 @@
 #include <array>
 #include <cctype>
 #include <chrono>
+#include <cinttypes>
 #include <cstdio>
 #include <functional>
+#include <limits>
 #include <vector>
 
 #include "action_msgs/msg/goal_status.hpp"
@@ -105,11 +107,14 @@ ActionStatusBridgeNode::~ActionStatusBridgeNode() {
 }
 
 void ActionStatusBridgeNode::load_parameters() {
-  const int aborted_severity =
-      static_cast<int>(declare_parameter<int>("aborted_severity", ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR));
+  // Read as int64 and checked before narrowing. A ROS parameter is an int64, so
+  // declaring this as int narrowed first and a value above INT_MAX wrapped back
+  // into [0,3] and was accepted in silence: 4294967298 becomes 2.
+  const int64_t aborted_severity =
+      declare_parameter<int64_t>("aborted_severity", ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR);
   if (aborted_severity < ros2_medkit_msgs::msg::Fault::SEVERITY_INFO ||
       aborted_severity > ros2_medkit_msgs::msg::Fault::SEVERITY_CRITICAL) {
-    RCLCPP_WARN(get_logger(), "aborted_severity %d out of range [0,3]; clamping to ERROR", aborted_severity);
+    RCLCPP_WARN(get_logger(), "aborted_severity %" PRId64 " out of range [0,3]; clamping to ERROR", aborted_severity);
     aborted_severity_ = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
   } else {
     aborted_severity_ = static_cast<uint8_t>(aborted_severity);
@@ -143,9 +148,10 @@ void ActionStatusBridgeNode::load_parameters() {
   include_only_actions_ =
       declare_parameter<std::vector<std::string>>("include_only_actions", std::vector<std::string>{});
 
-  const int dedup_capacity = static_cast<int>(declare_parameter<int>("dedup_capacity", 4096));
-  if (dedup_capacity <= 0) {
-    RCLCPP_WARN(get_logger(), "dedup_capacity %d not positive; using 4096", dedup_capacity);
+  // Same reason as aborted_severity: checked as int64, narrowed afterwards.
+  const int64_t dedup_capacity = declare_parameter<int64_t>("dedup_capacity", 4096);
+  if (dedup_capacity <= 0 || dedup_capacity > std::numeric_limits<int>::max()) {
+    RCLCPP_WARN(get_logger(), "dedup_capacity %" PRId64 " out of range; using 4096", dedup_capacity);
     logged_capacity_ = 4096;
   } else {
     logged_capacity_ = static_cast<size_t>(dedup_capacity);

--- a/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_action_status_bridge/test/test_integration.test.py
@@ -80,15 +80,34 @@ def generate_test_description():
         sigkill_timeout='15',
     )
 
+    # A second bridge carrying two values above INT_MAX. Both parameters used to
+    # be declared as int, so the value was narrowed before its range check and
+    # wrapped back into the accepted band: 4294967298 arrived as 2 and passed
+    # silently as ERROR severity. Only this node's startup log is read.
+    bad_params_bridge_node = launch_ros.actions.Node(
+        package='ros2_medkit_action_status_bridge',
+        executable='action_status_bridge_node',
+        name='action_status_bridge_bad_params',
+        output='screen',
+        parameters=[{
+            'aborted_severity': 4294967298,
+            'dedup_capacity': 4294967296,
+        }],
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
     return (
         LaunchDescription([
             fault_manager_node,
             action_status_bridge_node,
+            bad_params_bridge_node,
             launch_testing.actions.ReadyToTest(),
         ]),
         {
             'fault_manager_node': fault_manager_node,
             'action_status_bridge_node': action_status_bridge_node,
+            'bad_params_bridge_node': bad_params_bridge_node,
         },
     )
 
@@ -197,6 +216,28 @@ class TestActionStatusBridgeIntegration(unittest.TestCase):
         )
         self.assertIsNotNone(fault, f'{ABORTED_CODE} fault not HEALED in time')
         self.assertEqual(fault.status, Fault.STATUS_HEALED)
+
+
+class TestActionStatusBridgeParameterRefusal(unittest.TestCase):
+    """A value that wrapped into the accepted band is refused and named."""
+
+    def test_out_of_range_parameters_are_reported(self, proc_output, bad_params_bridge_node):
+        """
+        Both parameters name the value that was actually supplied.
+
+        Reading them as int narrowed first, so 4294967298 became 2 and was
+        taken as a valid ERROR severity with nothing logged. The warning has to
+        carry the requested value, not the wrapped one, or the operator cannot
+        tell which setting was refused.
+        """
+        for fragment in (
+            'aborted_severity 4294967298 out of range [0,3]',
+            'dedup_capacity 4294967296 out of range',
+        ):
+            with self.subTest(fragment=fragment):
+                proc_output.assertWaitFor(
+                    fragment, process=bad_params_bridge_node, timeout=30,
+                )
 
 
 @launch_testing.post_shutdown_test()

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -5,6 +5,15 @@
 #   - Command line: --ros-args -p server.port:=9000
 #   - Launch files: parameters=[...]
 #   - This YAML file
+#
+# Ranges: where a parameter below documents a valid range, that range is
+# enforced when the value is read. An out-of-range value does not abort startup
+# and does not silently take effect either - it is coerced to the nearest
+# endpoint and the gateway logs a warning naming both the requested and the
+# effective value, e.g.
+#   [WARN] server.http_thread_pool_size 0 clamped to 1
+# So if the gateway behaves as though a parameter were different from what this
+# file says, its startup log will name the parameter.
 
 ros2_medkit_gateway:
   ros__parameters:

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -11,13 +11,14 @@
 # in silence. What happens next differs by parameter:
 #   - most are coerced to the nearest endpoint, and the gateway logs both
 #     values:   [WARN] [rest_server]: server.http_thread_pool_size 0 clamped to 1
-#   - server.port, refresh_interval_ms, discovery.refresh_debounce_ms,
-#     topic_sample_timeout_sec, bulk_data.max_upload_size, sse.max_subscriptions
-#     and sse.max_duration_sec are refused and the documented default is used
-#     instead; the warning names the value that was refused
-#   - parameter_service_timeout_sec and parameter_service_negative_cache_sec are
-#     declared with a floating-point range descriptor, so rclcpp rejects the
-#     value and the gateway does not start at all
+#   - some are refused instead, because clamping them makes no sense (half a
+#     port number is not a port); the documented default is used and the
+#     warning names the value that was refused
+#   - a couple are declared with a floating-point range descriptor, so rclcpp
+#     itself rejects the value and the gateway does not start at all
+# Which parameter falls in which group is listed once, in the "Out-of-range
+# values" section of docs/config/server.rst. It is deliberately not repeated
+# here: the same list in two files is the kind that quietly drifts apart.
 # So if the gateway behaves as though a parameter were different from what this
 # file says, its startup log will name the parameter.
 

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -10,7 +10,7 @@
 # enforced when the value is read, and an out-of-range value is never accepted
 # in silence. What happens next differs by parameter:
 #   - most are coerced to the nearest endpoint, and the gateway logs both
-#     values:   [WARN] server.http_thread_pool_size 0 clamped to 1
+#     values:   [WARN] [rest_server]: server.http_thread_pool_size 0 clamped to 1
 #   - server.port, refresh_interval_ms, discovery.refresh_debounce_ms,
 #     topic_sample_timeout_sec, bulk_data.max_upload_size, sse.max_subscriptions
 #     and sse.max_duration_sec are refused and the documented default is used

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -7,11 +7,17 @@
 #   - This YAML file
 #
 # Ranges: where a parameter below documents a valid range, that range is
-# enforced when the value is read. An out-of-range value does not abort startup
-# and does not silently take effect either - it is coerced to the nearest
-# endpoint and the gateway logs a warning naming both the requested and the
-# effective value, e.g.
-#   [WARN] server.http_thread_pool_size 0 clamped to 1
+# enforced when the value is read, and an out-of-range value is never accepted
+# in silence. What happens next differs by parameter:
+#   - most are coerced to the nearest endpoint, and the gateway logs both
+#     values:   [WARN] server.http_thread_pool_size 0 clamped to 1
+#   - server.port, refresh_interval_ms, discovery.refresh_debounce_ms,
+#     topic_sample_timeout_sec, bulk_data.max_upload_size, sse.max_subscriptions
+#     and sse.max_duration_sec are refused and the documented default is used
+#     instead; the warning names the value that was refused
+#   - parameter_service_timeout_sec and parameter_service_negative_cache_sec are
+#     declared with a floating-point range descriptor, so rclcpp rejects the
+#     value and the gateway does not start at all
 # So if the gateway behaves as though a parameter were different from what this
 # file says, its startup log will name the parameter.
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/thread_pool_config.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/thread_pool_config.hpp
@@ -30,6 +30,16 @@ namespace ros2_medkit_gateway {
 // pathological thread count. The range is two-sided to match the established
 // clamp pattern used by the subscription_executor.* / data_provider.* knobs.
 //
+// This helper is deliberately silent: it is ROS-neutral (gateway_core links no
+// rclcpp), so it cannot log. Reporting the coercion is the CALLER's job and is
+// not optional - a clamp nobody hears leaves the config file and the running
+// process disagreeing with nothing to show it. Compare the result with the
+// requested value and RCLCPP_WARN when they differ, as main.cpp,
+// http/rest_server.cpp and gateway_node.cpp do. The one exception is a re-read
+// of a parameter another site has already reported (main.cpp compares the HTTP
+// pool against the SSE + cold-wait budget), where a second warning would only
+// teach operators to skim past the first.
+//
 // Pre-condition: 1 <= min_threads <= max_threads.
 inline std::size_t clamp_thread_count(int64_t requested, int64_t min_threads, int64_t max_threads) {
   return static_cast<std::size_t>(std::clamp<int64_t>(requested, min_threads, max_threads));
@@ -43,6 +53,9 @@ inline std::size_t clamp_thread_count(int64_t requested, int64_t min_threads, in
 // requests stall up to one timeout per cycle. Too small loses connection reuse
 // for legitimate clients (extra TCP/TLS handshakes). This clamps a mis-set value
 // to a closed [min_sec, max_sec] range so request serving can never break.
+//
+// Silent for the same reason as clamp_thread_count above, and with the same
+// obligation on the caller: report the coercion when it fires.
 //
 // Pre-condition: 1 <= min_sec <= max_sec.
 inline std::time_t clamp_keep_alive_timeout(int64_t requested, int64_t min_sec, int64_t max_sec) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 #include <cinttypes>
 #include <cstdlib>
+#include <limits>
 #include <mutex>
 #include <set>
 #include <string>
@@ -1873,10 +1874,15 @@ void GatewayNode::init_fault_trigger_engine() {
     return;
   }
   const std::string storage_path = get_parameter("fault_triggers.storage.path").as_string();
-  int poll_ms = static_cast<int>(get_parameter("fault_triggers.poll_interval_ms").as_int());
-  if (poll_ms < 50) {
-    poll_ms = 50;  // floor: never busy-spin the evaluation loop
+  // Floor so the evaluation loop can never busy-spin. Read as int64 and checked
+  // before narrowing, or a value above INT_MAX would wrap past the floor.
+  const int64_t poll_ms_raw = get_parameter("fault_triggers.poll_interval_ms").as_int();
+  const int64_t poll_ms_used = std::clamp<int64_t>(poll_ms_raw, 50, std::numeric_limits<int>::max());
+  if (poll_ms_used != poll_ms_raw) {
+    RCLCPP_WARN(get_logger(), "fault_triggers.poll_interval_ms %" PRId64 " clamped to %" PRId64, poll_ms_raw,
+                poll_ms_used);
   }
+  const int poll_ms = static_cast<int>(poll_ms_used);
 
   // Value fetch: same in-process x-plc-data route the freeze-frame capture uses,
   // so a rule always sees exactly the value the /data endpoint would serve.

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -658,7 +658,11 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   // Clamp like the pool knobs (issue #440): read raw, a negative value would wrap
   // to a huge size_t. Bounded to [1, 1024]; main.cpp warns at startup if this
   // exceeds the HTTP pool budget (pool < sse.max_clients + cold_wait_cap).
-  auto max_sse_clients = clamp_thread_count(get_parameter("sse.max_clients").as_int(), 1, 1024);
+  auto requested_sse_clients = get_parameter("sse.max_clients").as_int();
+  auto max_sse_clients = clamp_thread_count(requested_sse_clients, 1, 1024);
+  if (static_cast<int64_t>(max_sse_clients) != requested_sse_clients) {
+    RCLCPP_WARN(get_logger(), "sse.max_clients %" PRId64 " clamped to %zu", requested_sse_clients, max_sse_clients);
+  }
   sse_client_tracker_ = std::make_shared<SSEClientTracker>(max_sse_clients);
 
   // Initialize resource sampler and transport registries

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -654,12 +654,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
 
   // Parameter-service tuning parameters were declared at construction-time
   // alongside the rest of the gateway parameters; resolve them here.
-  // The FloatingPointRange descriptors on these two do NOT cover NaN: rclcpp's
-  // range check compares with < and >, and every comparison against NaN is
-  // false, so NaN is accepted as in-range and the gateway starts with it.
-  // Verified against a running gateway, which reported "timeout=nans". It then
-  // reaches a duration_cast and a try_lock_for, where it is undefined. Checked
-  // here with isfinite, which is the part rclcpp cannot do for us.
+  // The FloatingPointRange descriptors on these two do not cover NaN the same
+  // way everywhere: the range check compares with < and >, both false for NaN,
+  // so Jazzy accepts NaN as in-range (verified on a running gateway, which
+  // reported "timeout=nans") while Lyrical refuses it before main gets this
+  // far. Where it gets through it reaches a duration_cast and a try_lock_for,
+  // where it is undefined. isfinite here is what closes that distro gap.
   auto resolve_finite = [this](const char * name, double fallback) {
     const double value = get_parameter(name).as_double();
     if (std::isfinite(value)) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -654,8 +654,22 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
 
   // Parameter-service tuning parameters were declared at construction-time
   // alongside the rest of the gateway parameters; resolve them here.
-  const double parameter_service_timeout_sec = get_parameter("parameter_service_timeout_sec").as_double();
-  const double parameter_service_negative_cache_sec = get_parameter("parameter_service_negative_cache_sec").as_double();
+  // The FloatingPointRange descriptors on these two do NOT cover NaN: rclcpp's
+  // range check compares with < and >, and every comparison against NaN is
+  // false, so NaN is accepted as in-range and the gateway starts with it.
+  // Verified against a running gateway, which reported "timeout=nans". It then
+  // reaches a duration_cast and a try_lock_for, where it is undefined. Checked
+  // here with isfinite, which is the part rclcpp cannot do for us.
+  auto resolve_finite = [this](const char * name, double fallback) {
+    const double value = get_parameter(name).as_double();
+    if (std::isfinite(value)) {
+      return value;
+    }
+    RCLCPP_WARN(get_logger(), "%s is not a finite number. Using default %.1f.", name, fallback);
+    return fallback;
+  };
+  const double parameter_service_timeout_sec = resolve_finite("parameter_service_timeout_sec", 2.0);
+  const double parameter_service_negative_cache_sec = resolve_finite("parameter_service_negative_cache_sec", 60.0);
   parameter_transport_ = std::make_shared<ros2::Ros2ParameterTransport>(this, parameter_service_timeout_sec,
                                                                         parameter_service_negative_cache_sec);
   config_mgr_ = std::make_unique<ConfigurationManager>(parameter_transport_);
@@ -994,7 +1008,18 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     }
 
     TriggerConfig trigger_config;
-    trigger_config.max_triggers = static_cast<int>(get_parameter("triggers.max_triggers").as_int());
+    // The cap is stored as int here and compared against a size_t in
+    // TriggerManager, so a negative would become a huge unsigned bound and the
+    // documented "HTTP 503 when this limit is reached" would never fire - the
+    // trigger list would grow without one. Checked as int64 before narrowing.
+    const int64_t max_triggers_raw = get_parameter("triggers.max_triggers").as_int();
+    if (max_triggers_raw < 1 || max_triggers_raw > std::numeric_limits<int>::max()) {
+      RCLCPP_WARN(get_logger(), "triggers.max_triggers %" PRId64 " out of range. Using default 1000.",
+                  max_triggers_raw);
+      trigger_config.max_triggers = 1000;
+    } else {
+      trigger_config.max_triggers = static_cast<int>(max_triggers_raw);
+    }
     trigger_config.on_restart_behavior = get_parameter("triggers.on_restart_behavior").as_string();
 
     // Subscribe to data topics for data triggers. The adapter is created

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -321,8 +321,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
 
   // Get parameter values
   server_host_ = get_parameter("server.host").as_string();
-  server_port_ = static_cast<int>(get_parameter("server.port").as_int());
-  refresh_interval_ms_ = static_cast<int>(get_parameter("refresh_interval_ms").as_int());
+  // Port and backstop interval are read as int64 and validated below, before
+  // they are narrowed to int. Narrowing first would wrap a value above INT_MAX
+  // back into the valid band and let it through in silence: 4294976296 narrows
+  // to 9000, a legal port nobody asked for.
+  const int64_t server_port_raw = get_parameter("server.port").as_int();
+  const int64_t refresh_interval_raw = get_parameter("refresh_interval_ms").as_int();
   // Read as int64 and validate BEFORE narrowing to int: a value above INT_MAX
   // would otherwise wrap into the valid range and silently bypass the range
   // check (e.g. 4294967296 -> 0, disabling debounce). 0 disables debouncing
@@ -350,9 +354,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
                      .build();
 
   // Validate port range
-  if (server_port_ < 1024 || server_port_ > 65535) {
-    RCLCPP_ERROR(get_logger(), "Invalid port %d. Must be between 1024-65535. Using default 8080.", server_port_);
+  if (server_port_raw < 1024 || server_port_raw > 65535) {
+    RCLCPP_ERROR(get_logger(), "Invalid port %" PRId64 ". Must be between 1024-65535. Using default 8080.",
+                 server_port_raw);
     server_port_ = 8080;
+  } else {
+    server_port_ = static_cast<int>(server_port_raw);
   }
 
   // Validate host
@@ -370,11 +377,13 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   // graph events polled every 100 ms; this value only governs the
   // safety-backstop timer that periodically forces a refresh in case a
   // graph event is missed.
-  if (refresh_interval_ms_ < 100 || refresh_interval_ms_ > 60000) {
+  if (refresh_interval_raw < 100 || refresh_interval_raw > 60000) {
     RCLCPP_WARN(get_logger(),
-                "Invalid backstop refresh interval %dms. Must be between 100-60000ms. Using default 30000ms.",
-                refresh_interval_ms_);
+                "Invalid backstop refresh interval %" PRId64 "ms. Must be between 100-60000ms. Using default 30000ms.",
+                refresh_interval_raw);
     refresh_interval_ms_ = 30000;
+  } else {
+    refresh_interval_ms_ = static_cast<int>(refresh_interval_raw);
   }
 
   // Log configuration
@@ -593,7 +602,18 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     throw std::runtime_error("Discovery initialization failed");
   }
 
-  const auto topic_sample_timeout_sec = get_parameter("topic_sample_timeout_sec").as_double();
+  // Validated here, at the read, rather than in the two consumers. Both
+  // Ros2TopicTransport and DataAccessManager fall back to 1.0 on their own, but
+  // DataAccessManager lives in the ROS-neutral core and cannot log, so a value
+  // rejected there disappeared without a trace. Their fallbacks stay as
+  // contract guards; this is the one place that reports.
+  const auto raw_topic_sample_timeout_sec = get_parameter("topic_sample_timeout_sec").as_double();
+  auto topic_sample_timeout_sec = raw_topic_sample_timeout_sec;
+  if (topic_sample_timeout_sec < 0.1 || topic_sample_timeout_sec > 30.0) {
+    RCLCPP_WARN(get_logger(), "topic_sample_timeout_sec %.2f is outside 0.1-30.0. Using default 1.0.",
+                raw_topic_sample_timeout_sec);
+    topic_sample_timeout_sec = 1.0;
+  }
   topic_transport_ = std::make_shared<ros2::Ros2TopicTransport>(this, topic_sample_timeout_sec);
   data_access_mgr_ = std::make_unique<DataAccessManager>(topic_transport_, topic_sample_timeout_sec);
   // Shared callback groups for blocking-RPC response dispatch and action
@@ -637,7 +657,23 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
 
   // Initialize bulk data store
   auto bd_storage_dir = get_parameter("bulk_data.storage_dir").as_string();
-  auto bd_max_upload = static_cast<size_t>(get_parameter("bulk_data.max_upload_size").as_int());
+  // A negative value would wrap to a huge size_t and be handed to
+  // set_payload_max_length as an effectively unlimited cap. 0 already means
+  // unlimited by documented design, so a negative cannot be folded into it
+  // without turning a typo into that same silent "no limit". Reject it and say
+  // which value was refused.
+  const int64_t bd_max_upload_raw = get_parameter("bulk_data.max_upload_size").as_int();
+  size_t bd_max_upload = 0;
+  if (bd_max_upload_raw < 0) {
+    RCLCPP_WARN(get_logger(),
+                "bulk_data.max_upload_size %" PRId64
+                " is negative. Must be >= 0 (0 = unlimited). "
+                "Using default 104857600.",
+                bd_max_upload_raw);
+    bd_max_upload = 104857600;
+  } else {
+    bd_max_upload = static_cast<size_t>(bd_max_upload_raw);
+  }
   auto bd_categories = get_parameter("bulk_data.categories").as_string_array();
   bd_categories.erase(std::remove_if(bd_categories.begin(), bd_categories.end(),
                                      [](const auto & item) {
@@ -650,7 +686,18 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
               bd_max_upload, bd_categories.size());
 
   // Initialize subscription manager for cyclic subscriptions
-  auto max_subscriptions = static_cast<size_t>(get_parameter("sse.max_subscriptions").as_int());
+  // Same wrap hazard as bulk_data.max_upload_size: a negative here becomes a
+  // huge size_t, and the documented "HTTP 503 when this limit is reached" then
+  // never fires. There is no documented ceiling for this knob, so only the
+  // nonsensical low end is refused.
+  const int64_t max_subscriptions_raw = get_parameter("sse.max_subscriptions").as_int();
+  size_t max_subscriptions = 100;
+  if (max_subscriptions_raw < 1) {
+    RCLCPP_WARN(get_logger(), "sse.max_subscriptions %" PRId64 " must be >= 1. Using default 100.",
+                max_subscriptions_raw);
+  } else {
+    max_subscriptions = static_cast<size_t>(max_subscriptions_raw);
+  }
   subscription_mgr_ = std::make_unique<SubscriptionManager>(max_subscriptions);
   RCLCPP_INFO(get_logger(), "Subscription manager: max_subscriptions=%zu", max_subscriptions);
 
@@ -1078,7 +1125,15 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
                    agg_config.peer_scheme.c_str());
       agg_config.peer_scheme = "http";
     }
-    agg_config.max_discovered_peers = static_cast<size_t>(get_parameter("aggregation.max_discovered_peers").as_int());
+    // Documented range 1-1000. Unchecked, a negative wraps to a huge size_t and
+    // the cap that exists to stop rogue mDNS announcements stops existing.
+    const int64_t max_peers_raw = get_parameter("aggregation.max_discovered_peers").as_int();
+    const int64_t max_peers_used = std::clamp<int64_t>(max_peers_raw, 1, 1000);
+    if (max_peers_used != max_peers_raw) {
+      RCLCPP_WARN(get_logger(), "aggregation.max_discovered_peers %" PRId64 " clamped to %" PRId64, max_peers_raw,
+                  max_peers_used);
+    }
+    agg_config.max_discovered_peers = static_cast<size_t>(max_peers_used);
 
     // Parse static peers from parallel arrays
     auto peer_urls = get_parameter("aggregation.peer_urls").as_string_array();

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <chrono>
 #include <cinttypes>
+#include <cmath>
 #include <cstdlib>
 #include <limits>
 #include <mutex>
@@ -610,7 +611,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   // contract guards; this is the one place that reports.
   const auto raw_topic_sample_timeout_sec = get_parameter("topic_sample_timeout_sec").as_double();
   auto topic_sample_timeout_sec = raw_topic_sample_timeout_sec;
-  if (topic_sample_timeout_sec < 0.1 || topic_sample_timeout_sec > 30.0) {
+  // isfinite first, and the range as a positive test. Do NOT rewrite this as
+  // "below 0.1 or above 30.0": every comparison against NaN is false, so that
+  // form hands NaN to both consumers as a sampling timeout.
+  const bool timeout_in_range =
+      std::isfinite(topic_sample_timeout_sec) && topic_sample_timeout_sec >= 0.1 && topic_sample_timeout_sec <= 30.0;
+  if (!timeout_in_range) {
     RCLCPP_WARN(get_logger(), "topic_sample_timeout_sec %.2f is outside 0.1-30.0. Using default 1.0.",
                 raw_topic_sample_timeout_sec);
     topic_sample_timeout_sec = 1.0;

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -107,14 +107,14 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   const auto requested_keep_alive = node_->get_parameter("server.keep_alive_timeout_sec").as_int();
   const auto keep_alive_timeout_sec = clamp_keep_alive_timeout(requested_keep_alive, 1, 3600);
   if (static_cast<int64_t>(keep_alive_timeout_sec) != requested_keep_alive) {
-    RCLCPP_WARN(rclcpp::get_logger("rest_server"), "server.keep_alive_timeout_sec %" PRId64 " clamped to %ld",
-                requested_keep_alive, static_cast<long>(keep_alive_timeout_sec));
+    RCLCPP_WARN(rclcpp::get_logger("rest_server"), "server.keep_alive_timeout_sec %" PRId64 " clamped to %" PRId64,
+                requested_keep_alive, static_cast<int64_t>(keep_alive_timeout_sec));
   }
   http_server_ = std::make_unique<HttpServerManager>(tls_config_, http_thread_pool_size, keep_alive_timeout_sec);
   RCLCPP_INFO(rclcpp::get_logger("rest_server"),
               "HTTP request thread pool bounded to %zu workers (each active SSE stream holds one), "
-              "keep-alive timeout %lds",
-              http_thread_pool_size, static_cast<long>(keep_alive_timeout_sec));
+              "keep-alive timeout %" PRId64 "s",
+              http_thread_pool_size, static_cast<int64_t>(keep_alive_timeout_sec));
 
   // Set maximum payload size for uploads (cpp-httplib default is 8MB)
   auto * srv = http_server_->get_server();
@@ -174,8 +174,8 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   const int64_t max_duration_raw = node_->get_parameter("sse.max_duration_sec").as_int();
   int max_duration_sec = 3600;
   if (max_duration_raw < 1 || max_duration_raw > std::numeric_limits<int>::max()) {
-    RCLCPP_WARN(node_->get_logger(), "sse.max_duration_sec %" PRId64 " must be > 0. Using default 3600.",
-                max_duration_raw);
+    RCLCPP_WARN(rclcpp::get_logger("rest_server"),
+                "sse.max_duration_sec %" PRId64 " must be in [1, 2147483647]. Using default 3600.", max_duration_raw);
   } else {
     max_duration_sec = static_cast<int>(max_duration_raw);
   }

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -14,6 +14,7 @@
 
 #include "ros2_medkit_gateway/core/http/rest_server.hpp"
 
+#include <cinttypes>
 #include <exception>
 #include <rclcpp/rclcpp.hpp>
 #include <stdexcept>
@@ -94,10 +95,20 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   // timeout in [1, 3600]s: with a small pool, the cpp-httplib default (5s) lets
   // a burst of short-lived client connections pin every worker, so we shorten it
   // (default 2s) to recover workers quickly while retaining reuse.
-  const auto http_thread_pool_size =
-      clamp_thread_count(node_->get_parameter("server.http_thread_pool_size").as_int(), 1, 1024);
-  const auto keep_alive_timeout_sec =
-      clamp_keep_alive_timeout(node_->get_parameter("server.keep_alive_timeout_sec").as_int(), 1, 3600);
+  // Both clamps report when they fire: the pool that ends up serving requests
+  // must be traceable to the config file that asked for it.
+  const auto requested_pool_size = node_->get_parameter("server.http_thread_pool_size").as_int();
+  const auto http_thread_pool_size = clamp_thread_count(requested_pool_size, 1, 1024);
+  if (static_cast<int64_t>(http_thread_pool_size) != requested_pool_size) {
+    RCLCPP_WARN(rclcpp::get_logger("rest_server"), "server.http_thread_pool_size %" PRId64 " clamped to %zu",
+                requested_pool_size, http_thread_pool_size);
+  }
+  const auto requested_keep_alive = node_->get_parameter("server.keep_alive_timeout_sec").as_int();
+  const auto keep_alive_timeout_sec = clamp_keep_alive_timeout(requested_keep_alive, 1, 3600);
+  if (static_cast<int64_t>(keep_alive_timeout_sec) != requested_keep_alive) {
+    RCLCPP_WARN(rclcpp::get_logger("rest_server"), "server.keep_alive_timeout_sec %" PRId64 " clamped to %ld",
+                requested_keep_alive, static_cast<long>(keep_alive_timeout_sec));
+  }
   http_server_ = std::make_unique<HttpServerManager>(tls_config_, http_thread_pool_size, keep_alive_timeout_sec);
   RCLCPP_INFO(rclcpp::get_logger("rest_server"),
               "HTTP request thread pool bounded to %zu workers (each active SSE stream holds one), "

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -16,6 +16,7 @@
 
 #include <cinttypes>
 #include <exception>
+#include <limits>
 #include <rclcpp/rclcpp.hpp>
 #include <stdexcept>
 #include <type_traits>
@@ -166,10 +167,17 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   sse_client_tracker_ = node_->get_sse_client_tracker();
   sse_fault_handler_ = std::make_unique<handlers::SSEFaultHandler>(*handler_ctx_, sse_client_tracker_);
   bulkdata_handlers_ = std::make_unique<handlers::BulkDataHandlers>(*handler_ctx_);
-  auto max_duration_sec = static_cast<int>(node_->get_parameter("sse.max_duration_sec").as_int());
-  if (max_duration_sec <= 0) {
-    RCLCPP_WARN(node_->get_logger(), "sse.max_duration_sec must be > 0, using default 3600");
-    max_duration_sec = 3600;
+  // Validated as int64 before narrowing: narrowing first wraps a value above
+  // INT_MAX into a small positive one that passes the check, so 4294967300
+  // would silently cap every subscription at 4 seconds. The warning names the
+  // requested value, otherwise the operator cannot tell which value was refused.
+  const int64_t max_duration_raw = node_->get_parameter("sse.max_duration_sec").as_int();
+  int max_duration_sec = 3600;
+  if (max_duration_raw < 1 || max_duration_raw > std::numeric_limits<int>::max()) {
+    RCLCPP_WARN(node_->get_logger(), "sse.max_duration_sec %" PRId64 " must be > 0. Using default 3600.",
+                max_duration_raw);
+  } else {
+    max_duration_sec = static_cast<int>(max_duration_raw);
   }
   cyclic_sub_handlers_ = std::make_unique<handlers::CyclicSubscriptionHandlers>(
       *handler_ctx_, *node_->get_subscription_manager(), *node_->get_sampler_registry(),

--- a/src/ros2_medkit_gateway/src/main.cpp
+++ b/src/ros2_medkit_gateway/src/main.cpp
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -33,31 +34,93 @@ namespace {
 // because a runaway value here (e.g. queue_depth=1e9) can starve the gateway
 // process for memory. Defaults mirror the Config{} constructors so the stock
 // deployment behaviour is unchanged.
+//
+// Every clamp that fires is logged. A silent coercion leaves the config file
+// and the running process disagreeing with nothing in between to show it, and
+// the symptom of a wrong value (a slow or jittery gateway) shows up far from
+// the cause. The message shape matches the sibling clamps in gateway_node.cpp
+// so every coerced parameter reads the same way in a log.
 ros2_medkit_gateway::ros2_common::Ros2SubscriptionExecutor::Config declare_executor_config(rclcpp::Node & node) {
   ros2_medkit_gateway::ros2_common::Ros2SubscriptionExecutor::Config cfg;
+
   const auto queue_depth = node.declare_parameter<int64_t>("subscription_executor.max_queue_depth", 256);
-  cfg.max_queue_depth = static_cast<std::size_t>(std::clamp<int64_t>(queue_depth, 16, 4096));
+  const auto queue_depth_used = std::clamp<int64_t>(queue_depth, 16, 4096);
+  if (queue_depth_used != queue_depth) {
+    RCLCPP_WARN(node.get_logger(), "subscription_executor.max_queue_depth %" PRId64 " clamped to %" PRId64, queue_depth,
+                queue_depth_used);
+  }
+  cfg.max_queue_depth = static_cast<std::size_t>(queue_depth_used);
+
   const auto watchdog_ms = node.declare_parameter<int64_t>("subscription_executor.watchdog_threshold_ms", 5000);
-  cfg.watchdog_threshold = std::chrono::milliseconds{std::clamp<int64_t>(watchdog_ms, 100, 60000)};
+  const auto watchdog_ms_used = std::clamp<int64_t>(watchdog_ms, 100, 60000);
+  if (watchdog_ms_used != watchdog_ms) {
+    RCLCPP_WARN(node.get_logger(), "subscription_executor.watchdog_threshold_ms %" PRId64 " clamped to %" PRId64,
+                watchdog_ms, watchdog_ms_used);
+  }
+  cfg.watchdog_threshold = std::chrono::milliseconds{watchdog_ms_used};
+
   const auto watchdog_tick = node.declare_parameter<int64_t>("subscription_executor.watchdog_tick_ms", 1000);
-  cfg.watchdog_tick = std::chrono::milliseconds{std::clamp<int64_t>(watchdog_tick, 10, 10000)};
+  const auto watchdog_tick_used = std::clamp<int64_t>(watchdog_tick, 10, 10000);
+  if (watchdog_tick_used != watchdog_tick) {
+    RCLCPP_WARN(node.get_logger(), "subscription_executor.watchdog_tick_ms %" PRId64 " clamped to %" PRId64,
+                watchdog_tick, watchdog_tick_used);
+  }
+  cfg.watchdog_tick = std::chrono::milliseconds{watchdog_tick_used};
+
   const auto graph_tick = node.declare_parameter<int64_t>("subscription_executor.graph_poll_tick_ms", 100);
-  cfg.graph_poll_tick = std::chrono::milliseconds{std::clamp<int64_t>(graph_tick, 10, 10000)};
+  const auto graph_tick_used = std::clamp<int64_t>(graph_tick, 10, 10000);
+  if (graph_tick_used != graph_tick) {
+    RCLCPP_WARN(node.get_logger(), "subscription_executor.graph_poll_tick_ms %" PRId64 " clamped to %" PRId64,
+                graph_tick, graph_tick_used);
+  }
+  cfg.graph_poll_tick = std::chrono::milliseconds{graph_tick_used};
+
   return cfg;
 }
 
 ros2_medkit_gateway::Ros2TopicDataProvider::Config declare_data_provider_config(rclcpp::Node & node) {
   ros2_medkit_gateway::Ros2TopicDataProvider::Config cfg;
+
   const auto pool_size = node.declare_parameter<int64_t>("data_provider.max_pool_size", 256);
-  cfg.max_pool_size = static_cast<std::size_t>(std::clamp<int64_t>(pool_size, 1, 4096));
+  const auto pool_size_used = std::clamp<int64_t>(pool_size, 1, 4096);
+  if (pool_size_used != pool_size) {
+    RCLCPP_WARN(node.get_logger(), "data_provider.max_pool_size %" PRId64 " clamped to %" PRId64, pool_size,
+                pool_size_used);
+  }
+  cfg.max_pool_size = static_cast<std::size_t>(pool_size_used);
+
   const auto cold_cap = node.declare_parameter<int64_t>("data_provider.cold_wait_cap", 4);
-  cfg.cold_wait_cap = static_cast<std::size_t>(std::clamp<int64_t>(cold_cap, 0, 1024));
+  const auto cold_cap_used = std::clamp<int64_t>(cold_cap, 0, 1024);
+  if (cold_cap_used != cold_cap) {
+    RCLCPP_WARN(node.get_logger(), "data_provider.cold_wait_cap %" PRId64 " clamped to %" PRId64, cold_cap,
+                cold_cap_used);
+  }
+  cfg.cold_wait_cap = static_cast<std::size_t>(cold_cap_used);
+
   const auto max_parallel = node.declare_parameter<int64_t>("data_provider.max_parallel_samples", 8);
-  cfg.max_parallel_samples = static_cast<std::size_t>(std::clamp<int64_t>(max_parallel, 1, 256));
+  const auto max_parallel_used = std::clamp<int64_t>(max_parallel, 1, 256);
+  if (max_parallel_used != max_parallel) {
+    RCLCPP_WARN(node.get_logger(), "data_provider.max_parallel_samples %" PRId64 " clamped to %" PRId64, max_parallel,
+                max_parallel_used);
+  }
+  cfg.max_parallel_samples = static_cast<std::size_t>(max_parallel_used);
+
   const auto idle_safety_s = node.declare_parameter<int64_t>("data_provider.idle_safety_net_sec", 15 * 60);
-  cfg.idle_safety_net = std::chrono::seconds{std::clamp<int64_t>(idle_safety_s, 0, 24 * 3600)};
+  const auto idle_safety_s_used = std::clamp<int64_t>(idle_safety_s, 0, 24 * 3600);
+  if (idle_safety_s_used != idle_safety_s) {
+    RCLCPP_WARN(node.get_logger(), "data_provider.idle_safety_net_sec %" PRId64 " clamped to %" PRId64, idle_safety_s,
+                idle_safety_s_used);
+  }
+  cfg.idle_safety_net = std::chrono::seconds{idle_safety_s_used};
+
   const auto idle_sweep_s = node.declare_parameter<int64_t>("data_provider.idle_sweep_tick_sec", 60);
-  cfg.idle_sweep_tick = std::chrono::seconds{std::clamp<int64_t>(idle_sweep_s, 0, 3600)};
+  const auto idle_sweep_s_used = std::clamp<int64_t>(idle_sweep_s, 0, 3600);
+  if (idle_sweep_s_used != idle_sweep_s) {
+    RCLCPP_WARN(node.get_logger(), "data_provider.idle_sweep_tick_sec %" PRId64 " clamped to %" PRId64, idle_sweep_s,
+                idle_sweep_s_used);
+  }
+  cfg.idle_sweep_tick = std::chrono::seconds{idle_sweep_s_used};
+
   return cfg;
 }
 
@@ -93,8 +156,12 @@ int main(int argc, char ** argv) {
     // uses its own private executor. The Ros2SubscriptionExecutor built below
     // owns its own internal single-threaded executor (spun from its worker
     // thread); the subscription node is intentionally not added here.
-    const auto executor_threads =
-        ros2_medkit_gateway::clamp_thread_count(node->get_parameter("server.executor_threads").as_int(), 1, 256);
+    const auto requested_executor_threads = node->get_parameter("server.executor_threads").as_int();
+    const auto executor_threads = ros2_medkit_gateway::clamp_thread_count(requested_executor_threads, 1, 256);
+    if (static_cast<int64_t>(executor_threads) != requested_executor_threads) {
+      RCLCPP_WARN(node->get_logger(), "server.executor_threads %" PRId64 " clamped to %zu", requested_executor_threads,
+                  executor_threads);
+    }
     rclcpp::executors::MultiThreadedExecutor executor(rclcpp::ExecutorOptions(), executor_threads);
     executor.add_node(node);
     RCLCPP_INFO(node->get_logger(), "Main executor bounded to %zu threads", executor_threads);
@@ -117,6 +184,12 @@ int main(int argc, char ** argv) {
     // run a smaller pool. Values are clamped the same way their consumers clamp
     // them, so the comparison reflects effective sizes. cold_wait_cap is read
     // from dp_cfg (already clamped above).
+    //
+    // Both re-reads below use the silent clamp on purpose. Each of these two
+    // parameters is already reported by the site that owns it -
+    // http_thread_pool_size by RESTServer, sse.max_clients by GatewayNode - and
+    // logging the same coercion a second time here would train operators to
+    // skim past the warning that matters.
     {
       const auto http_pool = ros2_medkit_gateway::clamp_thread_count(
           node->get_parameter("server.http_thread_pool_size").as_int(), 1, 1024);

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <builtin_interfaces/msg/time.hpp>
 #include <chrono>
+#include <cmath>
 #include <string>
 
 #include "ros2_medkit_gateway/fault_manager_paths.hpp"
@@ -77,6 +78,20 @@ Ros2FaultServiceTransport::Ros2FaultServiceTransport(rclcpp::Node * node) : node
   // Pick up configurable timeout. GatewayNode declares this parameter up front,
   // but unit tests may construct the transport with a plain rclcpp::Node.
   if (!node_->get_parameter("fault_manager.service_timeout_sec", service_timeout_sec_)) {
+    service_timeout_sec_ = 5.0;
+  }
+  // isfinite first, and the range as a positive test. Do NOT rewrite this as
+  // "not positive or too large": every comparison against NaN is false, so that
+  // form lets NaN reach wait_for_service, where the duration_cast to
+  // nanoseconds is undefined and the result is treated as "wait forever" - one
+  // fault RPC then pins an HTTP worker for the life of the process. A
+  // non-positive value is the quiet version of the same problem: every fault
+  // RPC returns "service not available" with nothing in the log.
+  const bool timeout_usable = std::isfinite(service_timeout_sec_) && service_timeout_sec_ > 0.0;
+  if (!timeout_usable) {
+    RCLCPP_WARN(node_->get_logger(),
+                "fault_manager.service_timeout_sec %.2f must be finite and > 0. Using default 5.0.",
+                service_timeout_sec_);
     service_timeout_sec_ = 5.0;
   }
   fault_manager_base_path_ = build_fault_manager_base_path(node_);

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -187,11 +187,16 @@ if(BUILD_TESTING)
   # DOMAINS below is one for the test itself plus one per extra gateway; the
   # extras arrive as MEDKIT_SECONDARY_DOMAINS. The highest offset any of them
   # asks for is 3, so four domains covers all of them.
+  # test_startup_param_clamp_warnings is not an aggregation test, but it does
+  # launch four gateways. They have no reason to see each other, and sharing one
+  # domain makes each of them discover the other three's nodes and leaves four
+  # sets of participants dying on that domain at teardown.
   set(_MULTI_GATEWAY_TESTS
     test_peer_aggregation
     test_cross_ecu_fanout
     test_daisy_chain_aggregation
-    test_leaf_collision_aggregation)
+    test_leaf_collision_aggregation
+    test_startup_param_clamp_warnings)
   set(_MULTI_GATEWAY_DOMAINS 4)
 
   # Feature tests (atomic, independent, 120s timeout)

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/constants.py
@@ -154,12 +154,24 @@ def get_test_domain_id(offset=0):
     return secondary[offset - 1]
 
 
+# Every budget below is multiplied by get_time_scale(), which is 1.0 unless a
+# sanitizer job asks for slack. These are exactly the "budgets asserted inside a
+# test" that function was written for: ctest's own TIMEOUT is rewritten x3 by
+# those jobs, and a wall-clock assertion inside the test never saw that factor.
+# PARAM_SERVICE_TIMEOUT below carries the evidence - it was raised by hand to 90
+# because a parameter service was still answering 503 more than 15s into a TSan
+# run.
+#
+# The polling INTERVALS are deliberately NOT scaled. They are not budgets: a
+# slower poll under a sanitizer would only find out later that the thing it
+# waits for is ready.
+
 # Gateway startup
-GATEWAY_STARTUP_TIMEOUT = 30.0
+GATEWAY_STARTUP_TIMEOUT = 30.0 * get_time_scale()
 GATEWAY_STARTUP_INTERVAL = 0.5
 
 # Discovery
-DISCOVERY_TIMEOUT = 60.0
+DISCOVERY_TIMEOUT = 60.0 * get_time_scale()
 DISCOVERY_INTERVAL = 0.5  # seconds between discovery polls
 
 # Parameter service readiness
@@ -170,15 +182,15 @@ DISCOVERY_INTERVAL = 0.5  # seconds between discovery polls
 # larger timeout costs nothing on the passing path (the poll returns the moment
 # the endpoint answers 200) and only bounds how long a genuinely dead service
 # waits before failing, well inside the sanitizer jobs' 360s ctest budget.
-PARAM_SERVICE_TIMEOUT = 90.0
+PARAM_SERVICE_TIMEOUT = 90.0 * get_time_scale()
 
 # Operations
-ACTION_TIMEOUT = 30.0
+ACTION_TIMEOUT = 30.0 * get_time_scale()
 
 # Faults
-FAULT_TIMEOUT = 30.0
-ROSBAG_TIMEOUT = 30.0
-SNAPSHOT_TIMEOUT = 30.0
+FAULT_TIMEOUT = 30.0 * get_time_scale()
+ROSBAG_TIMEOUT = 30.0 * get_time_scale()
+SNAPSHOT_TIMEOUT = 30.0 * get_time_scale()
 
 # Shutdown
 ALLOWED_EXIT_CODES = {0, -2, -15}  # OK, SIGINT, SIGTERM

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -174,12 +174,14 @@ REJECTED_PARAMS = [
      'topic_sample_timeout_sec nan is outside 0.1-30.0'),
     ('fault_manager.service_timeout_sec', float('nan'),
      'fault_manager.service_timeout_sec nan must be finite and > 0'),
-    # This one carries a FloatingPointRange descriptor, so rclcpp refuses an
-    # ordinary out-of-range value before the gateway ever sees it. NaN is the
-    # exception: the descriptor compares with < and >, both false for NaN, so it
-    # is accepted as in-range and the gateway has to catch it at the read.
-    ('parameter_service_timeout_sec', float('nan'),
-     'parameter_service_timeout_sec is not a finite number'),
+    # parameter_service_timeout_sec deliberately has NO row here. It carries a
+    # FloatingPointRange descriptor, and what rclcpp does with NaN against that
+    # descriptor differs by distro: Jazzy accepts it as in-range (verified on a
+    # running gateway, which logged "timeout=nans") while Lyrical refuses it and
+    # the process exits 1 before reaching our check. Asserting either outcome
+    # pins rclcpp's behaviour rather than ours. The gateway's own isfinite check
+    # stays, because it is the only thing standing between NaN and a duration
+    # cast on the distros that let it through.
 ]
 
 # Ordinary out-of-range values for the same two floats. They cannot ride on the

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -156,15 +156,41 @@ REJECTED_PARAMS = [
     ('refresh_interval_ms', 4294967396,
      'Invalid backstop refresh interval 4294967396ms'),
     ('sse.max_duration_sec', 4294967300,
-     'sse.max_duration_sec 4294967300 must be > 0'),
+     'sse.max_duration_sec 4294967300 must be in [1, 2147483647]'),
     ('discovery.refresh_debounce_ms', 70000,
      'Invalid discovery.refresh_debounce_ms 70000ms'),
-    ('topic_sample_timeout_sec', 60.0,
-     'topic_sample_timeout_sec 60.00 is outside 0.1-30.0'),
     ('bulk_data.max_upload_size', -1,
      'bulk_data.max_upload_size -1 is negative'),
     ('sse.max_subscriptions', -1,
      'sse.max_subscriptions -1 must be >= 1'),
+    ('triggers.max_triggers', -1,
+     'triggers.max_triggers -1 out of range. Using default 1000.'),
+    # Two float checks that a "below or above the range" test would not catch,
+    # because every comparison against NaN is false. NaN does survive the launch
+    # path: launch_ros hands the parameter through as a double, verified against
+    # a running gateway. Both sites are written as isfinite plus a positive
+    # range test for this reason.
+    ('topic_sample_timeout_sec', float('nan'),
+     'topic_sample_timeout_sec nan is outside 0.1-30.0'),
+    ('fault_manager.service_timeout_sec', float('nan'),
+     'fault_manager.service_timeout_sec nan must be finite and > 0'),
+    # This one carries a FloatingPointRange descriptor, so rclcpp refuses an
+    # ordinary out-of-range value before the gateway ever sees it. NaN is the
+    # exception: the descriptor compares with < and >, both false for NaN, so it
+    # is accepted as in-range and the gateway has to catch it at the read.
+    ('parameter_service_timeout_sec', float('nan'),
+     'parameter_service_timeout_sec is not a finite number'),
+]
+
+# Ordinary out-of-range values for the same two floats. They cannot ride on the
+# gateway above - one parameter takes one value - and they are worth keeping
+# separate anyway: NaN pins the isfinite guard, these pin the range itself, and
+# a mutation that dropped either would leave the other green.
+FLOOR_EXTRA_REJECTED = [
+    ('topic_sample_timeout_sec', 60.0,
+     'topic_sample_timeout_sec 60.00 is outside 0.1-30.0'),
+    ('fault_manager.service_timeout_sec', -1.0,
+     'fault_manager.service_timeout_sec -1.00 must be finite and > 0'),
 ]
 
 # The three whose above-ceiling case is skipped (see the module docstring).
@@ -223,7 +249,11 @@ def generate_test_description():
     # Floor gateway on the default port: GatewayTestCase polls /health here, so
     # this gateway also proves the clamped-to-floor values still serve requests.
     gateway_node = create_gateway_node(
-        extra_params={**FLOOR_PARAMS, **reachable},
+        extra_params={
+            **FLOOR_PARAMS,
+            **{name: value for name, value, _fragment in FLOOR_EXTRA_REJECTED},
+            **reachable,
+        },
     )
 
     gw_ceiling = create_gateway_node(
@@ -285,6 +315,11 @@ class TestStartupParamClampWarnings(GatewayTestCase):
         for parameter, floor, _ceiling, below, _above in CLAMPED_PARAMS:
             with self.subTest(parameter=parameter, direction='floor'):
                 self.assertIn(expected_warning(parameter, below, floor), reported)
+
+        text = _output_text(proc_output, gateway_node)
+        for parameter, _value, fragment in FLOOR_EXTRA_REJECTED:
+            with self.subTest(parameter=parameter, direction='out-of-range'):
+                self.assertIn(fragment, text)
 
     def test_above_ceiling_values_are_reported(self, proc_output, gw_ceiling):
         """Every parameter set above its ceiling names both values in the log.

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every clamped startup parameter reports the clamp.
+
+A mis-set startup parameter is coerced into its documented range so the gateway
+cannot be broken by a typo. Until this test existed the coercion was silent for
+most of those parameters: the config file said one thing, the process ran
+another, and nothing in between said so. The symptom of a wrong value (a slow
+or jittery gateway) shows up far from the cause (one line in a YAML file), so
+the warning is the only thing that connects them.
+
+Two gateways launch with deliberately mis-set values and the test reads their
+own process output:
+
+- ``gateway_node`` (the default port) sets every clamped parameter BELOW its
+  documented floor. It also has to serve ``/health``: the clamp exists so a
+  typo cannot break request serving, and ``GatewayTestCase.setUpClass`` polls
+  ``/health`` before any test runs, so a floor value that killed the gateway
+  would fail the file rather than pass quietly.
+- ``gw_ceiling`` sets them ABOVE their documented ceiling.
+
+COVERAGE LIMIT, stated so nobody reads more into a green run than it has:
+``PARAMS_FLOOR_ONLY`` lists three parameters whose above-ceiling case is NOT
+exercised - ``server.executor_threads`` (256), ``server.http_thread_pool_size``
+(1024) and ``entity_cache.capacity`` (1,000,000). Clamping means the gateway
+then RUNS at the ceiling, and that is not free. Measured, not estimated: one
+gateway launched past all three ceilings serves ``/health`` correctly and warns
+for each parameter, at **1299 threads and 1486 MB RSS**. Paying that (times a
+runner already hosting the two gateways below, and again under a sanitizer) buys
+one log line per parameter from the same four-line compare-and-warn the floor
+case already drives, and that the other 11 parameters already drive in the
+ceiling direction. Their below-floor case IS exercised, on the floor gateway.
+"""
+
+import unittest
+
+from launch import LaunchDescription
+import launch_testing
+import launch_testing.actions
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
+
+# Every startup parameter that is clamped on read, with its documented range and
+# the out-of-range value each gateway launches with.
+#
+#   (parameter, floor, ceiling, below_floor_value, above_ceiling_value)
+#
+# Ranges are the ones in docs/config: keep this table and the docs in step, a
+# range that moves in code without moving here is exactly the regression this
+# file is meant to catch. ``above_ceiling_value`` is None for the parameters in
+# the coverage limit described in the module docstring.
+CLAMPED_PARAMS = [
+    # server.* - main.cpp and http/rest_server.cpp
+    ('server.executor_threads', 1, 256, 0, None),
+    ('server.http_thread_pool_size', 1, 1024, 0, None),
+    ('server.keep_alive_timeout_sec', 1, 3600, 0, 7200),
+    # sse.* / node-level knobs - gateway_node.cpp
+    ('sse.max_clients', 1, 1024, 0, 4096),
+    ('service_call_timeout_sec', 1, 3600, 0, 7200),
+    ('logs.buffer_size', 1, 100000, 0, 200000),
+    ('entity_cache.capacity', 16, 1000000, 8, None),
+    # subscription_executor.* - main.cpp declare_executor_config
+    ('subscription_executor.max_queue_depth', 16, 4096, 8, 8192),
+    ('subscription_executor.watchdog_threshold_ms', 100, 60000, 50, 120000),
+    ('subscription_executor.watchdog_tick_ms', 10, 10000, 5, 20000),
+    ('subscription_executor.graph_poll_tick_ms', 10, 10000, 5, 20000),
+    # data_provider.* - main.cpp declare_data_provider_config
+    ('data_provider.max_pool_size', 1, 4096, 0, 8192),
+    ('data_provider.cold_wait_cap', 0, 1024, -1, 2048),
+    ('data_provider.max_parallel_samples', 1, 256, 0, 512),
+    ('data_provider.idle_safety_net_sec', 0, 86400, -1, 172800),
+    ('data_provider.idle_sweep_tick_sec', 0, 3600, -1, 7200),
+]
+
+# The three whose above-ceiling case is skipped (see the module docstring).
+PARAMS_FLOOR_ONLY = {
+    name for name, _floor, _ceiling, _below, above in CLAMPED_PARAMS if above is None
+}
+
+FLOOR_PARAMS = {name: below for name, _f, _c, below, _a in CLAMPED_PARAMS}
+CEILING_PARAMS = {
+    name: above for name, _f, _c, _below, above in CLAMPED_PARAMS if above is not None
+}
+
+
+# The gateway logs one line per clamped parameter, in the shape the three
+# pre-existing sites already used: "<parameter> <requested> clamped to <effective>".
+def expected_warning(parameter, requested, effective):
+    """Build the log line the gateway must emit for one clamped parameter."""
+    return f'{parameter} {requested} clamped to {effective}'
+
+
+# Warnings are emitted during construction, so they are already in the buffer by
+# the time /health answers. The timeout only covers a slow runner's startup.
+WARNING_TIMEOUT = 20
+
+# Logged by GatewayNode::set_topic_data_provider, which main.cpp calls after the
+# last clamped parameter has been read (node constructor -> RESTServer -> the
+# executor and data-provider configs). The two tests that SCAN the output buffer
+# rather than wait for one line need this: without it they would read a buffer
+# that is still filling and pass on an empty one.
+STARTUP_COMPLETE = 'TopicDataProvider attached'
+
+
+def generate_test_description():
+    # Floor gateway on the default port: GatewayTestCase polls /health here, so
+    # this gateway also proves the clamped-to-floor values still serve requests.
+    gateway_node = create_gateway_node(extra_params=dict(FLOOR_PARAMS))
+
+    gw_ceiling = create_gateway_node(
+        port=get_test_port(1),
+        name='gateway_clamp_ceiling',
+        extra_params=dict(CEILING_PARAMS),
+    )
+
+    return (
+        LaunchDescription([
+            gateway_node,
+            gw_ceiling,
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'gateway_node': gateway_node,
+            'gw_ceiling': gw_ceiling,
+        },
+    )
+
+
+class TestStartupParamClampWarnings(GatewayTestCase):
+    """A clamped startup parameter is never absorbed without a trace."""
+
+    MIN_EXPECTED_APPS = 0  # no demo nodes; the gateways only need to start
+
+    def test_below_floor_values_are_reported(self, proc_output, gateway_node):
+        """Every parameter set below its floor names both values in the log.
+
+        The requested value has to appear too. A line that reported only the
+        effective value would still leave the operator unable to see that the
+        config file and the process disagree, which is the whole defect.
+        """
+        reported = _clamp_lines(proc_output, gateway_node)
+        for parameter, floor, _ceiling, below, _above in CLAMPED_PARAMS:
+            with self.subTest(parameter=parameter, direction='floor'):
+                self.assertIn(expected_warning(parameter, below, floor), reported)
+
+    def test_above_ceiling_values_are_reported(self, proc_output, gw_ceiling):
+        """Every parameter set above its ceiling names both values in the log.
+
+        The floor gateway alone would pass against a clamp that only guarded
+        the lower bound, so the upper endpoint gets its own gateway.
+        """
+        reported = _clamp_lines(proc_output, gw_ceiling)
+        for parameter, _floor, ceiling, _below, above in CLAMPED_PARAMS:
+            if above is None:
+                continue
+            with self.subTest(parameter=parameter, direction='ceiling'):
+                self.assertIn(expected_warning(parameter, above, ceiling), reported)
+
+    def test_in_range_values_stay_quiet(self, proc_output, gw_ceiling):
+        """An in-range parameter is not reported as clamped.
+
+        A "warn on every read" regression would satisfy both tests above while
+        burying the real misconfigurations in noise. The ceiling gateway leaves
+        the floor-only parameters at their defaults, so their names must not
+        appear in a clamp line at all.
+        """
+        reported = _clamp_lines(proc_output, gw_ceiling)
+        for parameter in sorted(PARAMS_FLOOR_ONLY):
+            with self.subTest(parameter=parameter):
+                self.assertFalse(
+                    [line for line in reported if line.startswith(f'{parameter} ')],
+                    f'{parameter} was left at its default but still reported a clamp',
+                )
+
+    def test_repeated_reads_warn_once_per_parameter(self, proc_output, gateway_node):
+        """A parameter read twice at startup is reported once, not twice.
+
+        server.http_thread_pool_size and sse.max_clients are read a second time
+        in main.cpp to compare the pool against the SSE + cold-wait budget. That
+        re-read deliberately uses the silent clamp: two identical warnings for
+        one typo trains operators to skim past them.
+        """
+        reported = _clamp_lines(proc_output, gateway_node)
+        for parameter in ('server.http_thread_pool_size', 'sse.max_clients'):
+            with self.subTest(parameter=parameter):
+                matching = [
+                    line for line in reported if line.startswith(f'{parameter} ')
+                ]
+                self.assertEqual(
+                    len(matching), 1,
+                    f'{parameter} reported its clamp {len(matching)} times: {matching}',
+                )
+
+
+def _clamp_lines(proc_output, process):
+    """Return every 'X clamped to Y' fragment this process logged during startup.
+
+    Waits for STARTUP_COMPLETE first, so the buffer is whole before it is read.
+    Every check in this file scans rather than waits per parameter: waiting
+    would cost one timeout per missing warning, and a regression across all of
+    them would blow the test's own time budget and report "no result file"
+    instead of naming the parameter that went quiet.
+    """
+    proc_output.assertWaitFor(
+        STARTUP_COMPLETE, process=process, timeout=WARNING_TIMEOUT * get_time_scale(),
+    )
+    lines = []
+    for output in proc_output[process]:
+        for line in output.text.decode(errors='replace').splitlines():
+            marker = line.find(' clamped to ')
+            if marker == -1:
+                continue
+            # Strip the rclcpp prefix ("[WARN] [stamp] [logger]: ") so the
+            # fragment starts at the parameter name.
+            start = line.rfind(': ', 0, marker)
+            lines.append(line[start + 2:] if start != -1 else line)
+    return lines
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Both gateways exit cleanly.
+
+        A clamped value must leave a working gateway behind. An exit code here
+        would mean the coercion turned a typo into a crash.
+        """
+        for info in proc_info:
+            self.assertIn(
+                info.returncode, ALLOWED_EXIT_CODES,
+                f'{info.process_name} exited with code {info.returncode}',
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -47,9 +47,18 @@ then RUNS at the ceiling, and that is not free. Measured, not estimated: one
 gateway launched past all three ceilings serves ``/health`` correctly and warns
 for each parameter, at **1299 threads and 1486 MB RSS**. Paying that (on a
 runner already hosting the three other gateways, and again under a sanitizer)
-buys one log line per parameter from the same four-line compare-and-warn that
-the floor case already drives, that the in-range case pins the guard of, and
-that the other 15 parameters already drive in the ceiling direction.
+buys the same four-line compare-and-warn that the floor case already drives,
+that the in-range case pins the guard of, and that the other 15 parameters
+already drive in the ceiling direction.
+
+Be precise about what that costs, because it is more than a log line: for those
+three, and only those three, the CEILING CONSTANT ITSELF is unpinned. Widening
+``server.http_thread_pool_size`` from 1024 to 8, or ``server.executor_threads``
+from 256 to 4096, leaves every test in this file green while the config docs go
+on advertising the old range. The floor row still warns and the in-range value
+is still silent under either bound. The table comment below says a range that
+moves in code without moving here gets caught - that holds for the 15 rows with
+a ceiling value, not for these three.
 """
 
 import os
@@ -73,10 +82,10 @@ from ros2_medkit_test_utils.launch_helpers import create_gateway_node
 #
 #   (parameter, floor, ceiling, below_floor_value, above_ceiling_value)
 #
-# Ranges are the ones in docs/config: keep this table and the docs in step, a
-# range that moves in code without moving here is exactly the regression this
-# file is meant to catch. ``above_ceiling_value`` is None for the parameters in
-# the coverage limit described in the module docstring.
+# Ranges are the ones in docs/config: keep this table and the docs in step. A
+# range that moves in code without moving here is caught for every row that has
+# an ``above_ceiling_value``; for the three rows where it is None only the floor
+# is pinned, which the module docstring spells out.
 CLAMPED_PARAMS = [
     # server.* - main.cpp and http/rest_server.cpp
     ('server.executor_threads', 1, 256, 0, None),
@@ -180,12 +189,19 @@ def expected_warning(parameter, requested, effective):
 # the time /health answers. The timeout only covers a slow runner's startup.
 WARNING_TIMEOUT = 20
 
-# Logged by GatewayNode::set_topic_data_provider, which main.cpp calls after the
-# last clamped parameter has been read (node constructor -> RESTServer -> the
-# executor and data-provider configs). The two tests that SCAN the output buffer
-# rather than wait for one line need this: without it they would read a buffer
-# that is still filling and pass on an empty one.
-STARTUP_COMPLETE = 'TopicDataProvider attached'
+# Logged by GatewayNode::init_fault_trigger_engine, the LAST thing main.cpp does
+# before it starts spinning, and after every clamped parameter has been read
+# (node constructor -> RESTServer -> executor and data-provider configs ->
+# fault-trigger engine). Every check here scans the output buffer, so the anchor
+# has to sit after the last assertion target or a scan can read a buffer that is
+# still filling and pass on what is missing from it.
+#
+# 'TopicDataProvider attached' is NOT good enough and was the first choice:
+# main.cpp emits it at line 212 but reads fault_triggers.poll_interval_ms at
+# line 228, with a synchronous subscription creation in between. Every gateway
+# in this file loads a plugin, so the engine always starts and the line always
+# comes.
+STARTUP_COMPLETE = 'fault-trigger engine active'
 
 
 def generate_test_description():

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -22,7 +22,7 @@ another, and nothing in between said so. The symptom of a wrong value (a slow
 or jittery gateway) shows up far from the cause (one line in a YAML file), so
 the warning is the only thing that connects them.
 
-Two gateways launch with deliberately mis-set values and the test reads their
+Four gateways launch with deliberately mis-set values and the test reads their
 own process output:
 
 - ``gateway_node`` (the default port) sets every clamped parameter BELOW its
@@ -31,6 +31,13 @@ own process output:
   ``/health`` before any test runs, so a floor value that killed the gateway
   would fail the file rather than pass quietly.
 - ``gw_ceiling`` sets them ABOVE their documented ceiling.
+- ``gw_in_range`` sets every one of them to a legal value and must report
+  nothing at all. Without it, a site that lost its "did the clamp actually
+  fire" guard would warn at every boot of a correctly configured gateway, and
+  no other assertion in this file would notice.
+- ``gw_rejected`` carries the parameters that are REFUSED rather than clamped
+  (half a port number is not a port), including three values above INT_MAX
+  that used to wrap back into the legal band and be accepted in silence.
 
 COVERAGE LIMIT, stated so nobody reads more into a green run than it has:
 ``PARAMS_FLOOR_ONLY`` lists three parameters whose above-ceiling case is NOT
@@ -38,11 +45,11 @@ exercised - ``server.executor_threads`` (256), ``server.http_thread_pool_size``
 (1024) and ``entity_cache.capacity`` (1,000,000). Clamping means the gateway
 then RUNS at the ceiling, and that is not free. Measured, not estimated: one
 gateway launched past all three ceilings serves ``/health`` correctly and warns
-for each parameter, at **1299 threads and 1486 MB RSS**. Paying that (times a
-runner already hosting the two gateways below, and again under a sanitizer) buys
-one log line per parameter from the same four-line compare-and-warn the floor
-case already drives, and that the other 11 parameters already drive in the
-ceiling direction. Their below-floor case IS exercised, on the floor gateway.
+for each parameter, at **1299 threads and 1486 MB RSS**. Paying that (on a
+runner already hosting the three other gateways, and again under a sanitizer)
+buys one log line per parameter from the same four-line compare-and-warn that
+the floor case already drives, that the in-range case pins the guard of, and
+that the other 14 parameters already drive in the ceiling direction.
 """
 
 import unittest
@@ -89,6 +96,59 @@ CLAMPED_PARAMS = [
     ('data_provider.max_parallel_samples', 1, 256, 0, 512),
     ('data_provider.idle_safety_net_sec', 0, 86400, -1, 172800),
     ('data_provider.idle_sweep_tick_sec', 0, 3600, -1, 7200),
+    # aggregation.* - gateway_node.cpp, only read when aggregation is enabled
+    ('aggregation.max_discovered_peers', 1, 1000, 0, 2000),
+]
+
+# In-range values, one per clamped parameter. A gateway launched with these must
+# report NO clamp at all. Without this, no gateway in the file ever leaves most
+# of these parameters in range, and a site that dropped its `if (used !=
+# requested)` guard would warn on every boot of a correctly configured gateway
+# while every other assertion here stayed green.
+IN_RANGE_PARAMS = {
+    'server.executor_threads': 2,
+    'server.http_thread_pool_size': 6,
+    'server.keep_alive_timeout_sec': 2,
+    'sse.max_clients': 2,
+    'service_call_timeout_sec': 10,
+    'logs.buffer_size': 200,
+    'entity_cache.capacity': 256,
+    'subscription_executor.max_queue_depth': 256,
+    'subscription_executor.watchdog_threshold_ms': 5000,
+    'subscription_executor.watchdog_tick_ms': 1000,
+    'subscription_executor.graph_poll_tick_ms': 100,
+    'data_provider.max_pool_size': 256,
+    'data_provider.cold_wait_cap': 4,
+    'data_provider.max_parallel_samples': 8,
+    'data_provider.idle_safety_net_sec': 900,
+    'data_provider.idle_sweep_tick_sec': 60,
+    'aggregation.max_discovered_peers': 50,
+}
+
+# Parameters whose out-of-range value is REFUSED and replaced by the documented
+# default instead of being clamped. Clamping makes no sense for them: half a
+# port number is not a port. The warning still has to name the refused value.
+#
+#   (parameter, refused_value, expected log fragment)
+#
+# The first three carry a value above INT_MAX on purpose. Each of these was read
+# into an int BEFORE its range check, so the value wrapped back into the legal
+# band and was accepted in silence: port 4294976296 narrows to 9000.
+REJECTED_PARAMS = [
+    ('server.port', 4294976296,
+     'Invalid port 4294976296. Must be between 1024-65535. Using default 8080.'),
+    ('refresh_interval_ms', 4294967396,
+     'Invalid backstop refresh interval 4294967396ms'),
+    ('sse.max_duration_sec', 4294967300,
+     'sse.max_duration_sec 4294967300 must be > 0'),
+    ('discovery.refresh_debounce_ms', 70000,
+     'Invalid discovery.refresh_debounce_ms 70000ms'),
+    ('topic_sample_timeout_sec', 60.0,
+     'topic_sample_timeout_sec 60.00 is outside 0.1-30.0'),
+    ('bulk_data.max_upload_size', -1,
+     'bulk_data.max_upload_size -1 is negative'),
+    ('sse.max_subscriptions', -1,
+     'sse.max_subscriptions -1 must be >= 1'),
 ]
 
 # The three whose above-ceiling case is skipped (see the module docstring).
@@ -122,25 +182,56 @@ STARTUP_COMPLETE = 'TopicDataProvider attached'
 
 
 def generate_test_description():
+    # aggregation.max_discovered_peers is only read when aggregation is on. With
+    # no peers and mDNS off it does nothing else, so it is a cheap way to reach
+    # that parameter.
+    aggregation_on = {'aggregation.enabled': True}
+
     # Floor gateway on the default port: GatewayTestCase polls /health here, so
     # this gateway also proves the clamped-to-floor values still serve requests.
-    gateway_node = create_gateway_node(extra_params=dict(FLOOR_PARAMS))
+    gateway_node = create_gateway_node(
+        extra_params={**FLOOR_PARAMS, **aggregation_on},
+    )
 
     gw_ceiling = create_gateway_node(
         port=get_test_port(1),
         name='gateway_clamp_ceiling',
-        extra_params=dict(CEILING_PARAMS),
+        extra_params={**CEILING_PARAMS, **aggregation_on},
+    )
+
+    gw_in_range = create_gateway_node(
+        port=get_test_port(2),
+        name='gateway_clamp_in_range',
+        extra_params={**IN_RANGE_PARAMS, **aggregation_on},
+    )
+
+    # The refused values include server.port itself, so this gateway falls back
+    # to the default 8080 rather than the port it was given. Nothing here talks
+    # to it over HTTP; only its startup log is read. If 8080 is already taken the
+    # gateway logs that it could not start serving and keeps running, so the
+    # assertions and the exit code hold either way.
+    gw_rejected = create_gateway_node(
+        port=get_test_port(3),
+        name='gateway_param_rejected',
+        extra_params={
+            **{name: value for name, value, _fragment in REJECTED_PARAMS},
+            **aggregation_on,
+        },
     )
 
     return (
         LaunchDescription([
             gateway_node,
             gw_ceiling,
+            gw_in_range,
+            gw_rejected,
             launch_testing.actions.ReadyToTest(),
         ]),
         {
             'gateway_node': gateway_node,
             'gw_ceiling': gw_ceiling,
+            'gw_in_range': gw_in_range,
+            'gw_rejected': gw_rejected,
         },
     )
 
@@ -175,21 +266,34 @@ class TestStartupParamClampWarnings(GatewayTestCase):
             with self.subTest(parameter=parameter, direction='ceiling'):
                 self.assertIn(expected_warning(parameter, above, ceiling), reported)
 
-    def test_in_range_values_stay_quiet(self, proc_output, gw_ceiling):
-        """An in-range parameter is not reported as clamped.
+    def test_in_range_values_stay_quiet(self, proc_output, gw_in_range):
+        """A gateway configured entirely in range reports no clamp at all.
 
-        A "warn on every read" regression would satisfy both tests above while
-        burying the real misconfigurations in noise. The ceiling gateway leaves
-        the floor-only parameters at their defaults, so their names must not
-        appear in a clamp line at all.
+        A "warn on every read" regression - one site losing its
+        `if (effective != requested)` guard - would satisfy the floor and
+        ceiling tests while making a correctly configured gateway shout at
+        every boot. Only an in-range observation catches it, and every one of
+        the parameters needs its own, because a dropped guard at one site says
+        nothing about the others.
         """
-        reported = _clamp_lines(proc_output, gw_ceiling)
-        for parameter in sorted(PARAMS_FLOOR_ONLY):
+        reported = _clamp_lines(proc_output, gw_in_range)
+        self.assertEqual(
+            reported, [],
+            f'a gateway with every parameter in range still reported: {reported}',
+        )
+
+    def test_rejected_values_name_the_refused_value(self, proc_output, gw_rejected):
+        """A refused value is named in the log, not just replaced.
+
+        These parameters fall back to their documented default instead of being
+        clamped. Three of them are set above INT_MAX here: each used to be
+        narrowed to int before its range check, so the value wrapped back into
+        the legal band and was taken as valid without a word.
+        """
+        text = _output_text(proc_output, gw_rejected)
+        for parameter, _value, fragment in REJECTED_PARAMS:
             with self.subTest(parameter=parameter):
-                self.assertFalse(
-                    [line for line in reported if line.startswith(f'{parameter} ')],
-                    f'{parameter} was left at its default but still reported a clamp',
-                )
+                self.assertIn(fragment, text)
 
     def test_repeated_reads_warn_once_per_parameter(self, proc_output, gateway_node):
         """A parameter read twice at startup is reported once, not twice.
@@ -211,8 +315,8 @@ class TestStartupParamClampWarnings(GatewayTestCase):
                 )
 
 
-def _clamp_lines(proc_output, process):
-    """Return every 'X clamped to Y' fragment this process logged during startup.
+def _output_text(proc_output, process):
+    """Return this process's whole startup output as one string.
 
     Waits for STARTUP_COMPLETE first, so the buffer is whole before it is read.
     Every check in this file scans rather than waits per parameter: waiting
@@ -223,16 +327,22 @@ def _clamp_lines(proc_output, process):
     proc_output.assertWaitFor(
         STARTUP_COMPLETE, process=process, timeout=WARNING_TIMEOUT * get_time_scale(),
     )
+    return '\n'.join(
+        output.text.decode(errors='replace') for output in proc_output[process]
+    )
+
+
+def _clamp_lines(proc_output, process):
+    """Return every 'X clamped to Y' fragment this process logged during startup."""
     lines = []
-    for output in proc_output[process]:
-        for line in output.text.decode(errors='replace').splitlines():
-            marker = line.find(' clamped to ')
-            if marker == -1:
-                continue
-            # Strip the rclcpp prefix ("[WARN] [stamp] [logger]: ") so the
-            # fragment starts at the parameter name.
-            start = line.rfind(': ', 0, marker)
-            lines.append(line[start + 2:] if start != -1 else line)
+    for line in _output_text(proc_output, process).splitlines():
+        marker = line.find(' clamped to ')
+        if marker == -1:
+            continue
+        # Strip the rclcpp prefix ("[WARN] [stamp] [logger]: ") so the
+        # fragment starts at the parameter name.
+        start = line.rfind(': ', 0, marker)
+        lines.append(line[start + 2:] if start != -1 else line)
     return lines
 
 
@@ -240,10 +350,10 @@ def _clamp_lines(proc_output, process):
 class TestShutdown(unittest.TestCase):
 
     def test_exit_codes(self, proc_info):
-        """Both gateways exit cleanly.
+        """Every gateway exits cleanly.
 
-        A clamped value must leave a working gateway behind. An exit code here
-        would mean the coercion turned a typo into a crash.
+        A coerced or refused value must leave a working gateway behind. An exit
+        code here would mean a mis-set parameter turned a typo into a crash.
         """
         for info in proc_info:
             self.assertIn(

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -71,6 +71,7 @@ import launch_testing.actions
 
 from ros2_medkit_test_utils.constants import (
     ALLOWED_EXIT_CODES,
+    get_test_domain_id,
     get_test_port,
     get_time_scale,
 )
@@ -163,8 +164,11 @@ REJECTED_PARAMS = [
      'bulk_data.max_upload_size -1 is negative'),
     ('sse.max_subscriptions', -1,
      'sse.max_subscriptions -1 must be >= 1'),
-    ('triggers.max_triggers', -1,
-     'triggers.max_triggers -1 out of range. Using default 1000.'),
+    # Above INT_MAX on purpose: read as int this narrows to 0, which trips the
+    # same < 1 branch and logs "0", so a negative alone would not notice the
+    # read-before-narrowing order being reverted.
+    ('triggers.max_triggers', 4294967296,
+     'triggers.max_triggers 4294967296 out of range. Using default 1000.'),
     # Two float checks that a "below or above the range" test would not catch,
     # because every comparison against NaN is false. NaN does survive the launch
     # path: launch_ros hands the parameter through as a double, verified against
@@ -172,8 +176,12 @@ REJECTED_PARAMS = [
     # range test for this reason.
     ('topic_sample_timeout_sec', float('nan'),
      'topic_sample_timeout_sec nan is outside 0.1-30.0'),
-    ('fault_manager.service_timeout_sec', float('nan'),
-     'fault_manager.service_timeout_sec nan must be finite and > 0'),
+    # +inf, not NaN: the check is isfinite && > 0, and NaN already fails "> 0"
+    # on its own. Infinity is the only value that passes the comparison and is
+    # caught solely by isfinite - and the one that would reach wait_for_service
+    # and pin an HTTP worker for the life of the process.
+    ('fault_manager.service_timeout_sec', float('inf'),
+     'fault_manager.service_timeout_sec inf must be finite and > 0'),
     # parameter_service_timeout_sec deliberately has NO row here. It carries a
     # FloatingPointRange descriptor, and what rclcpp does with NaN against that
     # descriptor differs by distro: Jazzy accepts it as in-range (verified on a
@@ -189,10 +197,20 @@ REJECTED_PARAMS = [
 # separate anyway: NaN pins the isfinite guard, these pin the range itself, and
 # a mutation that dropped either would leave the other green.
 FLOOR_EXTRA_REJECTED = [
-    ('topic_sample_timeout_sec', 60.0,
-     'topic_sample_timeout_sec 60.00 is outside 0.1-30.0'),
+    ('topic_sample_timeout_sec', 0.05,
+     'topic_sample_timeout_sec 0.05 is outside 0.1-30.0'),
     ('fault_manager.service_timeout_sec', -1.0,
      'fault_manager.service_timeout_sec -1.00 must be finite and > 0'),
+    ('triggers.max_triggers', -1,
+     'triggers.max_triggers -1 out of range. Using default 1000.'),
+]
+
+# The upper end of the same float range. Split across gateways because one
+# parameter takes one value per process, and both ends have to be pinned: with
+# only 60.0, deleting the ">= 0.1" term from the check is a green mutation.
+CEILING_EXTRA_REJECTED = [
+    ('topic_sample_timeout_sec', 60.0,
+     'topic_sample_timeout_sec 60.00 is outside 0.1-30.0'),
 ]
 
 # The three whose above-ceiling case is skipped (see the module docstring).
@@ -213,8 +231,11 @@ def expected_warning(parameter, requested, effective):
     return f'{parameter} {requested} clamped to {effective}'
 
 
-# Warnings are emitted during construction, so they are already in the buffer by
-# the time /health answers. The timeout only covers a slow runner's startup.
+# Do NOT read this as "the warnings are there once /health answers".
+# start_rest_server() runs inside the GatewayNode constructor, so /health goes
+# live before main.cpp reads server.executor_threads, the subscription_executor
+# and data_provider groups, and fault_triggers - eleven of the eighteen clamp
+# warnings come after that. STARTUP_COMPLETE below is what actually bounds them.
 WARNING_TIMEOUT = 20
 
 # Logged by GatewayNode::init_fault_trigger_engine, the LAST thing main.cpp does
@@ -242,6 +263,14 @@ def generate_test_description():
         get_package_prefix('ros2_medkit_gateway'),
         'lib', 'ros2_medkit_gateway', 'libtest_gateway_plugin.so',
     )
+    # One DDS domain per gateway. Nothing here is a peer of anything else, and
+    # four gateways on one domain means each one runs its discovery over the
+    # other three's nodes for no reason - and four sets of participants expire
+    # on that domain at teardown, which the next test to lease it inherits.
+
+    def _domain(offset):
+        return {'ROS_DOMAIN_ID': str(get_test_domain_id(offset))}
+
     reachable = {
         'aggregation.enabled': True,
         'plugins': ['test_plugin'],
@@ -251,6 +280,7 @@ def generate_test_description():
     # Floor gateway on the default port: GatewayTestCase polls /health here, so
     # this gateway also proves the clamped-to-floor values still serve requests.
     gateway_node = create_gateway_node(
+        extra_env=_domain(0),
         extra_params={
             **FLOOR_PARAMS,
             **{name: value for name, value, _fragment in FLOOR_EXTRA_REJECTED},
@@ -261,12 +291,18 @@ def generate_test_description():
     gw_ceiling = create_gateway_node(
         port=get_test_port(1),
         name='gateway_clamp_ceiling',
-        extra_params={**CEILING_PARAMS, **reachable},
+        extra_env=_domain(1),
+        extra_params={
+            **CEILING_PARAMS,
+            **{name: value for name, value, _fragment in CEILING_EXTRA_REJECTED},
+            **reachable,
+        },
     )
 
     gw_in_range = create_gateway_node(
         port=get_test_port(2),
         name='gateway_clamp_in_range',
+        extra_env=_domain(2),
         extra_params={**IN_RANGE_PARAMS, **reachable},
     )
 
@@ -278,6 +314,7 @@ def generate_test_description():
     gw_rejected = create_gateway_node(
         port=get_test_port(3),
         name='gateway_param_rejected',
+        extra_env=_domain(3),
         extra_params={
             **{name: value for name, value, _fragment in REJECTED_PARAMS},
             **reachable,
@@ -336,6 +373,11 @@ class TestStartupParamClampWarnings(GatewayTestCase):
             with self.subTest(parameter=parameter, direction='ceiling'):
                 self.assertIn(expected_warning(parameter, above, ceiling), reported)
 
+        text = _output_text(proc_output, gw_ceiling)
+        for parameter, _value, fragment in CEILING_EXTRA_REJECTED:
+            with self.subTest(parameter=parameter, direction='out-of-range'):
+                self.assertIn(fragment, text)
+
     def test_in_range_values_stay_quiet(self, proc_output, gw_in_range):
         """A gateway configured entirely in range reports no clamp at all.
 
@@ -351,6 +393,38 @@ class TestStartupParamClampWarnings(GatewayTestCase):
             reported, [],
             f'a gateway with every parameter in range still reported: {reported}',
         )
+
+    def test_ceiling_coverage_is_not_dropped_by_accident(self):
+        """Only the three documented parameters may skip the ceiling direction.
+
+        The ceiling loop skips any row whose above-value is None. Without this,
+        setting one more row to None removes its ceiling coverage silently - no
+        failure, no skip marker, nothing in the output to notice.
+        """
+        self.assertEqual(
+            PARAMS_FLOOR_ONLY,
+            {'server.executor_threads', 'server.http_thread_pool_size',
+             'entity_cache.capacity'},
+            'the set of parameters exempt from the ceiling direction changed; '
+            'the module docstring explains why exactly these three are exempt',
+        )
+
+    def test_refused_values_take_the_documented_default(self, proc_output, gw_rejected):
+        """The value the gateway ends up using is the documented default.
+
+        Every other assertion here reads a warning. A warning is a claim: the
+        site could name the default in its message and then assign something
+        else, and nothing would notice. These three parameters log what they
+        actually installed, so they can be checked rather than believed.
+        """
+        text = _output_text(proc_output, gw_rejected)
+        for fragment in (
+            'Subscription manager: max_subscriptions=100',
+            'max_upload=104857600B',
+            'Trigger subsystem: enabled (max=1000',
+        ):
+            with self.subTest(fragment=fragment):
+                self.assertIn(fragment, text)
 
     def test_rejected_values_name_the_refused_value(self, proc_output, gw_rejected):
         """A refused value is named in the log, not just replaced.

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -49,11 +49,13 @@ for each parameter, at **1299 threads and 1486 MB RSS**. Paying that (on a
 runner already hosting the three other gateways, and again under a sanitizer)
 buys one log line per parameter from the same four-line compare-and-warn that
 the floor case already drives, that the in-range case pins the guard of, and
-that the other 14 parameters already drive in the ceiling direction.
+that the other 15 parameters already drive in the ceiling direction.
 """
 
+import os
 import unittest
 
+from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescription
 import launch_testing
 import launch_testing.actions
@@ -98,6 +100,10 @@ CLAMPED_PARAMS = [
     ('data_provider.idle_sweep_tick_sec', 0, 3600, -1, 7200),
     # aggregation.* - gateway_node.cpp, only read when aggregation is enabled
     ('aggregation.max_discovered_peers', 1, 1000, 0, 2000),
+    # fault_triggers.* - gateway_node.cpp, only read once a plugin is loaded.
+    # The ceiling is INT_MAX because the value is narrowed to int for the timer;
+    # it is a type boundary, not a tuning choice.
+    ('fault_triggers.poll_interval_ms', 50, 2147483647, 0, 4294967296),
 ]
 
 # In-range values, one per clamped parameter. A gateway launched with these must
@@ -123,6 +129,7 @@ IN_RANGE_PARAMS = {
     'data_provider.idle_safety_net_sec': 900,
     'data_provider.idle_sweep_tick_sec': 60,
     'aggregation.max_discovered_peers': 50,
+    'fault_triggers.poll_interval_ms': 1000,
 }
 
 # Parameters whose out-of-range value is REFUSED and replaced by the documented
@@ -182,27 +189,37 @@ STARTUP_COMPLETE = 'TopicDataProvider attached'
 
 
 def generate_test_description():
-    # aggregation.max_discovered_peers is only read when aggregation is on. With
-    # no peers and mDNS off it does nothing else, so it is a cheap way to reach
-    # that parameter.
-    aggregation_on = {'aggregation.enabled': True}
+    # Two parameters in the table are only read when something else is on:
+    # aggregation.max_discovered_peers needs aggregation, and the
+    # fault_triggers.* group needs at least one loaded plugin. With no peers,
+    # mDNS off and the plugin idle, neither does anything beyond making its
+    # parameter reachable.
+    plugin_path = os.path.join(
+        get_package_prefix('ros2_medkit_gateway'),
+        'lib', 'ros2_medkit_gateway', 'libtest_gateway_plugin.so',
+    )
+    reachable = {
+        'aggregation.enabled': True,
+        'plugins': ['test_plugin'],
+        'plugins.test_plugin.path': plugin_path,
+    }
 
     # Floor gateway on the default port: GatewayTestCase polls /health here, so
     # this gateway also proves the clamped-to-floor values still serve requests.
     gateway_node = create_gateway_node(
-        extra_params={**FLOOR_PARAMS, **aggregation_on},
+        extra_params={**FLOOR_PARAMS, **reachable},
     )
 
     gw_ceiling = create_gateway_node(
         port=get_test_port(1),
         name='gateway_clamp_ceiling',
-        extra_params={**CEILING_PARAMS, **aggregation_on},
+        extra_params={**CEILING_PARAMS, **reachable},
     )
 
     gw_in_range = create_gateway_node(
         port=get_test_port(2),
         name='gateway_clamp_in_range',
-        extra_params={**IN_RANGE_PARAMS, **aggregation_on},
+        extra_params={**IN_RANGE_PARAMS, **reachable},
     )
 
     # The refused values include server.port itself, so this gateway falls back
@@ -215,7 +232,7 @@ def generate_test_description():
         name='gateway_param_rejected',
         extra_params={
             **{name: value for name, value, _fragment in REJECTED_PARAMS},
-            **aggregation_on,
+            **reachable,
         },
     )
 
@@ -327,7 +344,14 @@ def _output_text(proc_output, process):
     proc_output.assertWaitFor(
         STARTUP_COMPLETE, process=process, timeout=WARNING_TIMEOUT * get_time_scale(),
     )
-    return '\n'.join(
+    # Concatenated with NO separator on purpose. proc_output yields raw stream
+    # chunks, not lines: a chunk boundary can fall in the middle of a log line,
+    # and joining with '\n' then splices a newline into the message so a
+    # substring match on it fails while the line is plainly there in the log.
+    # That is not hypothetical - it is how this file first failed under a
+    # sanitizer, where the timing moved the boundary. The stream carries its own
+    # newlines, so plain concatenation reconstructs it.
+    return ''.join(
         output.text.decode(errors='replace') for output in proc_output[process]
     )
 

--- a/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
+++ b/src/ros2_medkit_log_bridge/src/log_bridge_node.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cinttypes>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
@@ -85,11 +86,26 @@ void LogBridgeNode::load_parameters() {
   exclude_nodes_ = declare_parameter<std::vector<std::string>>("exclude_nodes", std::vector<std::string>{});
   include_only_nodes_ = declare_parameter<std::vector<std::string>>("include_only_nodes", std::vector<std::string>{});
   const int64_t max_tracked_nodes = declare_parameter<int64_t>("max_tracked_nodes", INT64_C(512));
-  max_tracked_nodes_ = static_cast<int>(
-      std::clamp(max_tracked_nodes, INT64_C(1), static_cast<int64_t>(std::numeric_limits<int>::max())));
-  report_cooldown_sec_ = declare_parameter<double>("report_cooldown_sec", 5.0);
-  if (report_cooldown_sec_ < 0.0) {
-    report_cooldown_sec_ = 0.0;
+  const int64_t max_tracked_nodes_used =
+      std::clamp(max_tracked_nodes, INT64_C(1), static_cast<int64_t>(std::numeric_limits<int>::max()));
+  if (max_tracked_nodes_used != max_tracked_nodes) {
+    RCLCPP_WARN(get_logger(), "max_tracked_nodes %" PRId64 " clamped to %" PRId64, max_tracked_nodes,
+                max_tracked_nodes_used);
+  }
+  max_tracked_nodes_ = static_cast<int>(max_tracked_nodes_used);
+
+  // isfinite plus a positive range test. Do NOT rewrite this as "negative ->
+  // 0.0": every comparison against NaN is false, so that form lets NaN past
+  // here AND past the "<= 0.0 disables the cooldown" check below it, into
+  // Duration::from_seconds, where converting NaN to nanoseconds is undefined
+  // and the resulting window silences either everything or nothing.
+  const double report_cooldown_raw = declare_parameter<double>("report_cooldown_sec", 5.0);
+  if (std::isfinite(report_cooldown_raw) && report_cooldown_raw >= 0.0) {
+    report_cooldown_sec_ = report_cooldown_raw;
+  } else {
+    RCLCPP_WARN(get_logger(), "report_cooldown_sec %.2f must be finite and >= 0. Using default 5.0.",
+                report_cooldown_raw);
+    report_cooldown_sec_ = 5.0;
   }
   exclude_medkit_stack_ = declare_parameter<bool>("exclude_medkit_stack", true);
 }

--- a/src/ros2_medkit_log_bridge/test/test_integration.test.py
+++ b/src/ros2_medkit_log_bridge/test/test_integration.test.py
@@ -67,17 +67,62 @@ def generate_test_description():
         sigkill_timeout='15',
     )
 
+    # A second bridge carrying two values the node used to swallow: a
+    # max_tracked_nodes below its own floor, and a NaN cooldown. NaN is the
+    # dangerous one - the old check was "negative -> 0.0", and every comparison
+    # against NaN is false, so it passed through into the duration the cooldown
+    # window is built from. Only this node's startup log is read.
+    bad_params_bridge_node = launch_ros.actions.Node(
+        package='ros2_medkit_log_bridge',
+        executable='log_bridge_node',
+        name='log_bridge_bad_params',
+        output='screen',
+        parameters=[{
+            'max_tracked_nodes': 0,
+            'report_cooldown_sec': float('nan'),
+            # Keep it out of the fault path; this node exists for its log only.
+            'include_only_nodes': ['__none__'],
+        }],
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
     return (
         LaunchDescription([
             fault_manager_node,
             log_bridge_node,
+            bad_params_bridge_node,
             launch_testing.actions.ReadyToTest(),
         ]),
         {
             'fault_manager_node': fault_manager_node,
             'log_bridge_node': log_bridge_node,
+            'bad_params_bridge_node': bad_params_bridge_node,
         },
     )
+
+
+class TestLogBridgeParameterRefusal(unittest.TestCase):
+    """A coerced parameter is reported, and NaN never reaches the window."""
+
+    def test_out_of_range_parameters_are_reported(self, proc_output, bad_params_bridge_node):
+        """
+        Both parameters name the value that was actually supplied.
+
+        max_tracked_nodes was clamped in silence, so a config asking for 0 ran
+        at 1 with nothing to show it. report_cooldown_sec was worse: the check
+        read "negative -> 0.0", which is false for NaN, so NaN passed both that
+        test and the "<= 0 disables the cooldown" test and reached
+        Duration::from_seconds, where converting it is undefined.
+        """
+        for fragment in (
+            'max_tracked_nodes 0 clamped to 1',
+            'report_cooldown_sec nan must be finite and >= 0',
+        ):
+            with self.subTest(fragment=fragment):
+                proc_output.assertWaitFor(
+                    fragment, process=bad_params_bridge_node, timeout=30,
+                )
 
 
 class TestLogBridgeIntegration(unittest.TestCase):

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -379,10 +379,21 @@ def poll_fault_describing(port, code, needles, timeout=60.0, interval=0.5):
     last_description = ''
     while time.monotonic() < deadline:
         fault = poll_faults(port, code, timeout=interval, interval=interval)
-        if fault is not None:
-            last_description = fault.get('description', '')
-            if all(needle in last_description for needle in needles):
-                return True, last_description
+        if fault is None:
+            # Nothing to see. poll_faults already slept `interval` before
+            # giving up, so sleeping again here would halve the sampling rate.
+            # Drop what we saw earlier too: the fault cleared or never
+            # appeared, and a timeout must not report a stale description.
+            last_description = ''
+            continue
+        last_description = fault.get('description', '')
+        if all(needle in last_description for needle in needles):
+            return True, last_description
+        # Present but incomplete - the case this helper exists for. poll_faults
+        # returns the moment it matches the code, BEFORE its own sleep, so this
+        # branch has to pace itself or it becomes a bare retry loop hammering
+        # GET /faults for the whole timeout, against the gateway whose detector
+        # we are waiting on.
         time.sleep(interval)
     return False, last_description
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -340,6 +340,53 @@ def poll_entity_faults(port, entity_path, code, timeout=30.0, interval=0.5):
     return None
 
 
+def poll_fault_describing(port, code, needles, timeout=60.0, interval=0.5):
+    """Poll the GLOBAL ``GET /faults`` until `code` is present AND names every needle.
+
+    :func:`poll_faults` returns the moment the code appears, which is not the
+    same thing as the fault being complete. An aggregating detector raises as
+    soon as its FIRST subject crosses the persistence gate and then rewrites the
+    description on later ticks as more subjects cross it. A test that wants two
+    subjects named has to wait for the second one, or it reads whichever
+    description happened to be current and fails on a slower runner.
+
+    Note the description is capped (``kMaxDescriptionChars``), so this can also
+    time out because the text was truncated rather than because a subject was
+    missing. The returned description lets the caller say which.
+
+    Parameters
+    ----------
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` to look for.
+    needles : iterable of str
+        Substrings that must all appear in the fault description.
+    timeout : float
+        Maximum time to wait in seconds.
+    interval : float
+        Sleep between retries in seconds.
+
+    Returns
+    -------
+    tuple of (bool, str)
+        ``(True, description)`` once every needle is present, otherwise
+        ``(False, last_description)`` on timeout - empty if the code never
+        appeared at all.
+
+    """
+    deadline = time.monotonic() + timeout
+    last_description = ''
+    while time.monotonic() < deadline:
+        fault = poll_faults(port, code, timeout=interval, interval=interval)
+        if fault is not None:
+            last_description = fault.get('description', '')
+            if all(needle in last_description for needle in needles):
+                return True, last_description
+        time.sleep(interval)
+    return False, last_description
+
+
 def poll_cleared(port, code, timeout=30.0, interval=0.5):
     """Poll the GLOBAL ``GET /faults`` endpoint until `code` is absent.
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
@@ -121,6 +121,16 @@ def generate_test_description():
     )
 
 
+def _pair_phrase(pub_topic, sub_topic):
+    """Return the exact wording the detector uses to name one orphaned pair.
+
+    Asserting the two topic names separately would also pass if a regression
+    paired either of them with something else, or reported them in two
+    unrelated findings. This pins the association.
+    """
+    return f"publisher-only '{pub_topic}' and subscriber-only '{sub_topic}'"
+
+
 class TestOrphanE2e(unittest.TestCase):
     """GRAPH_ORPHAN raises on a real pub-only/sub-only topic-name near-miss pair.
 
@@ -161,7 +171,7 @@ class TestOrphanE2e(unittest.TestCase):
         # for the code returns whichever description was current, so this asks
         # for the pair by name instead. The same applies to test_01a below.
         found, description = poll_fault_describing(
-            PORT, FAULT_CODE, (TYPO_TOPIC, TARGET_TOPIC), timeout=60.0)
+            PORT, FAULT_CODE, (_pair_phrase(TYPO_TOPIC, TARGET_TOPIC),), timeout=60.0)
         self.assertTrue(
             found,
             f'{FAULT_CODE} never named the pub-only {TYPO_TOPIC} / sub-only '
@@ -170,7 +180,7 @@ class TestOrphanE2e(unittest.TestCase):
 
     def test_01a_namespace_typo_pair_is_reported_too(self):
         found, description = poll_fault_describing(
-            PORT, FAULT_CODE, (NS_TYPO_TOPIC,), timeout=60.0)
+            PORT, FAULT_CODE, (_pair_phrase(NS_TYPO_TOPIC, NS_TARGET_TOPIC),), timeout=60.0)
         self.assertTrue(
             found,
             f'{NS_TYPO_TOPIC} / {NS_TARGET_TOPIC} differ only in the namespace, so they are '

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_orphan_e2e.test.py
@@ -56,7 +56,12 @@ from sensor_msgs.msg import LaserScan
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 # I100 as well as E402: `harness` is only importable because of the sys.path line above, so this
 # import cannot be moved up to where the alphabetical order would put it.
-from harness import create_watchdog_test_launch, poll_cleared, poll_faults  # noqa: E402, I100
+from harness import (  # noqa: E402, I100
+    create_watchdog_test_launch,
+    poll_cleared,
+    poll_fault_describing,
+    poll_faults,
+)
 
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
 
@@ -88,6 +93,14 @@ ALLOWLISTED_TARGET_TOPIC = '/hokuyo_scan'
 NS_TYPO_TOPIC = '/robott/odom'
 NS_TARGET_TOPIC = '/robot/odom'
 NAMESPACE_EDIT_DISTANCE = 1
+
+# Both non-allowlisted pairs land in ONE aggregated description, and that
+# description is capped at kMaxDescriptionChars (480). Measured with these
+# names: 217 chars for the LaserScan pair + 2 for the separator + 230 for the
+# namespace pair = 449, so 31 characters of headroom. Renaming a topic here, or
+# lengthening the detector's reason text, can push it over and truncate the pair
+# that sorts last - which fails as "the pair was never reported" and sends the
+# next reader hunting for a race that is not there.
 
 
 def generate_test_description():
@@ -143,23 +156,23 @@ class TestOrphanE2e(unittest.TestCase):
         rclpy.shutdown()
 
     def test_01_typo_pair_raises_naming_both(self):
-        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
-        self.assertIsNotNone(
-            fault,
-            f'{FAULT_CODE} never raised for a pub-only {TYPO_TOPIC} / sub-only '
-            f'{TARGET_TOPIC} near-miss pair',
+        # Both pairs in this fixture are aggregated into ONE fault, and each
+        # crosses the detector's persistence gate on its own tick. Waiting only
+        # for the code returns whichever description was current, so this asks
+        # for the pair by name instead. The same applies to test_01a below.
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE, (TYPO_TOPIC, TARGET_TOPIC), timeout=60.0)
+        self.assertTrue(
+            found,
+            f'{FAULT_CODE} never named the pub-only {TYPO_TOPIC} / sub-only '
+            f'{TARGET_TOPIC} near-miss pair: {description!r}',
         )
-        description = fault.get('description', '')
-        self.assertIn(TYPO_TOPIC, description)
-        self.assertIn(TARGET_TOPIC, description)
 
     def test_01a_namespace_typo_pair_is_reported_too(self):
-        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
-        self.assertIsNotNone(fault, f'{FAULT_CODE} is no longer raised')
-        description = fault.get('description', '')
-        self.assertIn(
-            NS_TYPO_TOPIC,
-            description,
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE, (NS_TYPO_TOPIC,), timeout=60.0)
+        self.assertTrue(
+            found,
             f'{NS_TYPO_TOPIC} / {NS_TARGET_TOPIC} differ only in the namespace, so they are '
             f'reported only if namespace_edit_distance={NAMESPACE_EDIT_DISTANCE} reached the '
             f'detector: {description}',


### PR DESCRIPTION
# Pull Request

## Summary

A startup parameter set outside its documented range was coerced or replaced and nothing was logged. The config file and the running process then disagreed, with no way to see it from outside. The symptom of a wrong value is a slow or jittery gateway, or a limit that never fires, and it shows up far from the cause.

**Clamped parameters now report the clamp.** Both values are named, in the shape three parameters already used:

```
[WARN] [ros2_medkit_gateway]: sse.max_clients 4096 clamped to 1024
```

This covers `server.executor_threads`, `server.http_thread_pool_size`, `server.keep_alive_timeout_sec`, `sse.max_clients`, `aggregation.max_discovered_peers`, the four `subscription_executor.*` knobs and the five `data_provider.*` knobs.

**Three parameters were checked in the wrong order.** `server.port`, `refresh_interval_ms` and `sse.max_duration_sec` were narrowed from int64 to int and range-checked after that, so a value above INT_MAX wrapped back into the legal band and was taken as valid:

```
server.port:=4294976296   ->   listens on 9000, nothing logged
```

They are validated as int64 first now, and the warning names the refused value rather than the wrapped one.

**Three more wrapped to SIZE_MAX.** `sse.max_subscriptions`, `bulk_data.max_upload_size` and `aggregation.max_discovered_peers` were cast straight to `size_t`, so a negative value became a huge one and the documented limit stopped existing: no HTTP 503 at the subscription cap, no bound on uploads, no cap on discovered peers.

**`topic_sample_timeout_sec` is validated at the read.** Both consumers already fell back to `1.0` on their own, but `DataAccessManager` is in the ROS-neutral core and cannot log, so a value rejected there vanished. Their fallbacks stay as contract guards; the read site is the one that reports.

Two parameters are read a second time in `main.cpp`, only to compare the HTTP pool against the SSE plus cold-wait budget. That read keeps the silent clamp on purpose. One typo should not produce two identical warnings.

`clamp_thread_count` and `clamp_keep_alive_timeout` stay silent, because `gateway_core` links no rclcpp and cannot log. Their comments now say that reporting the clamp is the caller's job.

### Docs

`docs/config/server.rst` and `gateway_params.yaml` claimed every documented range is clamped to the nearest endpoint. That was wrong for about a third of the ranges in the same files, and `server.rst` contradicted itself 320 lines apart. Both now describe the three real behaviours: clamped to the nearest endpoint, refused in favour of the documented default, or rejected by rclcpp so the gateway does not start at all.

`max_parallel_topic_samples` was documented in two places but does not exist in the code. It is replaced by the real `data_provider.max_parallel_samples`. The nine `subscription_executor.*` and `data_provider.*` knobs had no rows in the config docs, so they get a table.

---

## Issue

- closes #603

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

New integration test `test_startup_param_clamp_warnings` launches four gateways and reads their own process output:

- every clamped parameter below its floor. This gateway also has to serve `/health`, so a floor value that broke request serving would fail the test instead of passing quietly.
- every clamped parameter above its ceiling.
- every clamped parameter at a legal value, which must report nothing at all.
- the refused parameters, including three values above INT_MAX.

It also checks that a parameter read twice at startup is reported once.

To confirm the tests can fail, the changes were reverted with the tests kept:

- reverting the clamp warnings: 26 subtests failed in 0.5 s, each naming its parameter. The three parameters that already warned before this change kept passing.
- making one clamp site warn unconditionally: the in-range gateway test failed with `subscription_executor.max_queue_depth 256 clamped to 256`, which is what a correctly configured gateway would print.
- restoring the narrow-then-check order for `server.port`: the refused-value test failed.

Local runs, all green:

- gateway unit tests: 4032 tests, 0 failures
- integration suite: 878 tests, 0 failures
- sphinx, clang-format, clang-tidy on the changed files: clean

Not covered, and written in the test docstring: `server.executor_threads`, `server.http_thread_pool_size` and `entity_cache.capacity` are tested at the floor and in range, but not above their ceiling. A clamp means the gateway then runs at the ceiling, and a gateway launched past all three was measured at 1299 threads and 1486 MB RSS. The other 14 parameters cover the ceiling direction through the same compare-and-warn code.

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
