### PR TITLE
fix(gateway): read discovery configuration from the documented 'config:' key

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -362,7 +362,7 @@ jobs:
             | grep -oE 'TIMEOUT "[0-9]+"' | sort -t'"' -k2 -n | uniq -c
 
       - name: Run unit + integration tests with ASan + UBSan
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           # detect_leaks=0: FastDDS allocator leaks on shutdown (not our code)
           # new_delete_type_mismatch=0: ROS 2 DDS scalar/array new/delete mismatch
@@ -483,7 +483,7 @@ jobs:
             | grep -oE 'TIMEOUT "[0-9]+"' | sort -t'"' -k2 -n | uniq -c
 
       - name: Run unit + integration tests with TSan
-        timeout-minutes: 30
+        timeout-minutes: 45
         env:
           # Same factor as the ctest TIMEOUT rewrite above, for the wall-clock
           # budgets tests assert internally - ctest's clock cannot reach those.

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -59,11 +59,12 @@ Server Capabilities
    in config, which wires up an ``AggregationManager``). It does NOT
    require peers to be present - a gateway with aggregation enabled but
    zero peers still reports ``true`` and still emits the
-   aggregation-only response fields (``peers``, which may be an empty
-   array, and ``warnings`` on ``/health``; ``x-medkit.contributors`` on
-   entities, which will contain only ``"local"`` until a peer
-   contributes). Clients can feature-detect those fields using this
-   flag instead of probing for field presence.
+   aggregation-only response fields (``peers`` on ``/health``, which may
+   be an empty array; ``x-medkit.contributors`` on entities, which will
+   contain only ``"local"`` until a peer contributes). Clients can
+   feature-detect those fields using this flag instead of probing for
+   field presence. ``warnings`` is **not** one of them: it is served on
+   every ``/health`` response regardless of this flag.
 
 ``GET /api/v1/version-info``
    Get gateway version and status information.
@@ -88,20 +89,45 @@ Server Capabilities
 ``GET /api/v1/health``
    Health check endpoint. Returns HTTP 200 if gateway is operational.
 
-   When aggregation is enabled (``capabilities.aggregation == true`` in
-   the root response), the body includes additional x-medkit extension
-   fields:
+   The body always includes these x-medkit extension fields:
 
-   - ``peers`` - array of peer status objects (URL, name, reachability,
-     last-seen timestamp) for every configured or discovered peer.
-   - ``warnings`` - array of structured operator-actionable aggregation
-     warnings (always present when aggregation is active; empty when
-     there are no active anomalies). Each warning carries ``code``,
-     ``message``, ``entity_ids``, and ``peer_names``. See
-     :doc:`warning_codes` for the stable list of codes.
+   - ``warnings`` - array of structured operator-actionable warnings,
+     empty when there are no active anomalies. Each warning carries
+     ``code``, ``message``, ``entity_ids``, ``ros_node_fqns`` and
+     ``peer_names``. The three identifier arrays are always present, and a
+     code with nothing to say in one of them sends it empty.
+     ``entity_ids`` holds addressable SOVD entity ids only - never ROS node
+     names, which go in ``ros_node_fqns``. See :doc:`warning_codes` for the
+     stable list of codes and what each one fills in.
    - ``warning_schema_version`` - integer contract version for the
      ``warnings`` array. Clients key on this instead of string-matching
      codes. See :doc:`warning_codes` ``Schema versioning``.
+
+   .. note::
+
+      The OpenAPI component for a warning object is named ``HealthWarning``.
+      It was ``HealthAggregationWarning`` in earlier releases, renamed when
+      warnings stopped being aggregation-specific. The wire shape of the
+      object did not change, so ``warning_schema_version`` does not move for
+      the rename - but a client regenerated from the OpenAPI document will
+      see the generated type change name.
+
+   When aggregation is enabled (``capabilities.aggregation == true`` in
+   the root response), the body additionally includes:
+
+   - ``peers`` - array of peer status objects for every configured or
+     discovered peer. Each carries ``name``, ``url`` and ``status``
+     (``"online"`` or ``"offline"``).
+
+   The ``discovery`` object carries a ``linking`` sub-object describing
+   how manifest apps were bound to runtime ROS nodes: ``linked_count``,
+   ``orphan_count``, ``binding_conflicts``, ``unmanifested_policy`` (the
+   configured ``config.unmanifested_nodes`` value) and, when the linker
+   produced any, ``warnings`` (an array of strings). It appears only when
+   a linker ran, which means hybrid mode **with the runtime layer
+   enabled**: ``runtime_only`` and ``manifest_only`` run no linker, and
+   neither does a hybrid gateway configured with
+   ``discovery.runtime.enabled: false``.
 
    The body also always includes two subscription-pool vendor-extension
    sections, populated from atomic reads so ``/health`` never blocks even
@@ -136,27 +162,70 @@ Server Capabilities
       authenticating reverse proxy or restrict the peer-name field to
       admin-gated callers at the ingress.
 
-   **Example Response (aggregation enabled, one leaf collision):**
+   **Example Response.** A hybrid gateway with one declared app, six
+   undeclared ROS nodes and ``unmanifested_nodes: error``, captured from a
+   running gateway. The three ``x-medkit-*`` statistics objects are omitted
+   here for length; ``peers`` appears only when aggregation is enabled.
 
    .. code-block:: json
 
       {
         "status": "healthy",
-        "timestamp": 1776185189048036615,
+        "timestamp": 1786538411000000000,
+        "warning_schema_version": 2,
+        "warnings": [
+          {
+            "code": "unmanifested_nodes",
+            "message": "6 running ROS node(s) are not declared in the manifest while unmanifested_nodes is set to 'error' (listed in ros_node_fqns). The gateway keeps serving. Declare them in the manifest, or relax the policy to 'warn' or 'ignore'.",
+            "entity_ids": [],
+            "ros_node_fqns": [
+              "/powertrain/engine/rpm_sensor",
+              "/ros2_medkit_gateway",
+              "/_param_client_node",
+              "/ros2_medkit_gateway_fault_clients",
+              "/ros2_medkit_gateway_lifecycle_state_reader",
+              "/ros2_medkit_gateway_sub"
+            ],
+            "peer_names": []
+          }
+        ],
         "discovery": {
           "mode": "hybrid",
-          "strategy": "hybrid_discovery"
-        },
+          "strategy": "hybrid",
+          "pipeline": {
+            "layers": ["manifest", "runtime"],
+            "total_entities": 9,
+            "enriched_count": 0,
+            "conflict_count": 0,
+            "conflicts": [],
+            "id_collisions": 0,
+            "filtered_by_gap_fill": 0
+          },
+          "linking": {
+            "linked_count": 1,
+            "orphan_count": 6,
+            "binding_conflicts": 0,
+            "unmanifested_policy": "error"
+          }
+        }
+      }
+
+   With aggregation enabled the body additionally carries ``peers``, and a
+   Component announced by more than one peer adds a second warning:
+
+   .. code-block:: json
+
+      {
         "peers": [
-          {"name": "peer_b", "url": "http://peer-b:8080", "healthy": true},
-          {"name": "peer_c", "url": "http://peer-c:8080", "healthy": true}
+          {"name": "peer_b", "url": "http://peer-b:8080", "status": "online"},
+          {"name": "peer_c", "url": "http://peer-c:8080", "status": "online"}
         ],
-        "warning_schema_version": 1,
         "warnings": [
           {
             "code": "leaf_id_collision",
             "message": "Component 'ecu-x' is announced by multiple peers (peer_b, peer_c); routing falls back to last-writer-wins which is non-deterministic. Resolve by renaming the Component on one side or by modelling it as a hierarchical parent (declare a child Component with parentComponentId='ecu-x' on the owning peer).",
             "entity_ids": ["ecu-x"],
+            "ros_node_fqns": [],
             "peer_names": ["peer_b", "peer_c"]
           }
         ]

--- a/docs/api/warning_codes.rst
+++ b/docs/api/warning_codes.rst
@@ -1,8 +1,10 @@
 Warning Codes
 =============
 
-The ``/api/v1/health`` endpoint surfaces operator-actionable aggregation
-anomalies in the top-level ``warnings`` array (x-medkit extension).
+The ``/api/v1/health`` endpoint surfaces operator-actionable anomalies in the
+top-level ``warnings`` array (x-medkit extension). These are conditions the
+gateway flags without taking itself offline: ``status`` stays ``"healthy"``
+and every endpoint keeps serving.
 Each entry has the shape:
 
 .. code-block:: json
@@ -11,8 +13,13 @@ Each entry has the shape:
      "code": "leaf_id_collision",
      "message": "Component 'ecu-x' is announced by multiple peers (peer_b, peer_c); routing falls back to last-writer-wins which is non-deterministic. Resolve by renaming the Component on one side or by modelling it as a hierarchical parent (declare a child Component with parentComponentId='ecu-x' on the owning peer).",
      "entity_ids": ["ecu-x"],
+     "ros_node_fqns": [],
      "peer_names": ["peer_b", "peer_c"]
    }
+
+All five keys are always present. The three identifier arrays are empty
+rather than omitted when a code has nothing to put in them, so a client can
+read them without a presence check.
 
 Codes are stable machine-readable identifiers: renaming a code is a
 breaking change for downstream consumers that key on the string.
@@ -36,24 +43,98 @@ this page mirrors it for API consumers.
        Component with ``parentComponentId`` pointing at the colliding ID on
        the owning peer. The warning lists every claiming peer in
        ``peer_names``.
+   * - ``unmanifested_nodes``
+     - One or more running ROS nodes are not declared in the manifest while
+       ``config.unmanifested_nodes`` is set to ``error``. This is a report,
+       not an outage: the gateway keeps serving and ``status`` stays
+       ``"healthy"``. Resolve by declaring the nodes in the manifest, or by
+       relaxing the policy to ``warn`` or ``ignore``. The same document
+       carries ``discovery.linking.unmanifested_policy`` and
+       ``discovery.linking.orphan_count``, so a monitor can branch on
+       ``orphan_count > 0 && unmanifested_policy == "error"`` without reading
+       the message text.
 
-When aggregation is enabled (``GET /`` -> ``capabilities.aggregation``
-is ``true``), ``warnings`` is always an array on the ``/health`` response:
-empty when no anomalies are active, non-empty otherwise. When aggregation
-is disabled, the field is omitted entirely.
+``warnings`` is always an array on the ``/health`` response - empty when no
+anomalies are active, non-empty otherwise - whether or not aggregation is
+enabled. Aggregation-specific codes can only appear when aggregation is
+configured (``GET /`` -> ``capabilities.aggregation`` is ``true``), but the
+array itself is not conditional on it.
+
+The identifier arrays
+---------------------
+
+A warning object carries three identifier arrays. All three are always
+present; a code that has nothing to say in one of them sends an empty array
+rather than omitting the field, so a client never has to distinguish "absent"
+from "none".
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Field
+     - Contains
+   * - ``entity_ids``
+     - Addressable SOVD entity ids, and nothing else. **This holds for every
+       code, present and future.** Every value satisfies the entity-id rules
+       (alphanumerics, ``_`` and ``-``, at most 256 characters), so
+       ``GET /{collection}/{id}`` can be built from it directly.
+   * - ``ros_node_fqns``
+     - ROS node fully-qualified names, e.g.
+       ``/powertrain/engine/rpm_sensor``. These are *not* entity ids - a
+       leading or embedded ``/`` is rejected in an entity id because it
+       conflicts with URL routing - so they have their own field.
+   * - ``peer_names``
+     - The aggregation peers involved in the anomaly.
+
+Per code:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 25 25
+
+   * - Code
+     - ``entity_ids``
+     - ``ros_node_fqns``
+     - ``peer_names``
+   * - ``leaf_id_collision``
+     - the colliding Component id
+     - empty
+     - the announcing peers
+   * - ``unmanifested_nodes``
+     - empty
+     - every undeclared node
+     - empty
+
+``unmanifested_nodes`` reports nodes rather than entities on purpose, and not
+because an undeclared node necessarily lacks an entity - most of them have
+one. The reasons are that the reported set is deliberately wider than the
+entity tree, and that the node name is the stable identifier of the two:
+
+- The list is taken from the unfiltered runtime view, before gap-fill, before
+  the namespace filters and before the unmanifested-node policy itself. Nodes
+  that those filters remove are exactly the ones an operator most needs
+  named, and they have no entity to point at.
+- An App id is derived from the bare node name and only becomes
+  namespace-qualified if another node on the graph happens to share that
+  name. An unrelated node starting anywhere can therefore change an existing
+  orphan's App id between two ``/health`` polls, while its FQN cannot change.
 
 Schema versioning
 -----------------
 
 Alongside ``warnings`` the ``/health`` response exposes an integer
-``warning_schema_version`` (present whenever aggregation is enabled,
-regardless of whether any warnings are active). Typed clients key on this
-field to decide which codes they can feature-detect without reverting to
-string-matching every time a new anomaly class is added.
+``warning_schema_version``, present on every response regardless of whether
+any warnings are active. Typed clients key on this field to decide which
+codes they can feature-detect without reverting to string-matching every time
+a new anomaly class is added.
 
 The contract is:
 
-- Current version: ``1``.
+- Current version: ``2``. Version 2 added the ``unmanifested_nodes`` code and
+  the ``ros_node_fqns`` field, and made ``warnings`` and
+  ``warning_schema_version`` unconditional; version 1 emitted them only when
+  aggregation was enabled and had no ``ros_node_fqns``.
 - Bumped by one whenever a code is added, removed, or the shape of a
   warning object changes.
 - Within a given version, every code listed on this page is guaranteed to

--- a/docs/config/discovery-options.rst
+++ b/docs/config/discovery-options.rst
@@ -178,7 +178,10 @@ Field Groups
    * - ``status``
      - is_online, bound_fqn
    * - ``metadata``
-     - source, ros_binding, external, x-medkit extensions, custom metadata fields
+     - ros_binding, external, x-medkit extensions, custom metadata fields.
+       **Not** ``source``: an entity's provenance decides whether the orphan
+       filter may delete it, so it is never negotiated between layers and
+       setting ``layers.manifest.metadata`` does not move it.
 
 Merge Policies
 ^^^^^^^^^^^^^^
@@ -290,31 +293,47 @@ Health Endpoint
 ^^^^^^^^^^^^^^^
 
 ``GET /api/v1/health`` includes a ``discovery`` section in hybrid mode with
-pipeline stats, linking results, and merge warnings:
+pipeline stats and linking results. The ``warnings`` array and
+``warning_schema_version`` are unconditional - they are served in every mode,
+and an empty array means the gateway has no anomaly to report (see
+:doc:`/api/warning_codes`). ``discovery.linking`` is the conditional part: it
+appears only when a manifest is loaded, and ``unmanifested_policy`` carries the
+configured :ref:`unmanifested_nodes <manifest-unmanifested-nodes>` value so a
+client can evaluate ``orphan_count > 0 && unmanifested_policy == "error"``
+without parsing prose.
 
 .. code-block:: json
 
    {
      "status": "healthy",
+     "warnings": [],
+     "warning_schema_version": 2,
      "discovery": {
        "mode": "hybrid",
        "strategy": "hybrid",
        "pipeline": {
-         "layers": ["manifest", "runtime", "plugin"],
-         "total_entities": 6,
-         "enriched_count": 5,
+         "layers": ["manifest", "runtime"],
+         "total_entities": 9,
+         "enriched_count": 1,
          "conflict_count": 0,
          "conflicts": [],
          "id_collisions": 0,
          "filtered_by_gap_fill": 0
        },
        "linking": {
-         "linked_count": 5,
-         "orphan_count": 1,
-         "binding_conflicts": 0
+         "linked_count": 2,
+         "orphan_count": 5,
+         "binding_conflicts": 0,
+         "unmanifested_policy": "warn"
        }
      }
    }
+
+The response also carries the ``x-medkit-data-provider``,
+``x-medkit-entity-cache`` and ``x-medkit-subscription-executor`` statistics
+objects, omitted here. ``layers`` lists one entry per active layer, and a
+discovery plugin contributes under its own registered name (for example
+``"opcua"``) rather than a literal ``"plugin"``.
 
 Configuration Example
 ---------------------

--- a/docs/config/manifest-schema.rst
+++ b/docs/config/manifest-schema.rst
@@ -22,6 +22,7 @@ A manifest file has the following top-level structure:
      description: string
 
    config:                # Optional - discovery behavior settings
+                          # (deprecated alias for this key: "discovery:")
      unmanifested_nodes: string
      inherit_runtime_resources: boolean
      allow_manifest_override: boolean
@@ -32,6 +33,17 @@ A manifest file has the following top-level structure:
    apps: []               # Optional - app definitions
    functions: []          # Optional - function definitions
    scripts: []             # Optional - pre-defined script entries
+
+.. note::
+
+   **Unknown top-level keys are ignored, and the gateway says so.** Any
+   top-level key outside the set the parser reads
+   (``manifest_version``, ``metadata``, ``config``, ``discovery``, ``areas``,
+   ``components``, ``assets``, ``apps``, ``functions``, ``scripts``,
+   ``capabilities``) is skipped, and the gateway logs a warning naming the key
+   and listing the ones it does know. If a whole block of your manifest seems
+   to have no effect, that log line is the first place to look - a misspelled
+   or misplaced top-level key is the usual cause.
 
 manifest_version (Required)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -76,6 +88,26 @@ config (Optional)
 
 Discovery behavior configuration.
 
+Every setting in this block describes how the manifest is combined with what
+runtime discovery finds, so none of them does anything in ``manifest_only``
+(which parses the block and then runs without the merge pipeline that reads
+it) or in ``runtime_only`` (which has no manifest at all).
+
+Within ``hybrid`` mode they differ in what else they need.
+``unmanifested_nodes`` and ``inherit_runtime_resources`` are applied by the
+runtime linker, which only exists when the runtime layer is enabled.
+``allow_manifest_override`` is applied to the manifest layer's own policies,
+so it takes effect whenever the manifest layer is built - though with no
+runtime layer to merge against there is nothing for it to change.
+
+.. note::
+
+   ``config:`` is the canonical top-level key. ``discovery:`` is accepted as a
+   **deprecated alias** for the same block: it is read, the gateway logs a
+   deprecation warning naming it, and it will be removed in a future release.
+   A manifest that declares both keys uses ``config:`` and ignores
+   ``discovery:``; both facts are logged.
+
 .. list-table::
    :header-rows: 1
    :widths: 25 15 60
@@ -85,20 +117,187 @@ Discovery behavior configuration.
      - Description
    * - ``unmanifested_nodes``
      - string
-     - Policy for ROS nodes not in manifest
+     - Policy for running ROS nodes that the manifest does not declare
+       (default: ``warn``)
    * - ``inherit_runtime_resources``
      - boolean
-     - Copy topics/services from runtime nodes (default: true)
+     - Copy the bound node's topics, services and actions onto the linked
+       manifest app (default: true)
    * - ``allow_manifest_override``
      - boolean
-     - Manifest values can override runtime (default: true)
+     - Let manifest values outrank runtime values in the merge (default:
+       true). ``false`` is a blanket demotion of the manifest layer - see
+       :ref:`manifest-allow-manifest-override` for what it actually changes.
 
-**unmanifested_nodes options:**
+.. _manifest-unmanifested-nodes:
 
-- ``ignore`` - Don't expose unmanifested nodes
-- ``warn`` - Log warning, include as orphans (default)
-- ``error`` - Fail startup if orphan nodes detected
-- ``include_as_orphan`` - Include with ``source: "orphan"``
+unmanifested_nodes
+^^^^^^^^^^^^^^^^^^
+
+A node is *unmanifested* (an *orphan*) when it is present in the ROS graph and
+no manifest app binds to it.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Value
+     - Behaviour
+   * - ``ignore``
+     - Hide them. Every app that did not come from the manifest, the manual
+       asset inventory or a plugin is dropped from the entity tree, and
+       heuristic Components and Areas sitting in a namespace taken from one of
+       the orphan node FQNs are dropped with them. Note the reach: this
+       suppresses *every* non-manifest app, not only the ones that were
+       classified as orphans.
+   * - ``warn``
+     - Default. The nodes stay in the entity tree; the gateway logs one
+       warning per orphan node.
+   * - ``error``
+     - The nodes stay in the entity tree, exactly as under ``warn``. The
+       gateway logs one error naming the orphan count, and reports the nodes
+       on ``GET /api/v1/health`` in the ``warnings`` array under the code
+       ``unmanifested_nodes``, with the node fully-qualified names in
+       ``ros_node_fqns`` (``entity_ids`` is empty - a node name is not an
+       addressable entity id). **It does not fail startup.** The gateway keeps serving
+       and ``status`` stays ``"healthy"`` - see :doc:`/api/warning_codes`.
+   * - ``include_as_orphan``
+     - The same entity tree as ``warn``. The logging differs in shape as
+       well as level: ``warn`` emits one warning line per orphan node,
+       ``include_as_orphan`` emits a single info line giving the count. No
+       entity is tagged ``source: "orphan"`` - nothing in discovery ever
+       assigns that value.
+
+The four values are lower-case. ``Warn`` is not ``warn``: it is an
+unrecognised value and is treated as one.
+
+An unrecognised value raises validation warning ``R014``, and the parsed
+policy falls back to ``warn``. Because ``discovery.manifest_strict_validation``
+defaults to ``true`` and turns validation warnings into a load failure, a typo
+here rejects the manifest by default; with strict validation off the manifest
+loads, runs on ``warn``, and the gateway logs the rejected value along with
+the list of valid ones.
+
+.. _manifest-r015:
+
+Malformed structure: ``R015``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``R014`` is about a value the parser understands the *shape* of but not the
+*content* of. ``R015`` is the other half: the key is there but its YAML kind
+is wrong. It is raised when
+
+- the ``config:`` block (or the deprecated ``discovery:`` alias) is not a
+  mapping - a scalar or a sequence; or
+- one of the settings inside it is not the kind it must be:
+  ``unmanifested_nodes`` not a string, ``inherit_runtime_resources`` or
+  ``allow_manifest_override`` not a boolean.
+
+A key that carries no value at all is YAML null and means "not set". That is
+never an error: ``unmanifested_nodes:`` with nothing after it loads silently
+and the default applies.
+
+.. important::
+
+   **Advisory in this release.** ``R014`` and ``R015`` are reported on the log
+   channel only: they do **not** fail the load, whatever
+   ``discovery.manifest_strict_validation`` is set to. The manifest loads, the
+   offending block or setting is ignored, and its documented default applies.
+
+   This is a deliberate one-release grace period. The settings in this block
+   were parsed but never read before, so a manifest carrying
+   ``unmanifested_nodes: Warn`` or ``inherit_runtime_resources: 0`` loaded
+   without complaint; making them validation warnings immediately would refuse
+   that same file on upgrade under the shipped strict default, taking hybrid
+   discovery down to ``runtime_only`` for a deployment nobody edited.
+
+   **They become validation warnings in the next release**, at which point the
+   strictness dial does apply and a strict gateway rejects a manifest carrying
+   either. Fix them now while they are only noisy: grep your gateway log for
+   ``[R014]`` and ``[R015]``.
+
+Either way the malformed part costs only itself: the rest of the manifest is
+parsed normally rather than the whole file being abandoned.
+
+.. _manifest-inherit-runtime-resources:
+
+inherit_runtime_resources
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a manifest app is linked to a running node, the default (``true``) copies
+that node's topics, services and actions onto the app, so its ``/data`` and
+``/operations`` collections describe what the node really exposes.
+
+With ``false``, the link itself is unchanged - the app still reports
+``is_online`` and still names the node it is bound to - but the copy does not
+happen, so the app exposes only the resources the manifest declares for it.
+An app that declares none therefore serves empty ``/data`` and
+``/operations`` collections while still being reported as online.
+
+This holds however the app is named. An app whose ``id`` equals the bound
+node's name is one entity by id with the runtime layer's view of that node, so
+the merge would otherwise fold the node's live topics and services in before
+linking runs; the declared collections are restored after the merge precisely
+so the flag means the same thing in both spellings.
+
+.. _manifest-allow-manifest-override:
+
+allow_manifest_override
+^^^^^^^^^^^^^^^^^^^^^^^
+
+**What it means.** With the shipped manifest and runtime layers, this flag
+controls exactly one thing: whether the manifest claims *exclusivity* over the
+hierarchy. ``true`` (the default) means a declared parent-child relationship is
+the whole truth and runtime-discovered members are dropped. ``false`` means the
+manifest stops claiming exclusivity, so runtime-discovered hosts and children
+join the union instead of being discarded.
+
+Against that layer pair it changes nothing else. (A discovery plugin is a
+third layer and widens this - see **Mechanism** below.) In particular it does
+**not** change
+an entity's provenance: ``x-medkit.source`` keeps naming the layer that
+declared the entity under every layer policy, because provenance is what the
+gateway keys its delete decisions on and is never negotiated between layers.
+
+If you need per-field-group control, do not reach for this flag - it is a
+blunt switch. Use ``discovery.merge_pipeline.layers.manifest.<group>`` in the
+gateway parameters, which sets one group at a time; the field groups and the
+policy values are listed under
+:doc:`Merge Policies </config/discovery-options>`. That page documents the
+parameters themselves and does not discuss this flag.
+
+**Mechanism.** The flag is shorthand for the per-field-group merge policies of
+the manifest layer: ``false`` demotes all five groups - identity, hierarchy,
+live_data, status, metadata - to ``fallback``, so the manifest layer only fills
+gaps the runtime layer leaves. Four of those five demotions are inert against
+the shipped runtime layer, which is why the visible result is narrower than the
+mechanism suggests:
+
+- **hierarchy** - the one that shows. Collection fields (``depends_on``, a
+  Function's ``hosted_by`` list) become the union of the manifest's and the
+  runtime layer's, rather than the manifest's alone. The scalar hierarchy
+  fields are unchanged: an App's ``is_located_on``, a Component's ``area``,
+  ``parent_component_id``, ``fqn`` and ``namespace``, and an Area's
+  ``namespace`` and ``parent_area``.
+- **identity**, **live_data**, **status** - no change. The runtime layer is
+  already ``fallback`` for identity and already ``authoritative`` for live data
+  and status, and a scalar merge behaves identically whether the manifest layer
+  outranks the runtime layer or ties with it.
+- **metadata** - no change, because ``source`` is the only metadata field the
+  runtime layer contributes and provenance is exempt from the policy. This
+  demotion becomes visible only when a discovery plugin contributes metadata of
+  its own: a ``variant`` or an external-entity classification from the plugin
+  layer then wins over the manifest's.
+
+**Precedence.** The blanket demotion is applied *before* the per-group gateway
+parameters, so an explicitly configured
+``discovery.merge_pipeline.layers.manifest.<group>`` wins over
+``allow_manifest_override: false`` for that one group; the other four stay
+demoted. Pinning ``hierarchy`` back to ``authoritative`` therefore restores
+manifest exclusivity while leaving the rest of the switch in force.
+
+The flag also only matters for an entity that both layers contribute under the
+same id. An entity that only the manifest declares is unaffected.
 
 .. code-block:: yaml
 

--- a/docs/tutorials/migration-to-manifest.rst
+++ b/docs/tutorials/migration-to-manifest.rst
@@ -297,6 +297,15 @@ Combine all sections into a complete manifest:
 
 Save as ``system_manifest.yaml`` in your config directory.
 
+.. note::
+
+   The discovery-configuration block is spelled ``config:``. Older manifests
+   written against the gateway source rather than this documentation may spell
+   it ``discovery:``; that key still works as a deprecated alias and the
+   gateway logs a warning naming it, but it will be removed in a future
+   release - rename it to ``config:``. A manifest that declares both keys uses
+   ``config:`` and ignores ``discovery:``.
+
 Step 7: Test in Hybrid Mode
 ---------------------------
 
@@ -343,7 +352,18 @@ Based on testing results:
 **Orphan nodes appearing:**
 
 - Add app entries for missing nodes
-- Or set ``config.unmanifested_nodes: ignore`` to hide them
+- Or set ``config.unmanifested_nodes: ignore`` to hide them. Note how wide
+  that setting reaches: it drops every app that did not come from the
+  manifest, the asset inventory or a discovery plugin, so nodes you have not
+  declared yet disappear from the entity tree along with the ones you meant to
+  hide. "From a plugin" means the plugin's layer *declared* the entity - a
+  plugin that only adds detail to an app another layer discovered does not
+  shield it, whatever ``x-medkit.source`` ends up saying.
+  While you are still filling the manifest in, ``warn`` keeps them visible.
+- ``config.unmanifested_nodes: error`` does not stop the gateway. It logs at
+  error level and lists the orphan nodes on ``GET /api/v1/health`` under the
+  ``unmanifested_nodes`` warning code, which is the form to use if you want CI
+  or a monitor to fail on an incomplete manifest.
 
 **Missing data/operations:**
 

--- a/scripts/clang-tidy-diff.sh
+++ b/scripts/clang-tidy-diff.sh
@@ -48,9 +48,21 @@ ERRORS=0
 # when the base ref is unavailable (a fresh clone, a detached checkout, a fork with a
 # different remote name), and the filter below is then skipped rather than silencing
 # the hook.
+#
+# "What this branch changes" has to include work that is not committed yet, or the
+# pre-commit stage - the one this script was written for, which passes STAGED
+# filenames - matches nothing and the script exits 0 having analysed no files at all.
+# A silent pass is indistinguishable from a clean one, so the three sources are
+# unioned: committed branch diff, staged, and working tree.
 BRANCH_FILES=""
 if BASE_REF="$(git merge-base origin/main HEAD 2>/dev/null)"; then
-  BRANCH_FILES="$(git diff --name-only "$BASE_REF" HEAD 2>/dev/null || true)"
+  BRANCH_FILES="$(
+    {
+      git diff --name-only "$BASE_REF" HEAD 2>/dev/null || true   # committed on this branch
+      git diff --name-only --cached 2>/dev/null || true           # staged, not yet committed
+      git diff --name-only 2>/dev/null || true                    # modified in the working tree
+    } | sort -u
+  )"
 fi
 
 for file in "$@"; do

--- a/src/ros2_medkit_gateway/config/examples/demo_nodes_manifest.yaml
+++ b/src/ros2_medkit_gateway/config/examples/demo_nodes_manifest.yaml
@@ -13,7 +13,9 @@ metadata:
   description: "Demo vehicle system for integration testing"
 
 config:
-  # Fail on orphan nodes during testing to catch manifest mismatches
+  # Log a warning per undeclared node during testing to catch manifest
+  # mismatches. Use `error` to additionally have them reported on
+  # GET /api/v1/health - no policy value stops the gateway.
   unmanifested_nodes: warn
   inherit_runtime_resources: true
 

--- a/src/ros2_medkit_gateway/config/examples/multi_robot_manifest.yaml
+++ b/src/ros2_medkit_gateway/config/examples/multi_robot_manifest.yaml
@@ -11,7 +11,11 @@ metadata:
   description: "Fleet of mobile robots with central coordinator"
 
 config:
-  # Include orphan nodes (useful for discovering new robots)
+  # Keep undeclared nodes visible, so a robot that joins the fleet before its
+  # manifest entry does still shows up. This is the same entity tree the
+  # default `warn` produces - the two policies differ only in logging, where
+  # `include_as_orphan` reports one aggregate line instead of one line per
+  # node. Nothing is tagged `source: "orphan"`.
   unmanifested_nodes: include_as_orphan
   inherit_runtime_resources: true
 

--- a/src/ros2_medkit_gateway/config/examples/turtlebot3_manifest.yaml
+++ b/src/ros2_medkit_gateway/config/examples/turtlebot3_manifest.yaml
@@ -3,7 +3,7 @@
 # This manifest describes a TurtleBot3 robot running the Nav2 navigation stack.
 #
 # Use this manifest as a template for your own robot systems.
-# See documentation: https://ros2-medkit.readthedocs.io/tutorials/manifest-discovery.html
+# See documentation: https://selfpatch.github.io/ros2_medkit/tutorials/manifest-discovery.html
 
 manifest_version: "1.0"
 
@@ -13,8 +13,10 @@ metadata:
   description: "TurtleBot3 robot with Nav2 navigation stack for autonomous navigation"
 
 config:
-  # Policy for ROS nodes not declared in manifest
-  # Options: ignore, warn, error, include_as_orphan
+  # Policy for ROS nodes not declared in manifest.
+  # Options: ignore (hide them), warn (log a warning), error (log an error and
+  # report them on GET /api/v1/health), include_as_orphan (log at info level).
+  # None of them stops the gateway; only `ignore` changes the entity tree.
   unmanifested_nodes: warn
 
   # Copy topics/services from runtime nodes to manifest apps

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -329,6 +329,11 @@ ros2_medkit_gateway:
         # Values: "authoritative", "enrichment", "fallback"
         # Defaults: manifest=AUTH for identity/hierarchy/metadata, ENRICH for live_data, FALLBACK for status
         #           runtime=AUTH for live_data/status, ENRICH for metadata, FALLBACK for identity/hierarchy
+        #
+        # A manifest can demote all five manifest-layer groups at once with
+        # `config.allow_manifest_override: false`. An explicit (non-empty) value
+        # set here is applied afterwards and therefore wins for that group,
+        # while the remaining groups stay demoted to fallback.
         layers:
           manifest:
             identity: ""

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/discovery_layer.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/discovery_layer.hpp
@@ -65,6 +65,24 @@ class DiscoveryLayer {
 
   /// Whether this layer provides runtime apps for post-merge linking.
   /// Only RuntimeLayer (or test doubles) should return true.
+  /// True when entities this layer OWNS must survive orphan suppression.
+  ///
+  /// Protection used to be decided by matching `entity.source` against a list
+  /// of known strings. That string is chosen by whoever produced the entity -
+  /// a plugin provider may set anything, or nothing - so a provider that
+  /// picked an unlisted tag (`beacon`, say) had its entities deleted. The
+  /// decision belongs to the layer, which the pipeline knows for certain,
+  /// rather than to a value the layer's data happens to carry.
+  ///
+  /// Declared here rather than answered with dynamic_cast to match how the
+  /// pipeline already asks a layer what it is (see provides_runtime_apps).
+  /// DiscoveryLayer is gateway-internal - plugins implement
+  /// IntrospectionProvider, never this - so adding to it does not touch the
+  /// plugin ABI.
+  virtual bool owns_protected_entities() const {
+    return false;
+  }
+
   virtual bool provides_runtime_apps() const {
     return false;
   }

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/layers/manifest_layer.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/layers/manifest_layer.hpp
@@ -40,6 +40,10 @@ class ManifestLayer : public DiscoveryLayer {
 
   void set_policy(FieldGroup group, MergePolicy policy);
 
+  /// Restore the shipped policies. Needed on reload: a manifest that turns
+  /// allow_manifest_override back on must undo the previous demotion.
+  void reset_policies_to_defaults();
+
  private:
   ManifestManager * manifest_manager_;
   std::unordered_map<FieldGroup, MergePolicy> policies_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/manifest/manifest.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/manifest/manifest.hpp
@@ -38,10 +38,17 @@ struct ManifestConfig {
    * @brief Policy for ROS nodes not declared in manifest
    */
   enum class UnmanifestedNodePolicy {
-    IGNORE,            ///< Don't expose unmanifested nodes
-    WARN,              ///< Log warning, include as orphan
-    ERROR,             ///< Fail startup
-    INCLUDE_AS_ORPHAN  ///< Include with source="orphan"
+    IGNORE,  ///< Don't expose unmanifested nodes
+    WARN,    ///< Log warning, include as orphan
+    /// Same entity tree as WARN. Logs at error level and reports the orphan
+    /// node FQNs on GET /health under the `unmanifested_nodes` warning code.
+    /// Does NOT fail startup: the gateway keeps serving and status stays
+    /// "healthy".
+    ERROR,
+    /// Same entity tree as WARN; only the log level differs (info rather than
+    /// warning). No entity is tagged source="orphan" - nothing in discovery
+    /// ever assigns that value.
+    INCLUDE_AS_ORPHAN
   };
 
   UnmanifestedNodePolicy unmanifested_nodes{UnmanifestedNodePolicy::WARN};
@@ -52,6 +59,18 @@ struct ManifestConfig {
   static UnmanifestedNodePolicy parse_policy(const std::string & str);
   /// Convert policy to string
   static std::string policy_to_string(UnmanifestedNodePolicy policy);
+};
+
+/**
+ * @brief A parse-time notice that must obey the strictness dial
+ *
+ * ManifestManager copies these into ValidationResult as warnings, so
+ * `discovery.manifest_strict_validation` decides whether they reject the
+ * manifest or merely annotate it.
+ */
+struct ManifestParseNotice {
+  std::string rule_id;
+  std::string message;
 };
 
 /**
@@ -97,6 +116,17 @@ struct Manifest {
 
   /// Per-entity lock configuration overrides (entity_id -> lock config)
   std::unordered_map<std::string, ManifestLockConfig> lock_overrides;
+
+  /// Informational parse notices (deprecated key, key collision, unknown
+  /// top-level key). Logged by ManifestManager; deliberately NEVER copied into
+  /// ValidationResult, because strict mode turns validator warnings into load
+  /// failures and would make a deprecation notice fatal under the default
+  /// configuration.
+  std::vector<std::string> log_notices;
+
+  /// Parse notices that ARE correctness problems and must obey
+  /// discovery.manifest_strict_validation.
+  std::vector<ManifestParseNotice> validation_notices;
 
   /// Check if manifest has been loaded
   bool is_loaded() const {

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/manifest/manifest_parser.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/discovery/manifest/manifest_parser.hpp
@@ -67,7 +67,7 @@ class ManifestParser {
    * fragment MAY declare `manifest_version` but is not required to - when
    * omitted, a synthetic `"1.0"` value is injected so the shared
    * `parse_string` pipeline still sees a well-formed manifest. Forbidden
-   * top-level fields (`areas`, `metadata`, `discovery`, `scripts`,
+   * top-level fields (`areas`, `metadata`, `config`, `discovery`, `scripts`,
    * `capabilities`, `lock_overrides`) are still parsed into the returned
    * `Manifest` so the caller (`ManifestManager::apply_fragments`) can
    * detect and reject them with a specific validation error.
@@ -93,7 +93,25 @@ class ManifestParser {
   AssetIdentity parse_identity(const YAML::Node & node) const;
   App parse_app(const YAML::Node & node) const;
   Function parse_function(const YAML::Node & node) const;
-  ManifestConfig parse_config(const YAML::Node & node) const;
+  /// Validate the YAML kind of the discovery-configuration block (`config:`,
+  /// or the deprecated `discovery:` alias), then parse it. A null block means
+  /// "absent". A non-map block is reported under R015, which is a VALIDATION
+  /// notice: under the shipped `manifest_strict_validation: true` that rejects
+  /// the whole manifest, and only with strict validation off does the block
+  /// get ignored and the defaults apply. Either way parse_config() only ever
+  /// sees a map.
+  ManifestConfig parse_config_block(const YAML::Node & node, const std::string & key,
+                                    std::vector<ManifestParseNotice> & notices) const;
+  /// Parse the settings inside an already-validated block. Values that are
+  /// recognised but wrong - an unrecognised `unmanifested_nodes` (R014), or a
+  /// setting of the wrong YAML kind (R015) - are appended to @p notices so the
+  /// caller can put them through `discovery.manifest_strict_validation`.
+  ManifestConfig parse_config(const YAML::Node & node, std::vector<ManifestParseNotice> & notices) const;
+  /// Read one boolean discovery setting, leaving *target* alone when the key
+  /// is absent or null and reporting R015 when it is present but not a
+  /// boolean. Never throws: `.as<bool>()` would abort the whole manifest load.
+  void read_bool_setting(const YAML::Node & node, const std::string & key, bool & target,
+                         std::vector<ManifestParseNotice> & notices) const;
   ManifestMetadata parse_metadata(const YAML::Node & node) const;
   ManifestLockConfig parse_lock_config(const YAML::Node & node) const;
   ScriptEntryConfig parse_script_entry(const YAML::Node & node) const;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/warning_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/warning_codes.hpp
@@ -34,11 +34,29 @@ namespace ros2_medkit_gateway {
 /// ``parentComponentId`` pointing at the colliding ID on the owning peer).
 inline constexpr const char * WARN_LEAF_ID_COLLISION = "leaf_id_collision";
 
+/// One or more running ROS nodes are not declared in the manifest while
+/// unmanifested_nodes is set to "error". The gateway keeps serving; the node
+/// fully-qualified names are listed in ``ros_node_fqns`` and ``entity_ids`` is
+/// empty, because a node FQN is not an addressable SOVD entity id. Resolve by
+/// declaring them in the manifest, or by relaxing the policy to "warn" or
+/// "ignore".
+inline constexpr const char * WARN_UNMANIFESTED_NODES = "unmanifested_nodes";
+
 /// Schema version for the ``warnings`` array on ``GET /health``. Clients can
 /// key on this integer to detect supported warning codes without
 /// string-matching on individual codes. Increment whenever a code is added,
 /// removed, or the shape of an individual warning object changes. Keep in
 /// sync with docs/api/warning_codes.rst.
-inline constexpr int kWarningSchemaVersion = 1;
+///
+/// Version 2 added ``unmanifested_nodes`` and the ``ros_node_fqns`` field,
+/// and made the array unconditional: it used to be emitted only when
+/// aggregation was active, which left every non-aggregating gateway unable to
+/// report anything at all.
+///
+/// Invariant across all codes: ``entity_ids`` carries addressable SOVD entity
+/// ids only, ``ros_node_fqns`` carries ROS node names, ``peer_names`` carries
+/// aggregation peers, and all three are always present - empty when a code has
+/// nothing to say in one of them.
+inline constexpr int kWarningSchemaVersion = 2;
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/discovery_manager.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "ros2_medkit_gateway/core/discovery/discovery_enums.hpp"
+#include "ros2_medkit_gateway/core/discovery/layers/manifest_layer.hpp"
 #include "ros2_medkit_gateway/core/discovery/merge_types.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/app.hpp"
 #include "ros2_medkit_gateway/core/discovery/models/area.hpp"
@@ -365,6 +366,28 @@ class DiscoveryManager : public ServiceActionResolver {
    */
   discovery::ManifestManager * get_manifest_manager();
 
+  /**
+   * @brief Get the discovery configuration the manifest asked for
+   *
+   * Answers in every mode. There is no manifest manager in runtime_only, and
+   * a hybrid manifest that fails to load resets it, so this returns a
+   * default-constructed ManifestConfig in those cases - the same values the
+   * pipeline itself runs with.
+   */
+  discovery::ManifestConfig get_manifest_config() const;
+
+  /**
+   * @brief Re-read the manifest configuration into the running pipeline
+   *
+   * Call after a successful manifest reload. `/health` reads the config live
+   * from the ManifestManager, but the pipeline captured it when it was built,
+   * so without this the served `unmanifested_policy` and the policy the
+   * orphan filter actually runs drift apart. Keeps the existing layers - in
+   * particular plugin layers added at runtime - and only refreshes the config
+   * and the manifest layer's policies.
+   */
+  void refresh_manifest_config();
+
   // =========================================================================
   // Status
   // =========================================================================
@@ -430,6 +453,11 @@ class DiscoveryManager : public ServiceActionResolver {
    */
   template <typename LayerT>
   void apply_layer_policy_overrides(const std::string & layer_name, LayerT & layer);
+
+  /// Apply the manifest layer's two policy sources in their required order:
+  /// the `allow_manifest_override` blanket demotion first, then the per-group
+  /// gateway parameters, so an explicit parameter keeps beating the flag.
+  void apply_manifest_layer_policies(discovery::ManifestLayer & manifest_layer);
 
   rclcpp::Node * node_;
   DiscoveryConfig config_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/layers/plugin_layer.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/layers/plugin_layer.hpp
@@ -38,6 +38,13 @@ class PluginLayer : public DiscoveryLayer {
   std::string name() const override {
     return name_;
   }
+
+  /// A plugin declares entities the operator deliberately added; they are not
+  /// runtime noise and the orphan sweep must not remove them, whatever
+  /// `source` tag the provider chose to stamp on them.
+  bool owns_protected_entities() const override {
+    return true;
+  }
   LayerOutput discover() override;
   MergePolicy policy_for(FieldGroup group) const override;
   void set_discovery_context(const IntrospectionInput & context) override;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/manifest_manager.hpp
@@ -21,10 +21,13 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <atomic>
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <optional>
+#include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -286,6 +289,19 @@ class ManifestManager {
   rclcpp::Node * node_;
   mutable std::mutex mutex_;
 
+  /// Lock-free snapshot of the discovery configuration, for callers that must
+  /// never block on a manifest load.
+  ///
+  /// `/health` is one: it reads the configured policy on every request, and a
+  /// container liveness probe reads `/health`. load_manifest() holds mutex_
+  /// from entry through parse, fragment scan, inventory CSV and validation, so
+  /// a plugin-triggered reload on a deployment with a fragments directory
+  /// would park every concurrent probe and get the gateway restarted
+  /// mid-reload. Kept in step with `manifest_` at every point that assigns it.
+  std::atomic<ManifestConfig> cached_config_{ManifestConfig{}};
+  static_assert(std::is_trivially_copyable_v<ManifestConfig>,
+                "ManifestConfig must stay trivially copyable to live in an atomic");
+
   /// Merge the fragments found in `fragments_dir_` on top of `base`.
   /// Returns true on success (or no fragments); false if any fragment
   /// failed to parse or declared disallowed top-level fields.
@@ -304,6 +320,29 @@ class ManifestManager {
   /// see set_inventory_csv_path) so a CSV row can never trip the validator's
   /// hard duplicate-id errors and abort the load.
   bool apply_inventory_csv(Manifest & base);
+
+  /// Route the parser's two notice channels to their destinations.
+  ///
+  /// `Manifest::log_notices` (deprecated key, key collision, unknown top-level
+  /// key) go to the plain logger only. They must NOT reach
+  /// `validation_result_`: strict validation is on by default and turns every
+  /// validator warning into a load failure, which in hybrid mode silently
+  /// degrades discovery to runtime_only - so a deprecation notice routed there
+  /// would be fatal under the default configuration.
+  ///
+  /// `Manifest::validation_notices` ARE correctness problems and become
+  /// warnings on `validation_result_`, so they obey
+  /// `discovery.manifest_strict_validation`.
+  ///
+  /// Must be called AFTER `validation_result_` has been assigned from
+  /// `validator_.validate()`, which overwrites anything merged before it.
+  /// @param source_path value used as the warning's `path` field.
+  void merge_parse_notices(const Manifest & loaded, const std::string & source_path);
+
+  /// Log-only notices already emitted, so a plugin-triggered reload does not
+  /// reprint a deprecation warning on every refresh for the life of the
+  /// process. Not applied to validation notices, which are rebuilt per load.
+  std::set<std::string> logged_notices_;
 
   std::optional<Manifest> manifest_;
   std::string manifest_path_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/runtime_linker.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/manifest/runtime_linker.hpp
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace ros2_medkit_gateway {
@@ -103,10 +104,15 @@ class RuntimeLinker {
    * @param manifest_apps Apps from manifest
    * @param runtime_apps Apps discovered from ROS graph (each node is an App)
    * @param config Manifest config with orphan policy
+   * @param protected_ids Ids whose owning discovery layer declares them
+   *        protected from suppression. Passed in rather than recomputed so
+   *        this filter and the pipeline's own orphan sweep decide from one
+   *        source of truth; an empty set falls back to the source-tag rule
+   *        alone, which is what a caller with no pipeline context gets.
    * @return LinkingResult with linked apps and orphan info
    */
   LinkingResult link(const std::vector<App> & manifest_apps, const std::vector<App> & runtime_apps,
-                     const ManifestConfig & config);
+                     const ManifestConfig & config, const std::unordered_set<std::string> & protected_ids = {});
 
   /**
    * @brief Check if a specific app is linked to a runtime node

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/merge_pipeline.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/discovery/merge_pipeline.hpp
@@ -24,6 +24,8 @@
 #include <rclcpp/logging.hpp>
 
 #include <memory>
+#include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace ros2_medkit_gateway {
@@ -92,6 +94,29 @@ class MergePipeline {
   void set_linker(std::unique_ptr<RuntimeLinker> linker, const ManifestConfig & config);
 
   /**
+   * @brief Replace the ManifestConfig the pipeline runs on, keeping the linker
+   *
+   * Used after a manifest reload. The config reached the pipeline once, at
+   * construction, while `/health` reads it live from the ManifestManager - so
+   * without this the two disagree after a reload and the documented
+   * `orphan_count > 0 && unmanifested_policy == "error"` recipe reports a
+   * policy the orphan filter is not running.
+   *
+   * Deliberately not "rebuild the pipeline": plugin layers are added at
+   * runtime through DiscoveryManager::add_plugin_layer and a rebuild would
+   * drop them.
+   */
+  void set_manifest_config(const ManifestConfig & config) {
+    manifest_config_ = config;
+  }
+
+  /**
+   * @brief Find a layer by name, or nullptr. Used to re-apply layer policies
+   *        after a reload without disturbing layer order or membership.
+   */
+  DiscoveryLayer * find_layer(const std::string & name);
+
+  /**
    * @brief Get the last linking result (returned by value for thread safety)
    * @warning NOT thread-safe on its own. In production, access only through
    * DiscoveryManager which holds a mutex around the cached pipeline result.
@@ -111,6 +136,12 @@ class MergePipeline {
   IdentityMergeConfig identity_config_;
   MergeReport last_report_;
   std::unique_ptr<RuntimeLinker> linker_;
+
+  /// Ids of entities whose OWNING layer declares them protected from orphan
+  /// suppression (see DiscoveryLayer::owns_protected_entities). Rebuilt from
+  /// scratch on every execute() - a layer that stops contributing an entity
+  /// must stop protecting it.
+  std::unordered_set<std::string> protected_entity_ids_;
   ManifestConfig manifest_config_;
   LinkingResult linking_result_;
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
@@ -65,5 +65,14 @@ inline constexpr std::string_view kExecutionCapabilityValues[] = {"stop", "execu
 /// Lifecycle status (LifecycleStatusResponse.status).
 inline constexpr std::string_view kLifecycleStatusValues[] = {"ready", "notReady"};
 
+/// Stable warning codes on GET /health. Keep in sync with
+/// core/http/warning_codes.hpp, which is the canonical list.
+inline constexpr std::string_view kHealthWarningCodeValues[] = {"leaf_id_collision", "unmanifested_nodes"};
+
+/// Values of the manifest's `unmanifested_nodes` setting, as reported by
+/// GET /health under discovery.linking. Lower-case; keep in sync with
+/// ManifestConfig::policy_to_string.
+inline constexpr std::string_view kUnmanifestedPolicyValues[] = {"ignore", "warn", "error", "include_as_orphan"};
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
@@ -22,7 +22,9 @@
 #include <tuple>
 #include <vector>
 
+#include "ros2_medkit_gateway/core/http/warning_codes.hpp"
 #include "ros2_medkit_gateway/dto/contract.hpp"
+#include "ros2_medkit_gateway/dto/enums.hpp"
 
 namespace ros2_medkit_gateway {
 namespace dto {
@@ -37,21 +39,27 @@ namespace dto {
 //                       NOTE: the old health_schema() declared this as
 //                       array<string>, but the handler always emitted size_t.
 //                       The DTO matches the actual wire format.
+//   unmanifested_policy - configured ManifestConfig::unmanifested_nodes value
+//                       ("ignore" | "warn" | "error" | "include_as_orphan"),
+//                       so a monitor can evaluate orphan_count > 0 &&
+//                       unmanifested_policy == "error" without parsing prose
 //   warnings          - optional list of diagnostic warning strings
 // =============================================================================
 struct HealthDiscoveryLinking {
   int64_t linked_count{0};
   int64_t orphan_count{0};
   int64_t binding_conflicts{0};
+  std::string unmanifested_policy;
   std::optional<std::vector<std::string>> warnings;
 };
 
 template <>
-inline constexpr auto dto_fields<HealthDiscoveryLinking> =
-    std::make_tuple(field("linked_count", &HealthDiscoveryLinking::linked_count),
-                    field("orphan_count", &HealthDiscoveryLinking::orphan_count),
-                    field("binding_conflicts", &HealthDiscoveryLinking::binding_conflicts),
-                    field("warnings", &HealthDiscoveryLinking::warnings));
+inline constexpr auto dto_fields<HealthDiscoveryLinking> = std::make_tuple(
+    field("linked_count", &HealthDiscoveryLinking::linked_count),
+    field("orphan_count", &HealthDiscoveryLinking::orphan_count),
+    field("binding_conflicts", &HealthDiscoveryLinking::binding_conflicts),
+    field_enum("unmanifested_policy", &HealthDiscoveryLinking::unmanifested_policy, kUnmanifestedPolicyValues),
+    field("warnings", &HealthDiscoveryLinking::warnings));
 
 template <>
 inline constexpr std::string_view dto_name<HealthDiscoveryLinking> = "HealthDiscoveryLinking";
@@ -81,30 +89,48 @@ template <>
 inline constexpr std::string_view dto_name<HealthDiscovery> = "HealthDiscovery";
 
 // =============================================================================
-// HealthAggregationWarning - single item inside Health::warnings array.
+// HealthWarning - single item inside Health::warnings array.
 //
-// Wire shape (from health_handlers.cpp handle_health agg-warning loop):
-//   code       - stable machine-readable warning code string (required)
-//   message    - human-readable description with remediation hints (required)
-//   entity_ids - SOVD entity IDs affected by the warning (required, array)
-//   peer_names - aggregation peers involved in the anomaly (required, array)
+// Wire shape (from health_handlers.cpp get_health):
+//   code          - stable machine-readable warning code string (required)
+//   message       - human-readable description with remediation hints (required)
+//   entity_ids    - SOVD entity ids this warning is about (required, array)
+//   ros_node_fqns - ROS node fully-qualified names this warning is about
+//                   (required, array)
+//   peer_names    - aggregation peers involved in the anomaly (required, array)
+//
+// INVARIANT, true for every code present and future: every element of
+// `entity_ids` is an addressable SOVD entity id - it satisfies
+// validate_entity_id() and `GET /{collection}/{id}` can be built from it. That
+// forbids ROS node FQNs there: validate_entity_id rejects '/' precisely
+// because it "conflicts with URL routing" (entity_validation.cpp), so a FQN in
+// `entity_ids` is a value no client can address. Node identifiers go in
+// `ros_node_fqns` instead. A warning that is not about ROS nodes leaves that
+// array empty, exactly as a warning that is not about aggregation leaves
+// `peer_names` empty.
+//
+// The three id arrays are plain vectors rather than std::optional on purpose:
+// SchemaWriter maps std::optional to anyOf:[T,null] (schema_writer.hpp), which
+// would publish a null state the server can never emit and hand every
+// generated client a tri-state to unpack. Empty array is the "none" value.
 // =============================================================================
-struct HealthAggregationWarning {
+struct HealthWarning {
   std::string code;
   std::string message;
   std::vector<std::string> entity_ids;
+  std::vector<std::string> ros_node_fqns;
   std::vector<std::string> peer_names;
 };
 
 template <>
-inline constexpr auto dto_fields<HealthAggregationWarning> =
-    std::make_tuple(field("code", &HealthAggregationWarning::code),
-                    field("message", &HealthAggregationWarning::message),
-                    field("entity_ids", &HealthAggregationWarning::entity_ids),
-                    field("peer_names", &HealthAggregationWarning::peer_names));
+inline constexpr auto dto_fields<HealthWarning> =
+    std::make_tuple(field_enum("code", &HealthWarning::code, kHealthWarningCodeValues),
+                    field("message", &HealthWarning::message), field("entity_ids", &HealthWarning::entity_ids),
+                    field("ros_node_fqns", &HealthWarning::ros_node_fqns),
+                    field("peer_names", &HealthWarning::peer_names));
 
 template <>
-inline constexpr std::string_view dto_name<HealthAggregationWarning> = "HealthAggregationWarning";
+inline constexpr std::string_view dto_name<HealthWarning> = "HealthWarning";
 
 // =============================================================================
 // Health - response for GET /health.
@@ -118,8 +144,10 @@ inline constexpr std::string_view dto_name<HealthAggregationWarning> = "HealthAg
 //   x-medkit-subscription-executor - optional free-form JSON stats object
 //                                    (from Ros2TopicDataProvider::x_medkit_stats())
 //   peers                         - optional free-form JSON array (agg peer status)
-//   warning_schema_version        - optional integer (agg schema contract version)
-//   warnings                      - optional array of HealthAggregationWarning
+//   warning_schema_version        - integer warnings-contract version; always
+//                                   emitted, aggregation or not
+//   warnings                      - array of HealthWarning; always emitted,
+//                                   empty when nothing is flagged
 //
 // The x-medkit-* keys use hyphens (endpoint-level vendor extensions, NOT the
 // nested "x-medkit" pattern). They are free-form nlohmann::json objects because
@@ -134,8 +162,12 @@ struct Health {
   std::optional<nlohmann::json> x_medkit_subscription_executor;  // wire key: "x-medkit-subscription-executor"
   std::optional<nlohmann::json> x_medkit_entity_cache;           // wire key: "x-medkit-entity-cache"
   std::optional<nlohmann::json> peers;                           // free-form array of peer status objects
-  std::optional<int64_t> warning_schema_version;
-  std::optional<std::vector<HealthAggregationWarning>> warnings;
+  // NOT optional: these two are emitted in every mode, aggregation or not, so
+  // the generated schema must list them in `required` and let a typed client
+  // read them without a presence check. An empty `warnings` array is the
+  // "nothing flagged" answer - absence is not a value this endpoint has.
+  int64_t warning_schema_version{kWarningSchemaVersion};
+  std::vector<HealthWarning> warnings;
 };
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
@@ -82,8 +82,8 @@ using AllDtos =
                // Auth domain DTOs
                AuthCredentials, AuthTokenResponse, AuthRevokeRequest, AuthRevokeResponse,
                // Health / Root domain DTOs
-               HealthDiscoveryLinking, HealthDiscovery, HealthAggregationWarning, Health, VersionInfoVendor,
-               VersionInfoEntry, XMedkitVersionInfo, VersionInfo, RootCapabilities, RootAuth, RootTls, RootOverview,
+               HealthDiscoveryLinking, HealthDiscovery, HealthWarning, Health, VersionInfoVendor, VersionInfoEntry,
+               XMedkitVersionInfo, VersionInfo, RootCapabilities, RootAuth, RootTls, RootOverview,
                // Lifecycle domain DTOs
                LifecycleStatusResponse>;
 

--- a/src/ros2_medkit_gateway/src/discovery/discovery_manager.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/discovery_manager.cpp
@@ -109,6 +109,50 @@ void DiscoveryManager::apply_layer_policy_overrides(const std::string & layer_na
   }
 }
 
+// The manifest layer's policies come from two sources that must be applied in
+// this order, at boot AND after every reload. Shared so the two paths cannot
+// drift: a reload that applied them in the other order would silently invert
+// R11a's precedence and let the blanket flag beat an explicit deployment
+// parameter.
+void DiscoveryManager::apply_manifest_layer_policies(discovery::ManifestLayer & manifest_layer) {
+  // allow_manifest_override=false is sugar over the layer policies: it demotes
+  // every field group of the manifest layer to FALLBACK, so the manifest only
+  // fills gaps the other layers leave. Applied BEFORE the per-group parameter
+  // overrides, so a deployment that explicitly pins
+  // discovery.merge_pipeline.layers.manifest.<group> still wins - only
+  // non-empty parameter values reach layer_policies at all, so this falls out
+  // of the existing last-writer-wins ordering.
+  if (!get_manifest_config().allow_manifest_override) {
+    for (auto fg : {discovery::FieldGroup::IDENTITY, discovery::FieldGroup::HIERARCHY, discovery::FieldGroup::LIVE_DATA,
+                    discovery::FieldGroup::STATUS, discovery::FieldGroup::METADATA}) {
+      manifest_layer.set_policy(fg, discovery::MergePolicy::FALLBACK);
+    }
+    RCLCPP_INFO(node_->get_logger(),
+                "Layer 'manifest': allow_manifest_override=false, every field group demoted to fallback");
+  } else {
+    // A reload can flip the flag back on, so restore the shipped defaults
+    // rather than leaving the previous demotion in place.
+    manifest_layer.reset_policies_to_defaults();
+  }
+  apply_layer_policy_overrides("manifest", manifest_layer);
+}
+
+void DiscoveryManager::refresh_manifest_config() {
+  if (!pipeline_) {
+    return;
+  }
+  // /health reads the config live from the ManifestManager while the pipeline
+  // captured it once at construction. After a reload the two disagree, and the
+  // documented monitor recipe then reports a policy the orphan filter is not
+  // actually running. Push the new config in and re-apply the layer policies
+  // it drives. NOT a pipeline rebuild: plugin layers added at runtime through
+  // add_plugin_layer would be lost.
+  pipeline_->set_manifest_config(get_manifest_config());
+  if (auto * layer = pipeline_->find_layer("manifest")) {
+    apply_manifest_layer_policies(*static_cast<discovery::ManifestLayer *>(layer));
+  }
+}
+
 void DiscoveryManager::build_pipeline() {
   // Configure runtime introspection (always-on adapter, used by all modes for
   // service/action queries even when the merge pipeline is bypassed).
@@ -130,7 +174,22 @@ void DiscoveryManager::build_pipeline() {
 
       if (config_.manifest_enabled) {
         auto manifest_layer = std::make_unique<discovery::ManifestLayer>(manifest_manager_.get());
-        apply_layer_policy_overrides("manifest", *manifest_layer);
+        // allow_manifest_override=false is sugar over the layer policies: it
+        // demotes every field group of the manifest layer to FALLBACK, so the
+        // manifest only fills gaps the other layers leave. Applied BEFORE the
+        // per-group parameter overrides, so a deployment that explicitly pins
+        // discovery.merge_pipeline.layers.manifest.<group> still wins - only
+        // non-empty parameter values reach layer_policies at all, so this falls
+        // out of the existing last-writer-wins ordering.
+        apply_manifest_layer_policies(*manifest_layer);
+        // LAYER ORDER IS PART OF THE CONTRACT, not a convenience. MergePipeline
+        // seeds each merged entity from the FIRST layer that declares it and
+        // fills provenance first-writer-wins (see fill_provenance() in
+        // merge_pipeline.cpp), so whichever layer is added first owns
+        // `source` - and `source` is what the orphan filter keys deletion on.
+        // The manifest must therefore be added before the runtime layer, and
+        // plugin layers are appended after both (add_plugin_layer). Reordering
+        // these calls would silently make manifest entities deletable.
         pipeline->add_layer(std::move(manifest_layer));
       } else {
         RCLCPP_INFO(node_->get_logger(), "Manifest layer disabled in hybrid mode");
@@ -154,8 +213,7 @@ void DiscoveryManager::build_pipeline() {
 
       // RuntimeLinker only makes sense when runtime is enabled.
       if (config_.runtime_enabled) {
-        auto manifest_config = manifest_manager_ ? manifest_manager_->get_config() : discovery::ManifestConfig{};
-        pipeline->set_linker(std::make_unique<discovery::RuntimeLinker>(node_), manifest_config);
+        pipeline->set_linker(std::make_unique<discovery::RuntimeLinker>(node_), get_manifest_config());
       }
 
       pipeline_ = std::move(pipeline);
@@ -418,6 +476,10 @@ void DiscoveryManager::add_plugin_layer(const std::string & plugin_name, Introsp
     RCLCPP_WARN(node_->get_logger(), "Cannot add plugin layer '%s': not in hybrid mode", plugin_name.c_str());
     return;
   }
+  // Appended AFTER the manifest and runtime layers, and that is load-bearing:
+  // provenance is first-writer-wins, so a plugin can never take `source` away
+  // from a manifest entity it also describes. See the note at the manifest
+  // add_layer() call above.
   pipeline_->add_layer(std::make_unique<discovery::PluginLayer>(plugin_name, provider));
   RCLCPP_INFO(node_->get_logger(), "Added plugin layer '%s' to merge pipeline", plugin_name.c_str());
 }
@@ -440,6 +502,10 @@ void DiscoveryManager::refresh_pipeline() {
 
 discovery::ManifestManager * DiscoveryManager::get_manifest_manager() {
   return manifest_manager_.get();
+}
+
+discovery::ManifestConfig DiscoveryManager::get_manifest_config() const {
+  return manifest_manager_ ? manifest_manager_->get_config() : discovery::ManifestConfig{};
 }
 
 std::string DiscoveryManager::get_strategy_name() const {

--- a/src/ros2_medkit_gateway/src/discovery/layers/manifest_layer.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/layers/manifest_layer.cpp
@@ -18,6 +18,10 @@ namespace ros2_medkit_gateway {
 namespace discovery {
 
 ManifestLayer::ManifestLayer(ManifestManager * manifest_manager) : manifest_manager_(manifest_manager) {
+  reset_policies_to_defaults();
+}
+
+void ManifestLayer::reset_policies_to_defaults() {
   policies_ = {{FieldGroup::IDENTITY, MergePolicy::AUTHORITATIVE},
                {FieldGroup::HIERARCHY, MergePolicy::AUTHORITATIVE},
                {FieldGroup::LIVE_DATA, MergePolicy::ENRICHMENT},

--- a/src/ros2_medkit_gateway/src/discovery/manifest/manifest_manager.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/manifest/manifest_manager.cpp
@@ -66,6 +66,7 @@ bool ManifestManager::load_manifest(const std::string & file_path, bool strict) 
     for (auto & warn : merge_errors.warnings) {
       validation_result_.warnings.push_back(std::move(warn));
     }
+    merge_parse_notices(loaded, file_path);
 
     // Always fail on ERRORs (broken references, circular deps, duplicate bindings)
     // These indicate a fundamentally broken manifest that would cause runtime issues
@@ -87,6 +88,7 @@ bool ManifestManager::load_manifest(const std::string & file_path, bool strict) 
     }
 
     manifest_ = std::move(loaded);
+    cached_config_.store(manifest_->config);
     build_lookup_maps();
 
     auto msg = "Manifest loaded successfully: " + std::to_string(manifest_->areas.size()) + " areas, " +
@@ -114,6 +116,7 @@ bool ManifestManager::load_manifest_from_string(const std::string & yaml_content
   try {
     Manifest loaded = parser_.parse_string(yaml_content);
     validation_result_ = validator_.validate(loaded);
+    merge_parse_notices(loaded, "<string>");
 
     // Always fail on ERRORs (broken references, circular deps, duplicate bindings)
     if (validation_result_.has_errors()) {
@@ -134,6 +137,7 @@ bool ManifestManager::load_manifest_from_string(const std::string & yaml_content
     }
 
     manifest_ = std::move(loaded);
+    cached_config_.store(manifest_->config);
     build_lookup_maps();
     return true;
 
@@ -141,6 +145,24 @@ bool ManifestManager::load_manifest_from_string(const std::string & yaml_content
     log_error("Failed to parse manifest: " + std::string(e.what()));
     validation_result_.add_error("LOAD", e.what(), "<string>");
     return false;
+  }
+}
+
+void ManifestManager::merge_parse_notices(const Manifest & loaded, const std::string & source_path) {
+  for (const auto & notice : loaded.log_notices) {
+    // Log-only notices describe the manifest FILE, not this particular load,
+    // so they are emitted once per distinct message rather than once per load.
+    // A plugin that calls notify_entities_changed re-reads the manifest, and
+    // without this a deprecated key would reprint its notice on every refresh
+    // for the life of the process. Validation notices below are rebuilt each
+    // time on purpose: they are the current validation state, which callers
+    // read back through get_validation_result().
+    if (logged_notices_.insert(notice).second) {
+      log_warn(notice);
+    }
+  }
+  for (const auto & notice : loaded.validation_notices) {
+    validation_result_.add_warning(notice.rule_id, notice.message, source_path);
   }
 }
 
@@ -159,6 +181,10 @@ bool ManifestManager::reload_manifest() {
     old_manifest = std::move(manifest_);
     old_strict_mode = strict_mode_;
     manifest_.reset();
+    // cached_config_ deliberately keeps the OLD value across the reload
+    // window. The pipeline is still running the old policy until the reload
+    // completes, so reporting it is accurate; blanking it to defaults would
+    // make /health briefly describe a configuration nothing is using.
   }
 
   std::string path_to_reload = manifest_path_;
@@ -167,6 +193,7 @@ bool ManifestManager::reload_manifest() {
     // Restore old manifest on failure
     std::lock_guard<std::mutex> lock(mutex_);
     manifest_ = std::move(old_manifest);
+    cached_config_.store(manifest_ ? manifest_->config : ManifestConfig{});
     log_warn("Manifest reload failed, keeping previous version");
     return false;
   }
@@ -179,6 +206,7 @@ void ManifestManager::unload_manifest() {
   std::lock_guard<std::mutex> lock(mutex_);
 
   manifest_.reset();
+  cached_config_.store(ManifestConfig{});
   manifest_path_.clear();
   validation_result_ = ValidationResult{};
   area_index_.clear();
@@ -213,11 +241,9 @@ std::optional<ManifestMetadata> ManifestManager::get_metadata() const {
 }
 
 ManifestConfig ManifestManager::get_config() const {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (manifest_) {
-    return manifest_->config;
-  }
-  return ManifestConfig{};
+  // Deliberately lock-free: see cached_config_. Taking mutex_ here would put
+  // the liveness path behind a full manifest load.
+  return cached_config_.load();
 }
 
 std::unordered_map<std::string, ManifestLockConfig> ManifestManager::get_lock_overrides() const {
@@ -688,8 +714,12 @@ bool ManifestManager::apply_fragments(Manifest & base) {
     // be detected by the struct checks. manifest_version is auto-injected by
     // parse_fragment_file when the fragment omits it, so we do not inspect it
     // here - fragments are free to declare or omit it.
+    // Both spellings of the discovery-configuration block are forbidden: a
+    // fragment that could declare configuration under either one would have it
+    // silently dropped by the merge below, which is the same class of bug one
+    // level down.
     static constexpr const char * kForbiddenKeys[] = {
-        "areas", "metadata", "scripts", "capabilities", "lock_overrides", "discovery",
+        "areas", "metadata", "scripts", "capabilities", "lock_overrides", "config", "discovery",
     };
     static constexpr const char * kAllowedKeys[] = {
         "apps",

--- a/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/manifest/manifest_parser.cpp
@@ -31,6 +31,49 @@
 namespace ros2_medkit_gateway {
 namespace discovery {
 
+namespace {
+// A top-level block counts as present only when it carries a value. yaml-cpp
+// reports a key with no value as defined-but-null, and treating that as
+// present makes an empty `config:` outrank a populated `discovery:`.
+bool is_present_block(const YAML::Node & node) {
+  return static_cast<bool>(node) && !node.IsNull();
+}
+
+}  // namespace
+
+namespace {
+
+/// Every top-level key `parse_string` reads, plus the deprecated `discovery`
+/// alias. Deliberately next to the parsing code: a new section cannot be added
+/// to `parse_string` without extending this list, and anything outside it is
+/// reported as ignored instead of being dropped in silence.
+constexpr const char * kKnownTopLevelKeys[] = {
+    "manifest_version", "metadata", "config",    "discovery", "areas",        "components",
+    "assets",           "apps",     "functions", "scripts",   "capabilities",
+};
+
+bool is_known_top_level_key(const std::string & key) {
+  for (const char * known : kKnownTopLevelKeys) {
+    if (key == known) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string known_top_level_keys_csv() {
+  std::string joined;
+  for (const char * known : kKnownTopLevelKeys) {
+    if (!joined.empty()) {
+      joined += ", ";
+    }
+    joined += known;
+  }
+  return joined;
+}
+
+}  // namespace
+
 Manifest ManifestParser::parse_file(const std::string & file_path) const {
   std::ifstream file(file_path);
   if (!file.is_open()) {
@@ -122,9 +165,42 @@ Manifest ManifestParser::parse_string(const std::string & yaml_content) const {
     manifest.metadata = parse_metadata(root["metadata"]);
   }
 
-  // Parse discovery config
-  if (root["discovery"]) {
-    manifest.config = parse_config(root["discovery"]);
+  // Parse discovery config. `config:` is the documented, canonical key.
+  // `discovery:` is the key the parser originally read and is kept working as
+  // a deprecated alias; when both are present, `config:` wins.
+  // "Present" must mean the same thing here as it does in parse_config_block,
+  // which treats a null value as absent. A bare `config:` with nothing under
+  // it used to win the precedence test and then parse to nothing, so a
+  // populated `discovery:` below it was skipped, the settings silently did not
+  // apply, and the operator was told "'config:' is used" - which reads as
+  // confirmation that it did.
+  const bool has_config = is_present_block(root["config"]);
+  const bool has_discovery_alias = is_present_block(root["discovery"]);
+  // R014/R015 are ADVISORY for this release: collected here and emitted as log
+  // notices rather than validation warnings. Reason: this branch is what makes
+  // the block read at all, so a manifest carrying `unmanifested_nodes: Warn` or
+  // `inherit_runtime_resources: 0` loaded fine before the upgrade and would be
+  // REFUSED after it, under the shipped `manifest_strict_validation: true` -
+  // taking hybrid discovery down to runtime_only for a file the operator never
+  // touched. They become validation warnings in the next release; a wrong
+  // value already falls back to the documented default either way.
+  std::vector<ManifestParseNotice> config_notices;
+  if (has_config) {
+    manifest.config = parse_config_block(root["config"], "config", config_notices);
+    if (has_discovery_alias) {
+      manifest.log_notices.emplace_back(
+          "Manifest declares both 'config:' and the deprecated 'discovery:' top-level keys; 'config:' is used and "
+          "'discovery:' is ignored.");
+    }
+  } else if (has_discovery_alias) {
+    manifest.config = parse_config_block(root["discovery"], "discovery", config_notices);
+    manifest.log_notices.emplace_back(
+        "Manifest uses the deprecated top-level 'discovery:' key for discovery configuration; rename it to 'config:'. "
+        "The alias still works and will be removed in a future release.");
+  }
+  for (const auto & notice : config_notices) {
+    manifest.log_notices.emplace_back("[" + notice.rule_id + "] " + notice.message +
+                                      " (advisory in this release; becomes a validation warning in the next one)");
   }
 
   // Parse areas (with recursive subareas)
@@ -189,6 +265,24 @@ Manifest ManifestParser::parse_string(const std::string & yaml_content) const {
     }
   }
 
+  // Anything the parser did not read is ignored - say so. A silently ignored
+  // top-level key is how a whole configuration block can go missing without a
+  // single line of output. Non-scalar keys are skipped, as the fragment path
+  // does, because they cannot be rendered into a message.
+  if (root.IsMap()) {
+    for (const auto & it : root) {
+      if (!it.first.IsScalar()) {
+        continue;
+      }
+      std::string key = it.first.as<std::string>();
+      if (is_known_top_level_key(key)) {
+        continue;
+      }
+      manifest.log_notices.emplace_back("Manifest has unknown top-level key '" + key +
+                                        "' - it is ignored. Known keys: " + known_top_level_keys_csv() + ".");
+    }
+  }
+
   return manifest;
 }
 
@@ -201,18 +295,110 @@ ManifestMetadata ManifestParser::parse_metadata(const YAML::Node & node) const {
   return meta;
 }
 
-ManifestConfig ManifestParser::parse_config(const YAML::Node & node) const {
+// Gate the discovery-configuration block on its YAML kind before indexing it.
+// parse_config() addresses the node by field name, and a node that is not a
+// map cannot be addressed that way: yaml-cpp THROWS on a scalar (which would
+// abandon the whole manifest, losing every entity in it over one bad key) and
+// silently yields nothing on a sequence (which would drop the operator's
+// configuration without a word). A key that carries no value at all is YAML
+// null and means "absent": it loads in silence, here and for every setting
+// inside the block (see read_bool_setting and parse_config).
+//
+// R015 is a VALIDATION notice, so what happens next depends on the strictness
+// dial: with the shipped default `manifest_strict_validation: true` the
+// manifest is rejected and hybrid mode degrades to runtime_only; with strict
+// validation off the manifest loads, the defaults apply and the notice is
+// logged. "The defaults apply" is only the non-strict half of the story.
+ManifestConfig ManifestParser::parse_config_block(const YAML::Node & node, const std::string & key,
+                                                  std::vector<ManifestParseNotice> & notices) const {
+  if (node.IsMap()) {
+    return parse_config(node, notices);
+  }
+  if (node.IsNull()) {
+    return ManifestConfig{};  // present but empty == absent
+  }
+
+  const char * kind = node.IsSequence() ? "sequence" : "scalar";
+  notices.push_back({"R015", "Manifest key '" + key + "' must be a mapping of discovery settings, but is a " +
+                                 std::string(kind) + "; the block is ignored and the defaults apply."});
+  return ManifestConfig{};
+}
+
+namespace {
+
+// Describe a node's YAML kind for an operator-facing message.
+const char * yaml_kind_name(const YAML::Node & node) {
+  if (node.IsSequence()) {
+    return "sequence";
+  }
+  if (node.IsMap()) {
+    return "mapping";
+  }
+  return "scalar";
+}
+
+// True when a settings key is present and carries an actual value. A key with
+// no value at all parses as YAML null, which means "not set" and must load in
+// silence - writing `unmanifested_nodes:` and nothing else is not an error.
+bool has_value(const YAML::Node & node, const std::string & key) {
+  return static_cast<bool>(node[key]) && !node[key].IsNull();
+}
+
+}  // namespace
+
+// Read one boolean setting. Same guard the block itself gets, one level down:
+// `.as<bool>()` THROWS on anything it cannot convert - including a key left
+// empty - and that exception would escape the whole manifest load, so a single
+// mistyped flag would cost every entity in the file. Wrong kind or wrong text
+// is reported under R015 and the default stands.
+void ManifestParser::read_bool_setting(const YAML::Node & node, const std::string & key, bool & target,
+                                       std::vector<ManifestParseNotice> & notices) const {
+  if (!has_value(node, key)) {
+    return;
+  }
+  const YAML::Node value = node[key];
+  if (value.IsScalar()) {
+    bool parsed = false;
+    if (YAML::convert<bool>::decode(value, parsed)) {
+      target = parsed;
+      return;
+    }
+    notices.push_back({"R015", "Manifest setting '" + key + "' must be a boolean, but is '" + value.as<std::string>() +
+                                   "'; the default (" + (target ? "true" : "false") + ") applies."});
+    return;
+  }
+  notices.push_back({"R015", "Manifest setting '" + key + "' must be a boolean, but is a " + yaml_kind_name(value) +
+                                 "; the default (" + (target ? "true" : "false") + ") applies."});
+}
+
+ManifestConfig ManifestParser::parse_config(const YAML::Node & node, std::vector<ManifestParseNotice> & notices) const {
   ManifestConfig config;
 
-  std::string policy = get_string(node, "unmanifested_nodes", "warn");
-  config.unmanifested_nodes = ManifestConfig::parse_policy(policy);
+  // A key with no value means "not set", which is the struct default and not a
+  // wrong value. Only a key that carries something is parsed - otherwise
+  // get_string() renders YAML null as the literal text "null" and the operator
+  // is told their empty key is an unknown policy.
+  if (has_value(node, "unmanifested_nodes")) {
+    const YAML::Node policy_node = node["unmanifested_nodes"];
+    if (!policy_node.IsScalar()) {
+      notices.push_back({"R015", "Manifest setting 'unmanifested_nodes' must be a string, but is a " +
+                                     std::string(yaml_kind_name(policy_node)) + "; the default ('warn') applies."});
+    } else if (const std::string policy = policy_node.as<std::string>(); !policy.empty()) {
+      config.unmanifested_nodes = ManifestConfig::parse_policy(policy);
+      // parse_policy is total - every unrecognised string maps to WARN - so at
+      // this call site a typo is indistinguishable from a deliberate "warn".
+      // Detect it by round-tripping the parsed value rather than by keeping a
+      // second copy of the valid-value list here.
+      if (ManifestConfig::policy_to_string(config.unmanifested_nodes) != policy) {
+        notices.push_back({"R014", "Unknown unmanifested_nodes value '" + policy +
+                                       "'; falling back to 'warn'. Valid values: ignore, warn, error, "
+                                       "include_as_orphan (lower-case)."});
+      }
+    }
+  }
 
-  if (node["inherit_runtime_resources"]) {
-    config.inherit_runtime_resources = node["inherit_runtime_resources"].as<bool>();
-  }
-  if (node["allow_manifest_override"]) {
-    config.allow_manifest_override = node["allow_manifest_override"].as<bool>();
-  }
+  read_bool_setting(node, "inherit_runtime_resources", config.inherit_runtime_resources, notices);
+  read_bool_setting(node, "allow_manifest_override", config.allow_manifest_override, notices);
 
   return config;
 }

--- a/src/ros2_medkit_gateway/src/discovery/manifest/runtime_linker.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/manifest/runtime_linker.cpp
@@ -15,6 +15,7 @@
 #include "ros2_medkit_gateway/discovery/manifest/runtime_linker.hpp"
 
 #include "ros2_medkit_gateway/core/discovery/merge_types.hpp"
+#include "ros2_medkit_gateway/core/http/warning_codes.hpp"
 
 #include <algorithm>
 
@@ -71,7 +72,8 @@ RuntimeLinker::RuntimeLinker(rclcpp::Node * node) : node_(node) {
 }
 
 LinkingResult RuntimeLinker::link(const std::vector<App> & manifest_apps, const std::vector<App> & runtime_apps,
-                                  const ManifestConfig & config) {
+                                  const ManifestConfig & config,
+                                  const std::unordered_set<std::string> & protected_ids) {
   LinkingResult result;
 
   // Track which runtime nodes have been matched
@@ -157,7 +159,12 @@ LinkingResult RuntimeLinker::link(const std::vector<App> & manifest_apps, const 
       const auto & match_fqn = match.bound_fqn.value();
       linked_app.bound_fqn = match_fqn;
       linked_app.is_online = true;
-      enrich_app(linked_app, match);
+      // inherit_runtime_resources=false keeps the manifest's declaration of
+      // what the app exposes: the binding still says which node it is, but the
+      // node's live topics, services and actions are not copied onto it.
+      if (config.inherit_runtime_resources) {
+        enrich_app(linked_app, match);
+      }
 
       result.app_to_node[manifest_app.id] = match_fqn;
       result.node_to_app[match_fqn] = manifest_app.id;
@@ -192,7 +199,11 @@ LinkingResult RuntimeLinker::link(const std::vector<App> & manifest_apps, const 
   }
 
   auto it = std::remove_if(result.linked_apps.begin(), result.linked_apps.end(), [&](const App & app) {
-    if (is_protected_source(app.source)) {
+    // Same two grounds the pipeline's orphan sweep uses, from the same set:
+    // the owning layer declares its entities protected, or the source tag is
+    // one the whitelist knows. Keying on the tag alone deleted entities from
+    // any provider that stamped a tag the whitelist had never heard of.
+    if (protected_ids.count(app.id) > 0 || is_protected_source(app.source)) {
       return false;
     }
     if (!app.bound_fqn.has_value()) {
@@ -219,11 +230,15 @@ LinkingResult RuntimeLinker::link(const std::vector<App> & manifest_apps, const 
         break;
 
       case ManifestConfig::UnmanifestedNodePolicy::ERROR:
-        log_error("Orphan nodes detected with 'error' policy. Discovery will fail.");
+        log_error("Orphan nodes detected with 'error' policy: " + std::to_string(result.orphan_nodes.size()) +
+                  " node(s) are not declared in the manifest. The gateway keeps serving; they are reported on "
+                  "GET /health as a '" +
+                  std::string(WARN_UNMANIFESTED_NODES) + "' warning.");
         break;
 
       case ManifestConfig::UnmanifestedNodePolicy::INCLUDE_AS_ORPHAN:
-        log_info("Including " + std::to_string(result.orphan_nodes.size()) + " orphan nodes with source='orphan'");
+        log_info("Including " + std::to_string(result.orphan_nodes.size()) +
+                 " orphan node(s), same as the 'warn' policy but logged at info level");
         break;
     }
   }

--- a/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/src/discovery/merge_pipeline.cpp
@@ -94,6 +94,46 @@ void merge_scalar(std::string & target, const std::string & source, MergeWinner 
   }
 }
 
+// Protection has two independent grounds, and an entity needs only one:
+//   1. the OWNING LAYER declares its entities protected (a plugin layer), or
+//   2. the entity carries a source tag the whitelist recognises.
+// (1) exists because (2) alone required every provider to pick a string from a
+// list it could not see; a provider that stamped its own tag lost its entities
+// to the orphan sweep. (2) stays because manifest and inventory entities are
+// identified that way and `source` is public API we do not get to redefine.
+bool is_protected_entity(const std::string & id, const std::string & source,
+                         const std::unordered_set<std::string> & protected_ids) {
+  return protected_ids.count(id) > 0 || is_protected_source(source);
+}
+
+// Merge an entity's `source` tag. Deliberately NOT merge_scalar: `source` is
+// provenance, not content. It records which layer declared the entity, and
+// is_protected_source() keys the orphan filter and the linked-app dedup on it -
+// so it decides whether the entity may be DELETED. A value that governs a
+// deletion must not be reassignable by a formatting policy: with the manifest
+// layer's METADATA policy demoted below the runtime layer's, merge_scalar would
+// take its SOURCE branch and rewrite "manifest" to "heuristic", after which the
+// filters remove the entity. So the resolution is ignored on purpose and this
+// is a pure gap fill - an entity that arrives without provenance still inherits
+// one, and an entity that has provenance keeps it under every layer policy.
+//
+// INVARIANT this relies on: provenance is first-writer-wins, so the layer that
+// declares an entity FIRST owns its `source` for the whole run. Two properties
+// of the callers make that safe, and both must hold:
+//   1. Layer order. merge_entities() seeds the merged entity from the first
+//      layer that contributed it, and DiscoveryManager adds the manifest layer
+//      before the runtime layer and appends plugin layers after both
+//      (discovery_manager.cpp). A plugin therefore cannot take `source` away
+//      from a manifest entity and make it deletable.
+//   2. No carry-over. execute() builds a fresh MergeResult per run, so a
+//      provenance filled in one pass never persists into the next.
+// If either ever changes, this function is the thing that breaks.
+void fill_provenance(std::string & target, const std::string & candidate) {
+  if (target.empty()) {
+    target = candidate;
+  }
+}
+
 void merge_bool(bool & target, bool source, MergeWinner winner) {
   switch (winner) {
     case MergeWinner::SOURCE:
@@ -218,7 +258,8 @@ void apply_field_group_merge(Entity & target, const Entity & source, FieldGroup 
         merge_scalar(target.parent_area_id, source.parent_area_id, res.scalar);
         break;
       case FieldGroup::METADATA:
-        merge_scalar(target.source, source.source, res.scalar);
+        // Provenance is exempt from the policy - see fill_provenance().
+        fill_provenance(target.source, source.source);
         break;
       case FieldGroup::LIVE_DATA:
       case FieldGroup::STATUS:
@@ -261,7 +302,8 @@ void apply_field_group_merge(Entity & target, const Entity & source, FieldGroup 
             res.collection);
         break;
       case FieldGroup::METADATA:
-        merge_scalar(target.source, source.source, res.scalar);
+        // Provenance is exempt from the policy - see fill_provenance().
+        fill_provenance(target.source, source.source);
         merge_scalar(target.variant, source.variant, res.scalar);
         merge_external(target.external, source.external, res.scalar);
         break;
@@ -301,7 +343,8 @@ void apply_field_group_merge(Entity & target, const Entity & source, FieldGroup 
         merge_optional(target.bound_fqn, source.bound_fqn, res.scalar);
         break;
       case FieldGroup::METADATA:
-        merge_scalar(target.source, source.source, res.scalar);
+        // Provenance is exempt from the policy - see fill_provenance().
+        fill_provenance(target.source, source.source);
         merge_optional(target.ros_binding, source.ros_binding, res.scalar);
         merge_external(target.external, source.external, res.scalar);
         break;
@@ -319,7 +362,8 @@ void apply_field_group_merge(Entity & target, const Entity & source, FieldGroup 
         merge_collection(target.depends_on, source.depends_on, res.collection);
         break;
       case FieldGroup::METADATA:
-        merge_scalar(target.source, source.source, res.scalar);
+        // Provenance is exempt from the policy - see fill_provenance().
+        fill_provenance(target.source, source.source);
         break;
       case FieldGroup::LIVE_DATA:
       case FieldGroup::STATUS:
@@ -344,6 +388,15 @@ void MergePipeline::add_layer(std::unique_ptr<DiscoveryLayer> layer) {
 void MergePipeline::set_linker(std::unique_ptr<RuntimeLinker> linker, const ManifestConfig & config) {
   linker_ = std::move(linker);
   manifest_config_ = config;
+}
+
+DiscoveryLayer * MergePipeline::find_layer(const std::string & name) {
+  for (auto & layer : layers_) {
+    if (layer->name() == name) {
+      return layer.get();
+    }
+  }
+  return nullptr;
 }
 
 template <typename Entity>
@@ -377,6 +430,21 @@ std::vector<Entity> MergePipeline::merge_entities(std::vector<std::pair<size_t, 
     Entity merged = std::move(entries[0].entity);
     size_t owner_layer_idx = entries[0].layer_idx;
     report.entity_source[id] = layers_[owner_layer_idx]->name();
+
+    // Record protection here, where the OWNING LAYER INDEX is in hand. The
+    // report keeps the layer's name for humans, but the filters must not key
+    // on a name: names are not guaranteed unique, and re-deriving the layer
+    // from its name would put the delete decision back on a string chosen
+    // elsewhere, which is the bug this replaces.
+    //
+    // Deliberately the owning layer only. A plugin that merely ENRICHES an
+    // entity another layer declared does not protect it - a beacon shadow
+    // contribution must not make a runtime app undeletable. If you are here
+    // because a plugin-enriched entity got swept, that is the intended
+    // behaviour, not a bug to fix.
+    if (layers_[owner_layer_idx]->owns_protected_entities()) {
+      protected_entity_ids_.insert(id);
+    }
 
     // Seed asset-identity provenance with the base entity's canonical source tag so
     // subsequent identity merges can compare authority per field.
@@ -423,6 +491,8 @@ std::vector<Entity> MergePipeline::merge_entities(std::vector<std::pair<size_t, 
 
 MergeResult MergePipeline::execute() {
   MergeReport report;
+  // Rebuilt per run: protection follows what the layers contribute THIS pass.
+  protected_entity_ids_.clear();
   for (const auto & layer : layers_) {
     report.layers.push_back(layer->name());
   }
@@ -436,6 +506,10 @@ MergeResult MergePipeline::execute() {
   // RuntimeLinker needs runtime-only apps (nodes as Apps, not merged with
   // manifest apps). Manifest apps lack bound_fqn until linked.
   std::vector<App> runtime_apps;
+
+  // The manifest's apps exactly as declared, before any merging. Needed to
+  // honour inherit_runtime_resources=false: see the restore below.
+  std::vector<App> manifest_declared_apps;
 
   for (size_t i = 0; i < layers_.size(); ++i) {
     // Build discovery context from entities collected so far (for plugin layers)
@@ -473,6 +547,9 @@ MergeResult MergePipeline::execute() {
     // the linker needs all runtime apps to bind manifest apps to live nodes.
     if (layers_[i]->provides_runtime_apps()) {
       runtime_apps = layers_[i]->get_linking_apps();
+    }
+    if (layers_[i]->name() == "manifest") {
+      manifest_declared_apps = output.apps;
     }
 
     if (!output.areas.empty()) {
@@ -516,9 +593,38 @@ MergeResult MergePipeline::execute() {
   check_ids(result.apps, "App");
   check_ids(result.functions, "Function");
 
+  // inherit_runtime_resources=false must mean the app exposes only what the
+  // manifest declares. Gating RuntimeLinker::enrich_app is not enough to
+  // deliver that: merge_entities<App>() has already run, and its LIVE_DATA
+  // field group unions the runtime layer's topics, services and actions into
+  // any app the two layers contribute under the same id - which is exactly
+  // what a manifest app named after the node it binds to looks like. So the
+  // flag would silently do nothing in the most natural configuration.
+  //
+  // Restore the declared collections here, after the merge and before
+  // linking. The manifest layer is the authority on what it declared, so this
+  // reads from its own untouched output rather than trying to unpick which
+  // entries the merge contributed.
+  if (!manifest_config_.inherit_runtime_resources && !manifest_declared_apps.empty()) {
+    std::unordered_map<std::string, const App *> declared;
+    declared.reserve(manifest_declared_apps.size());
+    for (const auto & app : manifest_declared_apps) {
+      declared.emplace(app.id, &app);
+    }
+    for (auto & app : result.apps) {
+      auto it = declared.find(app.id);
+      if (it == declared.end()) {
+        continue;  // not a manifest app; the flag says nothing about it
+      }
+      app.topics = it->second->topics;
+      app.services = it->second->services;
+      app.actions = it->second->actions;
+    }
+  }
+
   // Post-merge linking: bind manifest apps to runtime nodes (Apps, not Components)
   if (linker_) {
-    auto linking = linker_->link(result.apps, runtime_apps, manifest_config_);
+    auto linking = linker_->link(result.apps, runtime_apps, manifest_config_, protected_entity_ids_);
 
     // Replace apps with linked versions (have is_online, bound_fqn set)
     result.apps = std::move(linking.linked_apps);
@@ -593,7 +699,7 @@ MergeResult MergePipeline::execute() {
 
     auto app_it = std::remove_if(result.apps.begin(), result.apps.end(), [&](const App & app) {
       // Whitelist: manifest and plugin sources are always preserved
-      if (is_protected_source(app.source)) {
+      if (is_protected_entity(app.id, app.source, protected_entity_ids_)) {
         return false;
       }
       // Suppress non-protected apps whose ID matches a linked manifest app (dedup)
@@ -622,7 +728,7 @@ MergeResult MergePipeline::execute() {
 
     // Remove non-protected components whose namespace is covered by manifest or orphan suppression
     auto comp_it = std::remove_if(result.components.begin(), result.components.end(), [&](const Component & comp) {
-      if (is_protected_source(comp.source)) {
+      if (is_protected_entity(comp.id, comp.source, protected_entity_ids_)) {
         return false;
       }
       if (manifest_comp_ns.count(comp.namespace_path) > 0 || linked_namespaces.count(comp.namespace_path) > 0) {
@@ -638,7 +744,7 @@ MergeResult MergePipeline::execute() {
 
     // Remove non-protected areas whose namespace is covered
     auto area_it = std::remove_if(result.areas.begin(), result.areas.end(), [&](const Area & area) {
-      if (is_protected_source(area.source)) {
+      if (is_protected_entity(area.id, area.source, protected_entity_ids_)) {
         return false;
       }
       if (manifest_area_ns.count(area.namespace_path) > 0 || linked_namespaces.count(area.namespace_path) > 0) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -2145,6 +2145,12 @@ void GatewayNode::handle_entity_change_notification(const EntityChangeScope & sc
           RCLCPP_WARN(get_logger(),
                       "notify_entities_changed: manifest reload failed (see validation errors); "
                       "continuing refresh against the previously loaded manifest");
+        } else {
+          // The reloaded manifest may carry a different discovery
+          // configuration. /health reads it live, so without this the served
+          // unmanifested_policy would describe a policy the orphan filter is
+          // not running.
+          discovery_mgr_->refresh_manifest_config();
         }
       }
     }

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -20,6 +20,7 @@
 #include "ros2_medkit_gateway/core/auth/auth_models.hpp"
 #include "ros2_medkit_gateway/core/data/topic_data_provider.hpp"
 #include "ros2_medkit_gateway/core/discovery/discovery_enums.hpp"
+#include "ros2_medkit_gateway/core/entity_validation.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/http/fan_out_helpers.hpp"
 #include "ros2_medkit_gateway/core/http/http_utils.hpp"
@@ -56,6 +57,12 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
     response.status = "healthy";
     response.timestamp = std::chrono::system_clock::now().time_since_epoch().count();
 
+    // Operator-actionable warnings the gateway flags without taking itself
+    // offline. Collected across every subsystem that can produce one, so the
+    // array and its schema version are part of the /health contract whether or
+    // not aggregation is configured.
+    std::vector<dto::HealthWarning> warnings;
+
     // Add discovery info
     auto * dm = ctx_.node() ? ctx_.node()->get_discovery_manager() : nullptr;
     if (dm) {
@@ -70,14 +77,43 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
 
       auto linking = dm->get_linking_result();
       if (linking) {
+        const auto manifest_config = dm->get_manifest_config();
+        const auto policy = manifest_config.unmanifested_nodes;
+
         dto::HealthDiscoveryLinking linking_dto;
         linking_dto.linked_count = static_cast<int64_t>(linking->node_to_app.size());
         linking_dto.orphan_count = static_cast<int64_t>(linking->orphan_nodes.size());
         linking_dto.binding_conflicts = static_cast<int64_t>(linking->binding_conflicts);
+        linking_dto.unmanifested_policy = discovery::ManifestConfig::policy_to_string(policy);
         if (!linking->warnings.empty()) {
           linking_dto.warnings = linking->warnings;
         }
         discovery.linking = linking_dto;
+
+        // The 'error' policy reports, it does not stop the process: a
+        // documentation-level setting must not be able to take a running
+        // gateway offline, and a permanently unhealthy status would disable
+        // every deployment gate that keys on a healthy -> unhealthy edge.
+        if (linking->has_errors(policy)) {
+          dto::HealthWarning warning;
+          warning.code = WARN_UNMANIFESTED_NODES;
+          warning.message =
+              std::to_string(linking->orphan_nodes.size()) +
+              " running ROS node(s) are not declared in the manifest while unmanifested_nodes is set to 'error' "
+              "(listed in ros_node_fqns). The gateway keeps serving. Declare them in the manifest, or relax the "
+              "policy to 'warn' or 'ignore'.";
+          // The subjects of this warning are ROS nodes, so they go in
+          // ros_node_fqns and entity_ids stays empty. Not a formality: the
+          // orphan list is taken from the UNFILTERED runtime app list
+          // (runtime_layer.cpp), before gap-fill, the namespace filters and
+          // the policy filter, so some of these nodes have no SOVD entity at
+          // all - and for those that do, the App id is derived from the bare
+          // node name and only becomes namespace-qualified when some other
+          // node collides with it (ros2_runtime_introspection.cpp), so it can
+          // change between two polls while the FQN cannot.
+          warning.ros_node_fqns = linking->orphan_nodes;
+          warnings.push_back(std::move(warning));
+        }
       }
 
       response.discovery = std::move(discovery);
@@ -112,18 +148,8 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
     if (auto * agg = ctx_.aggregation_manager()) {
       response.peers = agg->get_peer_status();
 
-      // Contract version for the warnings array. Increment whenever a code
-      // is added or the shape of a warning object changes so typed clients
-      // (MCP, Web UI, Foxglove) can feature-detect instead of relying on
-      // capabilities.aggregation (a boolean, too coarse).
-      // Keep in sync with docs/api/warning_codes.rst "Schema versioning".
-      response.warning_schema_version = static_cast<int64_t>(kWarningSchemaVersion);
-
-      // Surface operator-actionable aggregation warnings (x-medkit extension).
-      // Always an array when aggregation is active; empty means no active
-      // warnings. Clients can feature-detect via /.capabilities.aggregation
-      // in the root response.
-      std::vector<dto::HealthAggregationWarning> warnings;
+      // Aggregation warnings are only collectable when there is an aggregation
+      // manager; the array itself is not conditional on one.
       for (const auto & w : agg->get_leaf_warnings()) {
         std::string peers_list;
         for (size_t i = 0; i < w.peer_names.size(); ++i) {
@@ -132,19 +158,41 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
           }
           peers_list += w.peer_names[i];
         }
-        dto::HealthAggregationWarning warning;
+        dto::HealthWarning warning;
         warning.code = WARN_LEAF_ID_COLLISION;
         warning.message = "Component '" + w.entity_id + "' is announced by multiple peers (" + peers_list +
                           "); routing falls back to last-writer-wins which is non-deterministic. Resolve by "
                           "renaming the Component on one side or by modelling it as a hierarchical parent "
                           "(declare a child Component with parentComponentId='" +
                           w.entity_id + "' on the owning peer).";
-        warning.entity_ids = {w.entity_id};
+        // A Component id, so it belongs in entity_ids and this code names no
+        // ROS nodes - but the id came verbatim from a remote peer and nothing
+        // on that path validated it. entity_ids promises every element is
+        // addressable, so an id a client could not put in a URL is withheld
+        // rather than published: the message above still names the component,
+        // so only the machine-readable link is lost, and that link would not
+        // have worked.
+        if (auto valid = validate_entity_id(w.entity_id); valid) {
+          warning.entity_ids = {w.entity_id};
+        } else {
+          RCLCPP_WARN(HandlerContext::logger(),
+                      "Peer(s) [%s] announced Component id '%s', which is not a valid entity id (%s); omitting it "
+                      "from the '%s' warning's entity_ids",
+                      peers_list.c_str(), w.entity_id.c_str(), valid.error().c_str(), WARN_LEAF_ID_COLLISION);
+        }
         warning.peer_names = w.peer_names;
         warnings.push_back(std::move(warning));
       }
-      response.warnings = std::move(warnings);
     }
+
+    // Contract version for the warnings array. Increment whenever a code is
+    // added or the shape of a warning object changes so typed clients (MCP,
+    // Web UI, Foxglove) can feature-detect. Emitted unconditionally: keying it
+    // on capabilities.aggregation used to hide the whole warnings channel from
+    // every gateway that does not aggregate.
+    // Keep in sync with docs/api/warning_codes.rst "Schema versioning".
+    response.warning_schema_version = static_cast<int64_t>(kWarningSchemaVersion);
+    response.warnings = std::move(warnings);
 
     return response;
   } catch (const std::exception & e) {

--- a/src/ros2_medkit_gateway/test/test_health_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_health_handlers.cpp
@@ -14,22 +14,30 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <arpa/inet.h>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <httplib.h>
 #include <netinet/in.h>
 #include <nlohmann/json.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <set>
 #include <string>
 #include <sys/socket.h>
 #include <thread>
 #include <unistd.h>
 #include <utility>
+#include <vector>
 
 #include "../src/openapi/route_registry.hpp"
+#include "ros2_medkit_gateway/core/entity_validation.hpp"
 #include "ros2_medkit_gateway/core/http/handlers/health_handlers.hpp"
+#include "ros2_medkit_gateway/discovery/discovery_manager.hpp"
 #include "ros2_medkit_gateway/dto/health.hpp"
 #include "ros2_medkit_gateway/dto/json_writer.hpp"
+#include "ros2_medkit_gateway/dto/registry.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/typed_router.hpp"
 
@@ -324,16 +332,28 @@ static int reserve_free_port() {
   return port;
 }
 
+// rclcpp is brought up once for the whole binary rather than per fixture: two
+// fixtures here need a live context, and cycling init/shutdown between them
+// would tear the default context down under the next suite.
+class RclcppEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  void TearDown() override {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+};
+
+const ::testing::Environment * kRclcppEnvironment = ::testing::AddGlobalTestEnvironment(new RclcppEnvironment);
+
 class HealthHandlersLiveTest : public ::testing::Test {
  protected:
-  static void SetUpTestSuite() {
-    rclcpp::init(0, nullptr);
-  }
-
-  static void TearDownTestSuite() {
-    rclcpp::shutdown();
-  }
-
   void SetUp() override {
     int free_port = reserve_free_port();
     ASSERT_NE(free_port, 0) << "Failed to reserve a free port for test";
@@ -437,4 +457,644 @@ TEST_F(HealthHandlersLiveTest, HealthEntityCacheStatsPresent) {
   EXPECT_TRUE(ec["grew"].is_boolean());
   // A fresh cache with default capacity=256 must not have grown
   EXPECT_FALSE(ec["grew"].get<bool>());
+}
+
+TEST_F(HealthHandlersLiveTest, RuntimeOnlyOmitsLinkingAndTheUnmanifestedPolicyField) {
+  // runtime_only has no RuntimeLinker, so there is nothing to report a policy
+  // about. The policy field must not appear on its own anywhere in the body.
+  httplib::Client client("127.0.0.1", server_port_);
+  auto res = client.Get(std::string(API_BASE_PATH) + "/health");
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(res->status, 200);
+
+  auto body = json::parse(res->body);
+  ASSERT_TRUE(body.contains("discovery"));
+  EXPECT_FALSE(body["discovery"].contains("linking"));
+  EXPECT_EQ(res->body.find("unmanifested_policy"), std::string::npos)
+      << "runtime_only must not emit unmanifested_policy; body: " << res->body;
+}
+
+TEST_F(HealthHandlersLiveTest, WarningsArrayAndSchemaVersionPresentWithoutAggregation) {
+  // Aggregation is disabled on this gateway. The warnings contract is no
+  // longer gated on it: the array and its schema version are always served.
+  httplib::Client client("127.0.0.1", server_port_);
+  auto res = client.Get(std::string(API_BASE_PATH) + "/health");
+
+  ASSERT_TRUE(res);
+  EXPECT_EQ(res->status, 200);
+
+  auto body = json::parse(res->body);
+  ASSERT_TRUE(body.contains("warnings")) << "/health must always carry a warnings array; body: " << res->body;
+  EXPECT_TRUE(body["warnings"].is_array());
+  EXPECT_TRUE(body["warnings"].empty()) << "a healthy runtime_only gateway has nothing to warn about";
+
+  ASSERT_TRUE(body.contains("warning_schema_version"));
+  EXPECT_EQ(body["warning_schema_version"].get<int>(), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Schema surface: the warning object is published under its own component
+// name, and the linking object carries the configured policy.
+// ---------------------------------------------------------------------------
+
+TEST(HealthSchemaSurface, WarningIsPublishedAsHealthWarning) {
+  auto schemas = ros2_medkit_gateway::dto::collect_component_schemas();
+
+  EXPECT_FALSE(schemas.contains("HealthAggregationWarning"))
+      << "the warning object is no longer aggregation-specific and must not keep the old component name";
+  ASSERT_TRUE(schemas.contains("HealthWarning"));
+
+  const auto & props = schemas["HealthWarning"]["properties"];
+  EXPECT_EQ(props.size(), 5u);
+  EXPECT_TRUE(props.contains("code"));
+  EXPECT_TRUE(props.contains("message"));
+  EXPECT_TRUE(props.contains("entity_ids"));
+  EXPECT_TRUE(props.contains("ros_node_fqns"));
+  EXPECT_TRUE(props.contains("peer_names"));
+
+  // All three identifier arrays are plain arrays, never anyOf:[array,null].
+  // std::optional would publish a null state the server cannot emit and give
+  // every generated client a tri-state to unpack.
+  for (const char * key : {"entity_ids", "ros_node_fqns", "peer_names"}) {
+    ASSERT_TRUE(props.contains(key)) << key;
+    EXPECT_EQ(props[key].value("type", std::string{}), "array") << key;
+    EXPECT_FALSE(props[key].contains("anyOf")) << key << " must not be optional";
+  }
+}
+
+TEST(HealthSchemaSurface, LinkingCarriesTheUnmanifestedPolicy) {
+  auto schemas = ros2_medkit_gateway::dto::collect_component_schemas();
+
+  ASSERT_TRUE(schemas.contains("HealthDiscoveryLinking"));
+  const auto & props = schemas["HealthDiscoveryLinking"]["properties"];
+  ASSERT_TRUE(props.contains("unmanifested_policy"));
+  EXPECT_EQ(props["unmanifested_policy"]["type"], "string");
+}
+
+// ---------------------------------------------------------------------------
+// Hybrid-mode /health: the unmanifested-node policy and its warning.
+//
+// Driven through a real GatewayNode over real HTTP, because the claim is about
+// the served document: which policy string it reports, and whether the warning
+// appears for the orphans the linker actually found. A handler test holding a
+// hand-built DTO could not tell whether the handler ever reads the manifest.
+//
+// Discovery is advanced by calling refresh_topic_map() - the same entry point
+// the gateway's own refresh timer uses - so the test does not have to run an
+// executor to make a pass happen.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr const char * kBoundNodeName = "linking_bound_node";
+constexpr const char * kOrphanAlpha = "linking_orphan_alpha";
+constexpr const char * kOrphanBeta = "linking_orphan_beta";
+
+std::string linking_manifest(const std::string & policy, const std::vector<std::string> & extra_bound_fqns = {},
+                             const std::string & extra_config = "") {
+  std::string yaml =
+      "manifest_version: \"1.0\"\n"
+      "metadata:\n"
+      "  name: \"Health linking fixture\"\n"
+      "  version: \"1.0.0\"\n"
+      "config:\n"
+      "  unmanifested_nodes: \"" +
+      policy + "\"\n" + extra_config +
+      "areas:\n"
+      "  - id: linkarea\n"
+      "    name: \"Linking Area\"\n"
+      "components:\n"
+      "  - id: linkecu\n"
+      "    name: \"Linking ECU\"\n"
+      "    area: linkarea\n"
+      "apps:\n"
+      "  - id: bound_app\n"
+      "    name: \"Bound App\"\n"
+      "    is_located_on: linkecu\n"
+      "    ros_binding:\n"
+      "      node_name: " +
+      std::string(kBoundNodeName) +
+      "\n"
+      "      namespace: \"/\"\n";
+
+  for (const auto & fqn : extra_bound_fqns) {
+    auto slash = fqn.rfind('/');
+    std::string node_name = fqn.substr(slash + 1);
+    std::string ns = (slash == 0) ? "/" : fqn.substr(0, slash);
+    std::string id = "app_" + fqn.substr(1);
+    std::replace(id.begin(), id.end(), '/', '_');
+    yaml += "  - id: " + id + "\n";
+    yaml += "    name: \"" + node_name + "\"\n";
+    yaml += "    is_located_on: linkecu\n";
+    yaml += "    ros_binding:\n";
+    yaml += "      node_name: " + node_name + "\n";
+    yaml += "      namespace: \"" + ns + "\"\n";
+  }
+  return yaml;
+}
+
+}  // namespace
+
+class HealthLinkingTest : public ::testing::Test {
+ protected:
+  void TearDown() override {
+    stop_gateway();
+    graph_nodes_.clear();
+    for (const auto & path : manifests_) {
+      std::error_code ec;
+      std::filesystem::remove(path, ec);
+    }
+    manifests_.clear();
+  }
+
+  /// Put nodes on the ROS graph. Nothing declares them unless a manifest says so.
+  void spawn_nodes(const std::vector<std::string> & names) {
+    for (const auto & name : names) {
+      graph_nodes_.push_back(std::make_shared<rclcpp::Node>(name));
+    }
+  }
+
+  void start_gateway(const std::string & manifest_yaml) {
+    const auto path = write_manifest(manifest_yaml);
+    server_port_ = reserve_free_port();
+    ASSERT_NE(server_port_, 0) << "Failed to reserve a free port for test";
+
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+        rclcpp::Parameter("server.port", server_port_),
+        rclcpp::Parameter("discovery.mode", std::string("hybrid")),
+        rclcpp::Parameter("discovery.manifest_path", path),
+        rclcpp::Parameter("discovery.manifest_strict_validation", false),
+    });
+    node_ = std::make_shared<ros2_medkit_gateway::GatewayNode>(options);
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    httplib::Client client("127.0.0.1", server_port_);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (auto res = client.Get(std::string(API_BASE_PATH) + "/health"); res && res->status == 200) {
+        return;
+      }
+      std::this_thread::sleep_for(50ms);
+    }
+    FAIL() << "HTTP server failed to start within timeout";
+  }
+
+  void stop_gateway() {
+    node_.reset();
+  }
+
+  /// Run discovery passes until *predicate* accepts the /health document.
+  json poll_health(const std::function<bool(const json &)> & predicate, const std::string & what) {
+    httplib::Client client("127.0.0.1", server_port_);
+    json last = json::object();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (auto * dm = node_->get_discovery_manager()) {
+        dm->refresh_topic_map();
+      }
+      if (auto res = client.Get(std::string(API_BASE_PATH) + "/health"); res && res->status == 200) {
+        last = json::parse(res->body);
+        if (predicate(last)) {
+          return last;
+        }
+      }
+      std::this_thread::sleep_for(200ms);
+    }
+    ADD_FAILURE() << "timed out waiting for " << what << "; last /health: " << last.dump();
+    return last;
+  }
+
+  /// Every node FQN currently on the graph, as the linker would see them.
+  std::vector<std::string> graph_fqns() {
+    std::vector<std::string> fqns;
+    if (graph_nodes_.empty()) {
+      return fqns;  // caller asserts on the result; this needs a node to query from
+    }
+    fqns = graph_nodes_.front()->get_node_names();
+    std::sort(fqns.begin(), fqns.end());
+    return fqns;
+  }
+
+  // Pins the HealthWarning invariant across every code the document carries:
+  // entity_ids holds addressable SOVD ids only. A ROS node FQN there would
+  // fail validate_entity_id on the '/' that "conflicts with URL routing".
+  static void expect_entity_ids_are_addressable(const json & health) {
+    ASSERT_TRUE(health.contains("warnings")) << health.dump();
+    ASSERT_TRUE(health["warnings"].is_array());
+    for (const auto & warning : health["warnings"]) {
+      const std::string code = warning.value("code", std::string{});
+      ASSERT_TRUE(warning.contains("entity_ids")) << code;
+      ASSERT_TRUE(warning.contains("ros_node_fqns")) << code;
+      ASSERT_TRUE(warning.contains("peer_names")) << code;
+      for (const auto & id : warning["entity_ids"]) {
+        const auto valid = ros2_medkit_gateway::validate_entity_id(id.get<std::string>());
+        EXPECT_TRUE(valid.has_value()) << "warning '" << code
+                                       << "' put a non-addressable value in entity_ids: " << id.dump() << " ("
+                                       << (valid.has_value() ? std::string{} : valid.error()) << ")";
+      }
+    }
+  }
+
+  static const json * find_warning(const json & health, const std::string & code) {
+    if (!health.contains("warnings") || !health["warnings"].is_array()) {
+      return nullptr;
+    }
+    for (const auto & w : health["warnings"]) {
+      if (w.value("code", std::string{}) == code) {
+        return &w;
+      }
+    }
+    return nullptr;
+  }
+
+  std::string write_manifest(const std::string & yaml) {
+    auto path = std::filesystem::temp_directory_path() / ("medkit-health-linking-" + std::to_string(::getpid()) + "-" +
+                                                          std::to_string(manifests_.size()) + ".yaml");
+    std::ofstream(path) << yaml;
+    manifests_.push_back(path.string());
+    return path.string();
+  }
+
+  /// Overwrite the manifest the running gateway was started from.
+  void rewrite_current_manifest(const std::string & yaml) {
+    ASSERT_FALSE(manifests_.empty()) << "no manifest to rewrite";
+    std::ofstream(manifests_.front(), std::ios::trunc) << yaml;
+  }
+
+  /// Drive the real reload path: this is the entry point a plugin reaches
+  /// through PluginContext::notify_entities_changed, which is the only way a
+  /// manifest is re-read while the gateway runs.
+  void trigger_reload() {
+    node_->handle_entity_change_notification(ros2_medkit_gateway::EntityChangeScope::full_refresh());
+  }
+
+  /// App ids currently served by GET /apps.
+  std::set<std::string> served_app_ids() {
+    httplib::Client client("127.0.0.1", server_port_);
+    auto res = client.Get(std::string(API_BASE_PATH) + "/apps");
+    if (!res || res->status != 200) {
+      return {};
+    }
+    std::set<std::string> ids;
+    for (const auto & item : json::parse(res->body).value("items", json::array())) {
+      ids.insert(item.value("id", std::string{}));
+    }
+    return ids;
+  }
+
+  std::vector<std::shared_ptr<rclcpp::Node>> graph_nodes_;
+  std::shared_ptr<ros2_medkit_gateway::GatewayNode> node_;
+  std::vector<std::string> manifests_;
+  int server_port_{0};
+};
+
+class HealthLinkingPolicyTest : public HealthLinkingTest, public ::testing::WithParamInterface<std::string> {};
+
+// The configured policy reaches the served document for every legal value, and
+// only "error" turns orphans into a warning.
+TEST_P(HealthLinkingPolicyTest, PolicyIsReportedAndOnlyErrorWarns) {
+  const std::string policy = GetParam();
+  spawn_nodes({kBoundNodeName, kOrphanAlpha, kOrphanBeta});
+  start_gateway(linking_manifest(policy));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  auto health = poll_health(
+      [](const json & h) {
+        return h.contains("discovery") && h["discovery"].contains("linking") &&
+               h["discovery"]["linking"].value("orphan_count", 0) >= 2;
+      },
+      "at least two orphan nodes under policy " + policy);
+  ASSERT_TRUE(health.contains("discovery")) << health.dump();
+  ASSERT_TRUE(health["discovery"].contains("linking")) << health.dump();
+
+  const auto & linking = health["discovery"]["linking"];
+  EXPECT_EQ(linking.value("unmanifested_policy", std::string{}), policy);
+
+  // R6: an "error" policy is a report, never an outage.
+  EXPECT_EQ(health.value("status", std::string{}), "healthy");
+  EXPECT_EQ(health.value("warning_schema_version", 0), 2);
+
+  const auto * warning = find_warning(health, "unmanifested_nodes");
+  if (policy != "error") {
+    EXPECT_EQ(warning, nullptr) << "policy '" << policy
+                                << "' must not raise the unmanifested-node warning: " << health["warnings"].dump();
+    return;
+  }
+
+  ASSERT_NE(warning, nullptr) << "policy 'error' with orphans must raise the warning: " << health.dump();
+
+  // The subjects are ROS nodes, so they are carried as node FQNs.
+  ASSERT_TRUE(warning->contains("ros_node_fqns"));
+  const auto fqns = (*warning)["ros_node_fqns"].get<std::set<std::string>>();
+
+  // Scale: every orphan is listed, not just the first one.
+  EXPECT_EQ(fqns.size(), static_cast<size_t>(linking.value("orphan_count", 0)));
+  EXPECT_TRUE(fqns.count(std::string("/") + kOrphanAlpha)) << "listed: " << (*warning)["ros_node_fqns"].dump();
+  EXPECT_TRUE(fqns.count(std::string("/") + kOrphanBeta)) << "listed: " << (*warning)["ros_node_fqns"].dump();
+  EXPECT_FALSE(fqns.count(std::string("/") + kBoundNodeName)) << "a linked node is not an orphan";
+
+  // ...and entity_ids stays empty: a node FQN is not an addressable entity id.
+  ASSERT_TRUE(warning->contains("entity_ids"));
+  EXPECT_TRUE((*warning)["entity_ids"].is_array());
+  EXPECT_TRUE((*warning)["entity_ids"].empty())
+      << "entity_ids must carry addressable SOVD ids only: " << (*warning)["entity_ids"].dump();
+
+  // A non-aggregation warning carries no peers, but keeps the field.
+  ASSERT_TRUE(warning->contains("peer_names"));
+  EXPECT_TRUE((*warning)["peer_names"].is_array());
+  EXPECT_TRUE((*warning)["peer_names"].empty());
+
+  EXPECT_FALSE(warning->value("message", std::string{}).empty());
+
+  // The invariant, checked against every warning this gateway emits rather
+  // than only the one under test: anything in entity_ids must be a value a
+  // client can put in a URL. validate_entity_id is the same function the
+  // routing layer applies, so this cannot drift from it.
+  expect_entity_ids_are_addressable(health);
+}
+
+// A reload must move the pipeline, not just the served field. /health reads
+// the manifest config live from the ManifestManager, while the pipeline
+// captured it when it was built - so a reload that refreshed only one of them
+// would make the documented monitor recipe
+// (orphan_count > 0 && unmanifested_policy == "error") report a policy the
+// orphan filter is not running.
+//
+// Asserting the field alone would pass against exactly that bug, so the entity
+// tree is asserted too: `warn` keeps undeclared nodes visible, `ignore` hides
+// them, and the difference is only produced by the pipeline's own copy.
+// entity_ids promises every element is addressable. The leaf-collision code is
+// the one path that can break that promise: the Component id comes verbatim
+// from a remote peer and nothing on the ingest path validates it. A peer
+// serving an id with a '/' in it would hand clients a value that builds a
+// malformed GET /components/{id}.
+class HealthPeerWarningTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    server_port_ = reserve_free_port();
+    ASSERT_NE(server_port_, 0) << "Failed to reserve a free port for test";
+
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+        rclcpp::Parameter("server.port", server_port_),
+        rclcpp::Parameter("aggregation.enabled", true),
+        rclcpp::Parameter("aggregation.peer_urls", std::vector<std::string>{"http://127.0.0.1:1"}),
+        rclcpp::Parameter("aggregation.peer_names", std::vector<std::string>{"rogue_peer"}),
+    });
+    node_ = std::make_shared<ros2_medkit_gateway::GatewayNode>(options);
+
+    httplib::Client client("127.0.0.1", server_port_);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (std::chrono::steady_clock::now() < deadline) {
+      if (auto res = client.Get(std::string(API_BASE_PATH) + "/health"); res && res->status == 200) {
+        return;
+      }
+      std::this_thread::sleep_for(50ms);
+    }
+    FAIL() << "HTTP server failed to start within timeout";
+  }
+
+  void TearDown() override {
+    node_.reset();
+  }
+
+  /// Seed a leaf-collision warning as if a peer had announced *entity_id*.
+  json health_with_peer_collision(const std::string & entity_id) {
+    auto * agg = node_->get_aggregation_manager();
+    EXPECT_NE(agg, nullptr) << "aggregation.enabled=true must give us a manager";
+    agg->set_leaf_warnings({{entity_id, {"rogue_peer"}}});
+
+    httplib::Client client("127.0.0.1", server_port_);
+    auto res = client.Get(std::string(API_BASE_PATH) + "/health");
+    EXPECT_TRUE(res && res->status == 200);
+    return json::parse(res->body);
+  }
+
+  // Returns a pointer INTO *health*, so it must index the document itself -
+  // value() would hand back a temporary array and the pointer would dangle.
+  static const json * warning_with_code(const json & health, const std::string & code) {
+    if (!health.contains("warnings") || !health["warnings"].is_array()) {
+      return nullptr;
+    }
+    for (const auto & w : health["warnings"]) {
+      if (w.value("code", std::string{}) == code) {
+        return &w;
+      }
+    }
+    return nullptr;
+  }
+
+  /// Same invariant check the linking suite applies, over the whole document.
+  static void expect_entity_ids_are_addressable(const json & health) {
+    ASSERT_TRUE(health.contains("warnings")) << health.dump();
+    for (const auto & warning : health["warnings"]) {
+      for (const auto & id : warning["entity_ids"]) {
+        const auto valid = ros2_medkit_gateway::validate_entity_id(id.get<std::string>());
+        EXPECT_TRUE(valid.has_value()) << "non-addressable id in entity_ids: " << id.dump();
+      }
+    }
+  }
+
+  std::shared_ptr<ros2_medkit_gateway::GatewayNode> node_;
+  int server_port_{0};
+};
+
+TEST_F(HealthPeerWarningTest, ValidPeerComponentIdIsPublishedInEntityIds) {
+  const auto health = health_with_peer_collision("ecu-x");
+
+  const auto * warning = warning_with_code(health, "leaf_id_collision");
+  ASSERT_NE(warning, nullptr) << health.dump();
+  EXPECT_EQ((*warning)["entity_ids"], json::array({"ecu-x"}));
+  expect_entity_ids_are_addressable(health);
+}
+
+TEST_F(HealthPeerWarningTest, UnaddressablePeerComponentIdIsWithheldFromEntityIds) {
+  // A '/' is rejected in an entity id because it conflicts with URL routing,
+  // so this is exactly the value a client could not address.
+  const auto health = health_with_peer_collision("fleet/ecu-x");
+
+  const auto * warning = warning_with_code(health, "leaf_id_collision");
+  ASSERT_NE(warning, nullptr) << "the warning must still be raised: " << health.dump();
+
+  EXPECT_TRUE((*warning)["entity_ids"].empty())
+      << "an id a client cannot put in a URL must not be published as one: " << (*warning)["entity_ids"].dump();
+
+  // Nothing an operator needs is lost - the prose still names the component.
+  EXPECT_NE(warning->value("message", std::string{}).find("fleet/ecu-x"), std::string::npos)
+      << "the message must still identify the component: " << warning->value("message", std::string{});
+  EXPECT_EQ((*warning)["peer_names"], json::array({"rogue_peer"}));
+
+  // And the document-wide invariant still holds.
+  expect_entity_ids_are_addressable(health);
+}
+
+TEST_F(HealthLinkingTest, ReloadMovesBothTheReportedPolicyAndTheServedTree) {
+  spawn_nodes({kBoundNodeName, kOrphanAlpha, kOrphanBeta});
+  start_gateway(linking_manifest("warn"));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  // Before: warn keeps the undeclared nodes in the tree.
+  poll_health(
+      [](const json & h) {
+        return h["discovery"]["linking"].value("orphan_count", 0) >= 2;
+      },
+      "the orphans to be discovered under warn");
+  EXPECT_EQ(node_->get_discovery_manager()->get_manifest_config().unmanifested_nodes,
+            ros2_medkit_gateway::discovery::ManifestConfig::UnmanifestedNodePolicy::WARN);
+
+  const auto before = served_app_ids();
+  EXPECT_TRUE(before.count(kOrphanAlpha)) << "warn must leave the undeclared node visible; got: " << before.size();
+  EXPECT_TRUE(before.count(kOrphanBeta));
+
+  // Change the policy on disk and drive the real reload path.
+  rewrite_current_manifest(linking_manifest("ignore"));
+  trigger_reload();
+
+  // After: the served field says ignore ...
+  auto health = poll_health(
+      [](const json & h) {
+        return h["discovery"]["linking"].value("unmanifested_policy", std::string{}) == "ignore";
+      },
+      "/health to report the reloaded policy");
+  EXPECT_EQ(health["discovery"]["linking"].value("unmanifested_policy", std::string{}), "ignore");
+
+  // ... and the tree the pipeline produces agrees with it.
+  std::set<std::string> after;
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  while (std::chrono::steady_clock::now() < deadline) {
+    node_->get_discovery_manager()->refresh_topic_map();
+    after = served_app_ids();
+    if (after.count(kOrphanAlpha) == 0 && after.count(kOrphanBeta) == 0) {
+      break;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_EQ(after.count(kOrphanAlpha), 0u)
+      << "the orphan filter is still running the pre-reload policy; served: " << after.size() << " apps";
+  EXPECT_EQ(after.count(kOrphanBeta), 0u);
+  EXPECT_TRUE(after.count("bound_app")) << "the declared app must survive the reload";
+}
+
+// The reload path carries more than the unmanifested policy. These two cover
+// the parts that only a reload exercises: the set_manifest_config push (which
+// is what makes inherit_runtime_resources take effect on the new config) and
+// reset_policies_to_defaults (which exists solely so a manifest turning
+// allow_manifest_override back ON undoes the previous demotion).
+
+TEST_F(HealthLinkingTest, ReloadTurningOverrideBackOnRestoresManifestExclusivity) {
+  spawn_nodes({kBoundNodeName, kOrphanAlpha});
+  start_gateway(linking_manifest("warn", {}, "  allow_manifest_override: false\n"));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  poll_health(
+      [](const json & h) {
+        return h["discovery"]["linking"].value("orphan_count", 0) >= 1;
+      },
+      "discovery to settle with override disabled");
+  EXPECT_FALSE(node_->get_discovery_manager()->get_manifest_config().allow_manifest_override);
+
+  // Flip it back on and reload. Without reset_policies_to_defaults the layer
+  // would still carry the FALLBACK demotion from the first load.
+  rewrite_current_manifest(linking_manifest("warn", {}, "  allow_manifest_override: true\n"));
+  trigger_reload();
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  bool restored = false;
+  while (std::chrono::steady_clock::now() < deadline) {
+    node_->get_discovery_manager()->refresh_topic_map();
+    if (node_->get_discovery_manager()->get_manifest_config().allow_manifest_override) {
+      restored = true;
+      break;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_TRUE(restored) << "the reloaded allow_manifest_override must reach the pipeline's config";
+
+  // And the declared app is still served - the reload did not lose the tree.
+  EXPECT_TRUE(served_app_ids().count("bound_app"));
+}
+
+TEST_F(HealthLinkingTest, ReloadTurningInheritOffStopsCopyingRuntimeResources) {
+  spawn_nodes({kBoundNodeName});
+  start_gateway(linking_manifest("warn", {}, "  inherit_runtime_resources: true\n"));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  poll_health(
+      [](const json & h) {
+        return h["discovery"].contains("linking");
+      },
+      "discovery to settle with inheritance on");
+  EXPECT_TRUE(node_->get_discovery_manager()->get_manifest_config().inherit_runtime_resources);
+
+  rewrite_current_manifest(linking_manifest("warn", {}, "  inherit_runtime_resources: false\n"));
+  trigger_reload();
+
+  // The push that carries this into the pipeline is the `else` branch that
+  // exists only for reload; without it the pipeline keeps the boot-time value.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+  bool applied = false;
+  while (std::chrono::steady_clock::now() < deadline) {
+    node_->get_discovery_manager()->refresh_topic_map();
+    if (!node_->get_discovery_manager()->get_manifest_config().inherit_runtime_resources) {
+      applied = true;
+      break;
+    }
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_TRUE(applied) << "the reloaded inherit_runtime_resources must reach the pipeline's config";
+
+  // The app is still linked and served; only the resource copy is gated.
+  EXPECT_TRUE(served_app_ids().count("bound_app"));
+}
+
+INSTANTIATE_TEST_SUITE_P(AllPolicies, HealthLinkingPolicyTest,
+                         ::testing::Values("ignore", "warn", "error", "include_as_orphan"),
+                         [](const ::testing::TestParamInfo<std::string> & param_info) {
+                           return param_info.param;
+                         });
+
+// The warning is about orphans, not about the policy: with everything on the
+// graph declared, "error" says nothing.
+TEST_F(HealthLinkingTest, ErrorPolicyWithoutOrphansRaisesNoWarning) {
+  spawn_nodes({kBoundNodeName});
+  start_gateway(linking_manifest("error"));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  // A gateway process puts several nodes of its own on the graph (parameter
+  // client, fault clients, subscription worker, ...). Read them off the live
+  // graph instead of hard-coding a list that would rot across distros.
+  poll_health(
+      [](const json & h) {
+        return h.contains("discovery") && h["discovery"].contains("linking");
+      },
+      "the linking block to appear");
+  auto fqns = graph_fqns();
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+  std::vector<std::string> to_declare;
+  for (const auto & fqn : fqns) {
+    if (fqn != std::string("/") + kBoundNodeName) {
+      to_declare.push_back(fqn);
+    }
+  }
+  ASSERT_FALSE(to_declare.empty()) << "expected the gateway process to own at least one node";
+
+  stop_gateway();
+  start_gateway(linking_manifest("error", to_declare));
+  ASSERT_FALSE(::testing::Test::HasFatalFailure());
+
+  auto health = poll_health(
+      [](const json & h) {
+        return h.contains("discovery") && h["discovery"].contains("linking") &&
+               h["discovery"]["linking"].value("orphan_count", -1) == 0;
+      },
+      "every node on the graph to be declared");
+
+  ASSERT_TRUE(health.contains("discovery")) << health.dump();
+  ASSERT_TRUE(health["discovery"].contains("linking")) << health.dump();
+  EXPECT_EQ(health["discovery"]["linking"].value("orphan_count", -1), 0);
+  EXPECT_EQ(health["discovery"]["linking"].value("unmanifested_policy", std::string{}), "error");
+  EXPECT_EQ(find_warning(health, "unmanifested_nodes"), nullptr)
+      << "no orphans means nothing to warn about: " << health["warnings"].dump();
+  EXPECT_EQ(health.value("status", std::string{}), "healthy");
 }

--- a/src/ros2_medkit_gateway/test/test_manifest_fragments.cpp
+++ b/src/ros2_medkit_gateway/test/test_manifest_fragments.cpp
@@ -255,6 +255,33 @@ apps:
   EXPECT_TRUE(found) << "expected FRAGMENT_FORBIDDEN_FIELD error naming 'discovery'";
 }
 
+TEST_F(FragmentsFixture, FragmentConfigBlockIsRejected) {
+  // `config:` is the canonical spelling of the same block, so a fragment must
+  // not be able to smuggle discovery configuration in under it either.
+  write_fragment("bad.yaml", R"(
+config:
+  unmanifested_nodes: error
+apps:
+  - id: helloApp
+    name: Hello
+    is_located_on: ecu-primary
+    ros_binding:
+      node_name: helloApp
+)");
+  ManifestManager mgr;
+  mgr.set_fragments_dir(fragments_dir.string());
+  EXPECT_FALSE(mgr.load_manifest(base_path.string(), /*strict=*/false));
+  auto vr = mgr.get_validation_result();
+  bool found = false;
+  for (const auto & err : vr.errors) {
+    if (err.rule_id == "FRAGMENT_FORBIDDEN_FIELD" && err.message.find("config") != std::string::npos) {
+      found = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found) << "expected FRAGMENT_FORBIDDEN_FIELD error naming 'config'";
+}
+
 TEST_F(FragmentsFixture, DuplicateIdsAcrossFragmentsFailValidation) {
   write_fragment("a.yaml", R"(
 apps:

--- a/src/ros2_medkit_gateway/test/test_manifest_manager.cpp
+++ b/src/ros2_medkit_gateway/test/test_manifest_manager.cpp
@@ -639,6 +639,212 @@ TEST_F(ManifestManagerTest, GetScriptsEmptyWhenNoManifest) {
   EXPECT_TRUE(scripts.empty());
 }
 
+// =============================================================================
+// Discovery configuration: `config:` block and parse notices
+// =============================================================================
+
+namespace {
+
+/// Manifest whose discovery configuration is written under the documented
+/// top-level key.
+const std::string config_block_manifest = R"(
+manifest_version: "1.0"
+metadata:
+  name: "config-block"
+config:
+  unmanifested_nodes: "ignore"
+  inherit_runtime_resources: false
+areas:
+  - id: "area1"
+)";
+
+/// Same content under the deprecated alias.
+const std::string discovery_block_manifest = R"(
+manifest_version: "1.0"
+metadata:
+  name: "discovery-block"
+discovery:
+  unmanifested_nodes: "ignore"
+  inherit_runtime_resources: false
+areas:
+  - id: "area1"
+)";
+
+const std::string unknown_policy_manifest = R"(
+manifest_version: "1.0"
+metadata:
+  name: "unknown-policy"
+config:
+  unmanifested_nodes: "silent"
+areas:
+  - id: "area1"
+)";
+
+const std::string unknown_top_level_key_manifest = R"(
+manifest_version: "1.0"
+metadata:
+  name: "unknown-key"
+configuration:
+  unmanifested_nodes: "ignore"
+areas:
+  - id: "area1"
+)";
+
+/// Look up a warning by rule id. Takes the result by reference on purpose:
+/// `ManifestManager::get_validation_result()` returns BY VALUE, so the caller
+/// must keep the result alive for as long as it holds the returned pointer.
+const ros2_medkit_gateway::discovery::ValidationError *
+find_warning(const ros2_medkit_gateway::discovery::ValidationResult & result, const std::string & rule_id) {
+  for (const auto & warn : result.warnings) {
+    if (warn.rule_id == rule_id) {
+      return &warn;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+TEST_F(ManifestManagerTest, ConfigBlockReachesGetConfig) {
+  ManifestManager mgr(nullptr);
+  ASSERT_TRUE(mgr.load_manifest_from_string(config_block_manifest, true));
+
+  auto config = mgr.get_config();
+  EXPECT_EQ(config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+  EXPECT_FALSE(config.inherit_runtime_resources);
+}
+
+TEST_F(ManifestManagerTest, DeprecatedDiscoveryBlockReachesGetConfigAndSurvivesStrictMode) {
+  ManifestManager mgr(nullptr);
+  // Strict mode turns validator warnings into a load failure, so a deprecation
+  // routed through the validator would make this load fail.
+  ASSERT_TRUE(mgr.load_manifest_from_string(discovery_block_manifest, true));
+
+  auto config = mgr.get_config();
+  EXPECT_EQ(config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+  EXPECT_FALSE(config.inherit_runtime_resources);
+  EXPECT_FALSE(mgr.get_validation_result().has_warnings());
+}
+
+TEST_F(ManifestManagerTest, UnknownTopLevelKeySurvivesStrictMode) {
+  ManifestManager mgr(nullptr);
+  ASSERT_TRUE(mgr.load_manifest_from_string(unknown_top_level_key_manifest, true));
+  EXPECT_FALSE(mgr.get_validation_result().has_warnings());
+}
+
+// R014 is ADVISORY for this release. It reaches the LOG, never
+// ValidationResult, so the strictness dial cannot act on it. That is
+// deliberate: this branch is what makes the discovery block read at all, so a
+// manifest carrying a bad policy value loaded fine before the upgrade, and
+// turning it into a load failure afterwards would take hybrid discovery down
+// to runtime_only for a file the operator never edited. It becomes a
+// validation warning in the next release.
+
+TEST_F(ManifestManagerTest, UnknownPolicyValueIsAdvisoryAndLoadsNonStrict) {
+  ManifestManager mgr(nullptr);
+  ASSERT_TRUE(mgr.load_manifest_from_string(unknown_policy_manifest, false));
+
+  auto result = mgr.get_validation_result();
+  EXPECT_EQ(find_warning(result, "R014"), nullptr)
+      << "R014 must not be a validation warning this release: " << result.summary();
+  // The documented fallback still applies.
+  EXPECT_EQ(mgr.get_config().unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+}
+
+// The point of the whole item: strict validation is the SHIPPED DEFAULT, and it
+// must not refuse a manifest over an advisory notice.
+TEST_F(ManifestManagerTest, UnknownPolicyValueStillLoadsUnderStrictValidation) {
+  ManifestManager mgr(nullptr);
+  EXPECT_TRUE(mgr.load_manifest_from_string(unknown_policy_manifest, true))
+      << "a bad policy value must not fail the load while R014 is advisory";
+  EXPECT_TRUE(mgr.is_manifest_active());
+  EXPECT_EQ(find_warning(mgr.get_validation_result(), "R014"), nullptr);
+  EXPECT_EQ(mgr.get_config().unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+}
+
+TEST_F(ManifestManagerTest, UnknownPolicyValueFromFileStillLoads) {
+  std::string path = write_temp_file("unknown_policy.yaml", unknown_policy_manifest);
+
+  ManifestManager mgr(nullptr);
+  ASSERT_TRUE(mgr.load_manifest(path, true));
+  EXPECT_TRUE(mgr.is_manifest_active());
+  EXPECT_EQ(find_warning(mgr.get_validation_result(), "R014"), nullptr);
+}
+
+// get_config() is on the liveness path: /health calls it on every request and
+// a container probe calls /health. load_manifest() holds the manager's mutex
+// from entry through parse, fragment scan, inventory CSV and validation, so if
+// get_config() took that mutex a plugin-triggered reload would park every
+// concurrent probe - and a probe with a short timeout restarts the gateway
+// mid-reload.
+//
+// Made deterministic with a large fragments directory: the load is slow enough
+// that a lock-taking reader would visibly stall. Before the snapshot existed,
+// the slowest observed get_config() was the length of a whole load.
+TEST_F(ManifestManagerTest, GetConfigNeverBlocksBehindAManifestLoad) {
+  const std::string base = R"(
+manifest_version: "1.0"
+config:
+  unmanifested_nodes: "ignore"
+components:
+  - id: base-ecu
+    name: "Base ECU"
+)";
+  const std::string base_path = write_temp_file("lockfree_base.yaml", base);
+
+  // A fragments directory big enough that a load takes real time.
+  const auto frag_dir =
+      std::filesystem::temp_directory_path() / ("medkit-lockfree-frags-" + std::to_string(::getpid()));
+  std::filesystem::create_directories(frag_dir);
+  for (int i = 0; i < 400; ++i) {
+    std::ofstream(frag_dir / ("frag_" + std::to_string(i) + ".yaml"))
+        << "components:\n  - id: frag-" << i << "\n    name: \"Fragment " << i << "\"\n";
+  }
+
+  ManifestManager mgr(nullptr);
+  mgr.set_fragments_dir(frag_dir.string());
+  ASSERT_TRUE(mgr.load_manifest(base_path, false));
+  EXPECT_EQ(mgr.get_config().unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+
+  std::atomic<bool> stop{false};
+  std::atomic<int64_t> worst_us{0};
+  std::thread reader([&] {
+    while (!stop.load()) {
+      const auto t0 = std::chrono::steady_clock::now();
+      auto cfg = mgr.get_config();
+      const auto elapsed =
+          std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - t0).count();
+      // Only ever the configured value or the default - never a torn read.
+      EXPECT_TRUE(cfg.unmanifested_nodes == ManifestConfig::UnmanifestedNodePolicy::IGNORE ||
+                  cfg.unmanifested_nodes == ManifestConfig::UnmanifestedNodePolicy::WARN);
+      int64_t prev = worst_us.load();
+      while (elapsed > prev && !worst_us.compare_exchange_weak(prev, elapsed)) {
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(200));
+    }
+  });
+
+  // Several reloads, each re-reading all 400 fragments under the mutex.
+  const auto load_start = std::chrono::steady_clock::now();
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_TRUE(mgr.reload_manifest());
+  }
+  const auto load_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - load_start).count();
+
+  stop.store(true);
+  reader.join();
+  std::error_code ec;
+  std::filesystem::remove_all(frag_dir, ec);
+
+  // The loads must have taken long enough for this to mean something.
+  ASSERT_GT(load_ms, 20) << "the fragment load was too fast to prove anything";
+  // A reader that took the load mutex would show a stall on the order of a
+  // whole load. Allow a wide margin for scheduler noise and sanitizers.
+  EXPECT_LT(worst_us.load(), load_ms * 1000 / 4) << "get_config() stalled for " << worst_us.load() << "us while "
+                                                 << load_ms << "ms of loading ran - it is taking the manifest lock";
+}
+
 int main(int argc, char ** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/ros2_medkit_gateway/test/test_manifest_parser.cpp
+++ b/src/ros2_medkit_gateway/test/test_manifest_parser.cpp
@@ -21,14 +21,44 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
+
+#include <cstddef>
 #include <fstream>
 #include <string>
+#include <vector>
 
 #include "ros2_medkit_gateway/core/discovery/manifest/manifest_parser.hpp"
 
 using ros2_medkit_gateway::Component;
 using ros2_medkit_gateway::discovery::ManifestConfig;
 using ros2_medkit_gateway::discovery::ManifestParser;
+
+namespace {
+
+// R014 and R015 are ADVISORY this release: emitted on the log-only channel so
+// the strictness dial cannot turn a manifest that loaded before the upgrade
+// into a load failure after it. Returns the message with the rule-id prefix
+// and advisory suffix stripped, so assertions stay about the message itself.
+std::optional<std::string> find_notice(const ros2_medkit_gateway::discovery::Manifest & manifest,
+                                       const std::string & rule_id) {
+  const std::string prefix = "[" + rule_id + "] ";
+  const std::string suffix = " (advisory in this release; becomes a validation warning in the next one)";
+  for (const auto & notice : manifest.log_notices) {
+    if (notice.rfind(prefix, 0) != 0) {
+      continue;
+    }
+    std::string message = notice.substr(prefix.size());
+    if (message.size() >= suffix.size() &&
+        message.compare(message.size() - suffix.size(), suffix.size(), suffix) == 0) {
+      message.erase(message.size() - suffix.size());
+    }
+    return message;
+  }
+  return std::nullopt;
+}
+
+}  // namespace
 
 // =============================================================================
 // Valid Manifest Parsing Tests
@@ -68,10 +98,10 @@ metadata:
   EXPECT_EQ(manifest.metadata.created_at, "2025-01-15");
 }
 
-TEST_F(ManifestParserTest, ParseDiscoveryConfig) {
+TEST_F(ManifestParserTest, ParseConfigBlock) {
   const std::string yaml = R"(
 manifest_version: "1.0"
-discovery:
+config:
   unmanifested_nodes: "ignore"
   inherit_runtime_resources: false
   allow_manifest_override: true
@@ -82,18 +112,21 @@ discovery:
   EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
   EXPECT_FALSE(manifest.config.inherit_runtime_resources);
   EXPECT_TRUE(manifest.config.allow_manifest_override);
+  EXPECT_TRUE(manifest.log_notices.empty()) << "canonical key must not produce a notice";
+  EXPECT_TRUE(manifest.validation_notices.empty());
 }
 
-TEST_F(ManifestParserTest, ParseDiscoveryConfigDefaultPolicy) {
+TEST_F(ManifestParserTest, ParseConfigBlockDefaultPolicy) {
   const std::string yaml = R"(
 manifest_version: "1.0"
-discovery:
+config:
   unmanifested_nodes: "warn"
 )";
 
   auto manifest = parser_.parse_string(yaml);
 
   EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  EXPECT_TRUE(manifest.validation_notices.empty());
 }
 
 TEST_F(ManifestParserTest, ParseAreas) {
@@ -359,7 +392,7 @@ manifest_version: "1.0"
 metadata:
   name: "Robot System"
   version: "1.0.0"
-discovery:
+config:
   unmanifested_nodes: "include_as_orphan"
 areas:
   - id: "navigation"
@@ -384,6 +417,283 @@ functions:
   EXPECT_EQ(manifest.components.size(), 2);
   EXPECT_EQ(manifest.apps.size(), 1);
   EXPECT_EQ(manifest.functions.size(), 1);
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::INCLUDE_AS_ORPHAN);
+}
+
+// =============================================================================
+// Top-level `config:` key, deprecated `discovery:` alias, parse notices
+// =============================================================================
+
+namespace {
+
+constexpr const char * kDeprecatedDiscoveryNotice =
+    "Manifest uses the deprecated top-level 'discovery:' key for discovery configuration; rename it to 'config:'. "
+    "The alias still works and will be removed in a future release.";
+
+constexpr const char * kBothKeysNotice =
+    "Manifest declares both 'config:' and the deprecated 'discovery:' top-level keys; 'config:' is used and "
+    "'discovery:' is ignored.";
+
+std::string unknown_key_notice(const std::string & key) {
+  return "Manifest has unknown top-level key '" + key +
+         "' - it is ignored. Known keys: manifest_version, metadata, config, discovery, areas, components, assets, "
+         "apps, functions, scripts, capabilities.";
+}
+
+/// Count how many notices contain `needle`. Substring rather than equality so
+/// a caller can look for one key inside a set of notices.
+size_t count_containing(const std::vector<std::string> & notices, const std::string & needle) {
+  size_t n = 0;
+  for (const auto & notice : notices) {
+    if (notice.find(needle) != std::string::npos) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+}  // namespace
+
+TEST_F(ManifestParserTest, DeprecatedDiscoveryKeyStillAppliesItsValuesAndIsNoticed) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+discovery:
+  unmanifested_nodes: "ignore"
+  inherit_runtime_resources: false
+  allow_manifest_override: false
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+  EXPECT_FALSE(manifest.config.inherit_runtime_resources);
+  EXPECT_FALSE(manifest.config.allow_manifest_override);
+  ASSERT_EQ(manifest.log_notices.size(), 1u);
+  EXPECT_EQ(manifest.log_notices[0], kDeprecatedDiscoveryNotice);
+  // A deprecation must never reach the validator: strict validation is on by
+  // default and would turn it into a load failure.
+  EXPECT_TRUE(manifest.validation_notices.empty());
+}
+
+TEST_F(ManifestParserTest, ConfigKeyWinsWhenBothBlocksArePresent) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+config:
+  unmanifested_nodes: "ignore"
+  inherit_runtime_resources: true
+discovery:
+  unmanifested_nodes: "error"
+  inherit_runtime_resources: false
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+  EXPECT_TRUE(manifest.config.inherit_runtime_resources);
+  ASSERT_EQ(manifest.log_notices.size(), 1u);
+  EXPECT_EQ(manifest.log_notices[0], kBothKeysNotice);
+}
+
+TEST_F(ManifestParserTest, DeprecatedDiscoveryKeyAlsoReportsAnUnknownPolicyValue) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+discovery:
+  unmanifested_nodes: "quiet"
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  // Advisory this release, so it lands on the log-only channel. The alias adds
+  // its own deprecation notice there too, hence "at least one".
+  EXPECT_TRUE(manifest.validation_notices.empty());
+  EXPECT_TRUE(find_notice(manifest, "R014").has_value())
+      << "the alias must report a bad policy value just as `config:` does";
+}
+
+TEST_F(ManifestParserTest, UnknownTopLevelKeyIsNoticedAndTheManifestStillLoads) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+configuration:
+  unmanifested_nodes: "ignore"
+apps:
+  - id: "nav2"
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_TRUE(manifest.is_loaded());
+  EXPECT_EQ(manifest.apps.size(), 1u);
+  // The typo'd block is ignored, so the defaults stand.
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  ASSERT_EQ(manifest.log_notices.size(), 1u);
+  EXPECT_EQ(manifest.log_notices[0], unknown_key_notice("configuration"));
+}
+
+TEST_F(ManifestParserTest, EveryUnknownTopLevelKeyGetsItsOwnNotice) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+configuration: {}
+app:
+  - id: "nav2"
+area: []
+lock_overrides: {}
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.log_notices.size(), 4u) << "expected one notice per unknown key, got: " << [&] {
+    std::string joined;
+    for (const auto & notice : manifest.log_notices) {
+      joined += "\n  " + notice;
+    }
+    return joined;
+  }();
+  EXPECT_EQ(count_containing(manifest.log_notices, "'configuration'"), 1u);
+  EXPECT_EQ(count_containing(manifest.log_notices, "'app'"), 1u);
+  EXPECT_EQ(count_containing(manifest.log_notices, "'area'"), 1u);
+  EXPECT_EQ(count_containing(manifest.log_notices, "'lock_overrides'"), 1u);
+}
+
+TEST_F(ManifestParserTest, EveryKnownTopLevelKeyIsAccepted) {
+  // Every section parse_string reads, in one document. If a section is ever
+  // added to the parser without being added to the known-key set, this test
+  // starts reporting it as unknown.
+  const std::string yaml = R"(
+manifest_version: "1.0"
+metadata:
+  name: "Everything"
+config:
+  unmanifested_nodes: "warn"
+discovery:
+  unmanifested_nodes: "warn"
+areas:
+  - id: "navigation"
+components:
+  - id: "nav_server"
+    area: "navigation"
+assets:
+  - id: "cabinet-1"
+apps:
+  - id: "nav2"
+    is_located_on: "nav_server"
+functions:
+  - id: "path_planning"
+scripts:
+  - id: "diag"
+    path: "/opt/diag.sh"
+    format: "bash"
+capabilities:
+  nav2:
+    data: true
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  // Only the both-keys collision notice; nothing reported as unknown.
+  EXPECT_EQ(count_containing(manifest.log_notices, "unknown top-level key"), 0u);
+}
+
+TEST_F(ManifestParserTest, AllUnmanifestedNodePoliciesParseFromConfigBlock) {
+  const struct {
+    const char * text;
+    ManifestConfig::UnmanifestedNodePolicy expected;
+  } cases[] = {
+      {"ignore", ManifestConfig::UnmanifestedNodePolicy::IGNORE},
+      {"warn", ManifestConfig::UnmanifestedNodePolicy::WARN},
+      {"error", ManifestConfig::UnmanifestedNodePolicy::ERROR},
+      {"include_as_orphan", ManifestConfig::UnmanifestedNodePolicy::INCLUDE_AS_ORPHAN},
+  };
+
+  for (const auto & tc : cases) {
+    const std::string yaml =
+        std::string("manifest_version: \"1.0\"\nconfig:\n  unmanifested_nodes: \"") + tc.text + "\"\n";
+    auto manifest = parser_.parse_string(yaml);
+    EXPECT_EQ(manifest.config.unmanifested_nodes, tc.expected) << "value: " << tc.text;
+    EXPECT_TRUE(manifest.validation_notices.empty()) << "value: " << tc.text;
+    EXPECT_TRUE(manifest.log_notices.empty()) << "value: " << tc.text;
+  }
+}
+
+TEST_F(ManifestParserTest, UnknownPolicyValueProducesAnR014Notice) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+config:
+  unmanifested_nodes: "IGNORE"
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  // Falls back to the default policy...
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  // ...and says so. ADVISORY for this release: it must NOT reach
+  // validation_notices, because the strictness dial defaults to true and would
+  // refuse a manifest that loaded fine before this branch made the block read.
+  EXPECT_TRUE(manifest.validation_notices.empty()) << "R014 must not be able to fail the load in this release";
+  const auto notice = find_notice(manifest, "R014");
+  ASSERT_TRUE(notice.has_value());
+  // The value list says "lower-case" because that is the trap this very case
+  // is: 'IGNORE' is a real policy word in the wrong case.
+  EXPECT_EQ(*notice,
+            "Unknown unmanifested_nodes value 'IGNORE'; falling back to 'warn'. "
+            "Valid values: ignore, warn, error, include_as_orphan (lower-case).");
+}
+
+TEST_F(ManifestParserTest, AbsentConfigBlockUsesDefaults) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+apps:
+  - id: "nav2"
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  EXPECT_TRUE(manifest.config.inherit_runtime_resources);
+  EXPECT_TRUE(manifest.config.allow_manifest_override);
+  EXPECT_TRUE(manifest.log_notices.empty());
+  EXPECT_TRUE(manifest.validation_notices.empty());
+}
+
+TEST_F(ManifestParserTest, EmptyConfigBlockUsesDefaults) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+config: {}
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  EXPECT_TRUE(manifest.config.inherit_runtime_resources);
+  EXPECT_TRUE(manifest.config.allow_manifest_override);
+  EXPECT_TRUE(manifest.validation_notices.empty());
+}
+
+TEST_F(ManifestParserTest, EmptyPolicyStringUsesTheDefaultWithoutANotice) {
+  const std::string yaml = R"(
+manifest_version: "1.0"
+config:
+  unmanifested_nodes: ""
+)";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+  EXPECT_TRUE(manifest.validation_notices.empty()) << "an omitted value is not a wrong value";
+}
+
+TEST_F(ManifestParserTest, BothBooleanFlagsSweepBothValues) {
+  for (bool inherit : {false, true}) {
+    for (bool allow_override : {false, true}) {
+      const std::string yaml = std::string("manifest_version: \"1.0\"\nconfig:\n  inherit_runtime_resources: ") +
+                               (inherit ? "true" : "false") +
+                               "\n  allow_manifest_override: " + (allow_override ? "true" : "false") + "\n";
+      auto manifest = parser_.parse_string(yaml);
+      EXPECT_EQ(manifest.config.inherit_runtime_resources, inherit)
+          << "inherit=" << inherit << " allow_override=" << allow_override;
+      EXPECT_EQ(manifest.config.allow_manifest_override, allow_override)
+          << "inherit=" << inherit << " allow_override=" << allow_override;
+    }
+  }
 }
 
 // =============================================================================
@@ -640,6 +950,290 @@ TEST(ManifestConfigTest, PolicyToString) {
   EXPECT_EQ(ManifestConfig::policy_to_string(ManifestConfig::UnmanifestedNodePolicy::ERROR), "error");
   EXPECT_EQ(ManifestConfig::policy_to_string(ManifestConfig::UnmanifestedNodePolicy::INCLUDE_AS_ORPHAN),
             "include_as_orphan");
+}
+
+// =============================================================================
+// Malformed discovery-configuration block
+//
+// The block is addressed by key and then indexed by field. A key that is
+// present but not a map cannot be indexed: yaml-cpp throws on a scalar, and
+// silently yields nothing on a sequence. Neither may reach the field parser.
+// Both spellings of the key are guarded, because both are read.
+// =============================================================================
+
+namespace {
+
+// A manifest whose only variable is the value of the discovery-config block.
+std::string manifest_with_config_block(const std::string & key, const std::string & value) {
+  return "manifest_version: \"1.0\"\n" + key + ":" + value +
+         "\ncomponents:\n"
+         "  - id: mc-ecu\n"
+         "    name: \"Malformed Config ECU\"\n";
+}
+
+}  // namespace
+
+// A key with no value is "absent", not "malformed". This must keep working:
+// it loads on the merge base and it loads here.
+TEST_F(ManifestParserTest, NullConfigBlockIsTreatedAsAbsent) {
+  for (const std::string & key : {std::string("config"), std::string("discovery")}) {
+    auto manifest = parser_.parse_string(manifest_with_config_block(key, ""));
+
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN) << key;
+    EXPECT_TRUE(manifest.config.inherit_runtime_resources) << key;
+    EXPECT_TRUE(manifest.config.allow_manifest_override) << key;
+    EXPECT_FALSE(find_notice(manifest, "R015").has_value()) << key << ": a null block is absent, not malformed";
+    ASSERT_EQ(manifest.components.size(), 1u) << key;
+  }
+}
+
+TEST_F(ManifestParserTest, EmptyMapConfigBlockIsTreatedAsAbsent) {
+  for (const std::string & key : {std::string("config"), std::string("discovery")}) {
+    auto manifest = parser_.parse_string(manifest_with_config_block(key, " {}"));
+
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN) << key;
+    EXPECT_FALSE(find_notice(manifest, "R015").has_value()) << key;
+    ASSERT_EQ(manifest.components.size(), 1u) << key;
+  }
+}
+
+// The regression: a scalar value made parse_config throw out of the whole
+// load, so the manifest was lost entirely rather than the block reported.
+TEST_F(ManifestParserTest, ScalarConfigBlockIsReportedAndDoesNotAbortTheLoad) {
+  for (const std::string & key : {std::string("config"), std::string("discovery")}) {
+    ros2_medkit_gateway::discovery::Manifest manifest;
+    ASSERT_NO_THROW(manifest = parser_.parse_string(manifest_with_config_block(key, " \"\"")))
+        << key << ": a malformed block must not throw the manifest away";
+
+    const auto notice = find_notice(manifest, "R015");
+    ASSERT_TRUE(notice.has_value()) << key << ": a malformed block must be reported, not ignored";
+    EXPECT_EQ(*notice, "Manifest key '" + key +
+                           "' must be a mapping of discovery settings, but is a scalar; "
+                           "the block is ignored and the defaults apply.");
+
+    // The rest of the manifest still loads, and the settings fall back.
+    ASSERT_EQ(manifest.components.size(), 1u) << key;
+    EXPECT_EQ(manifest.components[0].id, "mc-ecu") << key;
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN) << key;
+  }
+}
+
+// A sequence never threw - it was indexed, yielded nothing and was silently
+// dropped. Silent-drop of a configuration block is the bug class this branch
+// exists to close, so it is reported too.
+TEST_F(ManifestParserTest, SequenceConfigBlockIsReportedRatherThanSilentlyIgnored) {
+  for (const std::string & key : {std::string("config"), std::string("discovery")}) {
+    ros2_medkit_gateway::discovery::Manifest manifest;
+    ASSERT_NO_THROW(manifest =
+                        parser_.parse_string(manifest_with_config_block(key, "\n  - unmanifested_nodes: ignore")));
+
+    const auto notice = find_notice(manifest, "R015");
+    ASSERT_TRUE(notice.has_value()) << key << ": a sequence must not be dropped without a word";
+    EXPECT_EQ(*notice, "Manifest key '" + key +
+                           "' must be a mapping of discovery settings, but is a sequence; "
+                           "the block is ignored and the defaults apply.");
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN) << key;
+  }
+}
+
+// A malformed canonical key must not silently promote the deprecated alias:
+// `config:` present means `config:` is the block, well-formed or not.
+TEST_F(ManifestParserTest, MalformedConfigDoesNotFallThroughToTheAlias) {
+  const std::string yaml =
+      "manifest_version: \"1.0\"\n"
+      "config: \"\"\n"
+      "discovery:\n"
+      "  unmanifested_nodes: ignore\n";
+
+  auto manifest = parser_.parse_string(yaml);
+
+  ASSERT_TRUE(find_notice(manifest, "R015").has_value());
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN)
+      << "the alias must not quietly supply the configuration the canonical key failed to";
+}
+
+// =============================================================================
+// Malformed VALUES inside the discovery-configuration block
+//
+// The block guard above only proves the block is a mapping. Each setting
+// inside it is read by kind too: `.as<bool>()` throws on anything it cannot
+// convert, and a key left empty renders as the literal string "null" if it is
+// read as text. Either would cost the whole manifest, or accuse the operator
+// of a typo they did not make.
+// =============================================================================
+
+namespace {
+
+std::string manifest_with_setting(const std::string & key, const std::string & value) {
+  return "manifest_version: \"1.0\"\nconfig:\n  " + key + ":" + value +
+         "\ncomponents:\n"
+         "  - id: mc-ecu\n"
+         "    name: \"Malformed Config ECU\"\n";
+}
+
+}  // namespace
+
+// A key with no value is "not set". This is the case the block-level comment
+// promised and the one all three settings used to get wrong.
+TEST_F(ManifestParserTest, NullSettingValuesAreTreatedAsNotSet) {
+  for (const std::string & key : {std::string("unmanifested_nodes"), std::string("inherit_runtime_resources"),
+                                  std::string("allow_manifest_override")}) {
+    ros2_medkit_gateway::discovery::Manifest manifest;
+    ASSERT_NO_THROW(manifest = parser_.parse_string(manifest_with_setting(key, "")))
+        << key << ": an empty value must not throw the manifest away";
+
+    EXPECT_TRUE(manifest.validation_notices.empty())
+        << key << ": an empty value is 'not set', not a wrong value; got "
+        << (manifest.validation_notices.empty() ? std::string{} : manifest.validation_notices[0].message);
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN) << key;
+    EXPECT_TRUE(manifest.config.inherit_runtime_resources) << key;
+    EXPECT_TRUE(manifest.config.allow_manifest_override) << key;
+    ASSERT_EQ(manifest.components.size(), 1u) << key;
+  }
+}
+
+TEST_F(ManifestParserTest, WellFormedSettingValuesStillParse) {
+  auto manifest = parser_.parse_string(
+      "manifest_version: \"1.0\"\n"
+      "config:\n"
+      "  unmanifested_nodes: ignore\n"
+      "  inherit_runtime_resources: false\n"
+      "  allow_manifest_override: false\n");
+
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::IGNORE);
+  EXPECT_FALSE(manifest.config.inherit_runtime_resources);
+  EXPECT_FALSE(manifest.config.allow_manifest_override);
+  EXPECT_TRUE(manifest.validation_notices.empty());
+}
+
+TEST_F(ManifestParserTest, NonBooleanSettingValuesAreReportedAndDefaulted) {
+  struct Case {
+    std::string value;
+    std::string expected_kind;
+  };
+  const std::vector<Case> cases = {
+      {" \"yes-please\"", "'yes-please'"},
+      {"\n    - true", "a sequence"},
+      {"\n    enabled: true", "a mapping"},
+  };
+
+  for (const std::string & key : {std::string("inherit_runtime_resources"), std::string("allow_manifest_override")}) {
+    for (const auto & tc : cases) {
+      ros2_medkit_gateway::discovery::Manifest manifest;
+      ASSERT_NO_THROW(manifest = parser_.parse_string(manifest_with_setting(key, tc.value)))
+          << key << " / " << tc.value;
+
+      const auto notice = find_notice(manifest, "R015");
+      ASSERT_TRUE(notice.has_value()) << key << " / " << tc.value << ": must be reported, not thrown or ignored";
+      EXPECT_EQ(*notice, "Manifest setting '" + key + "' must be a boolean, but is " + tc.expected_kind +
+                             "; the default (true) applies.");
+
+      // The default stands and the rest of the manifest survives.
+      EXPECT_TRUE(manifest.config.inherit_runtime_resources) << key;
+      EXPECT_TRUE(manifest.config.allow_manifest_override) << key;
+      ASSERT_EQ(manifest.components.size(), 1u) << key;
+    }
+  }
+}
+
+TEST_F(ManifestParserTest, NonScalarPolicyValueIsReportedAndDefaulted) {
+  for (const std::string & value : {std::string("\n    - ignore"), std::string("\n    mode: ignore")}) {
+    ros2_medkit_gateway::discovery::Manifest manifest;
+    ASSERT_NO_THROW(manifest = parser_.parse_string(manifest_with_setting("unmanifested_nodes", value)));
+
+    const auto notice = find_notice(manifest, "R015");
+    ASSERT_TRUE(notice.has_value()) << value;
+    EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+    // A wrong KIND is R015, not R014: R014 is for a scalar that is not one of
+    // the known policy words.
+    EXPECT_FALSE(find_notice(manifest, "R014").has_value()) << value;
+  }
+}
+
+// The policy words are lower-case. Documented, and pinned here because under
+// the shipped strict default this rejects the whole manifest.
+TEST_F(ManifestParserTest, PolicyValueIsCaseSensitive) {
+  auto manifest = parser_.parse_string(manifest_with_setting("unmanifested_nodes", " Warn"));
+
+  const auto notice = find_notice(manifest, "R014");
+  ASSERT_TRUE(notice.has_value()) << "'Warn' is not 'warn'";
+  EXPECT_EQ(manifest.config.unmanifested_nodes, ManifestConfig::UnmanifestedNodePolicy::WARN);
+}
+
+// =============================================================================
+// Precedence between `config:` and the deprecated `discovery:` alias
+//
+// Both keys are read, so "which one is present" has to mean the same thing to
+// the precedence test as it does to the block parser. It did not: a bare
+// `config:` with no value counted as present, won, then parsed to nothing -
+// so a populated `discovery:` under it was skipped in silence while the log
+// said "'config:' is used", which reads as confirmation it applied.
+// =============================================================================
+
+namespace {
+
+std::string manifest_with_blocks(const std::string & config_block, const std::string & alias_block) {
+  return "manifest_version: \"1.0\"\n" + config_block + alias_block +
+         "components:\n"
+         "  - id: prec-ecu\n"
+         "    name: \"Precedence ECU\"\n";
+}
+
+// The four shapes the canonical key can take.
+const std::string kConfigAbsent;
+const std::string kConfigNull = "config:\n";
+const std::string kConfigEmptyMap = "config: {}\n";
+const std::string kConfigPopulated = "config:\n  unmanifested_nodes: ignore\n";
+
+const std::string kAliasAbsent;
+const std::string kAliasPopulated = "discovery:\n  unmanifested_nodes: error\n";
+
+bool has_collision_notice(const ros2_medkit_gateway::discovery::Manifest & manifest) {
+  for (const auto & notice : manifest.log_notices) {
+    if (notice.find("declares both") != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST_F(ManifestParserTest, ConfigAliasPrecedenceSweepsAllCombinations) {
+  using Policy = ManifestConfig::UnmanifestedNodePolicy;
+  struct Case {
+    std::string name;
+    std::string config_block;
+    std::string alias_block;
+    Policy expected;
+    bool expect_collision_notice;
+  };
+
+  const std::vector<Case> cases = {
+      // No canonical key: the alias applies, or nothing does.
+      {"absent/absent", kConfigAbsent, kAliasAbsent, Policy::WARN, false},
+      {"absent/alias", kConfigAbsent, kAliasPopulated, Policy::ERROR, false},
+      // A null canonical key is NOT a configuration. It must not shadow the
+      // alias, and it must not claim a collision.
+      {"null/absent", kConfigNull, kAliasAbsent, Policy::WARN, false},
+      {"null/alias", kConfigNull, kAliasPopulated, Policy::ERROR, false},
+      // An empty MAP is a real (if empty) configuration block: it wins, and
+      // the defaults apply.
+      {"emptymap/absent", kConfigEmptyMap, kAliasAbsent, Policy::WARN, false},
+      {"emptymap/alias", kConfigEmptyMap, kAliasPopulated, Policy::WARN, true},
+      // A populated canonical key wins outright.
+      {"populated/absent", kConfigPopulated, kAliasAbsent, Policy::IGNORE, false},
+      {"populated/alias", kConfigPopulated, kAliasPopulated, Policy::IGNORE, true},
+  };
+
+  for (const auto & tc : cases) {
+    auto manifest = parser_.parse_string(manifest_with_blocks(tc.config_block, tc.alias_block));
+
+    EXPECT_EQ(manifest.config.unmanifested_nodes, tc.expected) << tc.name;
+    EXPECT_EQ(has_collision_notice(manifest), tc.expect_collision_notice)
+        << tc.name << ": the collision notice must fire only when `config:` really carries a block";
+    ASSERT_EQ(manifest.components.size(), 1u) << tc.name;
+  }
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_manifest_validator.cpp
+++ b/src/ros2_medkit_gateway/test/test_manifest_validator.cpp
@@ -645,7 +645,7 @@ manifest_version: "1.0"
 metadata:
   name: "Robot System"
   version: "1.0.0"
-discovery:
+config:
   unmanifested_nodes: "warn"
 areas:
   - id: "navigation"

--- a/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
+++ b/src/ros2_medkit_gateway/test/test_merge_pipeline.cpp
@@ -30,12 +30,19 @@ using namespace ros2_medkit_gateway;
 // Concrete test layer for unit testing
 class TestLayer : public DiscoveryLayer {
  public:
-  TestLayer(std::string name, LayerOutput output, std::unordered_map<FieldGroup, MergePolicy> policies = {})
-    : name_(std::move(name)), output_(std::move(output)), policies_(std::move(policies)) {
+  TestLayer(std::string name, LayerOutput output, std::unordered_map<FieldGroup, MergePolicy> policies = {},
+            bool owns_protected = false)
+    : name_(std::move(name))
+    , output_(std::move(output))
+    , policies_(std::move(policies))
+    , owns_protected_(owns_protected) {
   }
 
   std::string name() const override {
     return name_;
+  }
+  bool owns_protected_entities() const override {
+    return owns_protected_;
   }
   bool provides_runtime_apps() const override {
     return name_ == "runtime";
@@ -59,6 +66,7 @@ class TestLayer : public DiscoveryLayer {
   std::string name_;
   LayerOutput output_;
   std::unordered_map<FieldGroup, MergePolicy> policies_;
+  bool owns_protected_{false};
 };
 
 // @verifies REQ_INTEROP_003
@@ -2296,4 +2304,532 @@ TEST_F(MergePipelineTest, IgnorePolicyFiltersHeuristicAppsWithoutBoundFqn) {
   ASSERT_EQ(result.apps.size(), 1u);
   EXPECT_EQ(result.apps[0].id, "nav_app");
   EXPECT_EQ(result.apps[0].source, "manifest");
+}
+
+// =============================================================================
+// Provenance (`source`) is not policy-driven content
+//
+// `is_protected_source(source)` decides whether the orphan/dedup filters may
+// delete an entity, so no field-group policy may reassign it. These cases pin
+// that at all four merge sites (Area, Component, App, Function) by demoting the
+// manifest layer's METADATA policy below the runtime layer's - which is what
+// `discovery.merge_pipeline.layers.manifest.metadata: fallback` and the
+// manifest's `allow_manifest_override: false` both do.
+// =============================================================================
+
+namespace {
+
+// The shipped manifest-layer policies (manifest_layer.cpp).
+std::unordered_map<FieldGroup, MergePolicy> manifest_policies(MergePolicy metadata) {
+  return {{FieldGroup::IDENTITY, MergePolicy::AUTHORITATIVE},
+          {FieldGroup::HIERARCHY, MergePolicy::AUTHORITATIVE},
+          {FieldGroup::LIVE_DATA, MergePolicy::ENRICHMENT},
+          {FieldGroup::STATUS, MergePolicy::FALLBACK},
+          {FieldGroup::METADATA, metadata}};
+}
+
+// The shipped runtime-layer policies (runtime_layer.cpp).
+std::unordered_map<FieldGroup, MergePolicy> runtime_policies() {
+  return {{FieldGroup::IDENTITY, MergePolicy::FALLBACK},
+          {FieldGroup::HIERARCHY, MergePolicy::FALLBACK},
+          {FieldGroup::LIVE_DATA, MergePolicy::AUTHORITATIVE},
+          {FieldGroup::STATUS, MergePolicy::AUTHORITATIVE},
+          {FieldGroup::METADATA, MergePolicy::ENRICHMENT}};
+}
+
+}  // namespace
+
+// --- Site 1: Area ---
+
+TEST_F(MergePipelineTest, AreaProvenanceSurvivesManifestMetadataDemotion) {
+  Area manifest_area = make_area("powertrain");
+  manifest_area.source = "manifest";
+
+  Area runtime_area = make_area("powertrain");
+  runtime_area.source = "heuristic";
+
+  LayerOutput manifest_out;
+  manifest_out.areas.push_back(manifest_area);
+  LayerOutput runtime_out;
+  runtime_out.areas.push_back(runtime_area);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.areas.size(), 1u);
+  EXPECT_EQ(result.areas[0].source, "manifest") << "a METADATA policy must not be able to rewrite an Area's provenance";
+}
+
+// --- Site 2: Component ---
+
+TEST_F(MergePipelineTest, ComponentProvenanceSurvivesManifestMetadataDemotion) {
+  Component manifest_comp = make_component("engine", "powertrain", "/powertrain");
+  manifest_comp.source = "manifest";
+
+  Component runtime_comp = make_component("engine", "powertrain", "/powertrain");
+  runtime_comp.source = "synthetic";
+
+  LayerOutput manifest_out;
+  manifest_out.components.push_back(manifest_comp);
+  LayerOutput runtime_out;
+  runtime_out.components.push_back(runtime_comp);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.components.size(), 1u);
+  EXPECT_EQ(result.components[0].source, "manifest")
+      << "a METADATA policy must not be able to rewrite a Component's provenance";
+}
+
+// --- Site 3: App ---
+
+TEST_F(MergePipelineTest, AppProvenanceSurvivesManifestMetadataDemotion) {
+  App manifest_app = make_app("temp_sensor", "engine");
+  manifest_app.source = "manifest";
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+  runtime_app.is_online = true;
+  runtime_app.bound_fqn = "/powertrain/engine/temp_sensor";
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.apps.size(), 1u);
+  EXPECT_EQ(result.apps[0].source, "manifest") << "a METADATA policy must not be able to rewrite an App's provenance";
+}
+
+// --- Site 4: Function ---
+
+TEST_F(MergePipelineTest, FunctionProvenanceSurvivesManifestMetadataDemotion) {
+  Function manifest_fn = make_function("braking");
+  manifest_fn.source = "manifest";
+
+  Function runtime_fn = make_function("braking");
+  runtime_fn.source = "heuristic";
+
+  LayerOutput manifest_out;
+  manifest_out.functions.push_back(manifest_fn);
+  LayerOutput runtime_out;
+  runtime_out.functions.push_back(runtime_fn);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.functions.size(), 1u);
+  EXPECT_EQ(result.functions[0].source, "manifest")
+      << "a METADATA policy must not be able to rewrite a Function's provenance";
+}
+
+// --- The consequence the provenance rewrite had: the entity was deleted ---
+
+namespace {
+
+// Builds the exact shape that reproduces the defect on a live gateway: a
+// manifest app whose `id` equals the name of the node it binds to, so both
+// layers contribute an entity under the same id and the merge runs.
+void seed_self_named_manifest_app(MergePipeline & pipeline, MergePolicy manifest_metadata) {
+  App manifest_app = make_app("temp_sensor", "engine");
+  manifest_app.source = "manifest";
+  App::RosBinding binding;
+  binding.node_name = "temp_sensor";
+  binding.namespace_pattern = "/powertrain/engine";
+  binding.topic_namespace = "";
+  manifest_app.ros_binding = binding;
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+  runtime_app.is_online = true;
+  runtime_app.bound_fqn = "/powertrain/engine/temp_sensor";
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(manifest_metadata)));
+  pipeline.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+  pipeline.set_linker(std::make_unique<RuntimeLinker>(nullptr), ManifestConfig{});
+}
+
+}  // namespace
+
+TEST_F(MergePipelineTest, SelfNamedManifestAppSurvivesTheOrphanFilterUnderMetadataDemotion) {
+  seed_self_named_manifest_app(pipeline_, MergePolicy::FALLBACK);
+
+  auto result = pipeline_.execute();
+
+  ASSERT_EQ(result.apps.size(), 1u) << "the linked manifest app must not be deduplicated against itself; "
+                                       "losing its 'manifest' provenance is what let the filter delete it";
+  EXPECT_EQ(result.apps[0].id, "temp_sensor");
+  EXPECT_EQ(result.apps[0].source, "manifest");
+  EXPECT_TRUE(result.apps[0].is_online);
+  ASSERT_TRUE(result.apps[0].bound_fqn.has_value());
+  EXPECT_EQ(*result.apps[0].bound_fqn, "/powertrain/engine/temp_sensor");
+}
+
+// There are TWO filters keyed on is_protected_source, and they run in
+// different translation units: RuntimeLinker::link drops unprotected apps whose
+// bound_fqn is already linked, and only afterwards does MergePipeline run its
+// own id-based dedup. The case above cannot say which of the two deleted the
+// app. This one isolates the linker leg.
+//
+// The runtime app reports is_online=false, and STATUS resolves to the runtime
+// layer, so the merge alone can only produce is_online=false. The single place
+// that can turn it true is RuntimeLinker::link, and that assignment happens
+// BEFORE the linker's own suppression pass. So a final is_online==true proves
+// the app was linked AND survived the linker's filter - not just the pipeline's.
+TEST_F(MergePipelineTest, SelfNamedManifestAppSurvivesTheLinkersOwnFilterUnderMetadataDemotion) {
+  App manifest_app = make_app("temp_sensor", "engine");
+  manifest_app.source = "manifest";
+  manifest_app.is_online = false;
+  App::RosBinding binding;
+  binding.node_name = "temp_sensor";
+  binding.namespace_pattern = "/powertrain/engine";
+  binding.topic_namespace = "";
+  manifest_app.ros_binding = binding;
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+  runtime_app.is_online = false;  // the merge cannot make this true
+  runtime_app.bound_fqn = "/powertrain/engine/temp_sensor";
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+  pipeline_.set_linker(std::make_unique<RuntimeLinker>(nullptr), ManifestConfig{});
+
+  auto result = pipeline_.execute();
+
+  // Direct measurement of the linker leg: LinkingResult is snapshotted at the
+  // END of RuntimeLinker::link, after its own suppression pass, so this counts
+  // what survived THAT filter specifically - before MergePipeline's dedup has
+  // had any chance to run.
+  ASSERT_EQ(result.linking_result.linked_apps.size(), 1u)
+      << "the app was removed inside RuntimeLinker::link, not by the pipeline";
+  EXPECT_EQ(result.linking_result.linked_apps[0].source, "manifest");
+  EXPECT_EQ(result.linking_result.app_to_node.count("temp_sensor"), 1u);
+
+  // ... and it also survives the pipeline's own id-based dedup afterwards.
+  ASSERT_EQ(result.apps.size(), 1u);
+  EXPECT_EQ(result.apps[0].source, "manifest");
+  EXPECT_TRUE(result.apps[0].is_online) << "only RuntimeLinker::link sets is_online here, so a false value means "
+                                           "the app never came back out of the linker's suppression pass";
+}
+
+// Control: the identical fixture under the shipped default METADATA policy.
+// Pins that the difference above is the policy and not the fixture, and that
+// this slice changed nothing in the default configuration.
+TEST_F(MergePipelineTest, SelfNamedManifestAppSurvivesUnderDefaultMetadataPolicy) {
+  seed_self_named_manifest_app(pipeline_, MergePolicy::AUTHORITATIVE);
+
+  auto result = pipeline_.execute();
+
+  ASSERT_EQ(result.apps.size(), 1u);
+  EXPECT_EQ(result.apps[0].id, "temp_sensor");
+  EXPECT_EQ(result.apps[0].source, "manifest");
+}
+
+// --- Protection follows the OWNING LAYER, not the `source` string ---
+//
+// A plugin provider chooses its own `source` tag. The whitelist could never
+// know them all: a provider that stamped "beacon" (or anything else unlisted)
+// had its entities swept by unmanifested_nodes=ignore. The owning layer is
+// what the pipeline knows for certain, so that is what protection reads.
+
+TEST_F(MergePipelineTest, PluginOwnedEntityWithUnlistedSourceSurvivesIgnorePolicy) {
+  App manifest_app = make_app("nav_app", "compute_unit");
+  manifest_app.source = "manifest";
+  App::RosBinding binding;
+  binding.node_name = "nav_controller";
+  binding.namespace_pattern = "/navigation";
+  binding.topic_namespace = "";
+  manifest_app.ros_binding = binding;
+
+  App runtime_orphan;
+  runtime_orphan.id = "_param_client_node";
+  runtime_orphan.name = "_param_client_node";
+  runtime_orphan.source = "heuristic";
+  runtime_orphan.is_online = true;
+  runtime_orphan.bound_fqn = "/_param_client_node";
+
+  // The entity under test: contributed by a plugin layer, carrying a tag the
+  // source whitelist does not list.
+  App plugin_app = make_app("beacon_temp", "compute_unit");
+  plugin_app.source = "beacon";
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_orphan);
+  LayerOutput plugin_out;
+  plugin_out.apps.push_back(plugin_app);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "manifest", manifest_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::IDENTITY, MergePolicy::AUTHORITATIVE}}));
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "runtime", runtime_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::STATUS, MergePolicy::AUTHORITATIVE}}));
+  pipeline_.add_layer(std::make_unique<TestLayer>("some_plugin", plugin_out,
+                                                  std::unordered_map<FieldGroup, MergePolicy>{},
+                                                  /*owns_protected=*/true));
+
+  ManifestConfig config;
+  config.unmanifested_nodes = ManifestConfig::UnmanifestedNodePolicy::IGNORE;
+  pipeline_.set_linker(std::make_unique<RuntimeLinker>(nullptr), config);
+
+  auto result = pipeline_.execute();
+
+  std::set<std::string> ids;
+  for (const auto & a : result.apps) {
+    ids.insert(a.id);
+  }
+  EXPECT_TRUE(ids.count("beacon_temp"))
+      << "a plugin-owned app must survive `ignore` whatever source tag it carries; got: " << result.apps.size()
+      << " apps";
+  EXPECT_TRUE(ids.count("nav_app")) << "the manifest app must still survive";
+  EXPECT_FALSE(ids.count("_param_client_node")) << "a genuine runtime orphan must still be swept";
+
+  // Protection did NOT come from the string - the tag is untouched, because
+  // `source` is public API and feeds identity provenance.
+  for (const auto & a : result.apps) {
+    if (a.id == "beacon_temp") {
+      EXPECT_EQ(a.source, "beacon") << "the fix must not rewrite the provider's source tag";
+    }
+  }
+}
+
+// The limitation, pinned so nobody "fixes" it: enrichment does not protect.
+TEST_F(MergePipelineTest, PluginEnrichmentDoesNotProtectAnotherLayersEntity) {
+  App runtime_orphan;
+  runtime_orphan.id = "shadowed_node";
+  runtime_orphan.name = "shadowed_node";
+  runtime_orphan.source = "heuristic";
+  runtime_orphan.is_online = true;
+  runtime_orphan.bound_fqn = "/shadowed_node";
+
+  // Same id, contributed by the plugin layer - but the runtime layer is added
+  // first, so the runtime layer OWNS it and the plugin only enriches.
+  App plugin_shadow = make_app("shadowed_node", "");
+  plugin_shadow.source = "beacon";
+
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_orphan);
+  LayerOutput plugin_out;
+  plugin_out.apps.push_back(plugin_shadow);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>(
+      "runtime", runtime_out,
+      std::unordered_map<FieldGroup, MergePolicy>{{FieldGroup::STATUS, MergePolicy::AUTHORITATIVE}}));
+  pipeline_.add_layer(std::make_unique<TestLayer>("some_plugin", plugin_out,
+                                                  std::unordered_map<FieldGroup, MergePolicy>{},
+                                                  /*owns_protected=*/true));
+
+  ManifestConfig config;
+  config.unmanifested_nodes = ManifestConfig::UnmanifestedNodePolicy::IGNORE;
+  pipeline_.set_linker(std::make_unique<RuntimeLinker>(nullptr), config);
+
+  auto result = pipeline_.execute();
+
+  for (const auto & a : result.apps) {
+    EXPECT_NE(a.id, "shadowed_node") << "a plugin that only enriches a runtime app must not make it undeletable";
+  }
+}
+
+// --- inherit_runtime_resources gates the MERGE, not only enrich_app ---
+//
+// merge_entities<App>() runs before RuntimeLinker::link(), and its LIVE_DATA
+// group unions the runtime layer's topics and services into any app both
+// layers contribute under the same id. Gating only enrich_app would leave the
+// flag inert for exactly the app someone names after its own node.
+
+namespace {
+
+// A manifest app and a runtime app under the SAME id, each carrying its own
+// live data, so the LIVE_DATA merge has something to union.
+void seed_same_id_app_with_resources(MergePipeline & pipeline, bool inherit_runtime_resources) {
+  App manifest_app = make_app("temp_sensor", "engine");
+  manifest_app.source = "manifest";
+  App::RosBinding binding;
+  binding.node_name = "temp_sensor";
+  binding.namespace_pattern = "/powertrain/engine";
+  binding.topic_namespace = "";
+  manifest_app.ros_binding = binding;
+  manifest_app.topics.publishes = {"/declared/topic"};
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+  runtime_app.is_online = true;
+  runtime_app.bound_fqn = "/powertrain/engine/temp_sensor";
+  runtime_app.topics.publishes = {"/powertrain/engine/temperature"};
+  ServiceInfo svc;
+  svc.full_path = "/powertrain/engine/calibrate";
+  runtime_app.services.push_back(svc);
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline.add_layer(
+      std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::AUTHORITATIVE)));
+  pipeline.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  ManifestConfig config;
+  config.inherit_runtime_resources = inherit_runtime_resources;
+  pipeline.set_linker(std::make_unique<RuntimeLinker>(nullptr), config);
+}
+
+}  // namespace
+
+TEST_F(MergePipelineTest, InheritFalseKeepsSameNamedAppToItsDeclaredResources) {
+  seed_same_id_app_with_resources(pipeline_, /*inherit_runtime_resources=*/false);
+
+  auto result = pipeline_.execute();
+
+  ASSERT_EQ(result.apps.size(), 1u);
+  const auto & app = result.apps[0];
+  EXPECT_EQ(app.source, "manifest");
+  EXPECT_EQ(app.topics.publishes, std::vector<std::string>{"/declared/topic"})
+      << "the merge must not slip runtime topics past inherit_runtime_resources=false";
+  EXPECT_TRUE(app.services.empty()) << "nor runtime services";
+  // The binding itself is unaffected: the app is still online and still names
+  // the node. Only the resource copy is gated.
+  EXPECT_TRUE(app.is_online);
+  ASSERT_TRUE(app.bound_fqn.has_value());
+  EXPECT_EQ(*app.bound_fqn, "/powertrain/engine/temp_sensor");
+}
+
+TEST_F(MergePipelineTest, InheritTrueStillGivesSameNamedAppTheRuntimeResources) {
+  seed_same_id_app_with_resources(pipeline_, /*inherit_runtime_resources=*/true);
+
+  auto result = pipeline_.execute();
+
+  ASSERT_EQ(result.apps.size(), 1u);
+  const auto & app = result.apps[0];
+  EXPECT_NE(std::find(app.topics.publishes.begin(), app.topics.publishes.end(), "/powertrain/engine/temperature"),
+            app.topics.publishes.end())
+      << "with the flag on, the runtime topic must still arrive";
+  EXPECT_FALSE(app.services.empty()) << "and the runtime service too";
+}
+
+// --- The exemption is `source` alone, not the whole METADATA group ---
+
+TEST_F(MergePipelineTest, MetadataDemotionStillHandsComponentVariantToTheLowerLayer) {
+  Component manifest_comp = make_component("engine", "powertrain", "/powertrain");
+  manifest_comp.source = "manifest";
+  manifest_comp.variant = "declared-variant";
+
+  Component runtime_comp = make_component("engine", "powertrain", "/powertrain");
+  runtime_comp.source = "synthetic";
+  runtime_comp.variant = "observed-variant";
+
+  LayerOutput manifest_out;
+  manifest_out.components.push_back(manifest_comp);
+  LayerOutput runtime_out;
+  runtime_out.components.push_back(runtime_comp);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.components.size(), 1u);
+  EXPECT_EQ(result.components[0].variant, "observed-variant")
+      << "only `source` is exempt from the METADATA policy; ordinary metadata still follows it";
+  EXPECT_EQ(result.components[0].source, "manifest");
+}
+
+TEST_F(MergePipelineTest, MetadataDemotionStillHandsAppMetadataToTheLowerLayer) {
+  App manifest_app = make_app("temp_sensor", "engine");
+  manifest_app.source = "manifest";
+  manifest_app.external = false;
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+  runtime_app.external = true;
+  App::RosBinding runtime_binding;
+  runtime_binding.node_name = "temp_sensor";
+  runtime_binding.namespace_pattern = "/powertrain/engine";
+  runtime_binding.topic_namespace = "";
+  runtime_app.ros_binding = runtime_binding;
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(manifest_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.apps.size(), 1u);
+  ASSERT_TRUE(result.apps[0].external.has_value());
+  EXPECT_TRUE(*result.apps[0].external) << "the lower layer still wins ordinary METADATA under FALLBACK";
+  ASSERT_TRUE(result.apps[0].ros_binding.has_value());
+  EXPECT_EQ(result.apps[0].ros_binding->node_name, "temp_sensor");
+  EXPECT_EQ(result.apps[0].source, "manifest");
+}
+
+// --- Provenance is still gap-filled when the target has none ---
+//
+// A layer may contribute an entity with no `source` at all (plugin stubs do).
+// The gap fill must stay resolution-independent: it has to work under the
+// TARGET branch (manifest AUTHORITATIVE) as well as the SOURCE branch
+// (manifest FALLBACK), because otherwise an entity would reach the orphan
+// filter with an empty provenance string.
+
+TEST_F(MergePipelineTest, EmptyProvenanceIsGapFilledUnderAuthoritativeMetadata) {
+  App target_app = make_app("temp_sensor", "engine");
+  target_app.source.clear();
+
+  App runtime_app = make_app("temp_sensor", "engine");
+  runtime_app.source = "heuristic";
+
+  LayerOutput manifest_out;
+  manifest_out.apps.push_back(target_app);
+  LayerOutput runtime_out;
+  runtime_out.apps.push_back(runtime_app);
+
+  pipeline_.add_layer(
+      std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::AUTHORITATIVE)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.apps.size(), 1u);
+  EXPECT_EQ(result.apps[0].source, "heuristic") << "an entity with no provenance must still inherit one";
+}
+
+TEST_F(MergePipelineTest, EmptyProvenanceIsGapFilledUnderFallbackMetadata) {
+  Function target_fn = make_function("braking");
+  target_fn.source.clear();
+
+  Function runtime_fn = make_function("braking");
+  runtime_fn.source = "heuristic";
+
+  LayerOutput manifest_out;
+  manifest_out.functions.push_back(target_fn);
+  LayerOutput runtime_out;
+  runtime_out.functions.push_back(runtime_fn);
+
+  pipeline_.add_layer(std::make_unique<TestLayer>("manifest", manifest_out, manifest_policies(MergePolicy::FALLBACK)));
+  pipeline_.add_layer(std::make_unique<TestLayer>("runtime", runtime_out, runtime_policies()));
+
+  auto result = pipeline_.execute();
+  ASSERT_EQ(result.functions.size(), 1u);
+  EXPECT_EQ(result.functions[0].source, "heuristic");
 }

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -262,7 +262,12 @@ if(BUILD_TESTING)
   unset(_MEDKIT_TEST_TIMEOUT_OVERRIDES_SEEN)
 
   # Feature tests (atomic, independent, 120s timeout unless overridden above)
-  file(GLOB FEATURE_TESTS test/features/*.test.py)
+  # CONFIGURE_DEPENDS is load-bearing, not tidiness: a glob is expanded at
+  # configure time, so without it a test file added after the build tree was
+  # configured is never registered. The suite then reports a clean pass while
+  # silently not running it, and the absence of a whole test file looks
+  # exactly like success.
+  file(GLOB FEATURE_TESTS CONFIGURE_DEPENDS test/features/*.test.py)
   foreach(test_file ${FEATURE_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
     set(_test_domains 1)
@@ -286,7 +291,12 @@ if(BUILD_TESTING)
   endforeach()
 
   # Scenario tests (E2E stories, 300s timeout unless overridden above)
-  file(GLOB SCENARIO_TESTS test/scenarios/*.test.py)
+  # CONFIGURE_DEPENDS is load-bearing, not tidiness: a glob is expanded at
+  # configure time, so without it a test file added after the build tree was
+  # configured is never registered. The suite then reports a clean pass while
+  # silently not running it, and the absence of a whole test file looks
+  # exactly like success.
+  file(GLOB SCENARIO_TESTS CONFIGURE_DEPENDS test/scenarios/*.test.py)
   foreach(test_file ${SCENARIO_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
     set(_test_domains 1)

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/convergence.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/convergence.py
@@ -1,0 +1,94 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Comparing two served documents that may take a moment to agree.
+
+Two gateways on one ROS graph can disagree for an instant while one of them is
+mid-refresh, so equality needs a grace period. Getting that grace period wrong
+in the obvious way produces a test that passes having compared nothing:
+
+    left = right = None
+    try:
+        left, right = fetch_left(), fetch_right()   # tuple built THEN unpacked
+    except RequestException:
+        pass
+    ...
+    assertEqual(left, right)                        # None == None -> green
+
+If either fetch raises, Python never unpacks, both names keep their initial
+``None``, and the final assertion compares two ``None`` values and passes. A
+gateway that was down for the entire window therefore looked like a match - and
+in the test this was written for, the right-hand gateway is the thing under
+test. This module exists so there is one implementation of the comparison and
+it fails loudly instead.
+"""
+
+import time
+
+DEFAULT_TIMEOUT_SEC = 15.0
+DEFAULT_INTERVAL_SEC = 0.5
+
+
+class DocumentsNeverFetched(AssertionError):
+    """Raised when no successful pair of documents was ever obtained."""
+
+
+def assert_documents_match(
+    test,
+    fetch_left,
+    fetch_right,
+    *,
+    what,
+    timeout=DEFAULT_TIMEOUT_SEC,
+    interval=DEFAULT_INTERVAL_SEC,
+):
+    """Assert two documents converge, distinguishing "differ" from "never read".
+
+    Retries until *timeout*. Three outcomes, all of them explicit:
+
+    * a pair was fetched and matched -> returns ``(left, right)``
+    * a pair was fetched and never matched -> ``assertEqual`` shows the diff
+    * no pair was ever fetched -> fails naming the last error, rather than
+      quietly comparing two placeholder values
+
+    Both fetches are evaluated separately so a failure on either side is
+    attributed, instead of being lost in an all-or-nothing tuple unpack.
+    """
+    deadline = time.monotonic() + timeout
+    left = right = None
+    fetched = False
+    last_error = None
+
+    while True:
+        try:
+            left = fetch_left()
+            right = fetch_right()
+            fetched = True
+            if left == right:
+                return left, right
+        except Exception as exc:  # noqa: B902 - re-raised below if never fetched
+            last_error = exc
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+
+    if not fetched:
+        raise DocumentsNeverFetched(
+            f'{what}: no successful pair of documents was fetched in '
+            f'{timeout}s, so nothing was ever compared. Last error: '
+            f'{last_error!r}'
+        )
+
+    test.assertEqual(left, right, f'{what} still differed after {timeout}s')
+    return left, right

--- a/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_daisy_chain_aggregation.test.py
@@ -275,9 +275,9 @@ class TestDaisyChainAggregation(unittest.TestCase):
         self.assertIn('peers', body)
         self.assertIn('warnings', body)
         self.assertEqual(body['warnings'], [])
-        # Schema version must be present whenever aggregation is active so
-        # typed clients can feature-detect codes without string-matching.
-        self.assertEqual(body.get('warning_schema_version'), 1)
+        # Schema version must be present on every /health response so typed
+        # clients can feature-detect codes without string-matching.
+        self.assertEqual(body.get('warning_schema_version'), 2)
 
     # --- Root capability flag --------------------------------------------
 

--- a/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_leaf_collision_aggregation.test.py
@@ -218,7 +218,7 @@ class TestLeafCollisionAggregation(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         body = r.json()
         self.assertIn('warning_schema_version', body)
-        self.assertEqual(body['warning_schema_version'], 1)
+        self.assertEqual(body['warning_schema_version'], 2)
         collisions = [
             w for w in body.get('warnings', [])
             if w.get('code') == 'leaf_id_collision'

--- a/src/ros2_medkit_integration_tests/test/features/test_manifest_config_key.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_manifest_config_key.test.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests for the manifest's top-level discovery-configuration key.
+
+Four gateways run side by side on one ROS graph, all in hybrid mode against
+the same entity declarations, differing only in how the discovery
+configuration block is spelled and how strict validation is set:
+
+===================  ==========================  ======  ===========================
+Gateway              Block                       Strict  Expected
+===================  ==========================  ======  ===========================
+config-key           ``config: ignore``          no      policy applies
+alias-key            ``discovery: ignore``       no      identical entity tree
+bad-policy-lenient   ``config: <unknown>``       no      loads, falls back to warn
+bad-policy-strict    ``config: <unknown>``       yes     rejected -> runtime_only
+===================  ==========================  ======  ===========================
+
+The instrument is the entity tree from ``GET /apps``, not the gateway log: a
+log line proves a message was emitted, not that the policy took effect.
+
+Change, not steady state: the unmanifested node (``rpm_sensor``) and one
+manifest-declared node (``pressure_sensor``) are both started well AFTER the
+gateways are up, so the suppression has to hold for a node that appears
+mid-run.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.convergence import assert_documents_match
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_demo_nodes,
+    create_gateway_node,
+)
+
+# --------------------------------------------------------------------------
+# Ports - one gateway per spelling / strictness combination
+# --------------------------------------------------------------------------
+
+CONFIG_KEY_PORT = get_test_port(0)
+ALIAS_KEY_PORT = get_test_port(1)
+BAD_POLICY_LENIENT_PORT = get_test_port(2)
+BAD_POLICY_STRICT_PORT = get_test_port(3)
+
+
+def _base_url(port):
+    return f'http://localhost:{port}{API_BASE_PATH}'
+
+
+CONFIG_KEY_URL = _base_url(CONFIG_KEY_PORT)
+ALIAS_KEY_URL = _base_url(ALIAS_KEY_PORT)
+BAD_POLICY_LENIENT_URL = _base_url(BAD_POLICY_LENIENT_PORT)
+BAD_POLICY_STRICT_URL = _base_url(BAD_POLICY_STRICT_PORT)
+
+# --------------------------------------------------------------------------
+# Manifest fixture
+# --------------------------------------------------------------------------
+
+AREA_ID = 'cfgkey-area'
+COMPONENT_ID = 'cfgkey-ecu'
+TEMP_APP_ID = 'cfgkey-temp'
+PRESSURE_APP_ID = 'cfgkey-pressure'
+MANIFEST_APPS = {TEMP_APP_ID, PRESSURE_APP_ID}
+
+# Node started up-front, bound by the manifest.
+EARLY_NODE = 'temp_sensor'
+# Nodes started long after the gateways are up. pressure_sensor is bound by the
+# manifest and acts as the "this gateway has re-run discovery" witness;
+# rpm_sensor is deliberately absent from the manifest and is the orphan under
+# test.
+LATE_MANIFESTED_NODE = 'pressure_sensor'
+LATE_UNMANIFESTED_NODE = 'rpm_sensor'
+LATE_UNMANIFESTED_FQN = '/powertrain/engine/rpm_sensor'
+LATE_MANIFESTED_FQN = '/chassis/brakes/pressure_sensor'
+
+# Long enough that every gateway has answered /health and completed at least
+# one discovery pass before the late nodes join the graph.
+# Wall-clock BUDGETS are scaled by MEDKIT_TEST_TIME_SCALE. The sanitizer jobs
+# multiply every ctest timeout, but a deadline asserted inside a test is
+# invisible to that rewrite, so an ASan/TSan gateway blows it and the failure
+# reads as a regression rather than as instrumentation cost. Unscaled
+# elsewhere, so the budgets keep their falsifying edge on normal jobs.
+#
+# Poll INTERVALS and soak durations are deliberately NOT scaled: polling more
+# slowly would only notice the same answer later, and stretching a soak would
+# hold the gateways longer under exactly the instrumentation that made them
+# expensive - which is load this file would be adding, not absorbing.
+TIME_SCALE = get_time_scale()
+
+# The window the "before the late nodes" snapshot has to complete in. A budget:
+# too short under instrumentation and the baseline is taken after the nodes
+# already joined, which fails an assertion about the fixture, not the product.
+LATE_NODE_DELAY_SEC = 10.0 * TIME_SCALE
+
+# A value that is not one of ignore / warn / error / include_as_orphan.
+UNKNOWN_POLICY = 'quiesce'
+
+# How long the suppression must keep holding once it has been observed, in
+# seconds. The gateways refresh every 1000 ms, so this spans several passes.
+# Soak duration, not a budget - see the note above; left unscaled on purpose.
+HOLD_SEC = 4.0
+# Was a private 60.0; this is the shared discovery budget, scaled.
+POLL_TIMEOUT_SEC = DISCOVERY_TIMEOUT * TIME_SCALE
+POLL_INTERVAL_SEC = 0.5
+# How long a single HTTP call has to come back.
+HTTP_TIMEOUT_SEC = 5.0 * TIME_SCALE
+
+
+def _manifest_yaml(config_key, policy):
+    """Render the shared manifest under *config_key* with *policy*."""
+    return f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Manifest config key test vehicle"
+  version: "1.0.0"
+{config_key}:
+  unmanifested_nodes: "{policy}"
+areas:
+  - id: {AREA_ID}
+    name: "Config Key Test Area"
+components:
+  - id: {COMPONENT_ID}
+    name: "Config Key Test ECU"
+    area: {AREA_ID}
+apps:
+  - id: {TEMP_APP_ID}
+    name: "Engine Temperature Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: {EARLY_NODE}
+      namespace: /powertrain/engine
+  - id: {PRESSURE_APP_ID}
+    name: "Brake Pressure Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: {LATE_MANIFESTED_NODE}
+      namespace: /chassis/brakes
+"""
+
+
+# Manifests this module wrote, so the post-shutdown phase can remove them
+# instead of leaving a file per run behind in the temp directory.
+_MANIFEST_PATHS = []
+
+
+def _remove_manifests():
+    """Delete every manifest this module wrote."""
+    while _MANIFEST_PATHS:
+        try:
+            os.unlink(_MANIFEST_PATHS.pop())
+        except OSError:
+            pass
+
+
+def _write_manifest(name, content):
+    """Write manifest YAML to a temporary file, return its path."""
+    fd, path = tempfile.mkstemp(
+        suffix='.yaml', prefix=f'test_manifest_config_key_{name}_',
+    )
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    _MANIFEST_PATHS.append(path)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Shared HTTP helpers (cross-gateway, so not GatewayTestCase methods)
+# --------------------------------------------------------------------------
+
+def _collection_items(base_url, path):
+    response = requests.get(f'{base_url}{path}', timeout=HTTP_TIMEOUT_SEC)
+    response.raise_for_status()
+    return response.json().get('items', [])
+
+
+def _app_ids(base_url):
+    return {app['id'] for app in _collection_items(base_url, '/apps')}
+
+
+def _comparable_entity(entity):
+    """Return the part of a served entity two gateways must agree on exactly.
+
+    Nothing is dropped. Both gateways run the same manifest against the same
+    ROS graph and differ only in how the discovery-configuration block is
+    spelled, so every served field - name, description, hierarchy, tags,
+    bindings, provenance, online state, hyperlinks - has to be identical. The
+    only fields that could carry a per-gateway value are the port-bearing
+    ones, and the API serves relative hrefs, so there are none to exclude.
+    """
+    return entity
+
+
+def _comparable_collection(base_url, path):
+    """Return a collection keyed by id, so a diff names the entity involved."""
+    return {
+        item['id']: _comparable_entity(item)
+        for item in _collection_items(base_url, path)
+    }
+
+
+# Convergence comparison lives in ros2_medkit_test_utils so there is one
+# implementation: the obvious inline version passes when neither side was ever
+# fetched. See convergence.py for why.
+DOCUMENT_MATCH_TIMEOUT_SEC = 15.0 * TIME_SCALE
+
+
+def _assert_documents_match(test, fetch_left, fetch_right, *, what):
+    return assert_documents_match(
+        test, fetch_left, fetch_right,
+        what=what, timeout=DOCUMENT_MATCH_TIMEOUT_SEC,
+        interval=POLL_INTERVAL_SEC,
+    )
+
+
+def _bound_nodes(base_url):
+    """Return the set of ROS node FQNs any app on *base_url* is bound to."""
+    nodes = set()
+    for app in _collection_items(base_url, '/apps'):
+        node = app.get('x-medkit', {}).get('ros2', {}).get('node')
+        if node:
+            nodes.add(node)
+    return nodes
+
+
+def _poll(predicate, *, what, timeout=POLL_TIMEOUT_SEC):
+    """Poll *predicate* until it returns a truthy value, else fail loudly."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            last = predicate()
+            if last:
+                return last
+        except requests.exceptions.RequestException as exc:
+            last = exc
+        time.sleep(POLL_INTERVAL_SEC)
+    raise AssertionError(f'timed out after {timeout}s waiting for {what}; last={last!r}')
+
+
+def _wait_for_orphan_witness():
+    """Block until the warn-policy gateway shows the unmanifested node.
+
+    That gateway shares the ROS graph with every other gateway in this file,
+    so once it has surfaced ``rpm_sensor`` the node is demonstrably live and
+    discoverable - which is what makes the *absence* of the same node on the
+    ``ignore`` gateways evidence of the policy rather than of a slow start.
+    """
+    return _poll(
+        lambda: LATE_UNMANIFESTED_FQN in _bound_nodes(BAD_POLICY_LENIENT_URL),
+        what=f'{BAD_POLICY_LENIENT_URL} to surface {LATE_UNMANIFESTED_FQN}',
+    )
+
+
+def _wait_for_late_link(base_url):
+    """Block until *base_url* has linked the late manifest-declared node.
+
+    Proves this gateway has run a discovery pass that saw the late nodes, so a
+    subsequent absence assertion is not just reading a pre-launch snapshot.
+    """
+    return _poll(
+        lambda: LATE_MANIFESTED_FQN in _bound_nodes(base_url),
+        what=f'{base_url} to link {LATE_MANIFESTED_FQN}',
+    )
+
+
+# --------------------------------------------------------------------------
+# Launch description
+# --------------------------------------------------------------------------
+
+def generate_test_description():
+    config_key_manifest = _write_manifest(
+        'config', _manifest_yaml('config', 'ignore'),
+    )
+    alias_key_manifest = _write_manifest(
+        'alias', _manifest_yaml('discovery', 'ignore'),
+    )
+    bad_policy_manifest = _write_manifest(
+        'badpolicy', _manifest_yaml('config', UNKNOWN_POLICY),
+    )
+
+    def gateway(name, port, manifest_path, strict):
+        return create_gateway_node(
+            port=port,
+            name=name,
+            extra_params={
+                'discovery.mode': 'hybrid',
+                'discovery.manifest_path': manifest_path,
+                'discovery.manifest_strict_validation': strict,
+            },
+        )
+
+    gateways = [
+        gateway('gw_config_key', CONFIG_KEY_PORT, config_key_manifest, False),
+        gateway('gw_alias_key', ALIAS_KEY_PORT, alias_key_manifest, False),
+        gateway(
+            'gw_bad_policy_lenient', BAD_POLICY_LENIENT_PORT,
+            bad_policy_manifest, False,
+        ),
+        gateway(
+            'gw_bad_policy_strict', BAD_POLICY_STRICT_PORT,
+            bad_policy_manifest, True,
+        ),
+    ]
+
+    early_nodes = create_demo_nodes([EARLY_NODE])
+    late_nodes = TimerAction(
+        period=LATE_NODE_DELAY_SEC,
+        actions=create_demo_nodes(
+            [LATE_MANIFESTED_NODE, LATE_UNMANIFESTED_NODE],
+        ),
+    )
+
+    return (
+        LaunchDescription(
+            gateways + early_nodes + [late_nodes, launch_testing.actions.ReadyToTest()],
+        ),
+        {'gateway_node': gateways[0]},
+    )
+
+
+# --------------------------------------------------------------------------
+# U1: `config: unmanifested_nodes: ignore` actually hides unmanifested nodes
+# --------------------------------------------------------------------------
+
+# @verifies REQ_INTEROP_003
+class TestConfigKeyAppliesUnmanifestedPolicy(GatewayTestCase):
+    """The documented `config:` block drives the unmanifested-node policy."""
+
+    BASE_URL = CONFIG_KEY_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    def test_health_reports_hybrid_mode(self):
+        """The manifest loaded, so the gateway stayed in hybrid mode."""
+        # @verifies REQ_INTEROP_003
+        health = self.get_json('/health')
+        self.assertEqual(health.get('discovery', {}).get('mode'), 'hybrid')
+
+    def test_late_unmanifested_node_never_enters_the_entity_tree(self):
+        """A node that joins after startup and is not declared stays hidden."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_orphan_witness()
+        _wait_for_late_link(self.BASE_URL)
+
+        deadline = time.monotonic() + HOLD_SEC
+        while True:
+            app_ids = _app_ids(self.BASE_URL)
+            bound = _bound_nodes(self.BASE_URL)
+            self.assertEqual(
+                app_ids, MANIFEST_APPS,
+                f'unmanifested_nodes=ignore must leave only the manifest apps; '
+                f'extra: {app_ids - MANIFEST_APPS}, missing: {MANIFEST_APPS - app_ids}',
+            )
+            self.assertNotIn(
+                LATE_UNMANIFESTED_FQN, bound,
+                f'{LATE_UNMANIFESTED_FQN} is not declared in the manifest and '
+                f'must not be bound to any app; bound nodes: {sorted(bound)}',
+            )
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(POLL_INTERVAL_SEC)
+
+    def test_manifest_declared_nodes_are_linked(self):
+        """Both manifest apps bind to their runtime nodes, early and late."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_late_link(self.BASE_URL)
+        bound = _bound_nodes(self.BASE_URL)
+        self.assertIn('/powertrain/engine/temp_sensor', bound)
+        self.assertIn(LATE_MANIFESTED_FQN, bound)
+
+
+# --------------------------------------------------------------------------
+# U2: the deprecated `discovery:` alias produces the same entity tree
+# --------------------------------------------------------------------------
+
+# @verifies REQ_INTEROP_003
+class TestDeprecatedDiscoveryKeyIsAnAlias(GatewayTestCase):
+    """`discovery:` keeps working and behaves exactly like `config:`."""
+
+    BASE_URL = ALIAS_KEY_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    def test_health_reports_hybrid_mode(self):
+        """The deprecated key is a deprecation, not a load failure."""
+        # @verifies REQ_INTEROP_003
+        health = self.get_json('/health')
+        self.assertEqual(health.get('discovery', {}).get('mode'), 'hybrid')
+
+    def test_entity_tree_matches_the_canonical_key(self):
+        """Every collection matches the `config:` gateway, document for document.
+
+        Comparing id sets alone would not notice the alias applying a
+        different configuration value, or producing different names,
+        hierarchy, bindings, provenance or online state - all of which are
+        things a second parse path can get wrong. So the whole served item is
+        compared, minus only the fields that cannot be equal by construction
+        (see ``_comparable_entity``).
+        """
+        # @verifies REQ_INTEROP_003
+        _wait_for_orphan_witness()
+        _wait_for_late_link(self.BASE_URL)
+        _wait_for_late_link(CONFIG_KEY_URL)
+
+        for path in ('/areas', '/components', '/apps', '/functions'):
+            _assert_documents_match(
+                self,
+                lambda path=path: _comparable_collection(self.BASE_URL, path),
+                lambda path=path: _comparable_collection(CONFIG_KEY_URL, path),
+                what=f'{path} between the alias and canonical gateways',
+            )
+
+    def test_entity_detail_documents_match_the_canonical_key(self):
+        """The collection view can agree while the detail view does not."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_late_link(self.BASE_URL)
+        _wait_for_late_link(CONFIG_KEY_URL)
+
+        def detail(base_url, app_id):
+            response = requests.get(f'{base_url}/apps/{app_id}', timeout=HTTP_TIMEOUT_SEC)
+            response.raise_for_status()
+            return _comparable_entity(response.json())
+
+        for app_id in sorted(MANIFEST_APPS):
+            _assert_documents_match(
+                self,
+                lambda app_id=app_id: detail(self.BASE_URL, app_id),
+                lambda app_id=app_id: detail(CONFIG_KEY_URL, app_id),
+                what=f'/apps/{app_id} between the two gateways',
+            )
+
+    def test_late_unmanifested_node_never_enters_the_entity_tree(self):
+        """The alias applies the policy, not just the entity declarations."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_orphan_witness()
+        _wait_for_late_link(self.BASE_URL)
+        self.assertEqual(_app_ids(self.BASE_URL), MANIFEST_APPS)
+        self.assertNotIn(LATE_UNMANIFESTED_FQN, _bound_nodes(self.BASE_URL))
+
+
+# --------------------------------------------------------------------------
+# U5: an unrecognised policy value
+# --------------------------------------------------------------------------
+
+# @verifies REQ_INTEROP_003
+class TestUnknownPolicyValueNonStrict(GatewayTestCase):
+    """Non-strict: the manifest loads and the default policy applies."""
+
+    BASE_URL = BAD_POLICY_LENIENT_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    def test_manifest_still_loads(self):
+        """A bad value is a warning, so hybrid mode survives it."""
+        # @verifies REQ_INTEROP_003
+        health = self.get_json('/health')
+        self.assertEqual(health.get('discovery', {}).get('mode'), 'hybrid')
+
+    def test_policy_falls_back_to_warn_so_the_orphan_is_visible(self):
+        """Fallback is `warn`, which keeps unmanifested nodes in the tree."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_orphan_witness()
+        bound = _bound_nodes(self.BASE_URL)
+        self.assertIn(
+            LATE_UNMANIFESTED_FQN, bound,
+            'the fallback policy is warn, which must not hide orphans; '
+            f'bound nodes: {sorted(bound)}',
+        )
+
+
+# @verifies REQ_INTEROP_003
+class TestUnknownPolicyValueStrict(GatewayTestCase):
+    """Strict validation must NOT reject a manifest over an advisory notice.
+
+    ``R014`` is advisory for this release: it reaches the log, never
+    ``ValidationResult``, so the strictness dial cannot act on it. The reason
+    is upgrade safety - the discovery-config block was parsed but never read
+    before, so a manifest carrying a bad policy value loaded fine, and making
+    it a hard failure on upgrade would take hybrid discovery down to
+    ``runtime_only`` for a deployment nobody edited. It becomes a validation
+    warning in the next release, at which point this class flips back.
+    """
+
+    BASE_URL = BAD_POLICY_STRICT_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    def test_manifest_still_loads_and_discovery_stays_hybrid(self):
+        """The advisory notice does not fail the load, even under strict."""
+        # @verifies REQ_INTEROP_003
+        health = _poll(
+            lambda: requests.get(f'{self.BASE_URL}/health', timeout=HTTP_TIMEOUT_SEC).json(),
+            what=f'{self.BASE_URL} health document',
+        )
+        self.assertEqual(
+            health.get('discovery', {}).get('mode'), 'hybrid',
+            'an advisory R014 must not degrade discovery under strict validation',
+        )
+
+    def test_manifest_entities_are_served(self):
+        """The manifest loaded, so its entities are in the tree."""
+        # @verifies REQ_INTEROP_003
+        _wait_for_orphan_witness()
+        self.assertEqual(_app_ids(self.BASE_URL) & MANIFEST_APPS, MANIFEST_APPS)
+        area_ids = {a['id'] for a in _collection_items(self.BASE_URL, '/areas')}
+        self.assertIn(AREA_ID, area_ids)
+
+    def test_the_documented_fallback_still_applies(self):
+        """Advisory does not mean ignored: the value still falls back to warn."""
+        # @verifies REQ_INTEROP_003
+        health = _poll(
+            lambda: requests.get(f'{self.BASE_URL}/health', timeout=HTTP_TIMEOUT_SEC).json(),
+            what=f'{self.BASE_URL} linking block',
+        )
+        linking = health.get('discovery', {}).get('linking', {})
+        self.assertEqual(
+            linking.get('unmanifested_policy'), 'warn',
+            f'the unrecognised value must fall back to the default: {linking}',
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_manifests_are_cleaned_up(self):
+        """The temp manifests this module wrote do not outlive the run."""
+        _remove_manifests()
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_manifest_malformed_config.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_manifest_malformed_config.test.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests: a malformed discovery-configuration block costs the block only.
+
+The block is addressed by key and then indexed by field, so a key whose value
+is not a mapping cannot be read that way. Getting this wrong is expensive in
+both directions: indexing a scalar throws, which abandons the entire manifest
+over one bad key, and indexing a sequence yields nothing, which drops the
+operator's configuration in silence.
+
+The contract is that a malformed block is *reported* under rule ``R015`` and
+costs only itself - the rest of the manifest still parses, the offending block
+is ignored and its defaults apply.
+
+``R015`` is ADVISORY for this release: it goes to the log only, so the
+strictness dial does not act on it and the outcome is the same either way.
+That is deliberate upgrade safety - this work is what makes the block read at
+all, so a manifest carrying a malformed one loaded fine before and must not
+start failing after. It becomes a validation warning in the next release.
+Both strictness settings are pinned below:
+
+====================  ==========================================  =====================
+Gateway               Manifest                                    Expected
+====================  ==========================================  =====================
+lenient               ``config: ""`` (scalar), strict off         loads, serves its
+                                                                  entities, defaults
+                                                                  apply
+alias-lenient         ``discovery:`` a sequence, strict off       identical - the
+                                                                  deprecated key is
+                                                                  guarded too
+strict                ``config: ""`` (scalar), strict on          identical: R015 is
+                                                                  advisory this
+                                                                  release
+====================  ==========================================  =====================
+
+The instrument is the served entity tree and ``/health.discovery.mode``, not a
+log line: a warning being logged is not evidence that the manifest survived.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_demo_nodes,
+    create_gateway_node,
+)
+
+# --------------------------------------------------------------------------
+# Ports
+# --------------------------------------------------------------------------
+
+LENIENT_PORT = get_test_port(0)
+ALIAS_LENIENT_PORT = get_test_port(1)
+STRICT_PORT = get_test_port(2)
+
+
+def _base_url(port):
+    return f'http://localhost:{port}{API_BASE_PATH}'
+
+
+LENIENT_URL = _base_url(LENIENT_PORT)
+ALIAS_LENIENT_URL = _base_url(ALIAS_LENIENT_PORT)
+STRICT_URL = _base_url(STRICT_PORT)
+
+# --------------------------------------------------------------------------
+# Manifest fixture
+# --------------------------------------------------------------------------
+
+AREA_ID = 'mmc-area'
+COMPONENT_ID = 'mmc-ecu'
+APP_ID = 'mmc-temp'
+DEMO_NODE = 'temp_sensor'
+DEMO_FQN = '/powertrain/engine/temp_sensor'
+
+# The node that is deliberately NOT declared. Under the default policy (warn)
+# it stays visible, which is how the test shows the defaults took effect after
+# the malformed block was discarded.
+UNDECLARED_NODE = 'rpm_sensor'
+UNDECLARED_FQN = '/powertrain/engine/rpm_sensor'
+
+# Wall-clock BUDGETS are scaled by MEDKIT_TEST_TIME_SCALE. The sanitizer jobs
+# multiply every ctest timeout, but a deadline asserted inside a test is
+# invisible to that rewrite, so an ASan/TSan gateway blows it and the failure
+# reads as a regression rather than as instrumentation cost. Unscaled
+# elsewhere, so the budgets keep their falsifying edge on normal jobs.
+#
+# Poll INTERVALS and soak durations are deliberately NOT scaled: polling more
+# slowly would only notice the same answer later, and stretching a soak would
+# hold the gateways longer under exactly the instrumentation that made them
+# expensive - which is load this file would be adding, not absorbing.
+TIME_SCALE = get_time_scale()
+
+# Was a private 60.0; this is the shared discovery budget, scaled.
+POLL_TIMEOUT_SEC = DISCOVERY_TIMEOUT * TIME_SCALE
+POLL_INTERVAL_SEC = 0.5
+# How long a single HTTP call has to come back.
+HTTP_TIMEOUT_SEC = 5.0 * TIME_SCALE
+
+# A scalar value: yaml-cpp throws when this is indexed by field name.
+SCALAR_BLOCK = ' ""'
+# A sequence value: indexing yields nothing, so it used to vanish silently.
+SEQUENCE_BLOCK = '\n  - unmanifested_nodes: ignore'
+
+
+def _manifest_yaml(key, block):
+    """Render the shared manifest with a malformed *key* block."""
+    return f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Malformed discovery config test vehicle"
+  version: "1.0.0"
+{key}:{block}
+areas:
+  - id: {AREA_ID}
+    name: "Malformed Config Area"
+components:
+  - id: {COMPONENT_ID}
+    name: "Malformed Config ECU"
+    area: {AREA_ID}
+apps:
+  - id: {APP_ID}
+    name: "Engine Temperature Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: {DEMO_NODE}
+      namespace: /powertrain/engine
+"""
+
+
+# Manifests this module wrote, so the post-shutdown phase can remove them
+# instead of leaving a file per run behind in the temp directory.
+_MANIFEST_PATHS = []
+
+
+def _remove_manifests():
+    """Delete every manifest this module wrote."""
+    while _MANIFEST_PATHS:
+        try:
+            os.unlink(_MANIFEST_PATHS.pop())
+        except OSError:
+            pass
+
+
+def _write_manifest(name, content):
+    """Write manifest YAML to a temporary file, return its path."""
+    fd, path = tempfile.mkstemp(
+        suffix='.yaml', prefix=f'test_manifest_malformed_config_{name}_',
+    )
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    _MANIFEST_PATHS.append(path)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Shared HTTP helpers
+# --------------------------------------------------------------------------
+
+def _get_json(base_url, path):
+    response = requests.get(f'{base_url}{path}', timeout=HTTP_TIMEOUT_SEC)
+    response.raise_for_status()
+    return response.json()
+
+
+def _item_ids(base_url, path):
+    return {item['id'] for item in _get_json(base_url, path).get('items', [])}
+
+
+def _bound_nodes(base_url):
+    nodes = set()
+    for app in _get_json(base_url, '/apps').get('items', []):
+        node = app.get('x-medkit', {}).get('ros2', {}).get('node')
+        if node:
+            nodes.add(node)
+    return nodes
+
+
+def _poll(predicate, *, what, timeout=POLL_TIMEOUT_SEC):
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            last = predicate()
+            if last:
+                return last
+        except requests.exceptions.RequestException as exc:
+            last = exc
+        time.sleep(POLL_INTERVAL_SEC)
+    raise AssertionError(
+        f'timed out after {timeout}s waiting for {what}; last={last!r}'
+    )
+
+
+# --------------------------------------------------------------------------
+# Launch description
+# --------------------------------------------------------------------------
+
+def generate_test_description():
+    scalar_manifest = _write_manifest(
+        'scalar', _manifest_yaml('config', SCALAR_BLOCK),
+    )
+    alias_sequence_manifest = _write_manifest(
+        'aliasseq', _manifest_yaml('discovery', SEQUENCE_BLOCK),
+    )
+
+    def gateway(name, port, manifest_path, strict):
+        return create_gateway_node(
+            port=port,
+            name=name,
+            extra_params={
+                'discovery.mode': 'hybrid',
+                'discovery.manifest_path': manifest_path,
+                'discovery.manifest_strict_validation': strict,
+            },
+        )
+
+    gateways = [
+        gateway('gw_mmc_lenient', LENIENT_PORT, scalar_manifest, False),
+        gateway(
+            'gw_mmc_alias_lenient', ALIAS_LENIENT_PORT,
+            alias_sequence_manifest, False,
+        ),
+        gateway('gw_mmc_strict', STRICT_PORT, scalar_manifest, True),
+    ]
+
+    demo_nodes = create_demo_nodes([DEMO_NODE, UNDECLARED_NODE])
+
+    return (
+        LaunchDescription(
+            gateways + demo_nodes + [launch_testing.actions.ReadyToTest()],
+        ),
+        {'gateway_node': gateways[0]},
+    )
+
+
+# --------------------------------------------------------------------------
+# Shared assertions for the two non-strict gateways
+# --------------------------------------------------------------------------
+
+class MalformedBlockCostsOnlyTheBlockMixin:
+    """Non-strict: the block is discarded, the rest of the manifest is not."""
+
+    REQUIRED_APPS = {APP_ID}
+
+    def test_manifest_still_loads_and_discovery_stays_hybrid(self):
+        """A malformed block must not abandon the manifest."""
+        health = _poll(
+            lambda: _get_json(self.BASE_URL, '/health'),
+            what=f'{self.BASE_URL} health document',
+        )
+        self.assertEqual(health.get('discovery', {}).get('mode'), 'hybrid')
+
+    def test_every_declared_entity_is_served(self):
+        """Areas, components and apps all survive the malformed block."""
+        self.assertIn(AREA_ID, _item_ids(self.BASE_URL, '/areas'))
+        self.assertIn(COMPONENT_ID, _item_ids(self.BASE_URL, '/components'))
+        self.assertIn(APP_ID, _item_ids(self.BASE_URL, '/apps'))
+
+        detail = _get_json(self.BASE_URL, f'/apps/{APP_ID}')
+        self.assertEqual(detail.get('id'), APP_ID)
+        self.assertEqual(detail.get('x-medkit', {}).get('source'), 'manifest')
+
+    def test_the_app_still_links_to_its_node(self):
+        """The declared binding is intact, so the block was the only loss."""
+        _poll(
+            lambda: DEMO_FQN in _bound_nodes(self.BASE_URL),
+            what=f'{self.BASE_URL} to link {DEMO_FQN}',
+        )
+
+    def test_the_discarded_block_falls_back_to_the_defaults(self):
+        """Not "the block was applied anyway", and not "the load half-failed".
+
+        The manifest's sequence form asked for ``unmanifested_nodes: ignore``.
+        The default is ``warn``, which keeps undeclared nodes visible - so the
+        undeclared node being present proves the defaults are in force rather
+        than whatever the malformed block appeared to say.
+        """
+        _poll(
+            lambda: UNDECLARED_FQN in _bound_nodes(self.BASE_URL),
+            what=f'{self.BASE_URL} to surface the undeclared {UNDECLARED_FQN}',
+        )
+        health = _get_json(self.BASE_URL, '/health')
+        linking = health.get('discovery', {}).get('linking', {})
+        self.assertEqual(
+            linking.get('unmanifested_policy'), 'warn',
+            f'the defaults must apply after the block is discarded: {linking}',
+        )
+
+
+class TestMalformedConfigKeyIsLenient(
+    MalformedBlockCostsOnlyTheBlockMixin, GatewayTestCase,
+):
+    """The canonical `config:` key holding a scalar."""
+
+    BASE_URL = LENIENT_URL
+
+
+class TestMalformedDiscoveryAliasIsLenient(
+    MalformedBlockCostsOnlyTheBlockMixin, GatewayTestCase,
+):
+    """The deprecated `discovery:` alias holding a sequence.
+
+    The alias is read by the same code path, so it carries the same hazard and
+    must carry the same guard.
+    """
+
+    BASE_URL = ALIAS_LENIENT_URL
+
+
+# --------------------------------------------------------------------------
+# Strict: the same manifest is a load failure
+# --------------------------------------------------------------------------
+
+class TestMalformedConfigUnderStrictValidation(GatewayTestCase):
+    """Strict validation must NOT reject a manifest over an advisory notice.
+
+    ``R015`` is advisory for this release, for the same upgrade-safety reason
+    as ``R014``: the block was parsed but never read before this work, so a
+    manifest carrying a malformed one loaded fine, and refusing it after an
+    upgrade would take a working deployment down to ``runtime_only``. It
+    becomes a validation warning in the next release.
+    """
+
+    BASE_URL = STRICT_URL
+    REQUIRED_APPS = {APP_ID}
+
+    def test_discovery_stays_hybrid(self):
+        """The malformed block is reported, not fatal - strict or not."""
+        health = _poll(
+            lambda: _get_json(self.BASE_URL, '/health'),
+            what=f'{self.BASE_URL} health document',
+        )
+        self.assertEqual(
+            health.get('discovery', {}).get('mode'), 'hybrid',
+            'an advisory R015 must not degrade discovery under strict validation',
+        )
+
+    def test_every_declared_entity_is_still_served(self):
+        """The rest of the manifest is untouched by the malformed block."""
+        self.assertIn(AREA_ID, _item_ids(self.BASE_URL, '/areas'))
+        self.assertIn(COMPONENT_ID, _item_ids(self.BASE_URL, '/components'))
+        self.assertIn(APP_ID, _item_ids(self.BASE_URL, '/apps'))
+
+    def test_the_defaults_apply_after_the_block_is_discarded(self):
+        """Advisory does not mean ignored: the block still does not take effect."""
+        health = _get_json(self.BASE_URL, '/health')
+        linking = health.get('discovery', {}).get('linking', {})
+        self.assertEqual(linking.get('unmanifested_policy'), 'warn', linking)
+
+    def test_the_gateway_is_still_serving(self):
+        """Malformed configuration, but not a dead gateway."""
+        health = _get_json(self.BASE_URL, '/health')
+        self.assertEqual(health.get('status'), 'healthy')
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_manifests_are_cleaned_up(self):
+        """The temp manifests this module wrote do not outlive the run."""
+        _remove_manifests()
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_merge_provenance.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_merge_provenance.test.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests: a manifest entity keeps its provenance under every layer policy.
+
+``x-medkit.source`` is provenance, and the merge pipeline's orphan and
+deduplication filters key their delete decision on it: a manifest-sourced
+entity is protected, a runtime-sourced one is not. A field-group policy must
+therefore never be able to rewrite it.
+
+Three gateways run side by side on one ROS graph against the same entity
+declarations, differing only in how the manifest layer's METADATA policy ends
+up configured:
+
+====================  ==============================================  ==============
+Gateway               Configuration                                   Manifest layer
+====================  ==============================================  ==============
+default               shipped defaults                                authoritative
+no-override           manifest ``config: allow_manifest_override:      fallback
+                      false``
+metadata-fallback     gateway param                                    fallback
+                      ``...layers.manifest.metadata: fallback``
+====================  ==============================================  ==============
+
+The two demoting gateways are the two doors onto the same code path. All three
+must serve the same answer.
+
+**The app under test is deliberately named after its node.** ``temp_sensor``
+binds to the node ``temp_sensor``, so the manifest layer and the runtime layer
+contribute an entity under the *same* id and the per-field-group merge actually
+runs. ``mp-pressure`` binds to ``pressure_sensor`` under a different id and is
+the control: no merge, so it was never at risk.
+
+**Why this test polls instead of checking once.** The failure it guards is not
+a clean, stable deletion - the entity can come and go between discovery passes,
+and the collection listing and the detail endpoint can contradict each other at
+the same instant. A single sample passes even against the broken gateway. So
+every sample is asserted, and the two views are compared against each other,
+not just against the expectation.
+
+**How the test knows discovery really kept running.** Elapsed wall time proves
+nothing: a gateway whose refresh timer died after its first pass would still
+sit there answering, and a sleep-based test would call that twelve passes. The
+gateway does publish a real counter - ``x-medkit-entity-cache.generation`` -
+but it is deliberately gated on the cache CONTENTS changing, so on a steady
+graph it never moves however many passes run (measured: flat across eight
+samples spanning ten passes). So the window is given something to notice: an
+undeclared node joins part-way through, and sampling continues until every
+gateway's generation has advanced past the value it had before. That advance is
+the proof the pipeline was alive during the window; it cannot be produced by a
+stopped timer.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+
+from launch import LaunchDescription
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_demo_nodes,
+    create_gateway_node,
+)
+
+# --------------------------------------------------------------------------
+# Ports - one gateway per configuration
+# --------------------------------------------------------------------------
+
+DEFAULT_PORT = get_test_port(0)
+NO_OVERRIDE_PORT = get_test_port(1)
+METADATA_FALLBACK_PORT = get_test_port(2)
+
+
+def _base_url(port):
+    return f'http://localhost:{port}{API_BASE_PATH}'
+
+
+DEFAULT_URL = _base_url(DEFAULT_PORT)
+NO_OVERRIDE_URL = _base_url(NO_OVERRIDE_PORT)
+METADATA_FALLBACK_URL = _base_url(METADATA_FALLBACK_PORT)
+
+ALL_URLS = (DEFAULT_URL, NO_OVERRIDE_URL, METADATA_FALLBACK_URL)
+
+# --------------------------------------------------------------------------
+# Manifest fixture
+# --------------------------------------------------------------------------
+
+AREA_ID = 'mp-area'
+COMPONENT_ID = 'mp-ecu'
+
+# The app under test: its id is deliberately identical to the name of the node
+# it binds to, which is what makes both discovery layers contribute an entity
+# under the same id.
+SELF_NAMED_APP_ID = 'temp_sensor'
+SELF_NAMED_NODE = 'temp_sensor'
+SELF_NAMED_FQN = '/powertrain/engine/temp_sensor'
+
+# The control app: distinct id, so the two layers never meet on it.
+DISTINCT_APP_ID = 'mp-pressure'
+DISTINCT_NODE = 'pressure_sensor'
+DISTINCT_FQN = '/chassis/brakes/pressure_sensor'
+
+MANIFEST_APPS = {SELF_NAMED_APP_ID, DISTINCT_APP_ID}
+
+# The node that joins mid-window purely so the gateways have a change to
+# notice. It is declared nowhere, and the default policy (warn) keeps it
+# visible, so every gateway's entity set changes and its cache generation
+# advances - which is what proves the discovery loop was alive. Started by the
+# test once every gateway is ready, so the change can never land before the
+# baseline is read.
+LATE_NODE_EXECUTABLE = 'demo_rpm_sensor'
+LATE_NODE_NAME = 'rpm_sensor'
+LATE_NODE_NAMESPACE = '/powertrain/engine'
+
+# Every gateway here runs at the shared test default of 1000 ms
+# (create_gateway_node sets refresh_interval_ms), so sampling a little slower
+# than that keeps consecutive samples on different passes.
+# Wall-clock BUDGETS are scaled by MEDKIT_TEST_TIME_SCALE. The sanitizer jobs
+# multiply every ctest timeout, but a deadline asserted inside a test is
+# invisible to that rewrite, so an ASan/TSan gateway blows it and the failure
+# reads as a regression rather than as instrumentation cost. Unscaled
+# elsewhere, so the budgets keep their falsifying edge on normal jobs.
+#
+# Poll INTERVALS and soak durations are deliberately NOT scaled: polling more
+# slowly would only notice the same answer later, and stretching a soak would
+# hold the gateways longer under exactly the instrumentation that made them
+# expensive - which is load this file would be adding, not absorbing.
+TIME_SCALE = get_time_scale()
+
+# Sample granularity, tied to the gateway's 1000 ms refresh - an INTERVAL, so
+# unscaled: stretching it would change how many passes the window spans.
+SAMPLE_INTERVAL_SEC = 1.25
+# Minimum samples per gateway. Sampling runs past this if the generation has
+# not advanced yet, so the liveness proof is a condition and not a guess.
+SAMPLE_COUNT = 12
+SAMPLE_DEADLINE_SEC = 70.0 * TIME_SCALE
+
+# Was a private 60.0; this is the shared discovery budget, scaled.
+POLL_TIMEOUT_SEC = DISCOVERY_TIMEOUT * TIME_SCALE
+POLL_INTERVAL_SEC = 0.5
+# How long a single HTTP call has to come back.
+HTTP_TIMEOUT_SEC = 5.0 * TIME_SCALE
+# How long the helper node has to exit when the test reaps it.
+PROCESS_REAP_TIMEOUT_SEC = 10.0 * TIME_SCALE
+
+
+def _manifest_yaml(allow_manifest_override):
+    """Render the shared manifest with the given override flag."""
+    flag = 'true' if allow_manifest_override else 'false'
+    return f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Merge provenance test vehicle"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: "warn"
+  allow_manifest_override: {flag}
+areas:
+  - id: {AREA_ID}
+    name: "Merge Provenance Area"
+components:
+  - id: {COMPONENT_ID}
+    name: "Merge Provenance ECU"
+    area: {AREA_ID}
+apps:
+  - id: {SELF_NAMED_APP_ID}
+    name: "Engine Temperature Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: {SELF_NAMED_NODE}
+      namespace: /powertrain/engine
+  - id: {DISTINCT_APP_ID}
+    name: "Brake Pressure Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: {DISTINCT_NODE}
+      namespace: /chassis/brakes
+"""
+
+
+# Manifests this module wrote, so the post-shutdown phase can remove them
+# instead of leaving a file per run behind in the temp directory.
+_MANIFEST_PATHS = []
+
+
+def _remove_manifests():
+    """Delete every manifest this module wrote."""
+    while _MANIFEST_PATHS:
+        try:
+            os.unlink(_MANIFEST_PATHS.pop())
+        except OSError:
+            pass
+
+
+def _write_manifest(name, content):
+    """Write manifest YAML to a temporary file, return its path."""
+    fd, path = tempfile.mkstemp(
+        suffix='.yaml', prefix=f'test_merge_provenance_{name}_',
+    )
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    _MANIFEST_PATHS.append(path)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Sampling helpers
+# --------------------------------------------------------------------------
+
+def _sample(base_url, app_id):
+    """Read the collection and the detail endpoint back to back.
+
+    Returns a dict describing one instant: whether the app is listed, what the
+    detail endpoint answers, and the provenance each view reports.
+    """
+    listing = requests.get(f'{base_url}/apps', timeout=HTTP_TIMEOUT_SEC)
+    detail = requests.get(f'{base_url}/apps/{app_id}', timeout=HTTP_TIMEOUT_SEC)
+
+    listing.raise_for_status()
+    items = listing.json().get('items', [])
+    listed = next((item for item in items if item.get('id') == app_id), None)
+
+    detail_source = None
+    if detail.status_code == 200:
+        detail_source = detail.json().get('x-medkit', {}).get('source')
+
+    return {
+        'in_collection': listed is not None,
+        'collection_source': (
+            listed.get('x-medkit', {}).get('source') if listed else None
+        ),
+        'detail_status': detail.status_code,
+        'detail_source': detail_source,
+        'listed_ids': sorted(item.get('id') for item in items),
+    }
+
+
+def _poll(predicate, *, what, timeout=POLL_TIMEOUT_SEC):
+    """Poll *predicate* until it returns a truthy value, else fail loudly."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            last = predicate()
+            if last:
+                return last
+        except requests.exceptions.RequestException as exc:
+            last = exc
+        time.sleep(POLL_INTERVAL_SEC)
+    raise AssertionError(
+        f'timed out after {timeout}s waiting for {what}; last={last!r}'
+    )
+
+
+def _bound_nodes(base_url):
+    """Return the set of ROS node FQNs any app on *base_url* is bound to."""
+    response = requests.get(f'{base_url}/apps', timeout=HTTP_TIMEOUT_SEC)
+    response.raise_for_status()
+    nodes = set()
+    for app in response.json().get('items', []):
+        node = app.get('x-medkit', {}).get('ros2', {}).get('node')
+        if node:
+            nodes.add(node)
+    return nodes
+
+
+def _wait_for_linking(base_url):
+    """Block until *base_url* has linked the control app to its node.
+
+    Proves the gateway has completed a discovery pass that saw the live ROS
+    graph, so the samples that follow are not reading a pre-graph snapshot.
+    The control app is used as the witness precisely because it is the app the
+    defect cannot touch.
+    """
+    return _poll(
+        lambda: DISTINCT_FQN in _bound_nodes(base_url),
+        what=f'{base_url} to link {DISTINCT_FQN}',
+    )
+
+
+_LATE_NODE_PROCESS = None
+
+
+def _start_late_node():
+    """Put one undeclared node on the graph, once, and keep it running.
+
+    Started from the test rather than the launch description so it cannot
+    appear before the baseline generations have been read.
+    """
+    global _LATE_NODE_PROCESS
+    if _LATE_NODE_PROCESS is not None:
+        return _LATE_NODE_PROCESS
+    executable = os.path.join(
+        get_package_prefix('ros2_medkit_integration_tests'),
+        'lib', 'ros2_medkit_integration_tests', LATE_NODE_EXECUTABLE,
+    )
+    _LATE_NODE_PROCESS = subprocess.Popen(  # noqa: S603
+        [executable, '--ros-args',
+         '-r', f'__ns:={LATE_NODE_NAMESPACE}',
+         '-r', f'__node:={LATE_NODE_NAME}'],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    return _LATE_NODE_PROCESS
+
+
+def _stop_late_node():
+    """Reap the helper so it cannot outlive the test as an orphan."""
+    global _LATE_NODE_PROCESS
+    if _LATE_NODE_PROCESS is None:
+        return
+    _LATE_NODE_PROCESS.terminate()
+    try:
+        _LATE_NODE_PROCESS.wait(timeout=PROCESS_REAP_TIMEOUT_SEC)
+    except subprocess.TimeoutExpired:
+        _LATE_NODE_PROCESS.kill()
+        _LATE_NODE_PROCESS.wait(timeout=PROCESS_REAP_TIMEOUT_SEC)
+    _LATE_NODE_PROCESS = None
+
+
+def _generation(base_url):
+    """Return the gateway's entity-cache generation counter.
+
+    Advances only when a refresh actually changes the cache contents, so it is
+    a true witness that the discovery pipeline ran AND saw something new - not
+    a tick count that a stopped timer could fake.
+    """
+    health = requests.get(f'{base_url}/health', timeout=HTTP_TIMEOUT_SEC)
+    health.raise_for_status()
+    return health.json().get('x-medkit-entity-cache', {}).get('generation')
+
+
+# All three gateways are sampled in one interleaved window rather than once per
+# test class: it is the same wall-clock window for each of them, it keeps the
+# file inside the feature-test budget, and it means the single late node lands
+# inside every gateway's window instead of only the first one's.
+_SAMPLES = None
+
+
+def _collect_samples():
+    """Sample every gateway until the window is long enough AND provably live.
+
+    Returns ``(samples_by_url, baseline_generation_by_url)``.
+    """
+    global _SAMPLES
+    if _SAMPLES is not None:
+        return _SAMPLES
+
+    for url in ALL_URLS:
+        _wait_for_linking(url)
+
+    baseline = {url: _generation(url) for url in ALL_URLS}
+    samples = {url: [] for url in ALL_URLS}
+
+    # The change that drives the liveness proof is started HERE, after every
+    # gateway has linked and its baseline generation has been read - not on a
+    # launch-time timer. A fixed timer races convergence: on a slow box the
+    # node joins before the baseline is taken, no generation advance is ever
+    # observed, and a correct implementation fails as an opaque timeout.
+    _start_late_node()
+
+    started = time.monotonic()
+    deadline = started + SAMPLE_DEADLINE_SEC
+    index = 0
+    while True:
+        if index:
+            time.sleep(SAMPLE_INTERVAL_SEC)
+        for url in ALL_URLS:
+            sample = _sample(url, SELF_NAMED_APP_ID)
+            sample['generation'] = _generation(url)
+            sample['index'] = index
+            sample['at'] = round(time.monotonic() - started, 3)
+            samples[url].append(sample)
+        index += 1
+
+        advanced = all(
+            samples[url][-1]['generation'] > baseline[url] for url in ALL_URLS
+        )
+        if index >= SAMPLE_COUNT and advanced:
+            break
+        if time.monotonic() > deadline:
+            latest = {u: samples[u][-1]['generation'] for u in ALL_URLS}
+            raise AssertionError(
+                f'after {SAMPLE_DEADLINE_SEC}s and {index} samples the cache '
+                f'generation had not advanced on every gateway; '
+                f'baseline={baseline}, latest={latest}. Either the late node '
+                f'never joined or a discovery loop is dead.'
+            )
+
+    _SAMPLES = (samples, baseline)
+    return _SAMPLES
+
+
+# --------------------------------------------------------------------------
+# Launch description
+# --------------------------------------------------------------------------
+
+def generate_test_description():
+    permissive_manifest = _write_manifest('override', _manifest_yaml(True))
+    restrictive_manifest = _write_manifest(
+        'nooverride', _manifest_yaml(False),
+    )
+
+    def gateway(name, port, manifest_path, extra=None):
+        params = {
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': manifest_path,
+            'discovery.manifest_strict_validation': False,
+        }
+        if extra:
+            params.update(extra)
+        return create_gateway_node(port=port, name=name, extra_params=params)
+
+    gateways = [
+        gateway('gw_mp_default', DEFAULT_PORT, permissive_manifest),
+        gateway('gw_mp_no_override', NO_OVERRIDE_PORT, restrictive_manifest),
+        gateway(
+            'gw_mp_metadata_fallback', METADATA_FALLBACK_PORT,
+            permissive_manifest,
+            {'discovery.merge_pipeline.layers.manifest.metadata': 'fallback'},
+        ),
+    ]
+
+    demo_nodes = create_demo_nodes([SELF_NAMED_NODE, DISTINCT_NODE])
+
+    return (
+        LaunchDescription(
+            gateways + demo_nodes + [launch_testing.actions.ReadyToTest()],
+        ),
+        {'gateway_node': gateways[0]},
+    )
+
+
+# --------------------------------------------------------------------------
+# Shared assertions
+# --------------------------------------------------------------------------
+
+class ProvenanceHoldsMixin:
+    """Assertions every gateway in this file must satisfy identically."""
+
+    # Only the control app is required up front. The app under test is the
+    # subject of the assertions, so waiting for it here would turn a clean
+    # failure into a setUpClass timeout.
+    REQUIRED_APPS = {DISTINCT_APP_ID}
+
+    @classmethod
+    def setUpClass(cls):
+        """Wait for the graph, then take (or reuse) the shared sample window."""
+        super().setUpClass()
+        all_samples, baseline = _collect_samples()
+        cls.samples = all_samples[cls.BASE_URL]
+        cls.baseline_generation = baseline[cls.BASE_URL]
+
+    def test_the_discovery_loop_ran_throughout_the_sampling_window(self):
+        """Guards the instrument, on a counter rather than on a sleep.
+
+        The cache generation advances only when a refresh changes the entity
+        set. An undeclared node joins mid-window, so an advance here means the
+        pipeline actually ran and saw it. A gateway whose refresh timer had
+        stopped after its first pass would fail this and could not be rescued
+        by waiting longer.
+        """
+        self.assertGreaterEqual(len(self.samples), SAMPLE_COUNT)
+        self.assertGreater(
+            self.samples[-1]['generation'], self.baseline_generation,
+            'the entity-cache generation never advanced, so nothing proves a '
+            'discovery pass ran during the window; generations seen: '
+            f'{[s["generation"] for s in self.samples]}',
+        )
+
+    def test_self_named_manifest_app_is_served_on_every_pass(self):
+        """The app is listed, answers 200, and stays manifest-sourced."""
+        bad = [s for s in self.samples if not s['in_collection']
+               or s['detail_status'] != 200]
+        self.assertEqual(
+            bad, [],
+            f"'{SELF_NAMED_APP_ID}' must be served on every one of "
+            f'{len(self.samples)} samples; failing samples: {bad}',
+        )
+
+        wrong_source = [
+            s for s in self.samples
+            if s['collection_source'] != 'manifest'
+            or s['detail_source'] != 'manifest'
+        ]
+        self.assertEqual(
+            wrong_source, [],
+            'provenance is not content: a layer policy must not rewrite '
+            f"'{SELF_NAMED_APP_ID}' away from manifest; failing samples: "
+            f'{wrong_source}',
+        )
+
+    def test_the_app_survives_the_graph_change_too(self):
+        """Change, not just steady state: a node joins and it still holds.
+
+        The samples straddle the moment the late node appeared, so the
+        assertions above already cover both sides of a real entity-set change.
+        This names the claim so it is not read as a steady-state result.
+        """
+        changed_at = next(
+            (s['index'] for s in self.samples
+             if s['generation'] > self.baseline_generation),
+            None,
+        )
+        self.assertIsNotNone(changed_at)
+        self.assertTrue(
+            any(s['index'] >= changed_at for s in self.samples)
+            and any(s['index'] < changed_at for s in self.samples),
+            f'the window must contain samples from before and after the '
+            f'change; it changed at sample {changed_at} of {len(self.samples)}',
+        )
+        after = [s for s in self.samples if s['index'] >= changed_at]
+        self.assertEqual(
+            [s for s in after if not s['in_collection']
+             or s['detail_status'] != 200], [],
+            f'the app must survive the entity-set change; after={after}',
+        )
+
+    def test_collection_and_detail_never_disagree(self):
+        """The two views of the same entity agree at every instant."""
+        disagreements = [
+            s for s in self.samples
+            if s['in_collection'] != (s['detail_status'] == 200)
+        ]
+        self.assertEqual(
+            disagreements, [],
+            f'GET /apps and GET /apps/{SELF_NAMED_APP_ID} contradicted each '
+            f'other on {len(disagreements)} of {len(self.samples)} samples: '
+            f'{disagreements}',
+        )
+
+    def test_control_app_with_a_distinct_id_is_unaffected(self):
+        """The app whose id differs from its node was never at risk."""
+        sample = _sample(self.BASE_URL, DISTINCT_APP_ID)
+        self.assertTrue(sample['in_collection'], sample)
+        self.assertEqual(sample['detail_status'], 200, sample)
+        self.assertEqual(sample['collection_source'], 'manifest', sample)
+
+    def test_both_manifest_apps_are_present(self):
+        """The manifest contributed both apps, whatever the layer policy."""
+        listed = _poll(
+            lambda: set(_sample(
+                self.BASE_URL, SELF_NAMED_APP_ID)['listed_ids']) or None,
+            what=f'{self.BASE_URL} to list any app',
+        )
+        self.assertEqual(
+            MANIFEST_APPS - listed, set(),
+            f'missing manifest apps: {sorted(MANIFEST_APPS - listed)}; '
+            f'listed: {sorted(listed)}',
+        )
+
+
+# --------------------------------------------------------------------------
+# Baseline: the shipped defaults
+# --------------------------------------------------------------------------
+
+class TestDefaultPolicies(ProvenanceHoldsMixin, GatewayTestCase):
+    """Control gateway: nothing demotes the manifest layer."""
+
+    BASE_URL = DEFAULT_URL
+
+
+# --------------------------------------------------------------------------
+# Door 1: the manifest's own `allow_manifest_override: false`
+# --------------------------------------------------------------------------
+
+class TestManifestOverrideDisabled(ProvenanceHoldsMixin, GatewayTestCase):
+    """`allow_manifest_override: false` demotes METADATA to fallback."""
+
+    BASE_URL = NO_OVERRIDE_URL
+
+
+# --------------------------------------------------------------------------
+# Door 2: the gateway parameter, reachable without any manifest flag
+# --------------------------------------------------------------------------
+
+class TestManifestMetadataFallback(ProvenanceHoldsMixin, GatewayTestCase):
+    """`layers.manifest.metadata: fallback` demotes the same field group."""
+
+    BASE_URL = METADATA_FALLBACK_URL
+
+
+# --------------------------------------------------------------------------
+# The three gateways must not merely each be self-consistent
+# --------------------------------------------------------------------------
+
+class TestAllConfigurationsAgree(GatewayTestCase):
+    """Provenance is identical across all three configurations."""
+
+    BASE_URL = DEFAULT_URL
+    REQUIRED_APPS = {DISTINCT_APP_ID}
+
+    def test_every_gateway_reports_the_same_provenance(self):
+        """One entity, three layer policies, one answer."""
+        urls = (DEFAULT_URL, NO_OVERRIDE_URL, METADATA_FALLBACK_URL)
+        for url in urls:
+            _wait_for_linking(url)
+
+        observed = {url: _sample(url, SELF_NAMED_APP_ID) for url in urls}
+        for url, sample in observed.items():
+            self.assertTrue(
+                sample['in_collection'],
+                f'{url} does not list {SELF_NAMED_APP_ID}: {sample}',
+            )
+            self.assertEqual(
+                sample['detail_status'], 200,
+                f'{url} does not serve {SELF_NAMED_APP_ID}: {sample}',
+            )
+            self.assertEqual(
+                sample['collection_source'], 'manifest',
+                f'{url} reports the wrong provenance: {sample}',
+            )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_helper_node_and_manifests_are_cleaned_up(self):
+        """The test owns the late node and its manifests, so it reaps them."""
+        _stop_late_node()
+        _remove_manifests()
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_plugin_entity_survives_ignore.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_plugin_entity_survives_ignore.test.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration test: `unmanifested_nodes: ignore` must not delete plugin entities.
+
+The orphan sweep used to decide protection by matching an entity's
+``x-medkit.source`` against a list of known strings. That string is chosen by
+whoever produced the entity: a discovery plugin may set anything, and the
+beacon mapper sets ``beacon``. A provider that picked a tag the list had never
+heard of therefore had its entities swept away - and this branch is what makes
+``ignore`` actually take effect, so the sweep is newly reachable.
+
+Protection now follows the layer that OWNS the entity, which the pipeline knows
+for certain, rather than a string carried in the data. This test pins that end
+to end with the in-tree test plugin, which declares two apps:
+
+* ``plugin_dev`` - ``source: "plugin"``, a tag the old whitelist knew
+* ``plugin_unlisted_source`` - ``source: "beacon"``, a tag it did not
+
+Both must survive. The second is the one that regressed; the first is here so a
+failure tells you whether protection broke generally or only for unlisted tags.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    DISCOVERY_TIMEOUT,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+# Apps the test plugin declares. The tag each carries is the whole point.
+PLUGIN_APP_LISTED_TAG = 'plugin_dev'
+PLUGIN_APP_UNLISTED_TAG = 'plugin_unlisted_source'
+PLUGIN_APPS = {PLUGIN_APP_LISTED_TAG, PLUGIN_APP_UNLISTED_TAG}
+
+PLUGIN_AREA = 'test_plugin_area'
+PLUGIN_COMPONENT = 'test_plugin_comp'
+
+# A node nothing declares. Under `ignore` it must be swept - that is what shows
+# the policy is in force rather than quietly doing nothing.
+UNDECLARED_NODE = 'rpm_sensor'
+UNDECLARED_FQN = '/powertrain/engine/rpm_sensor'
+
+# Wall-clock BUDGETS are scaled by MEDKIT_TEST_TIME_SCALE. The sanitizer jobs
+# multiply every ctest timeout, but a deadline asserted inside a test is
+# invisible to that rewrite, so an ASan/TSan gateway blows it and the failure
+# reads as a regression rather than as instrumentation cost. Unscaled
+# elsewhere, so the budgets keep their falsifying edge on normal jobs.
+#
+# Poll INTERVALS and soak durations are deliberately NOT scaled: polling more
+# slowly would only notice the same answer later, and stretching a soak would
+# hold the gateways longer under exactly the instrumentation that made them
+# expensive - which is load this file would be adding, not absorbing.
+TIME_SCALE = get_time_scale()
+
+# Was a private 60.0; this is the shared discovery budget, scaled.
+POLL_TIMEOUT_SEC = DISCOVERY_TIMEOUT * TIME_SCALE
+# The plugin's entities appear within a pass or two when protection works. A
+# short budget for "is it there" keeps a genuine deletion failing fast with a
+# diagnostic, instead of every test burning the long timeout and the whole
+# launch test dying as an uninformative ctest timeout.
+ENTITY_TIMEOUT_SEC = 20.0 * TIME_SCALE
+POLL_INTERVAL_SEC = 0.5
+# How long a single HTTP call has to come back.
+HTTP_TIMEOUT_SEC = 5.0 * TIME_SCALE
+# The policy must keep holding, not merely hold once: the sweep runs on every
+# discovery pass, and the defect deleted the entity on a later pass.
+# Soak duration, not a budget - see the note above; left unscaled on purpose.
+HOLD_SEC = 5.0
+
+
+_MANIFEST_PATHS = []
+
+
+def _plugin_path():
+    return os.path.join(
+        get_package_prefix('ros2_medkit_integration_tests'),
+        'lib', 'ros2_medkit_integration_tests', 'libtopics_test_plugin.so',
+    )
+
+
+def _manifest_yaml():
+    """Render a manifest that declares nothing, with the sweep switched on.
+
+    `ignore` drops every app that is not protected, so with no manifest apps
+    at all the only things that may survive are the plugin's.
+    """
+    return """\
+manifest_version: "1.0"
+metadata:
+  name: "Plugin survives ignore"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: "ignore"
+areas:
+  - id: pi-area
+    name: "Plugin Ignore Area"
+"""
+
+
+def generate_test_description():
+    fd, manifest_path = tempfile.mkstemp(
+        suffix='.yaml', prefix='test_plugin_entity_survives_ignore_',
+    )
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(_manifest_yaml())
+    _MANIFEST_PATHS.append(manifest_path)
+
+    return create_test_launch(
+        demo_nodes=[UNDECLARED_NODE],
+        fault_manager=False,
+        gateway_params={
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': manifest_path,
+            'discovery.manifest_strict_validation': False,
+            'plugins': ['topics_test'],
+            'plugins.topics_test.path': _plugin_path(),
+        },
+    )
+
+
+def _remove_manifests():
+    """Delete every manifest this module wrote."""
+    while _MANIFEST_PATHS:
+        try:
+            os.unlink(_MANIFEST_PATHS.pop())
+        except OSError:
+            pass
+
+
+class TestPluginEntitySurvivesIgnorePolicy(GatewayTestCase):
+    """A plugin-owned entity is protected whatever `source` tag it carries."""
+
+    MIN_EXPECTED_APPS = 0
+
+    def _app_documents(self):
+        response = requests.get(f'{self.BASE_URL}/apps', timeout=HTTP_TIMEOUT_SEC)
+        response.raise_for_status()
+        return {
+            item['id']: item for item in response.json().get('items', [])
+        }
+
+    def _poll_until(self, predicate, *, what, timeout=POLL_TIMEOUT_SEC):
+        deadline = time.monotonic() + timeout
+        last = None
+        while time.monotonic() < deadline:
+            try:
+                last = self._app_documents()
+                if predicate(last):
+                    return last
+            except requests.exceptions.RequestException as exc:
+                last = exc
+            time.sleep(POLL_INTERVAL_SEC)
+        served = sorted(last) if isinstance(last, dict) else last
+        raise AssertionError(
+            f'timed out after {timeout}s waiting for {what}; served apps: {served}'
+        )
+
+    def test_the_ignore_policy_is_actually_in_force(self):
+        """Guards the fixture: without the sweep running this proves nothing."""
+        health = requests.get(f'{self.BASE_URL}/health', timeout=HTTP_TIMEOUT_SEC).json()
+        linking = health.get('discovery', {}).get('linking', {})
+        self.assertEqual(linking.get('unmanifested_policy'), 'ignore', health)
+
+        # The undeclared node must be gone - that is the sweep working.
+        def swept(apps):
+            return not any(
+                a.get('x-medkit', {}).get('ros2', {}).get('node') == UNDECLARED_FQN
+                for a in apps.values()
+            )
+
+        self._poll_until(swept, what=f'{UNDECLARED_FQN} to be swept by `ignore`')
+
+    def test_both_plugin_apps_survive_and_keep_their_source_tags(self):
+        """The unlisted tag is the regression; the listed one is the control."""
+        apps = self._poll_until(
+            lambda a: PLUGIN_APPS <= set(a),
+            what='both plugin apps to be served',
+            timeout=ENTITY_TIMEOUT_SEC,
+        )
+
+        self.assertEqual(
+            apps[PLUGIN_APP_UNLISTED_TAG].get('x-medkit', {}).get('source'), 'beacon',
+            'the fix must protect the entity WITHOUT rewriting the tag its '
+            'provider chose - `source` is public API and feeds identity '
+            'provenance',
+        )
+        self.assertEqual(
+            apps[PLUGIN_APP_LISTED_TAG].get('x-medkit', {}).get('source'), 'plugin',
+        )
+
+    def test_the_plugin_apps_keep_surviving_across_passes(self):
+        """The sweep runs every pass; surviving one pass is not enough."""
+        self._poll_until(
+            lambda a: PLUGIN_APPS <= set(a),
+            what='both plugin apps to be served',
+            timeout=ENTITY_TIMEOUT_SEC,
+        )
+
+        deadline = time.monotonic() + HOLD_SEC
+        while True:
+            served = set(self._app_documents())
+            missing = PLUGIN_APPS - served
+            self.assertEqual(
+                missing, set(),
+                f'a plugin app was swept on a later discovery pass: {sorted(missing)}',
+            )
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(POLL_INTERVAL_SEC)
+
+    def test_the_plugins_area_and_component_survive_too(self):
+        """Areas and Components go through the same suppression path."""
+        def collection_ids(path):
+            response = requests.get(f'{self.BASE_URL}{path}', timeout=HTTP_TIMEOUT_SEC)
+            response.raise_for_status()
+            return {item['id'] for item in response.json().get('items', [])}
+
+        deadline = time.monotonic() + ENTITY_TIMEOUT_SEC
+        while time.monotonic() < deadline:
+            if PLUGIN_AREA in collection_ids('/areas') and \
+                    PLUGIN_COMPONENT in collection_ids('/components'):
+                return
+            time.sleep(POLL_INTERVAL_SEC)
+        self.fail(
+            f'{PLUGIN_AREA} / {PLUGIN_COMPONENT} did not survive; '
+            f'areas={sorted(collection_ids("/areas"))}, '
+            f'components={sorted(collection_ids("/components"))}'
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_manifests_are_cleaned_up(self):
+        """The temp manifest this module wrote does not outlive the run."""
+        _remove_manifests()
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_unmanifested_policy.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_unmanifested_policy.test.py
@@ -1,0 +1,846 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests for the settings inside the manifest's discovery-config block.
+
+Six gateways run side by side on one ROS graph against the same entity
+declarations, differing only in the discovery configuration under test:
+
+=====================  ==============================================  =========================
+Gateway                Configuration                                   Expected
+=====================  ==============================================  =========================
+baseline               defaults (inherit on, override allowed)         runtime resources
+                                                                       inherited, manifest wins
+no-inherit             ``inherit_runtime_resources: false``            no runtime topics or
+                                                                       services on the app
+no-override            ``allow_manifest_override: false``              runtime hosts join the
+                                                                       hierarchy union;
+                                                                       provenance unchanged
+override-pinned        ``allow_manifest_override: false`` PLUS an      the explicit parameter
+                       explicit ``layers.manifest.hierarchy``          wins: the manifest keeps
+                       parameter                                       hosts exclusive
+error-policy           ``unmanifested_nodes: error``                   gateway keeps serving and
+                                                                       reports the orphans
+orphan-policy          ``unmanifested_nodes: include_as_orphan``       entity tree identical to
+                                                                       the baseline's (``warn``)
+=====================  ==============================================  =========================
+
+Every instrument is a served document: the app's own ``/data`` and
+``/operations`` collections, the merged Function's ``x-medkit`` block, and the
+``/health`` warnings array. None of them is a log line, and none of them is the
+setting that was configured read back to itself.
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+
+from launch import LaunchDescription
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.convergence import assert_documents_match
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_demo_nodes,
+    create_gateway_node,
+)
+
+# --------------------------------------------------------------------------
+# Ports - one gateway per configuration under test
+# --------------------------------------------------------------------------
+
+BASELINE_PORT = get_test_port(0)
+NO_INHERIT_PORT = get_test_port(1)
+NO_OVERRIDE_PORT = get_test_port(2)
+OVERRIDE_PINNED_PORT = get_test_port(3)
+ERROR_POLICY_PORT = get_test_port(4)
+ORPHAN_POLICY_PORT = get_test_port(5)
+
+
+def _base_url(port):
+    return f'http://localhost:{port}{API_BASE_PATH}'
+
+
+BASELINE_URL = _base_url(BASELINE_PORT)
+NO_INHERIT_URL = _base_url(NO_INHERIT_PORT)
+NO_OVERRIDE_URL = _base_url(NO_OVERRIDE_PORT)
+OVERRIDE_PINNED_URL = _base_url(OVERRIDE_PINNED_PORT)
+ERROR_POLICY_URL = _base_url(ERROR_POLICY_PORT)
+ORPHAN_POLICY_URL = _base_url(ORPHAN_POLICY_PORT)
+
+# --------------------------------------------------------------------------
+# Manifest fixture
+# --------------------------------------------------------------------------
+
+AREA_ID = 'mcfg-area'
+COMPONENT_ID = 'mcfg-ecu'
+TEMP_APP_ID = 'mcfg-temp'
+CALIB_APP_ID = 'mcfg-calib'
+ACTION_APP_ID = 'mcfg-action'
+MANIFEST_APPS = {TEMP_APP_ID, CALIB_APP_ID, ACTION_APP_ID}
+
+# The manifest declares a Function under the id the runtime layer derives from
+# the /powertrain/engine namespace, so both layers contribute the same entity
+# and the merge policies decide what the served document says.
+SHARED_FUNCTION_ID = 'powertrain'
+MANIFEST_FUNCTION_NAME = 'Powertrain (declared)'
+# Runtime app id for the temp_sensor node - present in the runtime layer's
+# view of the same Function, absent from the manifest's.
+RUNTIME_HOST_ID = 'temp_sensor'
+
+# Nodes present from the start; all are declared by the manifest. All three
+# resource kinds enrich_app() copies are represented: a topic, a service and an
+# action, because inherit_runtime_resources gates the copy of all three.
+EARLY_NODES = ['temp_sensor', 'calibration', 'long_calibration']
+TEMP_TOPIC = '/powertrain/engine/temperature'
+CALIB_SERVICE = '/powertrain/engine/calibrate'
+CALIB_ACTION = '/powertrain/engine/long_calibration'
+
+# Nodes that join after the baseline snapshot, declared nowhere. Started by
+# the test (see _start_late_nodes) rather than by the launch description, so
+# they cannot appear before the snapshot that must not see them.
+# (executable, node name, namespace) - mirrors DEMO_NODE_REGISTRY.
+LATE_NODE_SPECS = [
+    ('demo_rpm_sensor', 'rpm_sensor', '/powertrain/engine'),
+    ('demo_door_status_sensor', 'status_sensor', '/body/door/front_left'),
+]
+LATE_RPM_FQN = '/powertrain/engine/rpm_sensor'
+LATE_STATUS_FQN = '/body/door/front_left/status_sensor'
+
+WARN_UNMANIFESTED_NODES = 'unmanifested_nodes'
+WARNING_SCHEMA_VERSION = 2
+
+# Wall-clock BUDGETS are scaled by MEDKIT_TEST_TIME_SCALE; poll INTERVALS and
+# soak durations are not. See the note in test_manifest_config_key for why
+# stretching a soak under sanitizers is the wrong direction.
+TIME_SCALE = get_time_scale()
+POLL_TIMEOUT_SEC = 45.0 * TIME_SCALE
+POLL_INTERVAL_SEC = 0.5
+# How long a single HTTP call has to come back.
+HTTP_TIMEOUT_SEC = 5.0 * TIME_SCALE
+# How long a helper node has to exit when the test reaps it.
+PROCESS_REAP_TIMEOUT_SEC = 10.0 * TIME_SCALE
+# How long the gateway must keep answering normally after the orphans appeared.
+# Soak duration, NOT a budget: it is time this test spends holding six
+# gateways up, and tripling it under sanitizers adds exactly the load that
+# makes neighbouring tests miss their own deadlines. Unscaled on purpose.
+HOLD_SEC = 3.0
+
+
+def _manifest_yaml(policy='warn', inherit=True, allow_override=True):
+    """Render the shared manifest with the discovery configuration under test."""
+    return f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Discovery configuration policy test vehicle"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: "{policy}"
+  inherit_runtime_resources: {str(inherit).lower()}
+  allow_manifest_override: {str(allow_override).lower()}
+areas:
+  - id: {AREA_ID}
+    name: "Policy Test Area"
+components:
+  - id: {COMPONENT_ID}
+    name: "Policy Test ECU"
+    area: {AREA_ID}
+apps:
+  - id: {TEMP_APP_ID}
+    name: "Engine Temperature Sensor"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: temp_sensor
+      namespace: /powertrain/engine
+  - id: {CALIB_APP_ID}
+    name: "Engine Calibration Service"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: calibration
+      namespace: /powertrain/engine
+  - id: {ACTION_APP_ID}
+    name: "Engine Long Calibration Action"
+    is_located_on: {COMPONENT_ID}
+    ros_binding:
+      node_name: long_calibration
+      namespace: /powertrain/engine
+functions:
+  - id: {SHARED_FUNCTION_ID}
+    name: "{MANIFEST_FUNCTION_NAME}"
+    hosted_by:
+      - {TEMP_APP_ID}
+      - {CALIB_APP_ID}
+      - {ACTION_APP_ID}
+"""
+
+
+# Manifests this module wrote, so the post-shutdown phase can remove them
+# instead of leaving a file per run behind in the temp directory.
+_MANIFEST_PATHS = []
+
+
+def _remove_manifests():
+    """Delete every manifest this module wrote."""
+    while _MANIFEST_PATHS:
+        try:
+            os.unlink(_MANIFEST_PATHS.pop())
+        except OSError:
+            pass
+
+
+def _write_manifest(name, content):
+    """Write manifest YAML to a temporary file, return its path."""
+    fd, path = tempfile.mkstemp(
+        suffix='.yaml', prefix=f'test_unmanifested_policy_{name}_',
+    )
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    _MANIFEST_PATHS.append(path)
+    return path
+
+
+# --------------------------------------------------------------------------
+# Shared HTTP helpers (cross-gateway, so not GatewayTestCase methods)
+# --------------------------------------------------------------------------
+
+def _get_json(base_url, path):
+    response = requests.get(f'{base_url}{path}', timeout=HTTP_TIMEOUT_SEC)
+    response.raise_for_status()
+    return response.json()
+
+
+def _item_ids(base_url, path):
+    return {item['id'] for item in _get_json(base_url, path).get('items', [])}
+
+
+def _poll(predicate, *, what, timeout=POLL_TIMEOUT_SEC):
+    """Poll *predicate* until it returns a truthy value, else fail loudly."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        try:
+            last = predicate()
+            if last:
+                return last
+        except requests.exceptions.RequestException as exc:
+            last = exc
+        time.sleep(POLL_INTERVAL_SEC)
+    raise AssertionError(f'timed out after {timeout}s waiting for {what}; last={last!r}')
+
+
+def _unmanifested_warning_in(health):
+    """Return the unmanifested-node warning inside an already-read document.
+
+    Separate from _unmanifested_warning so a caller that needs the warning AND
+    another field of the same document can read both from one response.
+    """
+    for warning in health.get('warnings', []):
+        if warning.get('code') == WARN_UNMANIFESTED_NODES:
+            return warning
+    return None
+
+
+def _unmanifested_warning(base_url):
+    """Return the unmanifested-node warning from /health, or None."""
+    return _unmanifested_warning_in(_get_json(base_url, '/health'))
+
+
+def _service_paths(base_url, app_id):
+    """Return the ROS service paths the app's /operations collection exposes."""
+    items = _get_json(base_url, f'/apps/{app_id}/operations').get('items', [])
+    return {op.get('x-medkit', {}).get('ros2', {}).get('service') for op in items}
+
+
+def _action_paths(base_url, app_id):
+    """Return the ROS action paths the app's /operations collection exposes.
+
+    Actions are the third resource kind ``enrich_app`` copies, alongside topics
+    and services, so ``inherit_runtime_resources`` has to be checked on them
+    too - a test that only looks at topics and services cannot tell whether the
+    action leg of the copy is gated at all.
+    """
+    items = _get_json(base_url, f'/apps/{app_id}/operations').get('items', [])
+    return {
+        op.get('x-medkit', {}).get('ros2', {}).get('action')
+        for op in items
+        if op.get('x-medkit', {}).get('ros2', {}).get('kind') == 'action'
+    }
+
+
+# Convergence comparison lives in ros2_medkit_test_utils so there is one
+# implementation: the obvious inline version passes when neither side was ever
+# fetched. See convergence.py for why.
+TREE_MATCH_TIMEOUT_SEC = 15.0 * TIME_SCALE
+
+
+def _assert_trees_match(test, fetch_left, fetch_right, *, what):
+    return assert_documents_match(
+        test, fetch_left, fetch_right,
+        what=what, timeout=TREE_MATCH_TIMEOUT_SEC,
+        interval=POLL_INTERVAL_SEC,
+    )
+
+
+def _function_extension(base_url, function_id=SHARED_FUNCTION_ID):
+    """Return the merged Function's x-medkit block."""
+    return _get_json(base_url, f'/functions/{function_id}').get('x-medkit', {})
+
+
+def _wait_for_manifest_apps(base_url):
+    """Block until *base_url* serves both manifest apps."""
+    return _poll(
+        lambda: True if MANIFEST_APPS <= _item_ids(base_url, '/apps') else None,
+        what=f'{base_url} to serve the manifest apps',
+    )
+
+
+_INITIAL_ORPHANS = None
+
+
+def _initial_orphans():
+    """Snapshot the error-policy gateway's orphan list before the late nodes.
+
+    Taken by whichever test class runs first, so the "before" state does not
+    depend on the order the classes happen to execute in. The gateways share
+    one ROS graph, so each of them is an undeclared node in the others' view -
+    the warning is therefore already present, and what the snapshot proves is
+    that the LATE nodes are not yet in it.
+    """
+    global _INITIAL_ORPHANS
+    if _INITIAL_ORPHANS is None:
+        warning = _poll(
+            lambda: _unmanifested_warning(ERROR_POLICY_URL),
+            what=f'{ERROR_POLICY_URL} to report its first unmanifested nodes',
+        )
+        _INITIAL_ORPHANS = set(warning['ros_node_fqns'])
+        # Only NOW may the late nodes appear. Starting them from the test
+        # rather than a launch-time timer removes the race: a fixed delay has
+        # to be longer than however long this snapshot takes to converge, and
+        # when it is not, a correct gateway fails an assertion about its own
+        # test fixture.
+        _start_late_nodes()
+    return _INITIAL_ORPHANS
+
+
+_LATE_NODE_PROCESSES = []
+
+
+def _start_late_nodes():
+    """Put the undeclared late nodes on the graph, once."""
+    if _LATE_NODE_PROCESSES:
+        return
+    lib_dir = os.path.join(
+        get_package_prefix('ros2_medkit_integration_tests'),
+        'lib', 'ros2_medkit_integration_tests',
+    )
+    for executable, node_name, namespace in LATE_NODE_SPECS:
+        _LATE_NODE_PROCESSES.append(subprocess.Popen(  # noqa: S603
+            [os.path.join(lib_dir, executable), '--ros-args',
+             '-r', f'__ns:={namespace}', '-r', f'__node:={node_name}'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        ))
+
+
+def _stop_late_nodes():
+    """Reap the helpers so they cannot outlive the test as orphans."""
+    while _LATE_NODE_PROCESSES:
+        proc = _LATE_NODE_PROCESSES.pop()
+        proc.terminate()
+        try:
+            proc.wait(timeout=PROCESS_REAP_TIMEOUT_SEC)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=PROCESS_REAP_TIMEOUT_SEC)
+
+
+# --------------------------------------------------------------------------
+# Launch description
+# --------------------------------------------------------------------------
+
+def generate_test_description():
+    baseline_manifest = _write_manifest('baseline', _manifest_yaml())
+    no_inherit_manifest = _write_manifest(
+        'noinherit', _manifest_yaml(inherit=False),
+    )
+    no_override_manifest = _write_manifest(
+        'nooverride', _manifest_yaml(allow_override=False),
+    )
+    error_manifest = _write_manifest('error', _manifest_yaml(policy='error'))
+    orphan_manifest = _write_manifest(
+        'orphan', _manifest_yaml(policy='include_as_orphan'),
+    )
+
+    def gateway(name, port, manifest_path, extra=None):
+        params = {
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': manifest_path,
+            'discovery.manifest_strict_validation': False,
+            # The runtime layer must contribute the namespace-derived Function
+            # so that the manifest's Function of the same id has something to
+            # be merged against.
+            'discovery.merge_pipeline.gap_fill.allow_heuristic_functions': True,
+        }
+        if extra:
+            params.update(extra)
+        return create_gateway_node(port=port, name=name, extra_params=params)
+
+    gateways = [
+        gateway('gw_baseline', BASELINE_PORT, baseline_manifest),
+        gateway('gw_no_inherit', NO_INHERIT_PORT, no_inherit_manifest),
+        gateway('gw_no_override', NO_OVERRIDE_PORT, no_override_manifest),
+        gateway(
+            'gw_override_pinned', OVERRIDE_PINNED_PORT, no_override_manifest,
+            extra={
+                # A deployment that explicitly pins a group must beat the
+                # manifest's blanket switch. `hierarchy` is the pin that can be
+                # observed: it is the only group whose demotion changes the
+                # served document against the shipped manifest+runtime pair, so
+                # it is the only one that can tell a pinned gateway from an
+                # unpinned one.
+                'discovery.merge_pipeline.layers.manifest.identity': 'authoritative',
+                'discovery.merge_pipeline.layers.manifest.hierarchy': 'authoritative',
+            },
+        ),
+        gateway('gw_error_policy', ERROR_POLICY_PORT, error_manifest),
+        gateway('gw_orphan_policy', ORPHAN_POLICY_PORT, orphan_manifest),
+    ]
+
+    early_nodes = create_demo_nodes(EARLY_NODES)
+
+    return (
+        LaunchDescription(
+            gateways + early_nodes + [launch_testing.actions.ReadyToTest()],
+        ),
+        {'gateway_node': gateways[0]},
+    )
+
+
+# --------------------------------------------------------------------------
+# U7 / U8: `unmanifested_nodes: error` reports, it does not stop the gateway
+# --------------------------------------------------------------------------
+
+class TestErrorPolicyHealthSurface(GatewayTestCase):
+    """`error` produces a /health warning and keeps the gateway serving."""
+
+    BASE_URL = ERROR_POLICY_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _initial_orphans()
+
+    def test_health_reports_the_configured_policy(self):
+        """`discovery.linking` names the policy a monitor has to branch on."""
+        linking = _poll(
+            lambda: _get_json(self.BASE_URL, '/health').get('discovery', {}).get('linking'),
+            what=f'{self.BASE_URL} to publish its linking block',
+        )
+        self.assertEqual(linking.get('unmanifested_policy'), 'error')
+
+    def test_late_unmanifested_nodes_join_the_warning(self):
+        """Nodes that appear after startup show up in a later /health poll."""
+        before = _initial_orphans()
+        self.assertNotIn(
+            LATE_RPM_FQN, before,
+            'the baseline must be taken before the late nodes start; '
+            '_initial_orphans() starts them itself, so this can only fail if '
+            'that ordering was broken',
+        )
+        self.assertNotIn(LATE_STATUS_FQN, before)
+
+        late = {LATE_RPM_FQN, LATE_STATUS_FQN}
+        warning = _poll(
+            lambda: (w := _unmanifested_warning(self.BASE_URL)) and (
+                w if late <= set(w['ros_node_fqns']) else None
+            ),
+            what=f'{self.BASE_URL} to list both late nodes as unmanifested',
+        )
+
+        # Scale: every orphan is listed, not just the first one. Both numbers
+        # come from ONE response - six gateways share this graph and nodes join
+        # late, so a count read from a second /health call can legitimately
+        # describe a different discovery pass and the comparison would be
+        # meaningless.
+        health = _poll(
+            lambda: (h := _get_json(self.BASE_URL, '/health')) and (
+                h if _unmanifested_warning_in(h) else None
+            ),
+            what=f'{self.BASE_URL} to serve the warning and its counts together',
+        )
+        same_response_warning = _unmanifested_warning_in(health)
+        self.assertEqual(
+            len(same_response_warning['ros_node_fqns']),
+            health['discovery']['linking']['orphan_count'],
+            'ros_node_fqns must carry every orphan the linker counted',
+        )
+        warning = same_response_warning
+        # The subjects are ROS nodes, so the SOVD-id field stays empty. A node
+        # FQN is not addressable: the '/' it always contains is rejected in an
+        # entity id because it conflicts with URL routing.
+        self.assertEqual(
+            warning['entity_ids'], [],
+            'entity_ids carries addressable SOVD ids only; node names belong '
+            f"in ros_node_fqns: {warning['entity_ids']}",
+        )
+        self.assertEqual(warning['peer_names'], [])
+        self.assertTrue(warning['message'])
+
+    def test_gateway_keeps_serving_after_the_orphans_appear(self):
+        """R6: the `error` policy is a report, never an outage."""
+        late = {LATE_RPM_FQN, LATE_STATUS_FQN}
+        _poll(
+            lambda: (w := _unmanifested_warning(self.BASE_URL)) and (
+                w if late <= set(w['ros_node_fqns']) else None
+            ),
+            what=f'{self.BASE_URL} to list both late nodes as unmanifested',
+        )
+
+        deadline = time.monotonic() + HOLD_SEC
+        while True:
+            health = _get_json(self.BASE_URL, '/health')
+            self.assertEqual(health['status'], 'healthy')
+            self.assertEqual(health['discovery']['mode'], 'hybrid')
+            self.assertTrue(MANIFEST_APPS <= _item_ids(self.BASE_URL, '/apps'))
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(POLL_INTERVAL_SEC)
+
+
+class TestErrorPolicyWarningsContract(GatewayTestCase):
+    """The warnings array is served whether or not aggregation is enabled."""
+
+    BASE_URL = BASELINE_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _initial_orphans()
+
+    def test_warnings_and_schema_version_present_without_aggregation(self):
+        """U8: no aggregation manager, still an array and a version."""
+        root = _get_json(self.BASE_URL, '/')
+        self.assertFalse(root['capabilities']['aggregation'])
+
+        health = _get_json(self.BASE_URL, '/health')
+        self.assertIn('warnings', health)
+        self.assertIsInstance(health['warnings'], list)
+        self.assertEqual(health.get('warning_schema_version'), WARNING_SCHEMA_VERSION)
+
+    def test_warn_policy_raises_no_unmanifested_warning(self):
+        """The baseline gateway has the same orphans and stays quiet."""
+        _poll(
+            lambda: _get_json(self.BASE_URL, '/health').get('discovery', {}).get('linking'),
+            what=f'{self.BASE_URL} to publish its linking block',
+        )
+        health = _get_json(self.BASE_URL, '/health')
+        self.assertGreater(health['discovery']['linking']['orphan_count'], 0)
+        self.assertEqual(health['discovery']['linking']['unmanifested_policy'], 'warn')
+        self.assertIsNone(
+            _unmanifested_warning(self.BASE_URL),
+            f'policy warn must not raise the warning: {health["warnings"]}',
+        )
+
+
+# --------------------------------------------------------------------------
+# include_as_orphan: documented as "warn with a quieter log", so the entity
+# tree - not the policy read back to itself - has to prove it
+# --------------------------------------------------------------------------
+
+class TestIncludeAsOrphanPolicyMatchesWarn(GatewayTestCase):
+    """The documented promise is an identical tree; assert exactly that.
+
+    Both gateways run the same manifest and differ only in this one setting,
+    and they share one ROS graph, so every collection must agree entity for
+    entity. Asserting the configured policy or the orphan count would only
+    read the setting back - it would not notice `include_as_orphan` quietly
+    hiding, renaming or unbinding anything.
+    """
+
+    BASE_URL = ORPHAN_POLICY_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    @staticmethod
+    def _app_documents(base_url):
+        """Project /apps into a form two gateways on one graph can be compared on."""
+        documents = {}
+        for app in _get_json(base_url, '/apps').get('items', []):
+            medkit = app.get('x-medkit', {})
+            documents[app['id']] = {
+                'name': app.get('name'),
+                'type': app.get('type'),
+                'source': medkit.get('source'),
+                'node': medkit.get('ros2', {}).get('node'),
+                'is_online': medkit.get('is_online'),
+                'component_id': medkit.get('component_id'),
+            }
+        return documents
+
+    def test_the_policy_is_actually_in_force(self):
+        """Guards the fixture: an ignored setting would make the rest vacuous."""
+        health = _poll(
+            lambda: _get_json(self.BASE_URL, '/health'),
+            what=f'{self.BASE_URL} health document',
+        )
+        linking = health.get('discovery', {}).get('linking', {})
+        self.assertEqual(linking.get('unmanifested_policy'), 'include_as_orphan')
+        self.assertGreater(
+            linking.get('orphan_count', 0), 0,
+            'the graph must contain undeclared nodes for this comparison to '
+            f'mean anything: {linking}',
+        )
+
+    def test_the_app_tree_is_identical_to_the_warn_gateways(self):
+        """Every app, with its name, binding, provenance and online state."""
+        _assert_trees_match(
+            self,
+            lambda: self._app_documents(self.BASE_URL),
+            lambda: self._app_documents(BASELINE_URL),
+            what='the include_as_orphan and warn app trees',
+        )
+
+    def test_no_entity_is_tagged_with_an_orphan_provenance(self):
+        """`include_as_orphan` does not invent a source value; nothing does."""
+        sources = {
+            doc['source'] for doc in self._app_documents(self.BASE_URL).values()
+        }
+        self.assertNotIn(
+            'orphan', sources,
+            f'no code assigns source="orphan"; got: {sorted(s for s in sources if s)}',
+        )
+
+    def test_the_other_collections_match_too(self):
+        """Areas, components and functions, not just apps."""
+        for path in ('/areas', '/components', '/functions'):
+            _assert_trees_match(
+                self,
+                lambda path=path: _item_ids(self.BASE_URL, path),
+                lambda path=path: _item_ids(BASELINE_URL, path),
+                what=f'{path} between include_as_orphan and warn',
+            )
+
+    def test_the_policy_raises_no_unmanifested_warning(self):
+        """Only `error` raises the warning; this policy is a log level."""
+        health = _get_json(self.BASE_URL, '/health')
+        self.assertIsNone(
+            _unmanifested_warning(self.BASE_URL),
+            f'include_as_orphan must stay quiet on /health: {health["warnings"]}',
+        )
+
+
+# --------------------------------------------------------------------------
+# U6: inherit_runtime_resources gates what a linked app carries
+# --------------------------------------------------------------------------
+
+class TestInheritRuntimeResources(GatewayTestCase):
+    """The linked app's own resource collections are the instrument."""
+
+    BASE_URL = BASELINE_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _initial_orphans()
+
+    def test_inherit_true_fills_the_apps_data_and_operations(self):
+        """With inheritance on, the runtime topic and service are served."""
+        data_ids = _poll(
+            lambda: _item_ids(self.BASE_URL, f'/apps/{TEMP_APP_ID}/data') or None,
+            what=f'{TEMP_APP_ID} to inherit its runtime topics',
+        )
+        self.assertIn(TEMP_TOPIC, data_ids)
+
+        op_paths = _poll(
+            lambda: _service_paths(self.BASE_URL, CALIB_APP_ID) or None,
+            what=f'{CALIB_APP_ID} to inherit its runtime services',
+        )
+        self.assertIn(CALIB_SERVICE, op_paths)
+
+        action_paths = _poll(
+            lambda: _action_paths(self.BASE_URL, ACTION_APP_ID) or None,
+            what=f'{ACTION_APP_ID} to inherit its runtime actions',
+        )
+        self.assertIn(
+            CALIB_ACTION, action_paths,
+            f'enrich_app copies actions too; got: {sorted(action_paths)}',
+        )
+
+    def test_inherit_false_leaves_the_app_without_runtime_resources(self):
+        """With inheritance off the same nodes contribute nothing."""
+        # Barrier: the gateway has linked the same apps, so absence below is
+        # the setting taking effect rather than discovery not having run.
+        _wait_for_manifest_apps(NO_INHERIT_URL)
+        _poll(
+            lambda: True if any(
+                app['id'] == TEMP_APP_ID
+                and app.get('x-medkit', {}).get('ros2', {}).get('node')
+                for app in _get_json(NO_INHERIT_URL, '/apps').get('items', [])
+            ) else None,
+            what=f'{NO_INHERIT_URL} to bind {TEMP_APP_ID} to its node',
+        )
+        # And the baseline gateway proves the resources are inheritable at all -
+        # all three kinds, so an empty collection below means "gated" and not
+        # "there was nothing to copy".
+        _poll(
+            lambda: _item_ids(BASELINE_URL, f'/apps/{TEMP_APP_ID}/data') or None,
+            what='the baseline gateway to inherit the same topics',
+        )
+        _poll(
+            lambda: _service_paths(BASELINE_URL, CALIB_APP_ID) or None,
+            what='the baseline gateway to inherit the same services',
+        )
+        _poll(
+            lambda: _action_paths(BASELINE_URL, ACTION_APP_ID) or None,
+            what='the baseline gateway to inherit the same actions',
+        )
+
+        self.assertEqual(
+            _item_ids(NO_INHERIT_URL, f'/apps/{TEMP_APP_ID}/data'), set(),
+            'inherit_runtime_resources=false must not copy runtime topics',
+        )
+        self.assertEqual(
+            _get_json(NO_INHERIT_URL, f'/apps/{CALIB_APP_ID}/operations').get('items', []), [],
+            'inherit_runtime_resources=false must not copy runtime services',
+        )
+        self.assertEqual(
+            _get_json(NO_INHERIT_URL, f'/apps/{ACTION_APP_ID}/operations').get('items', []), [],
+            'inherit_runtime_resources=false must not copy runtime actions',
+        )
+
+
+# --------------------------------------------------------------------------
+# U11 / U12: allow_manifest_override and its precedence against parameters
+# --------------------------------------------------------------------------
+
+class TestManifestOverridePrecedence(GatewayTestCase):
+    """The merged Function document is the instrument, not the setting."""
+
+    BASE_URL = BASELINE_URL
+    REQUIRED_APPS = MANIFEST_APPS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        _initial_orphans()
+
+    @staticmethod
+    def _merged_function(base_url):
+        return _poll(
+            lambda: _function_extension(base_url) or None,
+            what=f'{base_url} to merge the {SHARED_FUNCTION_ID} function',
+        )
+
+    def test_override_allowed_lets_the_manifest_win(self):
+        """Default: the manifest owns identity, hierarchy and metadata."""
+        ext = self._merged_function(BASELINE_URL)
+        self.assertEqual(ext.get('source'), 'manifest')
+        self.assertEqual(set(ext.get('hosts', [])), MANIFEST_APPS)
+
+    def test_override_denied_widens_the_hierarchy_union_not_provenance(self):
+        """U11: the blanket switch drops the manifest's hierarchy exclusivity.
+
+        It does NOT reassign provenance. `source` records which layer declared
+        the entity, and the orphan filter decides deletion from it, so no
+        field-group policy may rewrite it.
+        """
+        # Barrier: the baseline gateway has already merged the same Function,
+        # so a difference below is the setting, not a slower gateway.
+        baseline = self._merged_function(BASELINE_URL)
+        ext = self._merged_function(NO_OVERRIDE_URL)
+
+        self.assertEqual(
+            ext.get('source'), 'manifest',
+            'allow_manifest_override=false must not touch provenance: `source` '
+            'is what the orphan filter keys its delete decision on',
+        )
+        self.assertEqual(
+            baseline.get('source'), 'manifest',
+            'the baseline gateway reports the same provenance, so the line '
+            'above is a property of the entity, not of this one gateway',
+        )
+        self.assertIn(
+            RUNTIME_HOST_ID, ext.get('hosts', []),
+            'allow_manifest_override=false must let the runtime hosts through',
+        )
+        self.assertNotIn(
+            RUNTIME_HOST_ID, baseline.get('hosts', []),
+            'the baseline keeps the manifest exclusive over hosts, so the '
+            'widening asserted above is the setting and not something every '
+            'gateway does',
+        )
+
+    def test_explicit_layer_policy_beats_the_blanket_switch(self):
+        """U12: a pinned group keeps manifest exclusivity, unpinned does not.
+
+        `hierarchy` is the discriminator. Against the shipped manifest+runtime
+        pair it is the only group whose demotion changes the served document,
+        so the pinned and unpinned gateways are compared on it directly.
+        """
+        pinned = self._merged_function(OVERRIDE_PINNED_URL)
+        unpinned = self._merged_function(NO_OVERRIDE_URL)
+
+        # hierarchy was pinned authoritative in the gateway parameters, so the
+        # manifest keeps exclusive ownership of the hosts list ...
+        self.assertNotIn(
+            RUNTIME_HOST_ID, pinned.get('hosts', []),
+            'an explicit layers.manifest.hierarchy must beat '
+            'allow_manifest_override=false',
+        )
+        self.assertEqual(set(pinned.get('hosts', [])), MANIFEST_APPS)
+        # ... while the same manifest without that parameter lets the runtime
+        # host in. This pair is what makes the test falsifiable: drop the pin
+        # and the first assertion fails.
+        self.assertIn(
+            RUNTIME_HOST_ID, unpinned.get('hosts', []),
+            'without the explicit parameter the blanket switch still widens '
+            'the hosts union',
+        )
+
+        # Regression checks, not evidence of precedence. Provenance is never
+        # policy-driven, and demoting identity is a no-op against a runtime
+        # layer that is already fallback there - both read the same on the
+        # unpinned gateway too.
+        self.assertEqual(pinned.get('source'), 'manifest')
+        detail = _get_json(OVERRIDE_PINNED_URL, f'/functions/{SHARED_FUNCTION_ID}')
+        self.assertEqual(detail.get('name'), MANIFEST_FUNCTION_NAME)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_helpers_and_manifests_are_cleaned_up(self):
+        """The nodes and manifests this module owns do not outlive the run."""
+        _stop_late_nodes()
+        _remove_manifests()
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test_plugins/topics_test_plugin.cpp
+++ b/src/ros2_medkit_integration_tests/test_plugins/topics_test_plugin.cpp
@@ -107,6 +107,20 @@ class TopicsTestPlugin : public GatewayPlugin, public IntrospectionProvider {
     app.topics.publishes.push_back("/plugin_dev/value");
     result.new_entities.apps.push_back(std::move(app));
 
+    // A second app carrying a source tag the protection whitelist does NOT
+    // list. Providers pick their own tag (the beacon mapper stamps "beacon"),
+    // and protection must follow the owning LAYER rather than the string, so
+    // this app has to survive unmanifested_nodes=ignore exactly as the one
+    // above does.
+    App unlisted;
+    unlisted.id = "plugin_unlisted_source";
+    unlisted.name = "Plugin Device With Unlisted Source";
+    unlisted.component_id = "test_plugin_comp";
+    unlisted.external = true;
+    unlisted.is_online = true;
+    unlisted.source = "beacon";
+    result.new_entities.apps.push_back(std::move(unlisted));
+
     return result;
   }
 


### PR DESCRIPTION
# Pull Request

## Summary

The manifest's top-level `config:` block was never read. The parser looked only at an
undocumented `discovery:` key, so the block used by the schema, all seven shipped example
manifests, the demo manifests and the integration tests was ignored without a word in the log,
and every setting inside it stayed at its default.

This reads `config:` and keeps `discovery:` working as a deprecated alias, so a manifest written
against the source rather than the schema does not break. When both appear, `config:` wins and
both facts are logged.

**Closing the silent-failure class that hid this**

- An unrecognised top-level key is reported instead of vanishing.
- A `config:` block, or a value inside it, of the wrong YAML kind is reported and the default
  applies, instead of throwing and costing the whole manifest. A key with no value still means
  "not set".
- An unrecognised `unmanifested_nodes` value becomes a validation warning, so
  `discovery.manifest_strict_validation` decides whether it rejects the manifest.

**Making the three documented settings do what they say**

- `unmanifested_nodes` reaches the merge pipeline. `error` keeps the gateway serving and reports
  the undeclared nodes on `GET /health`; a startup abort was only ever promised in prose, never
  implemented, and a diagnostic gateway going down when the system misbehaves is the wrong
  trade.
- `inherit_runtime_resources: false` keeps a linked app to the resources it declares, including
  when its id matches the bound node's name.
- `allow_manifest_override: false` demotes the manifest layer's field groups; an explicitly
  configured per-group merge policy still wins.

All three now survive a manifest reload instead of freezing at startup.

**A merge defect found on the way**

An entity's `source` was merged as ordinary metadata content. Provenance is what decides whether
the orphan filter may delete an entity, so a field-group policy must not be able to reassign it:
with the manifest layer demoted for metadata, a declared entity was retagged and then deleted.
This is reachable on `main` today through the gateway parameters alone, without any of the
changes here. `source` is now filled only when absent and is never reassigned by a policy.

**Health contract**

`warnings` and `warning_schema_version` are emitted whenever the gateway can produce a warning,
not only when aggregation is active, and both are required in the schema. Warning objects keep
identifier domains apart: `entity_ids` carries addressable SOVD entity ids for every code, and
ROS node names live in the new `ros_node_fqns`. `discovery.linking` reports the configured
policy, so a monitor can branch on it without parsing prose.

That invariant is enforced on the one path that could break it. The `leaf_id_collision` warning
publishes a Component id announced by a remote peer, and nothing validated it. It is now checked
before it is published and withheld with a warning log when it is not addressable; the warning's
`message` still names the component, so only the link that would not have worked is dropped.

**Tooling**

Integration feature tests are registered with `CONFIGURE_DEPENDS`. Without it a test file added
to an existing build tree is never registered and the suite reports success without running it -
measured here: three of this branch's four new test files were silently skipped, and the same
suite went from 1036 to 1091 tests once the glob was re-evaluated.

For the same class of reason, `scripts/clang-tidy-diff.sh` now considers staged and working-tree
changes as well as committed ones. It was narrowing its file list to committed work only, so the
pre-commit stage its own header describes analysed nothing and exited 0.

**Deletion is decided by the owning layer, not by a string**

A discovery plugin may set its own `source` tag, and two shipped plugins do - `beacon` and, on
its authenticated path, `opcua`. Neither matched the `"plugin"` prefix the orphan filter checks,
so `unmanifested_nodes: ignore` erased those entities. The filters now consult the layer that
owns an entity, which the merge already tracks, instead of the string. No `source` value
changes: one capability is gated on the literal `"node"`, the value is served as
`x-medkit.source` and feeds identity provenance, and the `opcua` tag carries a deliberate trust
distinction that must not be collapsed.

This also makes true a promise the documentation already made - that `ignore` spares apps from
the manifest, the asset inventory or a plugin.

**Two things to know before merging**

1. **Behaviour changes on upgrade.** Anyone whose manifest sets `unmanifested_nodes: ignore` has
   had it ignored until now. It starts taking effect, so their entity tree gets smaller -
   runtime-discovered nodes that are not declared in the manifest disappear. In this repository
   that affects the `multi_ecu_aggregation` demo, whose documented entity counts shift.
2. **Release ordering.** `warnings` and `warning_schema_version` move from optional to required
   in the schema. A client regenerated from this spec would reject a response from a gateway
   that omits them, so the client regeneration belongs with the gateway release, not before it.
   The OpenAPI component `HealthAggregationWarning` is also renamed `HealthWarning`; the wire
   shape is unchanged, but a regenerated client sees a different schema name.
3. **The two new manifest notices are advisory in this release.** An unrecognised
   `unmanifested_nodes` value (R014) and a malformed configuration block (R015) are logged, not
   raised to the validator, and become validation warnings in the next release. Without that
   grace period a manifest carrying, say, `unmanifested_nodes: Warn` - which loaded fine before
   this change because the block was never read - would be refused under the default strict
   validation, and hybrid discovery would silently degrade to `runtime_only`.

---

## Issue

- closes #529

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [x] Breaking change
- [ ] Documentation only

---

## Testing

Unit suite 124/124. Full integration suite 1091 tests, 0 failures, on an otherwise idle machine.

Four new integration test files drive a live gateway rather than asserting on log text:

- the documented key and the deprecated alias produce the same entity tree, and a node that
  joins *after* the gateway is up stays out of it under `ignore`
- a malformed configuration block loads with a warning under non-strict validation and is
  rejected under strict
- provenance holds across repeated discovery passes, sampled until the entity cache has actually
  advanced rather than after a fixed sleep
- the policy surface on `/health`, the inheritance gate, and the override precedence, each with
  a control gateway so a difference is attributable to the setting

API differential against `main`, captured from two running gateways: 113 lines of schema change,
no routes added, removed or altered. The schema change is the `HealthWarning` rename, the new
required `ros_node_fqns`, `warnings` and `warning_schema_version` becoming required, and enum
constraints on `code` and `unmanifested_policy`.

The eight existing integration tests whose manifests set `unmanifested_nodes: ignore` were
re-read, not just re-run: each was checked for whether it now passes for a weaker reason, and
two that pinned the old warning-contract version were updated.

Reviewers can verify the core fix directly:

```
ros2 run ros2_medkit_gateway gateway_node --ros-args \
  -p discovery.mode:=hybrid -p discovery.manifest_path:=<manifest with config: unmanifested_nodes: ignore>
curl -s localhost:8080/api/v1/apps | jq '.items[].id'
```

Before this change the policy has no effect; after it, undeclared runtime nodes are absent.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
