### PR TITLE
Do not register launch tests in a system package build, and let the macro own their properties

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -187,7 +187,7 @@ TEST_F(LogHandlersTest, GetLogsReturnsBadRequestWhenMatchesMissing) {
 }
 ```
 
-**ROS_DOMAIN_ID isolation**: GTest targets creating `rclcpp::Node` need unique domain IDs. Current: 62-66 (fault_manager), 99 (gateway). Next available: 67.
+**ROS_DOMAIN_ID isolation**: GTest, gmock, pytest and launch tests that create `rclcpp::Node` get a domain automatically when registered through `medkit_add_gtest()` / `medkit_add_gmock()` / `medkit_add_pytest_test()` / `medkit_add_launch_test()` in `ROS2MedkitTestDomain.cmake` - a wrapper takes a free domain from a shared band at test start and holds it for exactly as long as the test runs. There is no hand-maintained ID table to update. A test that creates no ROS node calls `medkit_test_needs_no_domain()` instead.
 
 ### Integration Tests (Python launch_testing)
 
@@ -285,7 +285,7 @@ Every code change must include corresponding tests. A feature without tests is n
 
 **General test rules:**
 - **Flag** any use of `GTEST_SKIP()`, `@pytest.mark.skip`, `unittest.skip`, or equivalent - tests must not be skipped, fix the code or the test instead.
-- **Flag** GTest files that create `rclcpp::Node` without setting a unique `ROS_DOMAIN_ID` in CMakeLists.txt `set_tests_properties()`. Current IDs: 62-66, 99. Next available: 67.
+- **Flag** GTest/launch test files that create `rclcpp::Node` without registering through `medkit_add_gtest()` / `medkit_add_gmock()` / `medkit_add_launch_test()` in `ROS2MedkitTestDomain.cmake`, which allocate a `ROS_DOMAIN_ID` automatically - there is no hand-maintained ID table to update, and for a launch test a manual `set_tests_properties()` afterward fails the configure outright when the guard in that macro has not registered the test.
 - **Flag** integration tests that select `/parameter_events` or `/rosout` topics - these are ROS 2 system topics without continuous data flow.
 - **Flag** test files for SOVD-spec endpoints that are missing `// @verifies REQ_XXX` traceability tags.
 
@@ -314,7 +314,7 @@ Every code change must include corresponding tests. A feature without tests is n
 | `find_package(yaml-cpp REQUIRED)` | Use `medkit_find_yaml_cpp()` |
 | `res.set_header("Content-Type", ...)` + `set_chunked_content_provider(...)` | Remove `set_header` - provider sets Content-Type |
 | `GTEST_SKIP()` or `@pytest.mark.skip` | Fix the test or the code, never skip |
-| `set_tests_properties(... ENVIRONMENT "ROS_DOMAIN_ID=99")` reusing existing ID | Assign next available ID (67) |
+| `set_tests_properties(... ENVIRONMENT "ROS_DOMAIN_ID=99")` by hand | Use `medkit_add_gtest()` / `medkit_add_gmock()` / `medkit_add_launch_test()`, which allocate the domain |
 | New endpoint route for `/apps/` only | Add matching route for `/components/` (dual-path) |
 | Error string literal like `"not-found"` | Use constant `ERR_ENTITY_NOT_FOUND` from `error_codes.hpp` |
 | `res.status = 404; res.set_content(...)` manually | Use `HandlerContext::send_error(res, 404, ERR_ENTITY_NOT_FOUND, msg)` |

--- a/src/ros2_medkit_cmake/CMakeLists.txt
+++ b/src/ros2_medkit_cmake/CMakeLists.txt
@@ -115,6 +115,10 @@ if(BUILD_TESTING)
   set_tests_properties(test_lint_config PROPERTIES LABELS "unit")
   medkit_test_needs_no_domain(test_lint_config)
 
+  ament_add_pytest_test(test_launch_test_guard test/test_launch_test_guard.py TIMEOUT 300)
+  set_tests_properties(test_launch_test_guard PROPERTIES LABELS "unit")
+  medkit_test_needs_no_domain(test_launch_test_guard)
+
   set_property(TEST test_domain_band APPEND PROPERTY RESOURCE_LOCK medkit_domain_band)
   set_property(TEST test_domain_wrapper APPEND PROPERTY RESOURCE_LOCK medkit_domain_band)
 

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -12,7 +12,7 @@ build acceleration, and centralized linting configuration across all packages.
 | `ROS2MedkitCoverage.cmake` | gcov/lcov instrumentation behind `-DENABLE_COVERAGE=ON` |
 | `ROS2MedkitLinting.cmake` | Shared lint configs via `medkit_lint_config()`, plus the opt-in clang-tidy gate (CI runs `run-clang-tidy` instead) |
 | `ROS2MedkitSanitizers.cmake` | ASan / TSan / UBSan behind `-DSANITIZER=asan,ubsan` |
-| `ROS2MedkitTestDomain.cmake` | Per-package `ROS_DOMAIN_ID` allocation for test isolation |
+| `ROS2MedkitTestDomain.cmake` | Per-test `ROS_DOMAIN_ID` allocation for test isolation - an OS-level socket lock taken at test start and released when the process ends, not a per-package table |
 | `ROS2MedkitWarnings.cmake` | Shared warning flags and vendored-code relaxations |
 
 ### ROS2MedkitCompat
@@ -196,6 +196,103 @@ For a test that builds its own command line and so cannot take an ament test run
 `medkit_add_wrapped_test(<name> [DOMAINS <n>] COMMAND <cmd...>)`, which puts
 `medkit_run_with_domain.py` in front of the command instead.
 
+#### A launch test's properties belong to the call that registers it
+
+`medkit_add_launch_test(<name> <file> [TIMEOUT n] [DOMAINS n] [LABELS "a;b"] [ENV "K=V" ...]
+[ARGS "foo:=bar" ...])` is the only supported way to give a launch test a label or an
+environment variable:
+
+```cmake
+medkit_add_launch_test(test_multi test/test_multi.test.py TIMEOUT 300 DOMAINS 4
+  LABELS "integration" ENV "FOO=bar" "BAZ=qux" ARGS "foo:=bar")
+```
+
+Setting them afterwards - `set_tests_properties(test_multi PROPERTIES LABELS
+...)` or `set_property(TEST test_multi APPEND PROPERTY ENVIRONMENT ...)` - is
+not supported, and not merely discouraged: see the next section for why the
+build can register no launch test at all, and a property call that names a
+test CMake never registered is a hard configure error, not a no-op. `ENV` is
+applied after the domain the macro already set for the test, by appending, so
+a caller's own environment can never overwrite `MEDKIT_TEST_DOMAINS` - an
+`ENV` entry that sets the literal key `MEDKIT_TEST_DOMAINS=` fails the
+configure with `FATAL_ERROR` naming `DOMAINS` as the way to set it, rather
+than silently landing behind the macro's own entry and winning at run time
+the way a plain `set_tests_properties(... PROPERTIES ENVIRONMENT ...)` used
+to. This is a literal string match, not a generator-expression evaluation:
+it does not chase down a value spelled to avoid the literal key (e.g.
+`ENV "$<1:MEDKIT_TEST_DOMAINS=99>"`), which nobody writes by accident and
+which a blanket rejection of `$<` would also catch legitimate uses of.
+`LABELS` overrides `add_launch_test()`'s own default of `"launch_test"`, the same
+override callers used to apply by hand. `ARGS` forwards extra launch
+arguments straight to `add_launch_test()`, same as it always did - it has its
+own keyword rather than falling through as an unrecognised argument, because
+`LABELS` being multi-value (to survive `ENV`'s/`LABELS`'s own semicolon-split
+values, see the `.cmake` comment) would otherwise absorb an `ARGS` that had
+no keyword of its own instead of erroring on it.
+
+This does not reach `medkit_add_gtest`, `medkit_add_gmock`,
+`medkit_add_pytest_test` or `medkit_add_wrapped_test`: those are always
+registered, so `MEDKIT_TEST_DOMAINS` is appended to their `ENVIRONMENT` and a
+caller adding entries of its own still uses
+`set_property(TEST ... APPEND PROPERTY ENVIRONMENT ...)` afterwards, same as
+before. A plain `set_tests_properties(... PROPERTIES ENVIRONMENT ...)` drops
+the domain there too, and the check below says so.
+
+#### Launch tests are not registered in a system package build
+
+`medkit_add_launch_test()` registers nothing when two conditions both hold -
+the install prefix is the ROS distribution root, AND
+`CMAKE_INSTALL_LOCALSTATEDIR` is the absolute path `/var` - and prints why
+once per directory instead:
+
+```
+ros2_medkit: launch tests are not registered in this build. Installing into
+/opt/ros/humble is a system package build, whose test step runs before the
+install step, so a launch test cannot resolve this package through the ament
+index. gtests and pytest tests still run.
+```
+
+A launch test resolves the executables and the Python helper package of the
+package under test through the ament index, which only an installed prefix
+carries. Installing straight into the ROS distribution root is what a system
+package build does - the ROS build farm's binarydeb job - and that job runs
+its test step *before* the install step, so the package it is testing is not
+yet on `AMENT_PREFIX_PATH`. Every launch test then fails on resolution rather
+than on anything the test set out to check. Humble is the only distro whose
+binarydeb job still runs package tests at all; every distro from Iron onward
+disabled that step (`ros2/ros_buildfarm_config` PR 298). Because bloom runs it
+as `dh_auto_test || true`, the failures cannot stop the build, so what used to
+reach the build farm's log was every launch test failing for a reason that
+said nothing about the package.
+
+The install prefix alone is not a safe signal: `colcon build --install-base
+/opt/ros/<distro>` also installs straight into the distribution root, but its
+test step runs *after* its own install step, so its launch tests work fine.
+`CMAKE_INSTALL_LOCALSTATEDIR` is the second signal that tells the two apart -
+debhelper's `cmake` buildsystem always passes it
+(`-DCMAKE_INSTALL_LOCALSTATEDIR=/var`), and no `colcon build` ever does. The
+check is on the *value*, not merely `DEFINED`: a package that
+`include(GNUInstallDirs)`s defines `CMAKE_INSTALL_LOCALSTATEDIR` itself, to
+the relative `var` (no leading slash), which is a different value from what
+debhelper passes - `DEFINED` alone cannot tell those apart, so the guard
+requires the absolute `/var`. No in-tree package includes `GNUInstallDirs`
+today, so this is hardening against a real default rather than a fix for an
+observed failure. Both comparisons (the prefix and `CMAKE_INSTALL_LOCALSTATEDIR`)
+are exact (`STREQUAL`), so a trailing slash is stripped from each before
+comparing rather than trusted to match bloom's spelling.
+
+The "once per directory" of the printed message is a macro-scoped CMake
+variable, not a `CACHE` entry: a package that calls `medkit_add_launch_test`
+many times in one `CMakeLists.txt` sees the explanation once, and a different
+`CMakeLists.txt` in the same build - a different package, or a second
+`add_subdirectory()` - prints its own.
+
+gtests and pytest tests are untouched on purpose. That chroot is the only
+place our packages are exercised against a minimal dependency closure, and it
+is where the missing rosbag2 sqlite3 storage plugin was found - taking that
+coverage away along with the launch tests would trade one blind spot for
+another.
+
 Only domains **1-100 and 215-231** are drawn from. RTPS gives a domain the UDP slice
 `[7400 + 250 * d, 7400 + 250 * d + 249]`, and the kernel hands out ephemeral ports from
 `net.ipv4.ip_local_port_range` (32768-60999 by default), which covers domains 101-214. If an
@@ -237,7 +334,13 @@ part of what the other needs is a deadlock that only ends when both wait budgets
 `MEDKIT_TEST_DOMAINS` is appended to the test's `ENVIRONMENT`, so a caller adding its own
 entries must use `set_property(TEST ... APPEND PROPERTY ENVIRONMENT ...)`. A plain
 `set_tests_properties(... PROPERTIES ENVIRONMENT ...)` afterwards drops it, and the check
-below says so.
+below says so. This is the general rule for `medkit_add_gtest`, `medkit_add_gmock`,
+`medkit_add_pytest_test` and `medkit_add_wrapped_test` - all four are always registered, so a
+call naming the test afterwards is safe, just easy to get wrong in the APPEND direction.
+**A launch test is the one exception**: it is not always registered (see "Launch tests are not
+registered in a system package build" above), so a `set_tests_properties` or `set_property`
+call naming it afterwards is not a subtler bug to get right, it is unsupported - use
+`medkit_add_launch_test`'s own `LABELS` and `ENV` parameters instead.
 
 The failure this scheme has to guard against is silent: a test registered with plain
 `ament_add_gtest` or `add_launch_test` does not fail, it runs on domain 0 and sees every node

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -213,15 +213,18 @@ not supported, and not merely discouraged: see the next section for why the
 build can register no launch test at all, and a property call that names a
 test CMake never registered is a hard configure error, not a no-op. `ENV` is
 applied after the domain the macro already set for the test, by appending, so
-a caller's own environment can never overwrite `MEDKIT_TEST_DOMAINS` - an
-`ENV` entry that sets the literal key `MEDKIT_TEST_DOMAINS=` fails the
-configure with `FATAL_ERROR` naming `DOMAINS` as the way to set it, rather
-than silently landing behind the macro's own entry and winning at run time
-the way a plain `set_tests_properties(... PROPERTIES ENVIRONMENT ...)` used
-to. This is a literal string match, not a generator-expression evaluation:
-it does not chase down a value spelled to avoid the literal key (e.g.
-`ENV "$<1:MEDKIT_TEST_DOMAINS=99>"`), which nobody writes by accident and
-which a blanket rejection of `$<` would also catch legitimate uses of.
+a caller spelling the literal key `MEDKIT_TEST_DOMAINS=` cannot overwrite it -
+an `ENV` entry that does fails the configure with `FATAL_ERROR` naming
+`DOMAINS` as the way to set it, rather than silently landing behind the
+macro's own entry and winning at run time the way a plain
+`set_tests_properties(... PROPERTIES ENVIRONMENT ...)` used to. This is a
+literal string match, not a generator-expression evaluation, so the promise
+covers only that plain spelling: it does not chase down a value spelled to
+avoid the literal key (e.g. `ENV "$<1:MEDKIT_TEST_DOMAINS=99>"`), which still
+collides at run time exactly as if this check did not exist. Nobody writes
+that by accident, and a blanket rejection of `$<` would also catch legitimate
+uses of it in some other `ENV` entry, so this check only promises to catch
+the plain spelling.
 `LABELS` overrides `add_launch_test()`'s own default of `"launch_test"`, the same
 override callers used to apply by hand. `ARGS` forwards extra launch
 arguments straight to `add_launch_test()`, same as it always did - it has its

--- a/src/ros2_medkit_cmake/README.md
+++ b/src/ros2_medkit_cmake/README.md
@@ -241,7 +241,7 @@ the domain there too, and the check below says so.
 #### Launch tests are not registered in a system package build
 
 `medkit_add_launch_test()` registers nothing when two conditions both hold -
-the install prefix is the ROS distribution root, AND
+the install prefix matches `/opt/ros/<anything>`, AND
 `CMAKE_INSTALL_LOCALSTATEDIR` is the absolute path `/var` - and prints why
 once per directory instead:
 
@@ -265,21 +265,31 @@ as `dh_auto_test || true`, the failures cannot stop the build, so what used to
 reach the build farm's log was every launch test failing for a reason that
 said nothing about the package.
 
-The install prefix alone is not a safe signal: `colcon build --install-base
-/opt/ros/<distro>` also installs straight into the distribution root, but its
-test step runs *after* its own install step, so its launch tests work fine.
-`CMAKE_INSTALL_LOCALSTATEDIR` is the second signal that tells the two apart -
-debhelper's `cmake` buildsystem always passes it
-(`-DCMAKE_INSTALL_LOCALSTATEDIR=/var`), and no `colcon build` ever does. The
-check is on the *value*, not merely `DEFINED`: a package that
+The prefix check does not compare against `$ENV{ROS_DISTRO}`: an earlier
+version of this guard did, and it never fired in the job it exists for - the
+binarydeb chroot has no `ROS_DISTRO` in its environment at all. That export
+lives only in the `ros_environment` package, which nothing in this repository
+depends on, or in a `ros:<distro>` Docker image's own `ENV`, neither of which
+the build farm's chroot carries. The prefix is matched against
+`/opt/ros/<anything>` instead, which needs nothing from the environment.
+
+The install prefix alone is not a safe signal, however it is matched: `colcon
+build --install-base /opt/ros/<distro>` also installs straight into the
+distribution root, but its test step runs *after* its own install step, so
+its launch tests work fine. `CMAKE_INSTALL_LOCALSTATEDIR` is the second
+signal that tells the two apart - debhelper's `cmake` buildsystem always
+passes it (`-DCMAKE_INSTALL_LOCALSTATEDIR=/var`), and no `colcon build` ever
+does. The check is on the *value*, not merely `DEFINED`: a package that
 `include(GNUInstallDirs)`s defines `CMAKE_INSTALL_LOCALSTATEDIR` itself, to
 the relative `var` (no leading slash), which is a different value from what
 debhelper passes - `DEFINED` alone cannot tell those apart, so the guard
 requires the absolute `/var`. No in-tree package includes `GNUInstallDirs`
 today, so this is hardening against a real default rather than a fix for an
-observed failure. Both comparisons (the prefix and `CMAKE_INSTALL_LOCALSTATEDIR`)
-are exact (`STREQUAL`), so a trailing slash is stripped from each before
-comparing rather than trusted to match bloom's spelling.
+observed failure. `CMAKE_INSTALL_LOCALSTATEDIR` is compared exactly
+(`STREQUAL`), with a trailing slash stripped first, because it is an ordinary
+cache variable nothing else normalises. `CMAKE_INSTALL_PREFIX` needs no such
+stripping: CMake itself normalises a trailing slash out of it before project
+code ever sees it (confirmed on CMake 3.22, 3.28 and 4.4).
 
 The "once per directory" of the printed message is a macro-scoped CMake
 variable, not a `CACHE` entry: a package that calls `medkit_add_launch_test`
@@ -337,10 +347,29 @@ entries must use `set_property(TEST ... APPEND PROPERTY ENVIRONMENT ...)`. A pla
 below says so. This is the general rule for `medkit_add_gtest`, `medkit_add_gmock`,
 `medkit_add_pytest_test` and `medkit_add_wrapped_test` - all four are always registered, so a
 call naming the test afterwards is safe, just easy to get wrong in the APPEND direction.
-**A launch test is the one exception**: it is not always registered (see "Launch tests are not
-registered in a system package build" above), so a `set_tests_properties` or `set_property`
-call naming it afterwards is not a subtler bug to get right, it is unsupported - use
-`medkit_add_launch_test`'s own `LABELS` and `ENV` parameters instead.
+**A launch test is the one exception, and only for `LABELS` and `ENVIRONMENT`**: those two are
+the only properties `medkit_add_launch_test` sets itself, so it is the only macro that owns
+them, and a launch test is not always registered (see "Launch tests are not registered in a
+system package build" above) - a `set_tests_properties` or `set_property` call naming
+`LABELS` or `ENVIRONMENT` on it afterwards is not a subtler bug to get right, it is
+unsupported; use `medkit_add_launch_test`'s own `LABELS` and `ENV` parameters instead.
+
+The macro does not own anything else. `RESOURCE_LOCK`, `RUN_SERIAL`, `WILL_FAIL`, `DEPENDS`
+and `SKIP_RETURN_CODE` have no route through `medkit_add_launch_test` at all -
+`ros2_medkit_graph_watchdog` already sets `RESOURCE_LOCK` this way on some of its gtests, and
+the same call works on a launch test too, guarded so it does not turn into a hard configure
+error on a build where the guard suppressed the test:
+
+```cmake
+medkit_add_launch_test(test_multi test/test_multi.test.py TIMEOUT 300)
+if(TEST test_multi)
+  set_property(TEST test_multi APPEND PROPERTY RESOURCE_LOCK "some_resource")
+endif()
+```
+
+`if(TEST <name>)` is true exactly when CMake registered a test by that name, so this form is
+correct under both guard states without asking the caller to know which one is in effect:
+skipped entirely when the guard suppressed the test, and an ordinary `APPEND` otherwise.
 
 The failure this scheme has to guard against is silent: a test registered with plain
 `ament_add_gtest` or `add_launch_test` does not fail, it runs on domain 0 and sees every node

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -232,11 +232,12 @@ endfunction()
 # package build (see _medkit_launch_tests_can_register() above) registers no
 # launch test at all, and set_tests_properties on a test name that was never
 # registered is a hard CMake configure error, not a no-op. ENV is multi-value
-# and always APPENDs after the domain the macro already set, so a caller's
-# environment can never overwrite MEDKIT_TEST_DOMAINS - an ENV entry that sets
-# it with the literal key "MEDKIT_TEST_DOMAINS=" hits a FATAL_ERROR instead of
-# a silently-lost domain, which used to be what a plain
-# set_tests_properties(... PROPERTIES ENVIRONMENT ...) did.
+# and always APPENDs after the domain the macro already set, so a caller
+# spelling the literal key "MEDKIT_TEST_DOMAINS=" cannot overwrite it - that
+# hits a FATAL_ERROR instead of a silently-lost domain, which used to be what
+# a plain set_tests_properties(... PROPERTIES ENVIRONMENT ...) did. This is a
+# literal-string check, not a generator-expression evaluation - see the check
+# itself, further down, for the value it deliberately does not chase down.
 #
 # ARGS forwards extra launch arguments (e.g. "foo:=bar") straight to
 # add_launch_test(), same as it always did.
@@ -279,6 +280,23 @@ macro(medkit_add_launch_test TEST_NAME TEST_FILE)
     # "${_MALT_LABELS}" further down re-joins the collected words with ';' on
     # the way back out, which is exactly the list ctest expects.
     cmake_parse_arguments(_MALT "" "TIMEOUT;DOMAINS" "ENV;LABELS;ARGS" ${ARGN})
+    # cmake_parse_arguments records, rather than errors on, a keyword given
+    # with no value before the next token - which includes a value that
+    # happens to spell another recognised keyword's name, e.g.
+    # LABELS "ENV" DOMAINS 2: parsing sees ENV as a new keyword opening,
+    # not as a LABELS value, so LABELS silently ends up empty instead of
+    # containing "ENV" and nothing says so unless this is checked. Left
+    # unchecked, that is a caller's value silently misrouted or dropped,
+    # not merely an unhelpful error - worse than the CMake default of no
+    # error at all.
+    if(_MALT_KEYWORDS_MISSING_VALUES)
+      message(FATAL_ERROR
+        "medkit_add_launch_test(${TEST_NAME}): ${_MALT_KEYWORDS_MISSING_VALUES} given with no "
+        "value. If a value passed to a preceding keyword happens to spell one of TIMEOUT, "
+        "DOMAINS, ENV, LABELS or ARGS, cmake_parse_arguments starts a new keyword there "
+        "instead of taking it as a value - check the call for a value that collides with "
+        "one of those names.")
+    endif()
     if(NOT DEFINED _MALT_DOMAINS)
       set(_MALT_DOMAINS 1)
     endif()

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -146,6 +146,59 @@ macro(medkit_add_pytest_test TEST_NAME TEST_PATH)
   _medkit_declare_domains(${TEST_NAME} ${_MAPT_DOMAINS})
 endmacro()
 
+# A launch test resolves the executables and the Python helper package of the
+# package under test through the ament index, which only an installed prefix
+# carries. A system package build - the ROS build farm's binarydeb job - runs
+# `make test` before the install step, so the package is not on
+# AMENT_PREFIX_PATH and every launch test dies on resolution:
+#
+#   launch_test.py: error: "package 'ros2_medkit_fault_manager' not found,
+#                           searching: ['/opt/ros/humble']"
+#
+# Humble is the only distro that still runs package tests in that job; every
+# distro from Iron onward disables them (ros2/ros_buildfarm_config PR 298).
+# Because bloom runs the step as `dh_auto_test || true` the failures cannot stop
+# the build, so what they produce is a published log full of failures that say
+# nothing about the package.
+#
+# gtests and pytest tests are deliberately left alone. That chroot is the only
+# place our packages are exercised against a minimal dependency closure, and it
+# is where the missing rosbag2 sqlite3 storage plugin was found.
+#
+# Fires only in a system package build. Two independent signals, because either
+# one alone has a false positive that costs a developer their launch tests:
+#
+#   * the install prefix is the ROS distribution root, which is what bloom's
+#     debian/rules passes (-DCMAKE_INSTALL_PREFIX=/opt/ros/humble), and
+#   * CMAKE_INSTALL_LOCALSTATEDIR is the absolute path "/var", which debhelper's
+#     cmake buildsystem always passes (-DCMAKE_INSTALL_LOCALSTATEDIR=/var) and
+#     colcon never does.
+#
+# The second signal checks the value, not merely DEFINED: a package that
+# include(GNUInstallDirs)s defines CMAKE_INSTALL_LOCALSTATEDIR itself, to the
+# relative "var" (no leading slash), which is a different value from what
+# debhelper passes on the command line. DEFINED alone cannot tell those apart,
+# so this must be false there too - no in-tree package includes GNUInstallDirs
+# today, so this is hardening against a real GNUInstallDirs default rather
+# than a fix for an observed failure.
+#
+# The prefix alone would also catch `colcon build --install-base /opt/ros/jazzy`,
+# whose test step runs after its install step and whose launch tests work fine.
+# If this ever stops matching the build farm the guard simply does not fire and we
+# are back to a noisy log, which is the safe direction to be wrong in.
+function(_medkit_launch_tests_can_register _output_var)
+  set(${_output_var} TRUE PARENT_SCOPE)
+  if(NOT DEFINED ENV{ROS_DISTRO} OR NOT DEFINED CMAKE_INSTALL_LOCALSTATEDIR)
+    return()
+  endif()
+  # Exact comparison, so normalise a trailing slash first on both sides.
+  string(REGEX REPLACE "/+$" "" _malt_prefix "${CMAKE_INSTALL_PREFIX}")
+  string(REGEX REPLACE "/+$" "" _malt_localstatedir "${CMAKE_INSTALL_LOCALSTATEDIR}")
+  if(_malt_prefix STREQUAL "/opt/ros/$ENV{ROS_DISTRO}" AND _malt_localstatedir STREQUAL "/var")
+    set(${_output_var} FALSE PARENT_SCOPE)
+  endif()
+endfunction()
+
 # Register a launch_testing test AND give it a domain in one call.
 # This is the required way to add a launch test: it makes it impossible to add
 # one without isolation, and a launch test left on the default domain 0 sees
@@ -154,28 +207,132 @@ endmacro()
 # The domain is exported by the runner, so every process the launch description
 # starts inherits it.
 #
+# LABELS and ENV are the only supported way to give a launch test properties.
+# Passing them here rather than with a set_tests_properties(<name> ...) or a
+# set_property(TEST <name> ...) afterwards is required, not stylistic: a system
+# package build (see _medkit_launch_tests_can_register() above) registers no
+# launch test at all, and set_tests_properties on a test name that was never
+# registered is a hard CMake configure error, not a no-op. ENV is multi-value
+# and always APPENDs after the domain the macro already set, so a caller's
+# environment can never overwrite MEDKIT_TEST_DOMAINS - an ENV entry that sets
+# it with the literal key "MEDKIT_TEST_DOMAINS=" hits a FATAL_ERROR instead of
+# a silently-lost domain, which used to be what a plain
+# set_tests_properties(... PROPERTIES ENVIRONMENT ...) did.
+#
+# ARGS forwards extra launch arguments (e.g. "foo:=bar") straight to
+# add_launch_test(), same as it always did.
+#
+# Not registered at all in a system package build - see
+# _medkit_launch_tests_can_register() above.
+#
 # Usage:
 #   medkit_add_launch_test(test_integration test/test_integration.test.py)
-#   medkit_add_launch_test(test_multi test/test_multi.test.py TIMEOUT 300 DOMAINS 4)
+#   medkit_add_launch_test(test_multi test/test_multi.test.py TIMEOUT 300 DOMAINS 4
+#     LABELS "integration" ENV "FOO=bar" "BAZ=qux" ARGS "foo:=bar")
 macro(medkit_add_launch_test TEST_NAME TEST_FILE)
-  cmake_parse_arguments(_MALT "" "TIMEOUT;DOMAINS" "" ${ARGN})
-  if(NOT DEFINED _MALT_DOMAINS)
-    set(_MALT_DOMAINS 1)
+  _medkit_launch_tests_can_register(_MALT_CAN_REGISTER)
+  if(NOT _MALT_CAN_REGISTER)
+    # Printed once per directory: this flag is a macro-scoped variable, not a
+    # CACHE entry, so a package that calls medkit_add_launch_test many times in
+    # one CMakeLists.txt prints the explanation once, while a different
+    # CMakeLists.txt in the same build prints its own. It is directory-scoped,
+    # not project-scoped: a package built as several add_subdirectory()
+    # directories would print once per directory that registers a launch test.
+    if(NOT _MEDKIT_LAUNCH_TESTS_SKIPPED_REPORTED)
+      message(STATUS
+        "ros2_medkit: launch tests are not registered in this build. Installing into "
+        "${CMAKE_INSTALL_PREFIX} is a system package build, whose test step runs before "
+        "the install step, so a launch test cannot resolve this package through the "
+        "ament index. gtests and pytest tests still run.")
+      set(_MEDKIT_LAUNCH_TESTS_SKIPPED_REPORTED TRUE)
+    endif()
+  else()
+    # LABELS and ARGS are deliberately multi-value, not single-value: ${ARGN}
+    # above is an unquoted expansion, and CMake word-splits any argument that
+    # contains an embedded semicolon at that point - LABELS "integration;e2e"
+    # arrives here as two separate words, "integration" and "e2e", before
+    # parsing ever sees a keyword. A single-value LABELS would take only the
+    # first and leave the second as an unparsed argument that add_launch_test
+    # then rejects; a single-value ARGS has the same failure mode with a
+    # worse consequence - the overflow word would silently join whatever
+    # keyword came next instead of erroring, which is exactly how ARGS used
+    # to be able to leak into LABELS before ARGS got its own keyword below.
+    # "${_MALT_LABELS}" further down re-joins the collected words with ';' on
+    # the way back out, which is exactly the list ctest expects.
+    cmake_parse_arguments(_MALT "" "TIMEOUT;DOMAINS" "ENV;LABELS;ARGS" ${ARGN})
+    if(NOT DEFINED _MALT_DOMAINS)
+      set(_MALT_DOMAINS 1)
+    endif()
+    # A caller cannot set MEDKIT_TEST_DOMAINS through ENV with the literal key:
+    # it would land as a second, later entry in the ENVIRONMENT list behind
+    # the one _medkit_declare_domains sets below, and the later entry wins at
+    # run time - silently handing the test a domain count nothing allocated
+    # for it. DOMAINS <n> is the only supported way to set it.
+    #
+    # This is a literal string match against the "MEDKIT_TEST_DOMAINS=" prefix,
+    # not a CMake generator-expression evaluation: ENV "$<1:MEDKIT_TEST_DOMAINS=99>"
+    # would not match this MATCHES test and would still collide at run time,
+    # the same way it would if this check did not exist at all. Nobody writes
+    # that by accident, and rejecting every value containing "$<" would also
+    # block a caller from legitimately putting a generator expression in some
+    # other ENV entry, so this check only promises to catch the plain spelling.
+    foreach(_malt_env_name IN LISTS _MALT_ENV)
+      if(_malt_env_name MATCHES "^MEDKIT_TEST_DOMAINS=")
+        message(FATAL_ERROR
+          "medkit_add_launch_test(${TEST_NAME}): ENV must not set MEDKIT_TEST_DOMAINS "
+          "literally ('${_malt_env_name}') - that collides with the domain count the macro "
+          "sets for the test from DOMAINS <n>. Use DOMAINS instead of setting this directly.")
+      endif()
+    endforeach()
+    set(_MALT_EXTRA_ARGS "")
+    if(DEFINED _MALT_TIMEOUT)
+      list(APPEND _MALT_EXTRA_ARGS TIMEOUT ${_MALT_TIMEOUT})
+    endif()
+    # ARGS is a real add_launch_test() parameter (extra launch arguments, e.g.
+    # "foo:=bar"), forwarded explicitly rather than left to fall through
+    # _MALT_UNPARSED_ARGUMENTS, because LABELS being multi-value (above) means
+    # an ARGS keyword with no keyword of its own would otherwise be swallowed
+    # as more LABELS values instead of erroring. No in-tree caller uses ARGS
+    # today, so this line has no coverage from real call sites - only from the
+    # probe in test_launch_test_guard.py. Appended LAST into _MALT_EXTRA_ARGS,
+    # not before RUNNER below: ARGS is a multi-value keyword inside
+    # add_launch_test()'s own parser, which does not know RUNNER as a keyword
+    # at all, so anything placed after an open ARGS span - including RUNNER
+    # and its value - gets silently absorbed as more ARGS values instead of
+    # staying unparsed. That is exactly what happened here while writing this:
+    # RUNNER used to trail the call, ARGS's introduction swallowed it, and
+    # every launch test with ARGS would have quietly run unwrapped on domain 0.
+    if(DEFINED _MALT_ARGS)
+      list(APPEND _MALT_EXTRA_ARGS ARGS ${_MALT_ARGS})
+    endif()
+    # RUNNER is not a parameter add_launch_test knows; it forwards what it does
+    # not recognise to ament_add_test, which does. If a future launch_testing
+    # stopped forwarding it, the test would quietly run on domain 0 - which is
+    # exactly what test_dds_domain_allocation reads the generated command for.
+    # Placed right after TARGET, before TIMEOUT/ARGS: at this point no
+    # multi-value keyword of add_launch_test()'s own parser is open yet, so
+    # RUNNER and its value land in its UNPARSED_ARGUMENTS untouched, for the
+    # reason explained above ARGS.
+    add_launch_test(${TEST_FILE}
+      TARGET ${TEST_NAME}
+      RUNNER "${MEDKIT_TEST_DOMAIN_RUNNER}"
+      ${_MALT_UNPARSED_ARGUMENTS}
+      ${_MALT_EXTRA_ARGS})
+    _medkit_declare_domains(${TEST_NAME} ${_MALT_DOMAINS})
+    # add_launch_test() already defaulted LABELS to "launch_test"; this
+    # overrides it when the caller asked for something else, same as the
+    # set_tests_properties() callers used to do by hand - do not reorder this
+    # ahead of add_launch_test().
+    if(DEFINED _MALT_LABELS)
+      set_tests_properties(${TEST_NAME} PROPERTIES LABELS "${_MALT_LABELS}")
+    endif()
+    # APPEND, never a plain set: _medkit_declare_domains put MEDKIT_TEST_DOMAINS in
+    # ENVIRONMENT, and a plain set_tests_properties(... ENVIRONMENT ...) would drop
+    # it and leave the test on domain 0, seeing every node on the machine.
+    foreach(_malt_env IN LISTS _MALT_ENV)
+      set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "${_malt_env}")
+    endforeach()
   endif()
-  set(_MALT_EXTRA_ARGS "")
-  if(DEFINED _MALT_TIMEOUT)
-    list(APPEND _MALT_EXTRA_ARGS TIMEOUT ${_MALT_TIMEOUT})
-  endif()
-  # RUNNER is not a parameter add_launch_test knows; it forwards what it does
-  # not recognise to ament_add_test, which does. If a future launch_testing
-  # stopped forwarding it, the test would quietly run on domain 0 - which is
-  # exactly what test_dds_domain_allocation reads the generated command for.
-  add_launch_test(${TEST_FILE}
-    TARGET ${TEST_NAME}
-    ${_MALT_EXTRA_ARGS}
-    ${_MALT_UNPARSED_ARGUMENTS}
-    RUNNER "${MEDKIT_TEST_DOMAIN_RUNNER}")
-  _medkit_declare_domains(${TEST_NAME} ${_MALT_DOMAINS})
 endmacro()
 
 # Register an arbitrary command as a test that holds a domain.

--- a/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
+++ b/src/ros2_medkit_cmake/cmake/ROS2MedkitTestDomain.cmake
@@ -165,11 +165,21 @@ endmacro()
 # place our packages are exercised against a minimal dependency closure, and it
 # is where the missing rosbag2 sqlite3 storage plugin was found.
 #
-# Fires only in a system package build. Two independent signals, because either
-# one alone has a false positive that costs a developer their launch tests:
+# Fires only in a system package build. Two independent signals, both read
+# from CMake variables rather than the environment - an earlier version of
+# this guard also required ENV{ROS_DISTRO} to be defined, and that guard
+# never fired in the one job it exists for: the ROS build farm's binarydeb
+# chroot has no ROS_DISTRO in its environment at all. That export lives only
+# in the ros_environment package (no package.xml in this repository declares
+# it, and it is not part of the farm's chroot install) or in a ros:<distro>
+# Docker image's own ENV, neither of which the build farm's chroot carries.
+# Either signal alone also has a false positive that costs a developer their
+# launch tests:
 #
-#   * the install prefix is the ROS distribution root, which is what bloom's
-#     debian/rules passes (-DCMAKE_INSTALL_PREFIX=/opt/ros/humble), and
+#   * the install prefix matches /opt/ros/<anything> - not a specific distro
+#     name, since nothing in a bare CMake configure names the right one on
+#     its own - which is what bloom's debian/rules passes
+#     (-DCMAKE_INSTALL_PREFIX=/opt/ros/humble), and
 #   * CMAKE_INSTALL_LOCALSTATEDIR is the absolute path "/var", which debhelper's
 #     cmake buildsystem always passes (-DCMAKE_INSTALL_LOCALSTATEDIR=/var) and
 #     colcon never does.
@@ -182,19 +192,28 @@ endmacro()
 # today, so this is hardening against a real GNUInstallDirs default rather
 # than a fix for an observed failure.
 #
-# The prefix alone would also catch `colcon build --install-base /opt/ros/jazzy`,
-# whose test step runs after its install step and whose launch tests work fine.
-# If this ever stops matching the build farm the guard simply does not fire and we
-# are back to a noisy log, which is the safe direction to be wrong in.
+# The prefix alone would also catch `colcon build --install-base /opt/ros/jazzy`
+# (or any other distro name), whose test step runs after its install step and
+# whose launch tests work fine - colcon never passes
+# CMAKE_INSTALL_LOCALSTATEDIR, so the function returns TRUE before the prefix
+# is even inspected. If this ever stops matching the build farm the guard
+# simply does not fire and we are back to a noisy log, which is the safe
+# direction to be wrong in.
 function(_medkit_launch_tests_can_register _output_var)
   set(${_output_var} TRUE PARENT_SCOPE)
-  if(NOT DEFINED ENV{ROS_DISTRO} OR NOT DEFINED CMAKE_INSTALL_LOCALSTATEDIR)
+  if(NOT DEFINED CMAKE_INSTALL_LOCALSTATEDIR)
     return()
   endif()
-  # Exact comparison, so normalise a trailing slash first on both sides.
-  string(REGEX REPLACE "/+$" "" _malt_prefix "${CMAKE_INSTALL_PREFIX}")
+  # CMAKE_INSTALL_PREFIX needs no normalisation of its own: CMake strips a
+  # trailing slash from it before project code ever sees it - confirmed on
+  # CMake 3.22, 3.28 and 4.4 - so a trailing slash cannot change the outcome
+  # of the MATCHES below however the caller spells the prefix.
+  # CMAKE_INSTALL_LOCALSTATEDIR is an ordinary cache variable nothing else
+  # normalises, so its trailing slash is still stripped explicitly before the
+  # exact comparison.
+  set(_malt_prefix "${CMAKE_INSTALL_PREFIX}")
   string(REGEX REPLACE "/+$" "" _malt_localstatedir "${CMAKE_INSTALL_LOCALSTATEDIR}")
-  if(_malt_prefix STREQUAL "/opt/ros/$ENV{ROS_DISTRO}" AND _malt_localstatedir STREQUAL "/var")
+  if(_malt_prefix MATCHES "^/opt/ros/[^/]+$" AND _malt_localstatedir STREQUAL "/var")
     set(${_output_var} FALSE PARENT_SCOPE)
   endif()
 endfunction()

--- a/src/ros2_medkit_cmake/design/index.rst
+++ b/src/ros2_medkit_cmake/design/index.rst
@@ -70,18 +70,32 @@ new packages reintroducing the escape.
    - ``medkit_apply_compat_defs(target)`` - Applies compile definitions based on detected versions
    - ``medkit_target_dependencies(target ...)`` - Drop-in replacement for ``ament_target_dependencies`` that also works on Lyrical (where ``ament_target_dependencies`` was removed)
 
-5. **ROS2MedkitTestDomain.cmake** - ``ROS_DOMAIN_ID`` allocation for tests
+5. **ROS2MedkitTestDomain.cmake** - ``ROS_DOMAIN_ID`` allocation for tests, and the
+   system-package launch-test guard
 
-   - ``medkit_add_gtest()``, ``medkit_add_gmock()``, ``medkit_add_pytest_test()`` and
-     ``medkit_add_launch_test()`` register a test behind the domain wrapper, so a test
-     cannot be added without isolation
-   - ``medkit_add_wrapped_test(<name> COMMAND <cmd...>)`` does the same for a test that
-     builds its own command line
+   - ``medkit_add_gtest()``, ``medkit_add_gmock()`` and ``medkit_add_pytest_test()``
+     register a test behind the domain wrapper unconditionally, so a test cannot be
+     added without isolation
+   - ``medkit_add_launch_test()`` does the same, but conditionally:
+     ``_medkit_launch_tests_can_register()`` registers nothing at all when the configure
+     looks like the ROS build farm's binarydeb job - the install prefix matches
+     ``/opt/ros/<anything>`` AND ``CMAKE_INSTALL_LOCALSTATEDIR`` is the absolute path
+     ``/var``, both read from CMake variables, never from the environment. That job runs
+     its test step before its own install step, so a launch test cannot resolve the
+     package under test through the ament index and fails on that alone, on every launch
+     test, for every package, on Humble (the only distro whose binarydeb job still runs
+     package tests at all). gtests and pytest tests need no installed prefix and are
+     unaffected. See "The One Case That Cannot Live Here, Reconciled With the Guard"
+     below.
+   - ``medkit_add_wrapped_test(<name> COMMAND <cmd...>)`` does the same as the
+     unconditional three, for a test that builds its own command line
    - ``DOMAINS <n>`` on any of them for a test that holds several domains at once; the
      extras arrive as ``MEDKIT_SECONDARY_DOMAINS``
    - ``medkit_test_needs_no_domain(<test>)`` declares a test ROS-free
-   - the runtime guard described below registers itself in every package; no package
-     calls anything to get it
+   - the domain-allocation runtime guard described below (``test_dds_domain_allocation``)
+     registers itself in every package; no package calls anything to get it - a separate
+     mechanism from the launch-test guard above, which acts at configure time instead of
+     at test run time
    - the wrapper scripts themselves live in ``scripts/``: ``medkit_domain.py`` (the band
      and the allocator), ``medkit_domain_runner.py`` (ament test runner replacement),
      ``medkit_run_with_domain.py`` (generic command wrapper)
@@ -235,15 +249,33 @@ earlier shape registered them as two CTest tests and needed ``ctest -j`` to run 
 side; CTest cannot be asked for that, so the pair passed under a parallel run and failed
 under a serial one. Concurrency a test depends on is the test's to arrange.
 
-The one case that cannot live here is the launch test, which proves a launch test's children
-join its domain. ``launch_testing_ament_cmake`` reaches the deprecated ``FindPythonLibs``
-through ``python_cmake_module`` on Humble, and this project is declared ``NONE``: with no
-language enabled CMake leaves ``CMAKE_LIBRARY_ARCHITECTURE`` and ``CMAKE_SIZEOF_VOID_P``
-empty, so ``find_library`` never searches the multiarch directory and libpython is not found
-however the development headers are installed. Since every package depends on this one, a
-configure failure here stops the whole workspace, so that test lives in
-``ros2_medkit_fault_reporter``, which compiles and already runs a launch test on every
-distro. Keep test-only ``find_package`` calls out of this package.
+The One Case That Cannot Live Here, Reconciled With the Guard
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The one case that cannot live here is a real launch test of this package's own, which would
+prove a launch test's children join its domain. ``launch_testing_ament_cmake`` reaches the
+deprecated ``FindPythonLibs`` through ``python_cmake_module`` on Humble, and this project is
+declared ``NONE``: with no language enabled CMake leaves ``CMAKE_LIBRARY_ARCHITECTURE`` and
+``CMAKE_SIZEOF_VOID_P`` empty, so ``find_library`` never searches the multiarch directory and
+libpython is not found however the development headers are installed. Since every package
+depends on this one, a configure failure here stops the whole workspace, so that test lives
+in ``ros2_medkit_fault_reporter``, which compiles and already runs a launch test on every
+distro. Keep a real launch test of this package's own - one that would make ``project(
+ros2_medkit_cmake NONE)`` itself resolve ``launch_testing_ament_cmake`` - out of this package.
+
+That does not rule out ``find_package(launch_testing_ament_cmake)`` appearing here at all.
+``test/test_launch_test_guard.py`` proves the guard described above against a real ``cmake``
+configure by writing a throwaway ``CMakeLists.txt`` per case and running a separate ``cmake
+-S ... -B ...`` subprocess against it - every probe that needs it declares its own
+``project(... C)`` or ``project(... CXX)``, never ``NONE``, so the hazard above does not
+apply: it is the throwaway subprocess's own language that ``find_package`` and
+``find_library`` see, not this package's. ``ros2_medkit_cmake/CMakeLists.txt`` itself is
+still ``project(ros2_medkit_cmake NONE)`` and still never calls
+``find_package(launch_testing_ament_cmake)``; the package declares it a ``test_depend`` in
+``package.xml`` so the probes that do call it resolve on their own merits rather than by
+happening to ride in on some other package's dependency chain. What stays out of this package
+is a real launch test of its own; a subprocess that configures one, with a language of its
+own, is a different thing and always was.
 
 Separate Package
 ~~~~~~~~~~~~~~~~

--- a/src/ros2_medkit_cmake/package.xml
+++ b/src/ros2_medkit_cmake/package.xml
@@ -14,6 +14,7 @@
   <exec_depend>domain_coordinator</exec_depend>
 
   <test_depend>ament_cmake_flake8</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>python3-pytest</test_depend>

--- a/src/ros2_medkit_cmake/package.xml
+++ b/src/ros2_medkit_cmake/package.xml
@@ -15,6 +15,7 @@
 
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>std_msgs</test_depend>

--- a/src/ros2_medkit_cmake/test/test_launch_test_guard.py
+++ b/src/ros2_medkit_cmake/test/test_launch_test_guard.py
@@ -45,14 +45,20 @@ because this package cannot depend on the packages that consume it - that
 would be circular - so it needs a package whose own dependency chain already
 reaches them.
 
-The guard itself fires on two independent signals - the install prefix is the
-ROS distribution root, AND ``CMAKE_INSTALL_LOCALSTATEDIR`` equals ``/var`` -
+The guard itself fires on two independent signals, both read from CMake
+variables rather than the environment - the install prefix matches
+``/opt/ros/<anything>``, AND ``CMAKE_INSTALL_LOCALSTATEDIR`` equals ``/var`` -
 because either alone has a false positive: the prefix alone would also catch
 ``colcon build --install-base /opt/ros/<distro>``, whose test step runs after
 its own install step and whose launch tests work fine, and checking only
 ``DEFINED`` would also catch ``include(GNUInstallDirs)``, which defines it
 itself as the relative ``var`` rather than the absolute ``/var`` debhelper
-passes on the command line.
+passes on the command line. An earlier version of the prefix check compared
+against ``$ENV{ROS_DISTRO}`` instead of a wildcard, and never fired in the ROS
+build farm's binarydeb chroot as a result: that environment has no
+``ROS_DISTRO`` set at all, so the old guard always returned TRUE (register)
+there - see ``test_launch_test_is_not_registered_with_ros_distro_absent``
+below, which is the probe that would have caught it.
 
 The guard covers launch tests only. gtests run fine in that chroot and are the
 only place our packages meet a minimal dependency closure, which is how the
@@ -126,6 +132,32 @@ enable_testing()
 medkit_add_pytest_test(probe_pytest_test probe_pytest TIMEOUT 10)
 """
 
+# A CXX project, not C or NONE: ament_cmake_gtest's own find_package chain
+# needs a C++ compiler to locate GTest with, and medkit_add_gtest's whole
+# point is a compiled test binary. cmake_guard.py's
+# assert_guard_suppressed_launch_tests backstops "the guard did not remove
+# everything" with a bare `assert guarded_tests`, and its docstring names
+# gtests explicitly - but nothing before this probe actually exercised a
+# gtest through the guard: a guard that also swallowed gtests would still
+# pass every real-package check, because ros2_medkit_log_bridge's own pytest
+# test would still be there to satisfy the assertion.
+GTEST_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_gtest_guard_probe CXX)
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_gtest REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_gtest(probe_gtest_test probe_gtest.cpp)
+"""
+
+GTEST_PROBE_SOURCE = """#include <gtest/gtest.h>
+
+TEST(ProbeGtestGuard, Passes)
+{
+  EXPECT_TRUE(true);
+}
+"""
+
 # LABELS is a single word here on purpose: the point of this probe is ARGS,
 # not the LABELS multi-value splitting LAUNCH_PROBE already covers. If ARGS
 # leaked into LABELS the way it did before ARGS got its own keyword, LABELS
@@ -161,14 +193,23 @@ def configure_probe(
     """
     Configure a throwaway project and return the completed cmake process.
 
-    ROS_DISTRO is always set in the subprocess environment (jazzy by default,
-    overridable). A probe that skipped itself when ROS_DISTRO happened to be
-    unset in whoever runs this suite would let a deleted guard pass here right
-    along with a working one - that used to be true of this file and is
-    exactly what let the CRITICAL finding through unnoticed. The default is
-    jazzy rather than humble because that is the distro this suite otherwise
-    runs under; a guard hard-coded to jazzy would still pass every case here
-    if every case also used jazzy, which is why one case pins humble instead.
+    ROS_DISTRO is set to *ros_distro* in the subprocess environment (jazzy by
+    default, overridable) unless *ros_distro* is None, in which case it is
+    deleted from the environment instead of set - the actual state of the ROS
+    build farm's binarydeb chroot, which has no `ros_environment` package (the
+    only in-tree source of that export) and no Docker `ENV` setting it either.
+
+    The guard no longer reads ROS_DISTRO at all (see
+    ROS2MedkitTestDomain.cmake), so this parameter no longer decides the
+    guard's outcome the way it used to - but it did decide it, silently,
+    before this file gained `ros_distro=None` as a real case: every probe here
+    used to force ROS_DISTRO into the child environment unconditionally,
+    which is exactly the one state that does not hold in the target job, and
+    is how a guard that never fired there kept passing this whole file. The
+    default stays jazzy rather than humble because that is the distro this
+    suite otherwise runs under; a guard hard-coded to jazzy would still pass
+    every case here if every case also used jazzy, which is why one case pins
+    humble and another deletes ROS_DISTRO entirely.
     """
     source = tmp_path / 'probe'
     source.mkdir()
@@ -189,9 +230,13 @@ def configure_probe(
     # Override, not replace: cmake still needs the inherited AMENT_PREFIX_PATH /
     # CMAKE_PREFIX_PATH to resolve find_package(ament_cmake) and
     # find_package(launch_testing_ament_cmake) at all. Only ROS_DISTRO itself is
-    # pinned, so every probe imitates a chosen distro regardless of who runs it.
+    # touched, so every probe imitates a chosen distro - or its absence -
+    # regardless of who runs it.
     env = dict(os.environ)
-    env['ROS_DISTRO'] = ros_distro
+    if ros_distro is None:
+        env.pop('ROS_DISTRO', None)
+    else:
+        env['ROS_DISTRO'] = ros_distro
     return subprocess.run(
         cmake_args,
         capture_output=True,
@@ -313,20 +358,28 @@ def test_launch_test_is_registered_when_localstatedir_is_relative(tmp_path):
     assert 'probe_launch_test' in registered_tests(build), result.stdout
 
 
-def test_launch_test_is_not_registered_with_a_trailing_slash_on_the_prefix(tmp_path):
+def test_launch_test_is_not_registered_with_a_trailing_slash_on_localstatedir(tmp_path):
     """
-    A trailing slash on the install prefix does not disarm the guard.
+    A trailing slash on CMAKE_INSTALL_LOCALSTATEDIR does not disarm the guard.
 
-    The comparison is STREQUAL, which is exact, so the guard normalises the
-    prefix before comparing it rather than relying on the caller to spell it
-    exactly as bloom does.
+    This file used to probe a trailing slash on the install prefix instead,
+    and that probe could not fail however the guard's own code was written:
+    CMake itself strips a trailing slash from CMAKE_INSTALL_PREFIX before
+    project code ever sees it - confirmed on CMake 3.22, 3.28 and 4.4 - so
+    the guard's prefix match needs no normalisation of its own, and by the
+    time the guard runs the question was already settled upstream.
+    CMAKE_INSTALL_LOCALSTATEDIR is an ordinary cache variable nothing else
+    normalises, so the guard's own `string(REGEX REPLACE "/+$" ...)` on it is
+    the only thing standing between a trailing slash here and a failed
+    STREQUAL "/var" comparison - this is what actually needs a test, and this
+    pins that it works.
     """
     result, build = configure_probe(
         tmp_path,
         LAUNCH_PROBE,
-        '/opt/ros/jazzy/',
+        '/opt/ros/jazzy',
         {'probe_launch.test.py': '# empty launch test file\n'},
-        localstatedir='/var',
+        localstatedir='/var/',
     )
     assert result.returncode == 0, result.stderr
     assert 'probe_launch_test' not in registered_tests(build), result.stdout
@@ -353,6 +406,32 @@ def test_other_test_kinds_are_still_registered_in_a_system_build(tmp_path):
     assert 'probe_pytest_test' in registered_tests(build), result.stdout
 
 
+def test_gtest_is_still_registered_in_a_system_build(tmp_path):
+    """
+    The guard covers launch tests only, so a gtest still registers too.
+
+    The pytest half of this claim is
+    `test_other_test_kinds_are_still_registered_in_a_system_build` above;
+    this is the gtest half, which `cmake_guard.py`'s
+    `assert_guard_suppressed_launch_tests` docstring names but which no probe
+    here actually drove through the guard before this test: its own
+    backstop, a bare `assert guarded_tests`, would still pass for a guard
+    that also swallowed gtests, as long as some pytest test in the same
+    package survived to keep the set non-empty. This closes that gap
+    directly rather than relying on a real package always happening to carry
+    both kinds.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        GTEST_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_gtest.cpp': GTEST_PROBE_SOURCE},
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_gtest_test' in registered_tests(build), result.stdout
+
+
 def test_launch_test_is_registered_with_a_non_distribution_prefix_and_localstatedir_set(tmp_path):
     """
     CMAKE_INSTALL_LOCALSTATEDIR alone does not suppress; the prefix still has to match.
@@ -377,12 +456,16 @@ def test_launch_test_is_registered_with_a_non_distribution_prefix_and_localstate
 
 def test_launch_test_is_not_registered_on_humble(tmp_path):
     """
-    The guard reads ROS_DISTRO rather than being hard-coded to one distro.
+    The guard's prefix match is a wildcard, not hard-coded to one distro.
 
     Humble is the only distro whose binarydeb job still runs package tests -
     the one this whole task exists for - so a guard that happened to work only
     for jazzy (every other case in this file) would not fire on the build that
-    matters and would still pass the suite.
+    matters and would still pass the suite. ros_distro='humble' here only
+    controls what the probe's subprocess environment looks like, matching the
+    real chroot's distro; it plays no part in the guard's own decision - see
+    test_launch_test_is_not_registered_with_ros_distro_absent below for the
+    case that proves the guard does not need it at all.
     """
     result, build = configure_probe(
         tmp_path,
@@ -394,6 +477,40 @@ def test_launch_test_is_not_registered_on_humble(tmp_path):
     )
     assert result.returncode == 0, result.stderr
     assert 'probe_launch_test' not in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_not_registered_with_ros_distro_absent(tmp_path):
+    """
+    The guard suppresses launch tests even when ROS_DISTRO is not in the environment at all.
+
+    This is the actual state of the ROS build farm's binarydeb chroot, not a
+    hypothetical: no in-tree package.xml declares ros_environment (the only
+    source of the ROS_DISTRO export outside a Docker image's own ENV), and
+    ros-humble-ros-environment does not appear in the farm's chroot install
+    log, so ROS_DISTRO is genuinely unset there. An earlier version of this
+    guard read ENV{ROS_DISTRO} and returned TRUE (register) the instant it
+    was undefined - which is exactly this case - so the guard never fired in
+    the one job it exists for, and every launch test kept failing on
+    resolution exactly as before the guard was written. Every other probe in
+    this file sets ROS_DISTRO in the child environment (see
+    configure_probe's docstring for why that was not incidental); this one
+    deletes it instead, which is what makes this the probe that would have
+    caught the regression before it shipped.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/humble',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var',
+        ros_distro=None,
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' not in registered_tests(build), (
+        f'the guard did not suppress the launch test with ROS_DISTRO absent from the '
+        f'environment - this is the exact condition of the ROS build farm binarydeb '
+        f'chroot the guard exists for:\n{result.stdout}'
+    )
 
 
 def test_args_reaches_add_launch_test_and_is_not_absorbed_by_labels(tmp_path):

--- a/src/ros2_medkit_cmake/test/test_launch_test_guard.py
+++ b/src/ros2_medkit_cmake/test/test_launch_test_guard.py
@@ -1,0 +1,455 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The guard that keeps launch tests out of a build that cannot run them.
+
+A launch test resolves the executables and the Python helpers of the package
+under test through the ament index of an installed prefix. The ROS build farm's
+binarydeb job runs ``make test`` before the install step, so the package is
+absent from ``AMENT_PREFIX_PATH`` and every launch test fails on resolution
+rather than on the thing it set out to check. Humble is the only distro that
+still runs those tests, and because bloom runs the step as
+``dh_auto_test || true`` the failures cannot stop the build and nobody has to
+see them.
+
+Guarding registration is not enough by itself: a caller that names its launch
+test afterwards, with a ``set_tests_properties`` or a ``set_property(TEST ...)``,
+is naming a test a guarded build never registered, and CMake fails the
+configure outright rather than doing nothing. So ``medkit_add_launch_test`` owns
+``LABELS`` and ``ENV`` itself now.
+
+The regression test for "does this actually stay true across every
+``CMakeLists.txt`` in the tree" does not live in this file. A first attempt at
+it was a regex sweep over the tree's ``CMakeLists.txt`` text, and it was
+patched three times running for the same reason each time: a string proxy for
+"does this configure cleanly" always has one more shape it cannot see (a
+second name on one call, a name on a continuation line, a paren balanced
+across a comment, a mixed-case command spelling CMake itself does not care
+about). ``ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py``
+replaces it with a real ``cmake`` configure of every package that registers a
+launch test, under system-package conditions, which is exactly the property
+being promised and needs no proxy for it. It lives there rather than here
+because this package cannot depend on the packages that consume it - that
+would be circular - so it needs a package whose own dependency chain already
+reaches them.
+
+The guard itself fires on two independent signals - the install prefix is the
+ROS distribution root, AND ``CMAKE_INSTALL_LOCALSTATEDIR`` equals ``/var`` -
+because either alone has a false positive: the prefix alone would also catch
+``colcon build --install-base /opt/ros/<distro>``, whose test step runs after
+its own install step and whose launch tests work fine, and checking only
+``DEFINED`` would also catch ``include(GNUInstallDirs)``, which defines it
+itself as the relative ``var`` rather than the absolute ``/var`` debhelper
+passes on the command line.
+
+The guard covers launch tests only. gtests run fine in that chroot and are the
+only place our packages meet a minimal dependency closure, which is how the
+missing rosbag2 sqlite3 storage plugin was found.
+``test_other_test_kinds_are_still_registered_in_a_system_build`` is what stops
+the guard from growing into them.
+"""
+
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DOMAIN_MODULE = PACKAGE_ROOT / 'cmake' / 'ROS2MedkitTestDomain.cmake'
+
+# Every probe that find_package(launch_testing_ament_cmake)s is declared with
+# the C language, not NONE. On Humble, launch_testing_ament_cmake reaches the
+# deprecated FindPythonLibs through python_cmake_module, and a project with no
+# language enabled leaves CMAKE_LIBRARY_ARCHITECTURE and CMAKE_SIZEOF_VOID_P
+# empty, so find_library never searches the multiarch directory and libpython
+# is not found however the development headers are installed - see
+# design/index.rst ("The one case that cannot live here...") and
+# ros2_medkit_fault_reporter/CMakeLists.txt for the same reasoning applied to
+# why that package's own launch test lives there instead of in this one. This
+# package's real CMakeLists.txt is unaffected (declared NONE on purpose, and
+# never find_package(launch_testing_ament_cmake)s), but a throwaway probe
+# project that does both has the identical failure mode on Humble, and this
+# suite is labelled "unit", which CI runs on every distro.
+#
+# The pytest probe does not find_package(launch_testing_ament_cmake), so it
+# stays NONE.
+
+# One macro call, given LABELS and ENV, so the workspace-build probe can pin
+# the trap this migration removes: the domain the macro sets for itself has to
+# survive alongside a caller's own properties.
+LAUNCH_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_launch_guard_probe C)
+find_package(ament_cmake REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_launch_test(probe_launch_test probe_launch.test.py TIMEOUT 10
+  LABELS "integration;probe"
+  ENV "PROBE_FOO=bar" "PROBE_BAZ=qux")
+"""
+
+# Two calls in one project, so the "reported once" probe below can tell a flag
+# that is never set from one that is set and then wrongly cleared between calls
+# - a single-call probe cannot tell those apart.
+DOUBLE_LAUNCH_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_double_launch_guard_probe C)
+find_package(ament_cmake REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_launch_test(probe_launch_test_one probe_launch_one.test.py TIMEOUT 10)
+medkit_add_launch_test(probe_launch_test_two probe_launch_two.test.py TIMEOUT 10)
+"""
+
+PYTEST_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_pytest_guard_probe NONE)
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_pytest REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_pytest_test(probe_pytest_test probe_pytest TIMEOUT 10)
+"""
+
+# LABELS is a single word here on purpose: the point of this probe is ARGS,
+# not the LABELS multi-value splitting LAUNCH_PROBE already covers. If ARGS
+# leaked into LABELS the way it did before ARGS got its own keyword, LABELS
+# would read "integration;ARGS;probe_arg:=probe_value" instead of plain
+# "integration".
+ARGS_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_launch_guard_args_probe C)
+find_package(ament_cmake REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_launch_test(probe_launch_test probe_launch.test.py TIMEOUT 10
+  LABELS "integration"
+  ARGS "probe_arg:=probe_value")
+"""
+
+# A caller that tries to set MEDKIT_TEST_DOMAINS through ENV instead of
+# DOMAINS - this must fail the configure, not silently double the entry.
+DOMAINS_COLLISION_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_launch_guard_domains_collision_probe C)
+find_package(ament_cmake REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_launch_test(probe_launch_test probe_launch.test.py TIMEOUT 10
+  ENV "MEDKIT_TEST_DOMAINS=99")
+"""
+
+
+def configure_probe(
+    tmp_path, template, install_prefix, extra_files, *, localstatedir=None, ros_distro='jazzy'
+):
+    """
+    Configure a throwaway project and return the completed cmake process.
+
+    ROS_DISTRO is always set in the subprocess environment (jazzy by default,
+    overridable). A probe that skipped itself when ROS_DISTRO happened to be
+    unset in whoever runs this suite would let a deleted guard pass here right
+    along with a working one - that used to be true of this file and is
+    exactly what let the CRITICAL finding through unnoticed. The default is
+    jazzy rather than humble because that is the distro this suite otherwise
+    runs under; a guard hard-coded to jazzy would still pass every case here
+    if every case also used jazzy, which is why one case pins humble instead.
+    """
+    source = tmp_path / 'probe'
+    source.mkdir()
+    (source / 'CMakeLists.txt').write_text(template.format(module=DOMAIN_MODULE.as_posix()))
+    for name, content in extra_files.items():
+        target = source / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    build = tmp_path / 'build'
+    cmake_args = [
+        shutil.which('cmake') or 'cmake',
+        '-S', str(source),
+        '-B', str(build),
+        f'-DCMAKE_INSTALL_PREFIX={install_prefix}',
+    ]
+    if localstatedir is not None:
+        cmake_args.append(f'-DCMAKE_INSTALL_LOCALSTATEDIR={localstatedir}')
+    # Override, not replace: cmake still needs the inherited AMENT_PREFIX_PATH /
+    # CMAKE_PREFIX_PATH to resolve find_package(ament_cmake) and
+    # find_package(launch_testing_ament_cmake) at all. Only ROS_DISTRO itself is
+    # pinned, so every probe imitates a chosen distro regardless of who runs it.
+    env = dict(os.environ)
+    env['ROS_DISTRO'] = ros_distro
+    return subprocess.run(
+        cmake_args,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+        env=env,
+    ), build
+
+
+def read_ctest_testfile(build_dir):
+    """Return the raw CTestTestfile.cmake text, or '' when configure produced none."""
+    testfile = build_dir / 'CTestTestfile.cmake'
+    if not testfile.is_file():
+        return ''
+    return testfile.read_text()
+
+
+def registered_tests(build_dir):
+    """Return the names ctest would run for a configured probe."""
+    return [
+        line.split('(', 1)[1].split(' ', 1)[0].strip('"')
+        for line in read_ctest_testfile(build_dir).splitlines()
+        if line.lstrip().startswith('add_test(')
+    ]
+
+
+def test_launch_test_is_registered_in_a_workspace_build(tmp_path):
+    """
+    A colcon build installs into the workspace, so the launch test is registered.
+
+    No CMAKE_INSTALL_LOCALSTATEDIR here, matching an ordinary colcon build,
+    which never passes it. The caller's LABELS and ENV must both reach the
+    generated CTestTestfile.cmake alongside MEDKIT_TEST_DOMAINS - the domain
+    the macro set for itself - which is the trap this migration removes: a
+    plain set_tests_properties/set_property after the call used to be able to
+    drop it.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        tmp_path / 'install',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+    testfile = read_ctest_testfile(build)
+    assert 'MEDKIT_TEST_DOMAINS=1' in testfile, testfile
+    assert 'PROBE_FOO=bar' in testfile, testfile
+    assert 'PROBE_BAZ=qux' in testfile, testfile
+    assert 'integration;probe' in testfile, testfile
+
+
+def test_launch_tests_are_not_registered_in_a_system_package_build(tmp_path):
+    """
+    A system package build registers no launch test and says why exactly once.
+
+    This is the case the guard exists for. Without it the build farm publishes
+    a log in which every launch test of the package failed, none of them for a
+    reason that says anything about the package. Two calls in one project, so
+    that "exactly once" is a real assertion about the report flag rather than
+    a coincidence of there being only one call to not print twice.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        DOUBLE_LAUNCH_PROBE,
+        '/opt/ros/jazzy',
+        {
+            'probe_launch_one.test.py': '# empty launch test file\n',
+            'probe_launch_two.test.py': '# empty launch test file\n',
+        },
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    names = registered_tests(build)
+    assert 'probe_launch_test_one' not in names, result.stdout
+    assert 'probe_launch_test_two' not in names, result.stdout
+    assert result.stdout.count('launch tests are not registered') == 1, result.stdout
+
+
+def test_launch_test_is_registered_with_the_distribution_prefix_but_no_localstatedir(tmp_path):
+    """
+    `colcon build --install-base /opt/ros/jazzy` still gets its launch tests.
+
+    Its test step runs after its own install step, unlike a system package
+    build's, so the install prefix by itself is not a safe signal - only
+    CMAKE_INSTALL_LOCALSTATEDIR, which debhelper's cmake buildsystem always
+    passes and colcon never does, tells the two apart.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_registered_when_localstatedir_is_relative(tmp_path):
+    """
+    A relative CMAKE_INSTALL_LOCALSTATEDIR does not arm the guard.
+
+    `include(GNUInstallDirs)` defines CMAKE_INSTALL_LOCALSTATEDIR itself, to
+    the relative "var" rather than the absolute "/var" debhelper passes on
+    the command line. Checking only DEFINED cannot tell those apart; this
+    pins that the guard checks the value. No in-tree package includes
+    GNUInstallDirs today, so this is a regression guard for a real default,
+    not a reproduction of an observed failure.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_not_registered_with_a_trailing_slash_on_the_prefix(tmp_path):
+    """
+    A trailing slash on the install prefix does not disarm the guard.
+
+    The comparison is STREQUAL, which is exact, so the guard normalises the
+    prefix before comparing it rather than relying on the caller to spell it
+    exactly as bloom does.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/jazzy/',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' not in registered_tests(build), result.stdout
+
+
+def test_other_test_kinds_are_still_registered_in_a_system_build(tmp_path):
+    """
+    The guard covers launch tests only, so a pytest test still registers.
+
+    Under the full system-package condition (prefix AND
+    CMAKE_INSTALL_LOCALSTATEDIR both set): gtests and pytest tests run in the
+    binarydeb chroot, and they are the only coverage our packages get against
+    a minimal dependency closure. A guard that swallowed them would take that
+    away.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        PYTEST_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_pytest/test_probe.py': 'def test_probe():\n    assert True\n'},
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_pytest_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_registered_with_a_non_distribution_prefix_and_localstatedir_set(tmp_path):
+    """
+    CMAKE_INSTALL_LOCALSTATEDIR alone does not suppress; the prefix still has to match.
+
+    Fills the hole in the truth table every other probe leaves open: every
+    case that expects suppression sets both signals, and every case that
+    expects registration sets neither. A guard that suppressed whenever
+    CMAKE_INSTALL_LOCALSTATEDIR is defined, ignoring the prefix, would still
+    pass the whole rest of this file. This is the prefix-does-not-match,
+    localstatedir-set corner that catches it.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        tmp_path / 'install',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_not_registered_on_humble(tmp_path):
+    """
+    The guard reads ROS_DISTRO rather than being hard-coded to one distro.
+
+    Humble is the only distro whose binarydeb job still runs package tests -
+    the one this whole task exists for - so a guard that happened to work only
+    for jazzy (every other case in this file) would not fire on the build that
+    matters and would still pass the suite.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/humble',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var',
+        ros_distro='humble',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' not in registered_tests(build), result.stdout
+
+
+def test_args_reaches_add_launch_test_and_is_not_absorbed_by_labels(tmp_path):
+    """
+    ARGS still reaches add_launch_test, and does not leak into LABELS.
+
+    Before ARGS had its own keyword, LABELS being multi-value (to survive its
+    own semicolon-split values) meant an ARGS that cmake_parse_arguments did
+    not recognise as a keyword would be swallowed as more LABELS values
+    instead of forwarding to add_launch_test or erroring. No in-tree caller
+    passes ARGS today, so this was latent, not live - this probe is the only
+    coverage for it.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        ARGS_PROBE,
+        tmp_path / 'install',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+    testfile = read_ctest_testfile(build)
+    assert 'probe_arg:=probe_value' in testfile, testfile
+    labels_match = re.search(r'LABELS "([^"]*)"', testfile)
+    assert labels_match, testfile
+    assert labels_match.group(1) == 'integration', (
+        f'ARGS leaked into LABELS: {labels_match.group(1)!r}\n{testfile}'
+    )
+
+
+def test_env_cannot_set_medkit_test_domains_directly(tmp_path):
+    """
+    An ENV entry that sets MEDKIT_TEST_DOMAINS fails the configure.
+
+    Without this, a caller writing ENV "MEDKIT_TEST_DOMAINS=99" would append a
+    second, later ENVIRONMENT entry that wins over the one the macro sets from
+    DOMAINS at run time - the comment above the ENV foreach promises the
+    domain can never be overwritten, and this is what makes that true instead
+    of merely documented.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        DOMAINS_COLLISION_PROBE,
+        tmp_path / 'install',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+    )
+    assert result.returncode != 0, (
+        'configuring succeeded with ENV setting MEDKIT_TEST_DOMAINS directly, so a '
+        f'caller could silently override the domain the macro allocated:\n{result.stdout}'
+    )
+    assert 'MEDKIT_TEST_DOMAINS' in result.stderr, result.stderr
+    assert 'DOMAINS' in result.stderr, result.stderr
+    assert not (build / 'CTestTestfile.cmake').is_file(), (
+        'a failed configure left a CTestTestfile.cmake behind'
+    )
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v']))

--- a/src/ros2_medkit_cmake/test/test_launch_test_guard.py
+++ b/src/ros2_medkit_cmake/test/test_launch_test_guard.py
@@ -186,6 +186,24 @@ medkit_add_launch_test(probe_launch_test probe_launch.test.py TIMEOUT 10
   ENV "MEDKIT_TEST_DOMAINS=99")
 """
 
+# "ENV" here is meant as a plain LABELS value, but cmake_parse_arguments
+# cannot tell a value from a keyword by position, only by spelling: "ENV" is
+# itself one of this macro's recognised keywords, so it closes the open
+# LABELS collection - with nothing in it - and opens a new, equally empty
+# ENV collection instead. Both keywords land in _MALT_KEYWORDS_MISSING_VALUES,
+# and without checking that, the caller's intended value simply disappears -
+# no error, nothing in the generated CTestTestfile.cmake to say why LABELS
+# came out empty.
+KEYWORD_SHAPED_VALUE_PROBE = """cmake_minimum_required(VERSION 3.14)
+project(medkit_launch_guard_keyword_shaped_value_probe C)
+find_package(ament_cmake REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+include("{module}")
+enable_testing()
+medkit_add_launch_test(probe_launch_test probe_launch.test.py
+  LABELS "ENV")
+"""
+
 
 def configure_probe(
     tmp_path, template, install_prefix, extra_files, *, localstatedir=None, ros_distro='jazzy'
@@ -461,6 +479,74 @@ def test_launch_test_is_registered_with_a_non_distribution_prefix_and_localstate
     assert 'probe_launch_test' in registered_tests(build), result.stdout
 
 
+def test_launch_test_is_registered_with_a_ros_shaped_prefix_outside_opt(tmp_path):
+    """
+    A prefix shaped like a ROS distribution root under a different tree does not suppress.
+
+    ``/usr/ros/humble`` has the same ``<top>/ros/<name>`` shape bloom's own
+    ``/opt/ros/<distro>`` does, just rooted at ``/usr`` instead of ``/opt`` -
+    nowhere a build farm installs, and no colcon workspace either. A guard
+    broadened to ``^/(opt|usr)/ros/[^/]+$``, on the reasoning that a distro
+    root might live under either, would wrongly suppress this. The regex has
+    to name ``/opt`` specifically; nothing about "looks like a ROS prefix"
+    is the signal on its own.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/usr/ros/humble',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_registered_with_a_localstatedir_that_only_starts_with_var(tmp_path):
+    """
+    CMAKE_INSTALL_LOCALSTATEDIR has to equal "/var" exactly, not merely start with it.
+
+    ``/var/lib`` is a real, plausible absolute path a caller might pass - it
+    is not ``/var`` and must not suppress. A guard loosened from
+    ``STREQUAL "/var"`` to ``MATCHES "^/var"`` would wrongly suppress this,
+    because the string "/var" is a prefix of "/var/lib".
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/var/lib',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
+def test_launch_test_is_registered_with_a_localstatedir_that_merely_shares_the_var_prefix(
+    tmp_path,
+):
+    """
+    CMAKE_INSTALL_LOCALSTATEDIR "/variable" must not suppress either.
+
+    A second, distinct way the same ``MATCHES "^/var"`` loosening goes
+    wrong: "/variable" shares the four characters "/var" with no path
+    separator after them at all, which a start-anchored-only regex still
+    matches. This case and ``/var/lib`` above are not redundant: a mutation
+    narrowed to ``^/var/`` (requiring a trailing slash) would still wrongly
+    suppress ``/var/lib`` while correctly rejecting this one, so both
+    shapes have to be pinned separately for either mistake to be caught.
+    """
+    result, build = configure_probe(
+        tmp_path,
+        LAUNCH_PROBE,
+        '/opt/ros/jazzy',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+        localstatedir='/variable',
+    )
+    assert result.returncode == 0, result.stderr
+    assert 'probe_launch_test' in registered_tests(build), result.stdout
+
+
 def test_launch_test_is_not_registered_on_humble(tmp_path):
     """
     The guard's prefix match is a wildcard, not hard-coded to one distro.
@@ -554,9 +640,13 @@ def test_env_cannot_set_medkit_test_domains_directly(tmp_path):
 
     Without this, a caller writing ENV "MEDKIT_TEST_DOMAINS=99" would append a
     second, later ENVIRONMENT entry that wins over the one the macro sets from
-    DOMAINS at run time - the comment above the ENV foreach promises the
-    domain can never be overwritten, and this is what makes that true instead
-    of merely documented.
+    DOMAINS at run time - the comment above the ENV foreach promises a caller
+    cannot overwrite it by spelling the literal key, and this is what makes
+    that true instead of merely documented. It is not a promise about every
+    input: a value spelled to avoid the literal key (a generator expression
+    such as "$<1:MEDKIT_TEST_DOMAINS=99>") still collides at run time, same
+    as if this check did not exist at all - the check only ever promised the
+    plain spelling, and nothing here tests the generator-expression form.
     """
     result, build = configure_probe(
         tmp_path,
@@ -570,6 +660,38 @@ def test_env_cannot_set_medkit_test_domains_directly(tmp_path):
     )
     assert 'MEDKIT_TEST_DOMAINS' in result.stderr, result.stderr
     assert 'DOMAINS' in result.stderr, result.stderr
+    assert not (build / 'CTestTestfile.cmake').is_file(), (
+        'a failed configure left a CTestTestfile.cmake behind'
+    )
+
+
+def test_a_value_that_spells_a_keyword_fails_the_configure_instead_of_vanishing(tmp_path):
+    """
+    A LABELS value that spells another keyword's name fails loudly instead of disappearing.
+
+    `LABELS "ENV"` looks like it should set the label to the literal string
+    "ENV", but cmake_parse_arguments cannot distinguish a value from a
+    keyword by position, only by spelling - "ENV" is itself one of this
+    macro's own recognised keywords, so it closes the open LABELS collection
+    (with nothing in it) and opens a new, equally empty ENV collection
+    instead. Both end up in _MALT_KEYWORDS_MISSING_VALUES. Left unchecked,
+    this would register the launch test with neither the caller's intended
+    LABELS override nor any ENV entry - the value silently vanishes, no
+    error, nothing in the generated CTestTestfile.cmake to say why LABELS
+    came out empty (or missing entirely, since add_launch_test's own default
+    of "launch_test" would apply instead).
+    """
+    result, build = configure_probe(
+        tmp_path,
+        KEYWORD_SHAPED_VALUE_PROBE,
+        tmp_path / 'install',
+        {'probe_launch.test.py': '# empty launch test file\n'},
+    )
+    assert result.returncode != 0, (
+        'configuring succeeded with a LABELS value that spells another keyword name, so the '
+        f'value silently vanished instead of failing the configure:\n{result.stdout}'
+    )
+    assert 'given with no value' in result.stderr, result.stderr
     assert not (build / 'CTestTestfile.cmake').is_file(), (
         'a failed configure left a CTestTestfile.cmake behind'
     )

--- a/src/ros2_medkit_cmake/test/test_launch_test_guard.py
+++ b/src/ros2_medkit_cmake/test/test_launch_test_guard.py
@@ -231,7 +231,14 @@ def configure_probe(
     # CMAKE_PREFIX_PATH to resolve find_package(ament_cmake) and
     # find_package(launch_testing_ament_cmake) at all. Only ROS_DISTRO itself is
     # touched, so every probe imitates a chosen distro - or its absence -
-    # regardless of who runs it.
+    # regardless of who runs it. Those two stay present even in the ROS build
+    # farm's binarydeb chroot: the farm's test step runs
+    # `if [ -f "/opt/ros/humble/setup.sh" ]; then . "/opt/ros/humble/setup.sh";
+    # fi && dh_auto_test`, and sourcing setup.sh is what sets both - the same
+    # reason ROS_DISTRO is the one thing missing there: that export comes from
+    # the ros_environment package specifically, which the chroot does not
+    # install, not from setup.sh itself. A probe never needs to fake either
+    # path for that reason.
     env = dict(os.environ)
     if ros_distro is None:
         env.pop('ROS_DISTRO', None)

--- a/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
+++ b/src/ros2_medkit_diagnostic_bridge/CMakeLists.txt
@@ -113,11 +113,10 @@ if(BUILD_TESTING)
   # so the launch test ran in the unit phase together with all other unit tests
   # in one colcon invocation. Under that load the node could miss the launch
   # SIGINT shutdown window and get killed with SIGTERM, failing the
-  # post-shutdown exit-code check. Override the label to "integration" via
-  # set_tests_properties (the repo convention) so it runs only in the
-  # integration phase.
-  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60)
-  set_tests_properties(test_integration PROPERTIES LABELS "integration")
+  # post-shutdown exit-code check. LABELS overrides it to "integration" (the
+  # repo convention) so it runs only in the integration phase.
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60
+    LABELS "integration")
   ros2_medkit_relax_vendor_warnings()
 endif()
 

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -165,27 +165,27 @@ if(BUILD_TESTING)
     DESTINATION share/${PROJECT_NAME}
   )
 
-  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60)
-  set_tests_properties(test_integration PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_integration test/test_integration.test.py TIMEOUT 60
+    LABELS "integration")
 
-  medkit_add_launch_test(test_rosbag_integration test/test_rosbag_integration.test.py TIMEOUT 90)
-  set_tests_properties(test_rosbag_integration PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_rosbag_integration test/test_rosbag_integration.test.py TIMEOUT 90
+    LABELS "integration")
 
-  medkit_add_launch_test(test_entity_thresholds_integration test/test_entity_thresholds_integration.test.py TIMEOUT 60)
-  set_tests_properties(test_entity_thresholds_integration PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_entity_thresholds_integration test/test_entity_thresholds_integration.test.py
+    TIMEOUT 60 LABELS "integration")
 
-  medkit_add_launch_test(test_rosbag_entity_scope test/test_rosbag_entity_scope.test.py TIMEOUT 120)
-  set_tests_properties(test_rosbag_entity_scope PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_rosbag_entity_scope test/test_rosbag_entity_scope.test.py TIMEOUT 120
+    LABELS "integration")
 
   # Parametrized over both storage formats (sqlite3 + mcap), so the launch
   # runs twice inside one ctest invocation.
-  medkit_add_launch_test(test_rosbag_boundary test/test_rosbag_boundary.test.py TIMEOUT 240)
-  set_tests_properties(test_rosbag_boundary PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_rosbag_boundary test/test_rosbag_boundary.test.py TIMEOUT 240
+    LABELS "integration")
 
   # Drives the DEFAULT "entity" topic mode, where a boundary recording carries a
   # filter, over two full post-fault windows plus discovery.
-  medkit_add_launch_test(test_rosbag_boundary_scope test/test_rosbag_boundary_scope.test.py TIMEOUT 180)
-  set_tests_properties(test_rosbag_boundary_scope PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_rosbag_boundary_scope test/test_rosbag_boundary_scope.test.py TIMEOUT 180
+    LABELS "integration")
 
   # CaptureThreadPool unit tests
   medkit_add_gtest(test_capture_thread_pool test/test_capture_thread_pool.cpp)

--- a/src/ros2_medkit_fault_reporter/CMakeLists.txt
+++ b/src/ros2_medkit_fault_reporter/CMakeLists.txt
@@ -103,8 +103,8 @@ if(BUILD_TESTING)
   # launch_testing_ament_cmake reaches the deprecated FindPythonLibs, which
   # cannot find libpython without a language enabled. This package compiles and
   # already runs a launch test on every distro.
-  medkit_add_launch_test(test_domain_launch test/test_domain_launch.test.py TIMEOUT 300)
-  set_tests_properties(test_domain_launch PROPERTIES LABELS "integration")
+  medkit_add_launch_test(test_domain_launch test/test_domain_launch.test.py TIMEOUT 300
+    LABELS "integration")
 
   ros2_medkit_relax_vendor_warnings()
 endif()

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -182,6 +182,34 @@ if(BUILD_TESTING)
   set_tests_properties(test_test_utils_constants PROPERTIES LABELS "unit")
   medkit_test_needs_no_domain(test_test_utils_constants)
 
+  # Configures every launch-test-registering package this file can reach for
+  # real, twice each (ordinary workspace conditions and system-package
+  # conditions), and compares what each run actually registered. Lives here
+  # rather than in ros2_medkit_cmake because that package cannot depend on
+  # the packages it is shared by; this package's own dependency chain (via
+  # ros2_medkit_gateway) already reaches all six. ros2_medkit_graph_watchdog
+  # calls medkit_add_launch_test too but is covered by its own copy of this
+  # test instead - see the module docstring. ROS-free for the same reason as
+  # the fixture above - it spawns its own cmake subprocesses rather than
+  # creating ROS entities.
+  #
+  # Registered only when this package can reach a repository root above
+  # itself - reusing _medkit_launch_tests_can_register()'s own detection of a
+  # system-package build (ROS2MedkitTestDomain.cmake), because the two
+  # conditions are the same fact: the ROS build farm's binarydeb chroot
+  # builds this package alone, with no sibling packages beside it, which is
+  # exactly when this test's own repository_root fixture would find nothing.
+  # A test that can prove nothing about its own subject must not run to
+  # report a pass on that account; every other test in this file registers
+  # unconditionally.
+  _medkit_launch_tests_can_register(_malt_system_build_test_can_register)
+  if(_malt_system_build_test_can_register)
+    ament_add_pytest_test(test_launch_test_guard_system_build
+      test/test_launch_test_guard_system_build.py TIMEOUT 900)
+    set_tests_properties(test_launch_test_guard_system_build PROPERTIES LABELS "integration")
+    medkit_test_needs_no_domain(test_launch_test_guard_system_build)
+  endif()
+
   # Multi-gateway tests run a second and a third gateway, each on a domain of its
   # own, and reach them through ros2_medkit_test_utils.constants.get_test_domain_id.
   # DOMAINS below is one for the test itself plus one per extra gateway; the
@@ -199,7 +227,34 @@ if(BUILD_TESTING)
     test_startup_param_clamp_warnings)
   set(_MULTI_GATEWAY_DOMAINS 4)
 
-  # Feature tests (atomic, independent, 120s timeout)
+  # Tests whose polling budgets do not fit the glob's default timeout. Keyed by
+  # test name; anything not listed takes the default for its glob.
+  #
+  # test_rosbag_boundary_download drives three real rosbag recordings end to end
+  # (the demo node's own fault, then a burst across the post-fault window
+  # boundary), each with its own post-roll and finalize. Its polling deadlines
+  # add up past the 120s the feature glob assigns, so it gets its own budget
+  # rather than have a slow runner kill it with no test name in the output.
+  #
+  # test_graph_provider_greenwave drives a real greenwave_monitor node, which
+  # only publishes /diagnostics at ~1 Hz with the first useful reading a few
+  # seconds in, plus an 8s launch-ordering delay so greenwave starts strictly
+  # after the demo nodes it monitors are already publishing (see the test's
+  # module docstring). The default 120s feature timeout does not leave enough
+  # headroom for that startup delay plus the 30-90s polling budgets its cases
+  # need, so it is widened to match the scenario-test timeout.
+  #
+  # test_graph_provider_stale and test_graph_provider_sse also drive a real
+  # greenwave_monitor node through the same 10s launch-ordering delay plus
+  # warmup as test_graph_provider_greenwave above, and their staleness/SSE
+  # polling budgets are similarly generous - both widened to match.
+  set(_MEDKIT_TEST_TIMEOUT_OVERRIDES
+    test_rosbag_boundary_download 180
+    test_graph_provider_greenwave 300
+    test_graph_provider_stale 300
+    test_graph_provider_sse 300)
+
+  # Feature tests (atomic, independent, 120s timeout unless overridden above)
   file(GLOB FEATURE_TESTS test/features/*.test.py)
   foreach(test_file ${FEATURE_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
@@ -207,19 +262,22 @@ if(BUILD_TESTING)
     if(test_name IN_LIST _MULTI_GATEWAY_TESTS)
       set(_test_domains ${_MULTI_GATEWAY_DOMAINS})
     endif()
+    set(_test_timeout 120)
+    list(FIND _MEDKIT_TEST_TIMEOUT_OVERRIDES ${test_name} _test_timeout_idx)
+    if(NOT _test_timeout_idx EQUAL -1)
+      math(EXPR _test_timeout_value_idx "${_test_timeout_idx} + 1")
+      list(GET _MEDKIT_TEST_TIMEOUT_OVERRIDES ${_test_timeout_value_idx} _test_timeout)
+    endif()
     medkit_add_launch_test(${test_name} ${test_file}
-      TIMEOUT 120
+      TIMEOUT ${_test_timeout}
       DOMAINS ${_test_domains}
+      LABELS "integration;feature"
+      ENV "GATEWAY_TEST_PORT=${_INTEG_PORT}"
     )
-    # APPEND: medkit_add_launch_test put this test's domain count in ENVIRONMENT,
-    # and a plain set_tests_properties(... PROPERTIES ENVIRONMENT ...) would drop it.
-    set_tests_properties(${test_name} PROPERTIES LABELS "integration;feature")
-    set_property(TEST ${test_name} APPEND PROPERTY
-      ENVIRONMENT "GATEWAY_TEST_PORT=${_INTEG_PORT}")
     math(EXPR _INTEG_PORT "${_INTEG_PORT} + 10")
   endforeach()
 
-  # Scenario tests (E2E stories, 300s timeout)
+  # Scenario tests (E2E stories, 300s timeout unless overridden above)
   file(GLOB SCENARIO_TESTS test/scenarios/*.test.py)
   foreach(test_file ${SCENARIO_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
@@ -227,39 +285,20 @@ if(BUILD_TESTING)
     if(test_name IN_LIST _MULTI_GATEWAY_TESTS)
       set(_test_domains ${_MULTI_GATEWAY_DOMAINS})
     endif()
+    set(_test_timeout 300)
+    list(FIND _MEDKIT_TEST_TIMEOUT_OVERRIDES ${test_name} _test_timeout_idx)
+    if(NOT _test_timeout_idx EQUAL -1)
+      math(EXPR _test_timeout_value_idx "${_test_timeout_idx} + 1")
+      list(GET _MEDKIT_TEST_TIMEOUT_OVERRIDES ${_test_timeout_value_idx} _test_timeout)
+    endif()
     medkit_add_launch_test(${test_name} ${test_file}
-      TIMEOUT 300
+      TIMEOUT ${_test_timeout}
       DOMAINS ${_test_domains}
+      LABELS "integration;scenario"
+      ENV "GATEWAY_TEST_PORT=${_INTEG_PORT}"
     )
-    set_tests_properties(${test_name} PROPERTIES LABELS "integration;scenario")
-    set_property(TEST ${test_name} APPEND PROPERTY
-      ENVIRONMENT "GATEWAY_TEST_PORT=${_INTEG_PORT}")
     math(EXPR _INTEG_PORT "${_INTEG_PORT} + 10")
   endforeach()
-
-  # test_rosbag_boundary_download drives three real rosbag recordings end to end
-  # (the demo node's own fault, then a burst across the post-fault window
-  # boundary), each with its own post-roll and finalize. Its polling deadlines
-  # add up past the 120s the feature glob assigns, so give it its own budget
-  # rather than have a slow runner kill it with no test name in the output.
-  set_tests_properties(test_rosbag_boundary_download PROPERTIES TIMEOUT 180)
-
-  # test_graph_provider_greenwave drives a real greenwave_monitor node,
-  # which only publishes /diagnostics at ~1 Hz with the first useful
-  # reading a few seconds in, plus an 8s launch-ordering delay so
-  # greenwave starts strictly after the demo nodes it monitors are already
-  # publishing (see the test's module docstring). The default 120s feature
-  # timeout does not leave enough headroom for that startup delay plus the
-  # 30-90s polling budgets its cases need, so widen it to match the
-  # scenario-test timeout.
-  set_tests_properties(test_graph_provider_greenwave PROPERTIES TIMEOUT 300)
-
-  # test_graph_provider_stale and test_graph_provider_sse also drive a real
-  # greenwave_monitor node through the same 10s launch-ordering delay plus
-  # warmup as test_graph_provider_greenwave above, and their staleness/SSE
-  # polling budgets are similarly generous - widen both to match.
-  set_tests_properties(test_graph_provider_stale PROPERTIES TIMEOUT 300)
-  set_tests_properties(test_graph_provider_sse PROPERTIES TIMEOUT 300)
 endif()
 
 ament_package()

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -253,6 +253,13 @@ if(BUILD_TESTING)
     test_graph_provider_greenwave 300
     test_graph_provider_stale 300
     test_graph_provider_sse 300)
+  # Names actually matched against a discovered test_name in the two loops
+  # below. Checked against _MEDKIT_TEST_TIMEOUT_OVERRIDES itself after both
+  # loops finish - see the FATAL_ERROR check at the end of this block - so a
+  # renamed or deleted test file leaves a stale entry here that fails the
+  # configure instead of silently reverting that test's budget to the glob
+  # default.
+  unset(_MEDKIT_TEST_TIMEOUT_OVERRIDES_SEEN)
 
   # Feature tests (atomic, independent, 120s timeout unless overridden above)
   file(GLOB FEATURE_TESTS test/features/*.test.py)
@@ -267,6 +274,7 @@ if(BUILD_TESTING)
     if(NOT _test_timeout_idx EQUAL -1)
       math(EXPR _test_timeout_value_idx "${_test_timeout_idx} + 1")
       list(GET _MEDKIT_TEST_TIMEOUT_OVERRIDES ${_test_timeout_value_idx} _test_timeout)
+      list(APPEND _MEDKIT_TEST_TIMEOUT_OVERRIDES_SEEN ${test_name})
     endif()
     medkit_add_launch_test(${test_name} ${test_file}
       TIMEOUT ${_test_timeout}
@@ -290,6 +298,7 @@ if(BUILD_TESTING)
     if(NOT _test_timeout_idx EQUAL -1)
       math(EXPR _test_timeout_value_idx "${_test_timeout_idx} + 1")
       list(GET _MEDKIT_TEST_TIMEOUT_OVERRIDES ${_test_timeout_value_idx} _test_timeout)
+      list(APPEND _MEDKIT_TEST_TIMEOUT_OVERRIDES_SEEN ${test_name})
     endif()
     medkit_add_launch_test(${test_name} ${test_file}
       TIMEOUT ${_test_timeout}
@@ -299,6 +308,33 @@ if(BUILD_TESTING)
     )
     math(EXPR _INTEG_PORT "${_INTEG_PORT} + 10")
   endforeach()
+
+  # A stale entry in _MEDKIT_TEST_TIMEOUT_OVERRIDES used to be a silent
+  # no-op: list(FIND ...) above returns -1 for a name that matches no
+  # discovered test_name, the if() is skipped, and the test simply keeps
+  # whichever glob default it already had - nothing in either loop fails,
+  # and a test's budget quietly reverts from (say) 300 to 120 with no line
+  # in the configure log to say so. Every even-indexed name in the override
+  # list must therefore have matched some test_name in one of the two loops
+  # above, or this fails the configure instead of a test silently losing
+  # its budget.
+  list(LENGTH _MEDKIT_TEST_TIMEOUT_OVERRIDES _medkit_timeout_overrides_length)
+  if(_medkit_timeout_overrides_length GREATER 0)
+    math(EXPR _medkit_timeout_overrides_last_index "${_medkit_timeout_overrides_length} - 1")
+    foreach(_medkit_timeout_override_idx RANGE 0 ${_medkit_timeout_overrides_last_index} 2)
+      list(GET _MEDKIT_TEST_TIMEOUT_OVERRIDES ${_medkit_timeout_override_idx}
+        _medkit_timeout_override_name)
+      if(NOT _medkit_timeout_override_name IN_LIST _MEDKIT_TEST_TIMEOUT_OVERRIDES_SEEN)
+        message(FATAL_ERROR
+          "ros2_medkit_integration_tests: _MEDKIT_TEST_TIMEOUT_OVERRIDES names "
+          "'${_medkit_timeout_override_name}', which matched no test_name discovered "
+          "under test/features/*.test.py or test/scenarios/*.test.py. A stale entry "
+          "here used to be a silent no-op: the test it once named would quietly keep "
+          "the glob's default timeout instead of the override. Remove the entry, or "
+          "fix the name to match the renamed or moved test file.")
+      endif()
+    endforeach()
+  endif()
 endif()
 
 ament_package()

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -42,6 +42,32 @@
   <test_depend>ros2_medkit_graph_provider</test_depend>
   <test_depend>greenwave_monitor</test_depend>
 
+  <!-- Configured for real, not linked against, by
+       test/test_launch_test_guard_system_build.py, which is what actually
+       needs these declared: a package used at test time must be a
+       test_depend even when nothing here #includes or find_package()s it at
+       build time. ros2_medkit_gateway and ros2_medkit_fault_manager are
+       already declared above; these four were resolving only by luck,
+       through ros2_medkit_gateway's own exec_depend chain.
+
+       ros2_medkit_graph_watchdog is the seventh package that test file
+       configures and is deliberately NOT declared here: it already
+       test_depends on this package (its e2e harness imports
+       ros2_medkit_test_utils, installed as part of this package), and
+       colcon graph, scoped to just these two packages, confirms adding the
+       reverse edge makes the pair topologically unorderable - not a
+       theoretical concern, colcon build refuses to proceed. Its own
+       find_package() dependencies
+       (ros2_medkit_gateway, rcl_interfaces, lifecycle_msgs, tf2_msgs,
+       geometry_msgs, nlohmann_json) are already satisfied through
+       ros2_medkit_gateway above and the base ROS install, which is why its
+       configure resolves anyway; test_launch_test_guard_system_build.py's
+       own resolvability probe reports it by name rather than assuming so. -->
+  <test_depend>ros2_medkit_action_status_bridge</test_depend>
+  <test_depend>ros2_medkit_diagnostic_bridge</test_depend>
+  <test_depend>ros2_medkit_fault_reporter</test_depend>
+  <test_depend>ros2_medkit_log_bridge</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/ros2_medkit_integration_tests/package.xml
+++ b/src/ros2_medkit_integration_tests/package.xml
@@ -50,9 +50,8 @@
        already declared above; these four were resolving only by luck,
        through ros2_medkit_gateway's own exec_depend chain.
 
-       ros2_medkit_graph_watchdog is the seventh package that test file
-       configures and is deliberately NOT declared here: it already
-       test_depends on this package (its e2e harness imports
+       ros2_medkit_graph_watchdog is deliberately NOT declared here: it
+       already test_depends on this package (its e2e harness imports
        ros2_medkit_test_utils, installed as part of this package), and
        colcon graph, scoped to just these two packages, confirms adding the
        reverse edge makes the pair topologically unorderable - not a
@@ -61,8 +60,12 @@
        (ros2_medkit_gateway, rcl_interfaces, lifecycle_msgs, tf2_msgs,
        geometry_msgs, nlohmann_json) are already satisfied through
        ros2_medkit_gateway above and the base ROS install, which is why its
-       configure resolves anyway; test_launch_test_guard_system_build.py's
-       own resolvability probe reports it by name rather than assuming so. -->
+       configure resolves anyway - not that this file's own
+       test_launch_test_guard_system_build.py exercises it: that file covers
+       only the six packages listed above, and ros2_medkit_graph_watchdog
+       proves the same property about itself in its own copy of that test
+       instead, at
+       src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py. -->
   <test_depend>ros2_medkit_action_status_bridge</test_depend>
   <test_depend>ros2_medkit_diagnostic_bridge</test_depend>
   <test_depend>ros2_medkit_fault_reporter</test_depend>

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
@@ -35,6 +35,21 @@ build-order cycle and it cannot be covered from the other side.
 import shutil
 import subprocess
 
+# `add_launch_test()` (from `launch_testing_ament_cmake`) always generates a
+# COMMAND that runs `python3 -m launch_testing.launch_test <file>` - that is
+# how launch_testing_ament_cmake executes a launch test, not something any
+# macro in this tree spells or could get out of sync with, and every
+# generated `add_test(...)` call lands on a single physical line in
+# `CTestTestfile.cmake` (checked against every launch-test package in this
+# tree - the longest line is ~93 launch tests deep in
+# ros2_medkit_integration_tests and every one of them is still one line), so
+# a per-line substring check is exact rather than a heuristic. `LABELS`
+# cannot be used for this instead: `add_launch_test()` only defaults it to
+# `"launch_test"`, and every real launch test in this tree overrides it
+# (`"integration;feature"`, `"integration;probe"`, ...), so a label sweep
+# would undercount to whatever callers happened to leave unlabelled.
+LAUNCH_TEST_COMMAND_MARKER = 'launch_testing.launch_test'
+
 
 def configure(source_dir, build_dir, install_prefix, *, localstatedir=None):
     """Run a real `cmake` configure and return the completed process."""
@@ -61,36 +76,64 @@ def registered_test_names(build_dir):
     }
 
 
-def assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build_dir):
+def launch_test_names(build_dir):
     """
-    Assert a system-package configure suppressed something without failing.
+    Return the set of test names in *build_dir* whose command is a launch test.
+
+    Identified by `LAUNCH_TEST_COMMAND_MARKER` in the test's own `add_test(
+    ...)` line - see that constant's comment for why this, and not a label
+    or a name pattern, is the reliable signal. gtest and pytest tests never
+    contain it: `ament_add_gtest` invokes the compiled test binary directly
+    and `ament_add_pytest_test` invokes `pytest` on the test file, neither
+    goes through the `launch_testing.launch_test` module. A pytest test
+    whose own file path happens to contain the bare substring "launch_test"
+    (e.g. this package's own `test_launch_test_guard_system_build`) does not
+    match: the marker is the full dotted module name, not the bare word.
+    """
+    testfile = build_dir / 'CTestTestfile.cmake'
+    if not testfile.is_file():
+        return set()
+    names = set()
+    for line in testfile.read_text().splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith('add_test(') and LAUNCH_TEST_COMMAND_MARKER in stripped:
+            names.add(stripped.split('(', 1)[1].split(' ', 1)[0].strip('"'))
+    return names
+
+
+def assert_guard_suppressed_launch_tests(
+    name, baseline_tests, guarded, guarded_build_dir, baseline_build_dir, *, also_suppressed=()
+):
+    """
+    Assert a system-package configure suppressed exactly the launch tests.
 
     *baseline_tests* is the set of test names an ordinary workspace-style
-    configure of the same package registered. *guarded* is the completed
-    `cmake` process from configuring the same source directory under
-    system-package conditions, and *guarded_build_dir* is the build directory
-    that configure was pointed at.
+    configure of the same package registered, from *baseline_build_dir*.
+    *guarded* is the completed `cmake` process from configuring the same
+    source directory under system-package conditions, and
+    *guarded_build_dir* is the build directory that configure was pointed
+    at. *also_suppressed* names tests, besides the launch tests identified
+    from the baseline, that are known and documented to also not register
+    under system-package conditions for a reason unrelated to being a
+    launch test - see the call site for what that reason is; there is
+    exactly one such test in this tree today, and it is not this function's
+    place to special-case it silently.
 
     This is the CRITICAL regression the guard exists to prevent: a
     `set_tests_properties` / `set_property(TEST ...)` call naming a launch
     test the guard did not register makes CMake fail the configure outright.
-    Comparing the two real `CTestTestfile.cmake` outputs - not a name pattern
-    - is what this checks: the configure did not fail, the guard's own
-    "launch tests are not registered" message printed, something the
-    baseline registered is gone from the guarded run (the guard fired on at
-    least one test), what remains is a subset of the baseline (nothing new
-    appeared), and something remains at all (it did not remove everything).
-
-    It does NOT prove the removed set is exactly the launch tests and
-    nothing else, or that the surviving set specifically includes gtests and
-    pytest tests as opposed to some other kind - a guard that also swallowed
-    a package's gtests would still pass every one of these assertions for a
-    package whose pytest coverage alone kept the surviving set non-empty.
-    That narrower claim, that a gtest and a pytest test each individually
-    survive the guard, is proven in isolation by
-    `test_gtest_is_still_registered_in_a_system_build` and
-    `test_other_test_kinds_are_still_registered_in_a_system_build` in
-    `ros2_medkit_cmake/test/test_launch_test_guard.py`, not by this function.
+    Comparing the two real `CTestTestfile.cmake` outputs - not a name
+    pattern - is what this checks: the configure did not fail, the guard's
+    own "launch tests are not registered" message printed, and the guarded
+    run's test set is exactly the baseline's test set minus the baseline's
+    own launch tests (`launch_test_names(baseline_build_dir)`) minus
+    *also_suppressed* - nothing more suppressed, nothing less, and nothing
+    new. A guard that also swallowed a package's gtests, or that only
+    suppressed some of its launch tests, fails this even if a package's
+    pytest coverage alone would have kept the surviving set non-empty - the
+    earlier, weaker version of this function (non-empty-suppressed,
+    non-empty-survivors, survivors-subset-of-baseline) could not tell that
+    case apart from a correct guard.
     """
     assert guarded.returncode == 0, (
         f'{name}: configure failed under system-package conditions even though the same '
@@ -103,18 +146,22 @@ def assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_
         f'did not fire, or the message changed:\n{guarded.stdout}'
     )
 
-    guarded_tests = registered_test_names(guarded_build_dir)
-    suppressed = baseline_tests - guarded_tests
-    assert suppressed, (
-        f'{name}: nothing was suppressed under system-package conditions - the guard did not '
-        f'remove any test that the baseline configure registered:\n'
+    expected_launch_tests = launch_test_names(baseline_build_dir)
+    assert expected_launch_tests, (
+        f'{name}: the baseline configure registered no launch test at all (identified by the '
+        f'"{LAUNCH_TEST_COMMAND_MARKER}" marker in its own add_test(...) command), so this '
+        f'comparison cannot tell a working guard from a broken one:\n'
         f'baseline={sorted(baseline_tests)}'
     )
-    assert guarded_tests, (
-        f'{name}: every test the baseline registered was suppressed - the guard is removing '
-        f'more than launch tests:\nbaseline={sorted(baseline_tests)}'
-    )
-    assert guarded_tests <= baseline_tests, (
-        f'{name}: the guarded configure registered a test the baseline never did, which this '
-        f'comparison cannot explain:\nonly guarded={sorted(guarded_tests - baseline_tests)}'
+
+    guarded_tests = registered_test_names(guarded_build_dir)
+    expected_survivors = baseline_tests - expected_launch_tests - set(also_suppressed)
+    missing = sorted(expected_survivors - guarded_tests)
+    unexpected = sorted(guarded_tests - expected_survivors)
+    assert guarded_tests == expected_survivors, (
+        f'{name}: the guarded configure did not register exactly the non-launch, '
+        f'non-also_suppressed tests. missing (should have survived but did not)={missing}, '
+        f'unexpected (should have been suppressed, or never existed in the baseline, but is '
+        f'registered)={unexpected}. Expected exactly {sorted(expected_launch_tests)} '
+        f'(plus {sorted(also_suppressed)} named explicitly) to be suppressed and nothing else.'
     )

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
@@ -1,0 +1,109 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Real-`cmake`-configure checks for `medkit_add_launch_test`'s system-package guard.
+
+Shared by every package that proves, for itself, that a system-package
+configure (`CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO`,
+`CMAKE_INSTALL_LOCALSTATEDIR=/var` - what bloom's `debian/rules` passes)
+suppresses exactly its own launch tests without failing the configure. A
+regex sweep over `CMakeLists.txt` text was tried first and evaded three
+times running (a second name on one call, a name on a continuation line, a
+paren balanced across a comment); this asks CMake itself instead, which has
+no such blind spot.
+
+Two call sites use this: `ros2_medkit_integration_tests`, which reaches the
+six sibling packages it declares as `test_depend`, and
+`ros2_medkit_graph_watchdog`, which configures only itself - it already
+`test_depend`s on `ros2_medkit_integration_tests` for its own e2e harness
+(that is how it reaches this module), so the reverse edge would be a real
+build-order cycle and it cannot be covered from the other side.
+"""
+
+import shutil
+import subprocess
+
+
+def configure(source_dir, build_dir, install_prefix, *, localstatedir=None):
+    """Run a real `cmake` configure and return the completed process."""
+    args = [
+        shutil.which('cmake') or 'cmake',
+        '-S', str(source_dir),
+        '-B', str(build_dir),
+        f'-DCMAKE_INSTALL_PREFIX={install_prefix}',
+    ]
+    if localstatedir is not None:
+        args.append(f'-DCMAKE_INSTALL_LOCALSTATEDIR={localstatedir}')
+    return subprocess.run(args, capture_output=True, text=True, timeout=600, check=False)
+
+
+def registered_test_names(build_dir):
+    """Return the set of test names ctest would run for a configured build directory."""
+    testfile = build_dir / 'CTestTestfile.cmake'
+    if not testfile.is_file():
+        return set()
+    return {
+        line.split('(', 1)[1].split(' ', 1)[0].strip('"')
+        for line in testfile.read_text().splitlines()
+        if line.lstrip().startswith('add_test(')
+    }
+
+
+def assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build_dir):
+    """
+    Assert a system-package configure suppressed exactly the launch tests.
+
+    *baseline_tests* is the set of test names an ordinary workspace-style
+    configure of the same package registered. *guarded* is the completed
+    `cmake` process from configuring the same source directory under
+    system-package conditions, and *guarded_build_dir* is the build directory
+    that configure was pointed at.
+
+    This is the CRITICAL regression the guard exists to prevent: a
+    `set_tests_properties` / `set_property(TEST ...)` call naming a launch
+    test the guard did not register makes CMake fail the configure outright.
+    Comparing the two real `CTestTestfile.cmake` outputs - not a name pattern
+    - is what proves the guard suppressed exactly the launch tests and
+    nothing else: whatever the baseline registered that the guarded run did
+    not is, by definition, what the guard removed, and it must be non-empty
+    (the guard fired) while what remains registered must also be non-empty
+    (it did not remove everything).
+    """
+    assert guarded.returncode == 0, (
+        f'{name}: configure failed under system-package conditions even though the same '
+        f'package configures fine otherwise. This is the CRITICAL regression the guard exists '
+        f'to prevent - a property call naming a launch test the guard did not register:\n'
+        f'{guarded.stderr}'
+    )
+    assert 'launch tests are not registered' in guarded.stdout, (
+        f'{name}: configured cleanly but the guard never printed its explanation - either it '
+        f'did not fire, or the message changed:\n{guarded.stdout}'
+    )
+
+    guarded_tests = registered_test_names(guarded_build_dir)
+    suppressed = baseline_tests - guarded_tests
+    assert suppressed, (
+        f'{name}: nothing was suppressed under system-package conditions - the guard did not '
+        f'remove any test that the baseline configure registered:\n'
+        f'baseline={sorted(baseline_tests)}'
+    )
+    assert guarded_tests, (
+        f'{name}: every test the baseline registered was suppressed - the guard is removing '
+        f'more than launch tests:\nbaseline={sorted(baseline_tests)}'
+    )
+    assert guarded_tests <= baseline_tests, (
+        f'{name}: the guarded configure registered a test the baseline never did, which this '
+        f'comparison cannot explain:\nonly guarded={sorted(guarded_tests - baseline_tests)}'
+    )

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
@@ -63,7 +63,7 @@ def registered_test_names(build_dir):
 
 def assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build_dir):
     """
-    Assert a system-package configure suppressed exactly the launch tests.
+    Assert a system-package configure suppressed something without failing.
 
     *baseline_tests* is the set of test names an ordinary workspace-style
     configure of the same package registered. *guarded* is the completed
@@ -75,11 +75,22 @@ def assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_
     `set_tests_properties` / `set_property(TEST ...)` call naming a launch
     test the guard did not register makes CMake fail the configure outright.
     Comparing the two real `CTestTestfile.cmake` outputs - not a name pattern
-    - is what proves the guard suppressed exactly the launch tests and
-    nothing else: whatever the baseline registered that the guarded run did
-    not is, by definition, what the guard removed, and it must be non-empty
-    (the guard fired) while what remains registered must also be non-empty
-    (it did not remove everything).
+    - is what this checks: the configure did not fail, the guard's own
+    "launch tests are not registered" message printed, something the
+    baseline registered is gone from the guarded run (the guard fired on at
+    least one test), what remains is a subset of the baseline (nothing new
+    appeared), and something remains at all (it did not remove everything).
+
+    It does NOT prove the removed set is exactly the launch tests and
+    nothing else, or that the surviving set specifically includes gtests and
+    pytest tests as opposed to some other kind - a guard that also swallowed
+    a package's gtests would still pass every one of these assertions for a
+    package whose pytest coverage alone kept the surviving set non-empty.
+    That narrower claim, that a gtest and a pytest test each individually
+    survive the guard, is proven in isolation by
+    `test_gtest_is_still_registered_in_a_system_build` and
+    `test_other_test_kinds_are_still_registered_in_a_system_build` in
+    `ros2_medkit_cmake/test/test_launch_test_guard.py`, not by this function.
     """
     assert guarded.returncode == 0, (
         f'{name}: configure failed under system-package conditions even though the same '

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cmake_guard.py
@@ -16,7 +16,7 @@
 Real-`cmake`-configure checks for `medkit_add_launch_test`'s system-package guard.
 
 Shared by every package that proves, for itself, that a system-package
-configure (`CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO`,
+configure (`CMAKE_INSTALL_PREFIX=/opt/ros/<distro>`,
 `CMAKE_INSTALL_LOCALSTATEDIR=/var` - what bloom's `debian/rules` passes)
 suppresses exactly its own launch tests without failing the configure. A
 regex sweep over `CMakeLists.txt` text was tried first and evaded three

--- a/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
@@ -27,7 +27,7 @@ launch-test package's configure into a hard error" - is exactly what CMake
 itself evaluates, so this asks CMake instead of a proxy for it: for each
 package that registers a launch test, configure it for real, once as an
 ordinary workspace build and once under system-package conditions
-(`CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO`, `CMAKE_INSTALL_LOCALSTATEDIR=/var`
+(`CMAKE_INSTALL_PREFIX=/opt/ros/<distro>`, `CMAKE_INSTALL_LOCALSTATEDIR=/var`
 - exactly what bloom's `debian/rules` passes), and compare what each run
 actually registered. No regex, on either side, decides what counts as a
 launch test. The configure/compare mechanics live in
@@ -46,6 +46,18 @@ ros2_medkit_diagnostic_bridge, ros2_medkit_fault_reporter,
 ros2_medkit_log_bridge - declared for this test specifically, since a
 package used at test time must be a test_depend even when nothing here
 find_package()s it at build time).
+
+The system-package prefix each configure below uses is SYSTEM_INSTALL_PREFIX,
+a literal - not this environment's own ROS_DISTRO. The guard's install-prefix
+check (see ROS2MedkitTestDomain.cmake) is a wildcard, `/opt/ros/<anything>`,
+not a comparison against the environment, so any distro name proves the same
+thing, and a literal keeps this test's outcome from depending on which
+distro happens to run it. An earlier version of the guard compared against
+`$ENV{ROS_DISTRO}` instead and never fired in the ROS build farm's binarydeb
+chroot, which has no ROS_DISTRO in its environment at all - see
+ros2_medkit_cmake/test/test_launch_test_guard.py's
+test_launch_test_is_not_registered_with_ros_distro_absent for the probe that
+catches a regression back to that.
 
 A seventh package registers launch tests too: ros2_medkit_graph_watchdog. It
 cannot be covered from here. It already test_depends on this package for its
@@ -67,7 +79,6 @@ declares a dependency on, so anything less is a real break, not a
 degradation to shrug off.
 """
 
-import os
 import pathlib
 import sys
 
@@ -79,6 +90,12 @@ from ros2_medkit_test_utils.cmake_guard import (
 )
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# A literal, not this environment's own ROS_DISTRO - see the module docstring
+# above for why. Any name under /opt/ros/ proves the same thing against the
+# guard's wildcard prefix check, and humble is the one distro the guard exists
+# for.
+SYSTEM_INSTALL_PREFIX = '/opt/ros/humble'
 
 # The six packages ros2_medkit_integration_tests actually declares as
 # test_depend (directly, or - for ros2_medkit_gateway and
@@ -126,7 +143,7 @@ def repository_root():
 
     Unconditional, not a skip: this test is registered in CMakeLists.txt only
     when the same signal medkit_add_launch_test's own guard uses to detect a
-    system-package build (CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO plus
+    system-package build (CMAKE_INSTALL_PREFIX=/opt/ros/<distro> plus
     CMAKE_INSTALL_LOCALSTATEDIR) says otherwise - the ROS build farm's
     binarydeb chroot builds this package alone, with no sibling packages
     beside it, which is exactly when no repository root exists above it. A
@@ -142,22 +159,7 @@ def repository_root():
 
 
 @pytest.fixture(scope='session')
-def ros_distro():
-    """
-    Return ROS_DISTRO.
-
-    Unconditional, not a skip: colcon test always sources a ROS distribution
-    before running a test, so ROS_DISTRO is guaranteed to be set wherever
-    this test runs at all. Its absence is a broken environment, not a reason
-    to decline the check the environment promised it could run.
-    """
-    distro = os.environ.get('ROS_DISTRO')
-    assert distro, 'ROS_DISTRO is unset; colcon test always sources a ROS distribution first'
-    return distro
-
-
-@pytest.fixture(scope='session')
-def resolvable_packages(repository_root, ros_distro, tmp_path_factory):
+def resolvable_packages(repository_root, tmp_path_factory):
     """
     Baseline-configure every candidate exactly once; record which ones this environment reaches.
 
@@ -197,7 +199,7 @@ def resolvable_packages(repository_root, ros_distro, tmp_path_factory):
 
 @pytest.mark.parametrize('name', sorted(LAUNCH_TEST_PACKAGES))
 def test_guard_does_not_break_a_real_configure(
-    name, repository_root, ros_distro, resolvable_packages, tmp_path
+    name, repository_root, resolvable_packages, tmp_path
 ):
     """
     A system-package configure still succeeds, and suppresses the right tests.
@@ -219,7 +221,7 @@ def test_guard_does_not_break_a_real_configure(
     baseline_tests = registered_test_names(baseline_build)
 
     guarded_build = tmp_path / 'guarded_build'
-    guarded = configure(source_dir, guarded_build, f'/opt/ros/{ros_distro}', localstatedir='/var')
+    guarded = configure(source_dir, guarded_build, SYSTEM_INSTALL_PREFIX, localstatedir='/var')
     assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build)
 
 

--- a/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
@@ -70,6 +70,8 @@ where its own dependencies are already declared and guaranteed rather than
 ridden on someone else's. The invariant - for every package that registers
 launch tests, a guarded configure succeeds and suppresses exactly its launch
 tests - is therefore split across two packages, not weakened for either one.
+One package has a documented, unrelated exception to "exactly its launch
+tests": see ALSO_SUPPRESSED_BY_PACKAGE below.
 
 Confirmed empirically, not assumed: see the `resolvable_packages` fixture
 below, which baseline-configures every candidate once, and
@@ -117,6 +119,21 @@ LAUNCH_TEST_PACKAGES = {
     'ros2_medkit_fault_reporter': 'src/ros2_medkit_fault_reporter',
     'ros2_medkit_log_bridge': 'src/ros2_medkit_log_bridge',
     'ros2_medkit_integration_tests': 'src/ros2_medkit_integration_tests',
+}
+
+# ros2_medkit_integration_tests' own test_launch_test_guard_system_build (this
+# file, once installed and configured as part of that package for real) gates
+# its OWN registration on _medkit_launch_tests_can_register() too - see the
+# comment above its ament_add_pytest_test() call in that package's
+# CMakeLists.txt: it cannot prove anything about a system-package build's own
+# repository root while running inside one, so it declines to register there
+# rather than report a pass on nothing. That makes it disappear from a guarded
+# configure of ros2_medkit_integration_tests for a reason that has nothing to
+# do with being a launch test - cmake_guard.assert_guard_suppressed_launch_tests
+# needs to be told about it explicitly, via also_suppressed, or it reads as the
+# guard swallowing something it should not have.
+ALSO_SUPPRESSED_BY_PACKAGE = {
+    'ros2_medkit_integration_tests': {'test_launch_test_guard_system_build'},
 }
 
 # All six configure under colcon test's own dependency-derived environment
@@ -222,7 +239,10 @@ def test_guard_does_not_break_a_real_configure(
 
     guarded_build = tmp_path / 'guarded_build'
     guarded = configure(source_dir, guarded_build, SYSTEM_INSTALL_PREFIX, localstatedir='/var')
-    assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build)
+    assert_guard_suppressed_launch_tests(
+        name, baseline_tests, guarded, guarded_build, baseline_build,
+        also_suppressed=ALSO_SUPPRESSED_BY_PACKAGE.get(name, ()),
+    )
 
 
 def test_all_launch_test_packages_resolve(resolvable_packages):

--- a/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py
@@ -1,0 +1,248 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Proves the launch-test guard against a real configure, not a string sweep.
+
+A regex sweep over CMakeLists.txt text was tried first, and failed three
+times running: it read one physical line and only the first captured name,
+so a second name on the same `set_tests_properties(...)` call, a name on a
+continuation line, and (found in the round after that one was fixed) a
+paren balanced across a quoted string or comment, and a mixed-case command
+spelling (CMake command names are case-insensitive; a regex with a literal
+lowercase alternative is not) all slipped past it. Every fix bought one more
+evasion. The property this task promises - "the guard does not turn a
+launch-test package's configure into a hard error" - is exactly what CMake
+itself evaluates, so this asks CMake instead of a proxy for it: for each
+package that registers a launch test, configure it for real, once as an
+ordinary workspace build and once under system-package conditions
+(`CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO`, `CMAKE_INSTALL_LOCALSTATEDIR=/var`
+- exactly what bloom's `debian/rules` passes), and compare what each run
+actually registered. No regex, on either side, decides what counts as a
+launch test. The configure/compare mechanics live in
+`ros2_medkit_test_utils.cmake_guard`, shared with the one package this file
+cannot cover - see below.
+
+This lives in ros2_medkit_integration_tests rather than ros2_medkit_cmake on
+purpose. ros2_medkit_cmake cannot depend on the packages that consume it -
+that dependency would be circular - so a test that configures
+ros2_medkit_fault_reporter, ros2_medkit_diagnostic_bridge and the rest for
+real needs to run somewhere whose own dependency chain already reaches them.
+All six packages this file covers are declared test_depends of this package
+(two - ros2_medkit_gateway, ros2_medkit_fault_manager - for the demo nodes
+this package already builds; four more - ros2_medkit_action_status_bridge,
+ros2_medkit_diagnostic_bridge, ros2_medkit_fault_reporter,
+ros2_medkit_log_bridge - declared for this test specifically, since a
+package used at test time must be a test_depend even when nothing here
+find_package()s it at build time).
+
+A seventh package registers launch tests too: ros2_medkit_graph_watchdog. It
+cannot be covered from here. It already test_depends on this package for its
+own e2e harness, and colcon confirms the reverse edge is a real build-order
+cycle, not a theoretical one - see the comment in this package's package.xml.
+Its own guarded-configure coverage lives in its own package instead, at
+src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py,
+built on the same ros2_medkit_test_utils.cmake_guard helpers this file uses,
+where its own dependencies are already declared and guaranteed rather than
+ridden on someone else's. The invariant - for every package that registers
+launch tests, a guarded configure succeeds and suppresses exactly its launch
+tests - is therefore split across two packages, not weakened for either one.
+
+Confirmed empirically, not assumed: see the `resolvable_packages` fixture
+below, which baseline-configures every candidate once, and
+`test_all_launch_test_packages_resolve`, which fails if that ever regresses
+below all six - every one of them is a package this file's own package.xml
+declares a dependency on, so anything less is a real break, not a
+degradation to shrug off.
+"""
+
+import os
+import pathlib
+import sys
+
+import pytest
+from ros2_medkit_test_utils.cmake_guard import (
+    assert_guard_suppressed_launch_tests,
+    configure,
+    registered_test_names,
+)
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# The six packages ros2_medkit_integration_tests actually declares as
+# test_depend (directly, or - for ros2_medkit_gateway and
+# ros2_medkit_fault_manager - for the demo nodes this package already
+# builds), and their source directory relative to the repository root.
+# Listed explicitly rather than discovered by scanning CMakeLists.txt for the
+# macro call: that scan is exactly the kind of text-based proxy this test
+# replaces, and a package that forgot to update this list would rather be
+# caught by a reviewer than by this file quietly not exercising it.
+#
+# ros2_medkit_graph_watchdog also calls medkit_add_launch_test but is
+# deliberately not listed here - see the module docstring for the real
+# build-order cycle that rules out declaring it, and for where its own
+# coverage lives instead.
+LAUNCH_TEST_PACKAGES = {
+    'ros2_medkit_action_status_bridge': 'src/ros2_medkit_action_status_bridge',
+    'ros2_medkit_diagnostic_bridge': 'src/ros2_medkit_diagnostic_bridge',
+    'ros2_medkit_fault_manager': 'src/ros2_medkit_fault_manager',
+    'ros2_medkit_fault_reporter': 'src/ros2_medkit_fault_reporter',
+    'ros2_medkit_log_bridge': 'src/ros2_medkit_log_bridge',
+    'ros2_medkit_integration_tests': 'src/ros2_medkit_integration_tests',
+}
+
+# All six configure under colcon test's own dependency-derived environment
+# (verified empirically while writing this test). The floor is therefore the
+# exact count, not a conservative guess under it: an environment that starts
+# resolving fewer than all six is a real regression in a dependency this
+# package actually declares, and test_all_launch_test_packages_resolve
+# exists to fail on that rather than quietly accept less coverage.
+MINIMUM_RESOLVABLE_PACKAGES = len(LAUNCH_TEST_PACKAGES)
+
+
+def _repository_root():
+    """Return the repository root, or None when only this package is present."""
+    for candidate in PACKAGE_ROOT.parents:
+        if (candidate / 'src' / 'ros2_medkit_cmake' / 'package.xml').is_file():
+            return candidate
+    return None
+
+
+@pytest.fixture(scope='session')
+def repository_root():
+    """
+    Return the repository root.
+
+    Unconditional, not a skip: this test is registered in CMakeLists.txt only
+    when the same signal medkit_add_launch_test's own guard uses to detect a
+    system-package build (CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO plus
+    CMAKE_INSTALL_LOCALSTATEDIR) says otherwise - the ROS build farm's
+    binarydeb chroot builds this package alone, with no sibling packages
+    beside it, which is exactly when no repository root exists above it. A
+    missing repository root here means that registration guard itself broke,
+    which must fail rather than skip.
+    """
+    root = _repository_root()
+    assert root is not None, (
+        'no repository root found above this package, but this test is only registered '
+        '(see CMakeLists.txt) when one is expected to exist'
+    )
+    return root
+
+
+@pytest.fixture(scope='session')
+def ros_distro():
+    """
+    Return ROS_DISTRO.
+
+    Unconditional, not a skip: colcon test always sources a ROS distribution
+    before running a test, so ROS_DISTRO is guaranteed to be set wherever
+    this test runs at all. Its absence is a broken environment, not a reason
+    to decline the check the environment promised it could run.
+    """
+    distro = os.environ.get('ROS_DISTRO')
+    assert distro, 'ROS_DISTRO is unset; colcon test always sources a ROS distribution first'
+    return distro
+
+
+@pytest.fixture(scope='session')
+def resolvable_packages(repository_root, ros_distro, tmp_path_factory):
+    """
+    Baseline-configure every candidate exactly once; record which ones this environment reaches.
+
+    This is the only baseline (ordinary workspace-style) configure each
+    package gets. `test_guard_does_not_break_a_real_configure` below reuses
+    the build directory recorded here instead of configuring the baseline
+    again per parametrized case, which is what keeps the total configure
+    count at twelve (one baseline plus one guarded configure per package)
+    rather than eighteen.
+
+    A package whose baseline configure fails has a dependency this
+    environment cannot resolve. That is data, not a verdict on the guard by
+    itself - `test_guard_does_not_break_a_real_configure` and
+    `test_all_launch_test_packages_resolve` are what turn it into a pass or
+    a fail; this fixture only collects it and prints it (pytest shows the
+    print with -s or on failure) so a failure is traceable, not silent.
+
+    Returns {name: (resolvable, build_dir_or_None, stderr_or_None)}.
+    """
+    baselines = {}
+    for name, rel_path in sorted(LAUNCH_TEST_PACKAGES.items()):
+        source_dir = repository_root / rel_path
+        build_dir = tmp_path_factory.mktemp(f'baseline_{name}_build')
+        install_dir = tmp_path_factory.mktemp(f'baseline_{name}_install')
+        result = configure(source_dir, build_dir, install_dir)
+        if result.returncode == 0:
+            print(f'RESOLVABLE {name}: baseline configure succeeded')
+            baselines[name] = (True, build_dir, None)
+        else:
+            print(
+                f'UNRESOLVED {name}: baseline configure failed in this environment:\n'
+                f'{result.stderr}'
+            )
+            baselines[name] = (False, None, result.stderr)
+    return baselines
+
+
+@pytest.mark.parametrize('name', sorted(LAUNCH_TEST_PACKAGES))
+def test_guard_does_not_break_a_real_configure(
+    name, repository_root, ros_distro, resolvable_packages, tmp_path
+):
+    """
+    A system-package configure still succeeds, and suppresses the right tests.
+
+    Asserts unconditionally, including that the baseline itself resolved:
+    every package in LAUNCH_TEST_PACKAGES is a declared dependency of this
+    package (see the module docstring), so a baseline that fails to
+    configure is this test's problem to report, not a reason to decline it.
+    """
+    resolvable, baseline_build, baseline_stderr = resolvable_packages[name]
+    assert resolvable, (
+        f'{name}: baseline configure failed, so the system-package configure below cannot be '
+        f'compared against anything - this package is a declared dependency of '
+        f'ros2_medkit_integration_tests and must resolve:\n{baseline_stderr}'
+    )
+    source_dir = repository_root / LAUNCH_TEST_PACKAGES[name]
+    # Reuses the session-scoped baseline from the fixture rather than
+    # configuring it again here - see that fixture's docstring for why.
+    baseline_tests = registered_test_names(baseline_build)
+
+    guarded_build = tmp_path / 'guarded_build'
+    guarded = configure(source_dir, guarded_build, f'/opt/ros/{ros_distro}', localstatedir='/var')
+    assert_guard_suppressed_launch_tests(name, baseline_tests, guarded, guarded_build)
+
+
+def test_all_launch_test_packages_resolve(resolvable_packages):
+    """
+    A floor so the suite above cannot pass by having configured nothing.
+
+    Every package listed in LAUNCH_TEST_PACKAGES is a declared dependency of
+    this package, so this requires every one of them to resolve, not merely
+    most - a package failing to resolve is a real regression in a dependency
+    this package actually declares. test_guard_does_not_break_a_real_configure
+    already fails per-package on this; this is the aggregate view of the
+    same fact, for a run that has configured nothing to be unable to hide
+    behind individually plausible-looking per-package messages.
+    """
+    resolved = sorted(name for name, (ok, _, _) in resolvable_packages.items() if ok)
+    unresolved = sorted(name for name, (ok, _, _) in resolvable_packages.items() if not ok)
+    assert len(resolved) >= MINIMUM_RESOLVABLE_PACKAGES, (
+        f'only {len(resolved)} of {len(LAUNCH_TEST_PACKAGES)} launch-test packages could be '
+        f'configured in this environment (resolved={resolved}, unresolved={unresolved}), below '
+        f'the floor of {MINIMUM_RESOLVABLE_PACKAGES} - this run proves too little to trust'
+    )
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v', '-s']))

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -269,18 +269,14 @@ if(BUILD_TESTING)
   set(_WATCHDOG_E2E_ENV "GRAPH_WATCHDOG_PLUGIN_PATH=${_WATCHDOG_E2E_SO}")
 
   medkit_add_launch_test(test_e2e_test_qos_e2e.test.py test/e2e/test_qos_e2e.test.py
-    TIMEOUT 180)
-  set_tests_properties(test_e2e_test_qos_e2e.test.py PROPERTIES LABELS "integration;e2e")
-  # APPEND: medkit_add_launch_test put this test's domain count in ENVIRONMENT and a plain
-  # PROPERTIES assignment would drop it, leaving the test on the default domain.
-  set_property(TEST test_e2e_test_qos_e2e.test.py APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19120;${_WATCHDOG_E2E_ENV}")
+    TIMEOUT 180
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19120" "${_WATCHDOG_E2E_ENV}")
 
   medkit_add_launch_test(test_e2e_test_orphan_e2e.test.py test/e2e/test_orphan_e2e.test.py
-    TIMEOUT 180)
-  set_tests_properties(test_e2e_test_orphan_e2e.test.py PROPERTIES LABELS "integration;e2e")
-  set_property(TEST test_e2e_test_orphan_e2e.test.py APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19130;${_WATCHDOG_E2E_ENV}")
+    TIMEOUT 180
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19130" "${_WATCHDOG_E2E_ENV}")
 
   # param_drift e2e: the detector's DEFAULT mode. The config-plumbing scenarios below all set
   # baseline: false and none of them asserts a clear, so without this the self-capturing behaviour
@@ -291,10 +287,9 @@ if(BUILD_TESTING)
   # before any of the messages those deadlines exist to print reaches the log, which turns every
   # one of them into "timed out".
   medkit_add_launch_test(test_e2e_test_param_drift_e2e.test.py
-    test/e2e/test_param_drift_e2e.test.py TIMEOUT 300)
-  set_tests_properties(test_e2e_test_param_drift_e2e.test.py PROPERTIES LABELS "integration;e2e")
-  set_property(TEST test_e2e_test_param_drift_e2e.test.py APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19170;${_WATCHDOG_E2E_ENV}")
+    test/e2e/test_param_drift_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19170" "${_WATCHDOG_E2E_ENV}")
 
   # Round-trip cost e2e: what ONE parameter read really costs the node that serves it, counted
   # at a node that answers the parameter services by hand. param_drift's read budget is charged
@@ -309,11 +304,9 @@ if(BUILD_TESTING)
   # than the internal budgets kills the process before any of those diagnostics print, so the
   # failure reads as "test timed out" and says nothing about round trips.
   medkit_add_launch_test(test_e2e_test_param_roundtrip_e2e.test.py
-    test/e2e/test_param_roundtrip_e2e.test.py TIMEOUT 300)
-  set_tests_properties(test_e2e_test_param_roundtrip_e2e.test.py PROPERTIES
-    LABELS "integration;e2e")
-  set_property(TEST test_e2e_test_param_roundtrip_e2e.test.py APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19180;${_WATCHDOG_E2E_ENV}")
+    test/e2e/test_param_roundtrip_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19180" "${_WATCHDOG_E2E_ENV}")
 
   # === Config-plumbing e2e (launch_testing) ===
   #
@@ -327,27 +320,36 @@ if(BUILD_TESTING)
   # gateway launches rather than separate test methods in one. WATCHDOG_E2E_SCENARIO selects
   # which launch and which assertions run in each process.
   medkit_add_launch_test(test_config_plumbing_e2e_positive
-    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180)
-  set_tests_properties(test_config_plumbing_e2e_positive PROPERTIES LABELS "integration;e2e")
-  set_property(TEST test_config_plumbing_e2e_positive APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19140;WATCHDOG_E2E_SCENARIO=positive;${_WATCHDOG_E2E_ENV}")
+    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19140" "WATCHDOG_E2E_SCENARIO=positive" "${_WATCHDOG_E2E_ENV}")
 
   medkit_add_launch_test(test_config_plumbing_e2e_mode_off
-    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180)
-  set_tests_properties(test_config_plumbing_e2e_mode_off PROPERTIES LABELS "integration;e2e")
-  set_property(TEST test_config_plumbing_e2e_mode_off APPEND PROPERTY
-    ENVIRONMENT "GATEWAY_TEST_PORT=19150;WATCHDOG_E2E_SCENARIO=mode_off;${_WATCHDOG_E2E_ENV}")
+    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19150" "WATCHDOG_E2E_SCENARIO=mode_off" "${_WATCHDOG_E2E_ENV}")
 
   # Third launch: `mode: off` written BARE, which the ROS parser types as a YAML 1.1 boolean
   # rather than a string. That is the form operators write, and a string-only reader silently
   # keeps the detector raising.
   medkit_add_launch_test(test_config_plumbing_e2e_mode_off_yaml_bool
-    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180)
-  set_tests_properties(test_config_plumbing_e2e_mode_off_yaml_bool PROPERTIES
-    LABELS "integration;e2e")
-  set_property(TEST test_config_plumbing_e2e_mode_off_yaml_bool APPEND PROPERTY
-    ENVIRONMENT
-      "GATEWAY_TEST_PORT=19160;WATCHDOG_E2E_SCENARIO=mode_off_yaml_bool;${_WATCHDOG_E2E_ENV}")
+    test/e2e/test_config_plumbing_e2e.test.py TIMEOUT 180
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19160" "WATCHDOG_E2E_SCENARIO=mode_off_yaml_bool" "${_WATCHDOG_E2E_ENV}")
+
+  # Real-cmake-configure proof of the launch-test guard for this package -
+  # this package's own half of the pair described in
+  # ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py's
+  # module docstring. Registers unconditionally: it configures only this
+  # package's own source directory, present in every build context including
+  # the ROS build farm's binarydeb chroot, unlike the sibling test's need for
+  # a repository root above it. ROS-free: it spawns its own cmake
+  # subprocesses rather than creating ROS entities.
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_launch_test_guard_system_build
+    test/test_launch_test_guard_system_build.py TIMEOUT 180)
+  set_tests_properties(test_launch_test_guard_system_build PROPERTIES LABELS "integration")
+  medkit_test_needs_no_domain(test_launch_test_guard_system_build)
 
   ros2_medkit_relax_vendor_warnings()
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/package.xml
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/package.xml
@@ -44,6 +44,12 @@
   <test_depend>ros2_medkit_integration_tests</test_depend>
   <test_depend>ament_index_python</test_depend>
 
+  <!-- test_launch_test_guard_system_build.py: real cmake configures of this
+       package, via ros2_medkit_test_utils.cmake_guard (installed by
+       ros2_medkit_integration_tests above). -->
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
@@ -30,9 +30,19 @@ Unlike the sibling test, this one needs no repository root: it configures
 only its own source directory, which is always right where this test file
 is, in the ROS build farm's isolated binarydeb chroot exactly as much as in
 a full workspace checkout. It registers unconditionally.
+
+The system-package prefix the configure below uses is SYSTEM_INSTALL_PREFIX,
+a literal - not this environment's own ROS_DISTRO. The guard's install-prefix
+check (see ROS2MedkitTestDomain.cmake) is a wildcard, `/opt/ros/<anything>`,
+not a comparison against the environment, so any distro name proves the same
+thing. An earlier version of the guard compared against `$ENV{ROS_DISTRO}`
+instead and never fired in the ROS build farm's binarydeb chroot, which has
+no ROS_DISTRO in its environment at all - see
+ros2_medkit_cmake/test/test_launch_test_guard.py's
+test_launch_test_is_not_registered_with_ros_distro_absent for the probe that
+catches a regression back to that.
 """
 
-import os
 import pathlib
 import sys
 
@@ -45,32 +55,24 @@ from ros2_medkit_test_utils.cmake_guard import (
 
 PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
 
-
-@pytest.fixture(scope='session')
-def ros_distro():
-    """
-    Return ROS_DISTRO.
-
-    Unconditional, not a skip: colcon test always sources a ROS distribution
-    before running a test, so ROS_DISTRO is guaranteed to be set wherever
-    this test runs at all. Its absence is a broken environment, not a reason
-    to decline the check the environment promised it could run.
-    """
-    distro = os.environ.get('ROS_DISTRO')
-    assert distro, 'ROS_DISTRO is unset; colcon test always sources a ROS distribution first'
-    return distro
+# A literal, not this environment's own ROS_DISTRO - see the module docstring
+# above for why. Any name under /opt/ros/ proves the same thing against the
+# guard's wildcard prefix check, and humble is the one distro the guard exists
+# for.
+SYSTEM_INSTALL_PREFIX = '/opt/ros/humble'
 
 
-def test_guard_does_not_break_a_real_configure(ros_distro, tmp_path):
+def test_guard_does_not_break_a_real_configure(tmp_path):
     """
     A system-package configure of this package still succeeds, and suppresses the right tests.
 
     Configures this package's own source directory twice: once as an
     ordinary workspace-style build, once under system-package conditions
-    (CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO, CMAKE_INSTALL_LOCALSTATEDIR=
-    /var - what bloom's debian/rules passes), and compares what each run
-    actually registered. See ros2_medkit_test_utils.cmake_guard for what
-    "suppresses the right tests" asserts.
+    (CMAKE_INSTALL_PREFIX=SYSTEM_INSTALL_PREFIX, CMAKE_INSTALL_LOCALSTATEDIR=
+    /var - what bloom's debian/rules passes, with a literal distro name in
+    place of the real one), and compares what each run actually registered.
+    See ros2_medkit_test_utils.cmake_guard for what "suppresses the right
+    tests" asserts.
     """
     baseline_build = tmp_path / 'baseline_build'
     baseline_install = tmp_path / 'baseline_install'
@@ -83,7 +85,7 @@ def test_guard_does_not_break_a_real_configure(ros_distro, tmp_path):
 
     guarded_build = tmp_path / 'guarded_build'
     guarded = configure(
-        PACKAGE_ROOT, guarded_build, f'/opt/ros/{ros_distro}', localstatedir='/var'
+        PACKAGE_ROOT, guarded_build, SYSTEM_INSTALL_PREFIX, localstatedir='/var'
     )
     assert_guard_suppressed_launch_tests(
         'ros2_medkit_graph_watchdog', baseline_tests, guarded, guarded_build

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
@@ -88,7 +88,7 @@ def test_guard_does_not_break_a_real_configure(tmp_path):
         PACKAGE_ROOT, guarded_build, SYSTEM_INSTALL_PREFIX, localstatedir='/var'
     )
     assert_guard_suppressed_launch_tests(
-        'ros2_medkit_graph_watchdog', baseline_tests, guarded, guarded_build
+        'ros2_medkit_graph_watchdog', baseline_tests, guarded, guarded_build, baseline_build
     )
 
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_launch_test_guard_system_build.py
@@ -1,0 +1,94 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Proves the launch-test guard against a real configure of this package.
+
+The six-package sibling of this test,
+`ros2_medkit_integration_tests/test/test_launch_test_guard_system_build.py`,
+cannot cover ros2_medkit_graph_watchdog: this package already test_depends on
+ros2_medkit_integration_tests for its own e2e harness, and colcon confirms
+the reverse edge is a real build-order cycle, not a theoretical one - see the
+comment in ros2_medkit_integration_tests/package.xml. So this package proves
+the same property about itself instead, using the same configure/compare
+helpers (`ros2_medkit_test_utils.cmake_guard`) the sibling test uses - it
+already reaches that module through the same test_depend that creates the
+cycle in the other direction.
+
+Unlike the sibling test, this one needs no repository root: it configures
+only its own source directory, which is always right where this test file
+is, in the ROS build farm's isolated binarydeb chroot exactly as much as in
+a full workspace checkout. It registers unconditionally.
+"""
+
+import os
+import pathlib
+import sys
+
+import pytest
+from ros2_medkit_test_utils.cmake_guard import (
+    assert_guard_suppressed_launch_tests,
+    configure,
+    registered_test_names,
+)
+
+PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope='session')
+def ros_distro():
+    """
+    Return ROS_DISTRO.
+
+    Unconditional, not a skip: colcon test always sources a ROS distribution
+    before running a test, so ROS_DISTRO is guaranteed to be set wherever
+    this test runs at all. Its absence is a broken environment, not a reason
+    to decline the check the environment promised it could run.
+    """
+    distro = os.environ.get('ROS_DISTRO')
+    assert distro, 'ROS_DISTRO is unset; colcon test always sources a ROS distribution first'
+    return distro
+
+
+def test_guard_does_not_break_a_real_configure(ros_distro, tmp_path):
+    """
+    A system-package configure of this package still succeeds, and suppresses the right tests.
+
+    Configures this package's own source directory twice: once as an
+    ordinary workspace-style build, once under system-package conditions
+    (CMAKE_INSTALL_PREFIX=/opt/ros/$ROS_DISTRO, CMAKE_INSTALL_LOCALSTATEDIR=
+    /var - what bloom's debian/rules passes), and compares what each run
+    actually registered. See ros2_medkit_test_utils.cmake_guard for what
+    "suppresses the right tests" asserts.
+    """
+    baseline_build = tmp_path / 'baseline_build'
+    baseline_install = tmp_path / 'baseline_install'
+    baseline = configure(PACKAGE_ROOT, baseline_build, baseline_install)
+    assert baseline.returncode == 0, (
+        f'ros2_medkit_graph_watchdog: baseline configure failed, so the system-package '
+        f'configure below cannot be compared against anything:\n{baseline.stderr}'
+    )
+    baseline_tests = registered_test_names(baseline_build)
+
+    guarded_build = tmp_path / 'guarded_build'
+    guarded = configure(
+        PACKAGE_ROOT, guarded_build, f'/opt/ros/{ros_distro}', localstatedir='/var'
+    )
+    assert_guard_suppressed_launch_tests(
+        'ros2_medkit_graph_watchdog', baseline_tests, guarded, guarded_build
+    )
+
+
+if __name__ == '__main__':
+    sys.exit(pytest.main([__file__, '-v', '-s']))


### PR DESCRIPTION
# Pull Request

## Summary

A launch test resolves its own package through the ament index, which only an installed prefix carries. A system package build runs its test step before the install step, so every launch test in this repo failed in the Humble binarydeb job with `package '<name>' not found, searching: ['/opt/ros/humble']`. Humble is the only supported distro whose binarydeb job still runs package tests; every distro from Iron onward disables them. Because bloom runs that step as `dh_auto_test || true`, the failures could not stop the build, so what shipped was a published log full of errors that said nothing about the package.

The reported cause was incomplete. Adding `ros2_medkit_test_utils` to `PYTHONPATH` moves the failure from the import to `PackageNotFoundError`, because the launch tests also resolve their own executables through the ament index. The suite structurally needs an install space, so it is not registered where there is none.

Skipping registration alone is not enough either, and that is why the macro changed. Callers named the test afterwards to set labels and environment, and `set_tests_properties` on a test that does not exist is a hard CMake error, not a no-op. That would have replaced a noisy log with a failed configure, in five packages. `medkit_add_launch_test` now takes `LABELS`, `ENV` and `ARGS` and applies them itself, and every call site across seven packages moved onto it. This also removes a trap the tree documented in several comments: a plain `set_tests_properties(... ENVIRONMENT ...)` after the macro dropped the domain the macro had set, leaving the test on domain 0.

The guard needs two signals, because either alone has a false positive:

- the install prefix is the ROS distribution root, which also matches `colcon build --install-base /opt/ros/<distro>`, and
- `CMAKE_INSTALL_LOCALSTATEDIR` is `/var`, which debhelper always passes and no colcon build does. The value matters: `include(GNUInstallDirs)` defines the same variable as a relative `var`.

gtests and pytest tests are deliberately untouched. That chroot is the only place these packages are exercised against a minimal dependency closure, and it has already earned its keep: it exposed a missing runtime dependency in the fault manager, which is fixed separately.

---

## Issue

- closes #602

---

## Type

- [x] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

**The guard is proven by running a real cmake configure, not by matching text.** A test configures every package that registers launch tests, with the distribution prefix and `CMAKE_INSTALL_LOCALSTATEDIR=/var`, and requires the configure to succeed, the guard's message to appear, no launch test to be registered and at least one non-launch test to remain. Injecting a property call on a launch test by name makes it fail, including in the mixed-case spelling `Set_Tests_Properties(...)`, which is valid CMake.

`ros2_medkit_graph_watchdog` cannot be a dependency of the integration test package without a cycle, so it runs the same check in its own suite rather than being covered by accident. Neither test can skip: registration is decided in CMake, and where the test is registered it asserts unconditionally.

**The migration is behaviour-preserving.** `ros2_medkit_integration_tests` registers the same 91 tests before and after, with the same labels, the same `GATEWAY_TEST_PORT` values from 9100 to 9970 in steps of 10, and the four per-test timeout overrides unchanged at 180, 300, 300 and 300 seconds.

**Distros.** The probe projects declare a language, because a project with no language enabled reaches deprecated `FindPythonLibs` through `python_cmake_module` on Humble, which this repo documents in `ros2_medkit_cmake/design/index.rst`. That is verified by the Humble job, not locally.

**What this cannot prove.** That the binarydeb log is actually clean. The next Humble binarydeb run after a release is the check; everything here shows that in a build configured the same way, the configure succeeds and no launch test is registered.

---

## Note for reviewers

`medkit_add_launch_test` callers must now pass `LABELS`, `ENV` and `ARGS` to the macro. Naming a launch test afterwards to set properties is not supported, and a test will fail the build if it reappears.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
