### PR TITLE
Describe occurrence_count as the edge counter it is

### DIFF
--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -28,7 +28,9 @@ Core fault data model representing an aggregated fault condition.
    # Human-readable description of the fault condition
    string description
 
-   # Timestamp when this fault was first reported
+   # Timestamp when the current occurrence started (reset when a FAILED event
+   # reactivates a CLEARED fault, so it moves with occurrence_count instead of
+   # marking the fault's first report ever)
    builtin_interfaces/Time first_occurred
 
    # Timestamp when this fault last occurred (FAILED events only; a PASSED

--- a/docs/api/messages.rst
+++ b/docs/api/messages.rst
@@ -38,7 +38,10 @@ Core fault data model representing an aggregated fault condition.
    # Timestamp of the last PASSED event reported for this fault (zero = never)
    builtin_interfaces/Time last_passed
 
-   # Total number of FAILED events aggregated across all sources
+   # Number of times this fault has occurred, counted on edges: one for the first
+   # FAILED event, and one more each time a FAILED event arrives while the fault is
+   # CLEARED. Repeated FAILED events within one occurrence do not increment it;
+   # last_occurred is what advances on those.
    uint32 occurrence_count
 
    # Current fault status (PREFAILED, PREPASSED, CONFIRMED, HEALED, CLEARED)

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -184,8 +184,9 @@ single PASSED event); invalid thresholds fall back to safe defaults with a warni
 `CONFIRMED` and `HEALED` are **latched** (hysteresis): once reached, the status holds until the
 counter reaches the opposite threshold, so a single opposite-direction event cannot flip it. As a
 result a fault that becomes active again can take up to `healing_threshold - confirmation_threshold`
-events to return to the default (CONFIRMED-only) list; `occurrence_count` and `last_occurred` still
-update meanwhile.
+events to return to the default (CONFIRMED-only) list. During that window `last_occurred` still
+reflects the activity; `occurrence_count` does not, because it counts the edge that started the
+occurrence, not every report within it.
 
 ### Fault Lifecycle with Debounce
 

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -236,8 +236,9 @@ walks all the way to the opposite threshold. So PREFAILED/PREPASSED depend on th
 a CONFIRMED or HEALED fault keeps its status while the counter is between the thresholds - a single
 opposite-direction event cannot flip it. One consequence is a re-confirmation delay: a fault that
 becomes active again is not back in the default (CONFIRMED-only) list until the counter has fallen by
-up to ``healing_threshold - confirmation_threshold`` events. During that window ``occurrence_count``
-and ``last_occurred`` still reflect the activity.
+up to ``healing_threshold - confirmation_threshold`` events. During that window ``last_occurred``
+still reflects the activity; ``occurrence_count`` does not, because it counts the edge that started
+the occurrence, not every report within it.
 
 Thresholds must satisfy ``confirmation_threshold < 0 <= healing_threshold`` (``healing_threshold == 0``
 means heal on a single PASSED event); the node validates the

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -659,7 +659,8 @@ void FaultManagerNode::handle_report_fault(
       }
       just_confirmed = true;
     } else if (!is_new && fault_after->status == ros2_medkit_msgs::msg::Fault::STATUS_CONFIRMED) {
-      // Fault was already CONFIRMED, data updated (occurrence_count, sources, etc.)
+      // Fault was already CONFIRMED, data updated (last_occurred, severity, sources).
+      // Not occurrence_count: a re-report inside one occurrence does not touch it.
       if (!should_mute) {
         publish_fault_event(ros2_medkit_msgs::msg::FaultEvent::EVENT_UPDATED, *fault_after);
       }

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -822,7 +822,7 @@ Real-time fault event stream using Server-Sent Events (SSE). Clients receive ins
 
 **Event Types:**
 - `fault_confirmed` - Fault transitioned to CONFIRMED status
-- `fault_updated` - Fault data changed (occurrence_count, sources, etc.)
+- `fault_updated` - Fault data changed without a status transition (`last_occurred`, severity, reporting sources). Not `occurrence_count`, which only changes on an occurrence edge
 - `fault_cleared` - Fault ended: cleared via ClearFault service, or auto-healed by PASSED events (check `fault.status` for `CLEARED` vs `HEALED`)
 
 **Example:**

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -24,7 +24,7 @@ Core fault data model representing an aggregated fault condition with AUTOSAR DE
 | `first_occurred` | builtin_interfaces/Time | When fault was first reported |
 | `last_occurred` | builtin_interfaces/Time | When fault last occurred (FAILED events only) |
 | `last_passed` | builtin_interfaces/Time | When fault last reported PASSED (zero = never) |
-| `occurrence_count` | uint32 | Total FAILED events aggregated across all sources |
+| `occurrence_count` | uint32 | Times this fault has occurred, counted on edges (first FAILED, then each FAILED that arrives while CLEARED). Repeats within one occurrence do not increment it |
 | `status` | string | Current status (see STATUS_* constants) |
 | `reporting_sources` | string[] | List of source identifiers that reported this fault |
 

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -21,7 +21,7 @@ Core fault data model representing an aggregated fault condition with AUTOSAR DE
 | `fault_code` | string | Global fault identifier (e.g., "MOTOR_OVERHEAT") |
 | `severity` | uint8 | Severity level (use SEVERITY_* constants) |
 | `description` | string | Human-readable description |
-| `first_occurred` | builtin_interfaces/Time | When fault was first reported |
+| `first_occurred` | builtin_interfaces/Time | When the current occurrence started; reset when a FAILED event reactivates a CLEARED fault, so it moves with `occurrence_count` |
 | `last_occurred` | builtin_interfaces/Time | When fault last occurred (FAILED events only) |
 | `last_passed` | builtin_interfaces/Time | When fault last reported PASSED (zero = never) |
 | `occurrence_count` | uint32 | Times this fault has occurred, counted on edges (first FAILED, then each FAILED that arrives while CLEARED). Repeats within one occurrence do not increment it |

--- a/src/ros2_medkit_msgs/msg/Fault.msg
+++ b/src/ros2_medkit_msgs/msg/Fault.msg
@@ -32,7 +32,9 @@ uint8 severity
 # Human-readable description of the fault condition
 string description
 
-# Timestamp when this fault was first reported
+# Timestamp when the current occurrence started (reset when a FAILED event
+# reactivates a CLEARED fault, so it moves with occurrence_count instead of
+# marking the fault's first report ever)
 builtin_interfaces/Time first_occurred
 
 # Timestamp when this fault last occurred (FAILED events only; a PASSED

--- a/src/ros2_medkit_msgs/msg/Fault.msg
+++ b/src/ros2_medkit_msgs/msg/Fault.msg
@@ -42,7 +42,10 @@ builtin_interfaces/Time last_occurred
 # Timestamp of the last PASSED event reported for this fault (zero = never)
 builtin_interfaces/Time last_passed
 
-# Total number of FAILED events aggregated across all sources
+# Number of times this fault has occurred, counted on edges: one for the first
+# FAILED event, and one more each time a FAILED event arrives while the fault is
+# CLEARED. Repeated FAILED events within one occurrence do not increment it;
+# last_occurred is what advances on those.
 uint32 occurrence_count
 
 # Current fault status (use STATUS_* constants)

--- a/src/ros2_medkit_msgs/msg/FaultEvent.msg
+++ b/src/ros2_medkit_msgs/msg/FaultEvent.msg
@@ -34,8 +34,10 @@ string EVENT_CONFIRMED = "fault_confirmed"
 # PASSED events drive it past the healing threshold. Check fault.status to tell
 # the two apart.
 string EVENT_CLEARED = "fault_cleared"
-# Emitted when fault data changes without status transition
-# (e.g., occurrence_count incremented, new source added to reporting_sources).
+# Emitted when fault data changes without status transition (e.g., last_occurred
+# advanced, severity escalated, new source added to reporting_sources).
+# occurrence_count is not one of them: it only changes on an occurrence edge
+# (the first FAILED, or a FAILED that arrives while the fault is CLEARED).
 string EVENT_UPDATED = "fault_updated"
 
 # Correlation-related fields (populated when correlation is enabled)


### PR DESCRIPTION
# Pull Request

## Summary

`occurrence_count` counts occurrence edges: the first FAILED event, and each FAILED that arrives
while the fault is CLEARED. A repeated FAILED inside one occurrence does not change it and
advances `last_occurred` instead. That has been the behaviour since "fault_manager: count
occurrences on edges, not per report", and tests hold it in place, but the documentation was
never updated.

Eight places described it wrongly, in three groups.

**Three said it counts every FAILED event.** `Fault.msg`, the `ros2_medkit_msgs` README and the
API reference. A reader who trusts them will size a fault's activity with a field that answers a
different question.

**Three listed it as something `fault_updated` carries.** `FaultEvent.msg`, the gateway README
and the comment in the report handler. A re-report inside one occurrence emits `fault_updated`
but does not touch the counter.

**Two contradicted the storage header outright.** The fault_manager README and design doc said
`occurrence_count` and `last_occurred` both keep updating during the latch window, while
`FaultStorage`'s own header says `last_occurred` does and `occurrence_count` does not. Both now
use the header's wording, so the three descriptions of that window read the same.

`first_occurred` turned out to be wrong in the same way, and is fixed here too. It is reset when a
FAILED event reactivates a CLEARED fault, so it marks the start of the latest occurrence, not the
first report ever. Both backends do that deliberately (`fault_storage.cpp:155-158`,
`sqlite_fault_storage.cpp:437-441`, written back at `:485-492`) and both pin it in tests
(`test_fault_manager.cpp:402`/`423`, `test_sqlite_storage.cpp:480`/`501`). It matters more after
this PR rather than less: with `occurrence_count` now trustworthy as an edge counter, the obvious
next step is to pair the two into a rate, and that arithmetic is wrong precisely because the
timestamp moved with the last edge.

No behaviour changes. The only change under `src/` that is not a document is one comment.

---

## Issue

- closes #617

---

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [x] Documentation only

---

## Testing

`ros2_medkit_msgs` builds clean from an empty cache, so both edited `.msg` files still parse and
generate. `docs/api/messages.rst` and `fault_manager/design/index.rst` parse under docutils. The
`Fault.msg` block copied into `messages.rst` is byte-identical to the file again.

For a reviewer the useful check is the claim itself rather than the build. The write sites are
`fault_storage.cpp:130` (new fault) and `:162-163` (reactivation after CLEARED), with the SQLite
equivalents at `sqlite_fault_storage.cpp:573` and `:459-462`. The FAILED branch for an existing
non-CLEARED fault deliberately leaves the counter alone at `fault_storage.cpp:187-190`.
`FaultStorageTest.SameSourceMultipleReportsConfirms` and `ClearedFaultCanBeReactivated` pin both
directions.

I could not compile `ros2_medkit_fault_manager` locally, because the image I had available is a
runtime image without `nlohmann_json`. The change there is a comment inside an existing branch,
so CI is the check.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed

Notes on the last three: nothing breaks, since no field, type or behaviour changes. No tests were
added because nothing asserts these strings and the behaviour they now describe is already
covered by the tests named above. The documentation is the change.

One thing this does not fix. `docs/api/messages.rst` is a hand-made copy of twelve interface
files inside `code-block:: text`, which is how this drift happened. A `literalinclude` would need
start markers in every `.msg` and `.srv`, since they all open with the licence header, so it is a
larger change than this issue and I left it alone. Worth deciding separately.
