### PR TITLE
Detect a node that dies when nothing else is left to report it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,11 @@ jobs:
           RMW_IMPLEMENTATION: ${{ matrix.ros_distro == 'humble' && 'rmw_cyclonedds_cpp' || '' }}
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          # ros2_medkit_graph_watchdog is tested in graph-watchdog below. Its end-to-end suite
+          # is 24 minutes on its own, and this step is capped rather than the job, so a package
+          # that overruns takes every package behind it down and reports no test name doing it.
           colcon test --return-code-on-test-failure \
-            --packages-skip ros2_medkit_opcua \
+            --packages-skip ros2_medkit_opcua ros2_medkit_graph_watchdog \
             --ctest-args -LE linter \
             --event-handlers console_direct+
 
@@ -122,6 +125,120 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.ros_distro }}
+          path: |
+            log/
+            build/*/test_results/
+
+  # ros2_medkit_graph_watchdog on the two distros build-and-test covers, in a job of its own.
+  # Same reasoning as sanitizer-graph-watchdog in quality.yml: the package's end-to-end suite runs
+  # 24 minutes, the sweep it left had 3 minutes of headroom on humble and none at all on lyrical,
+  # and a suite that grows with every new detector should not decide whether the packages behind it
+  # get to run. Not path-filtered: the plugin drives the gateway, the fault manager and discovery,
+  # so the changes most likely to break it are outside its own tree.
+  graph-watchdog:
+    name: graph_watchdog (${{ matrix.ros_distro }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ros_distro: humble
+            os_image: ubuntu:jammy
+          - ros_distro: lyrical
+            os_image: ubuntu:resolute
+    container:
+      image: ${{ matrix.os_image }}
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
+      - name: Set up ROS 2 ${{ matrix.ros_distro }}
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: ${{ matrix.ros_distro }}
+
+      - name: Install ccache
+        run: apt-get install -y ccache
+
+      - name: Restore ccache
+        # Restore, never save. This job compiles a subset of the sources build-and-test compiles,
+        # with the same flags, so that job's cache is a superset of what this one needs and serves
+        # its misses. A second copy would spend the repository's Actions cache quota twice over for
+        # one set of objects.
+        uses: actions/cache/restore@v4
+        with:
+          path: /root/.cache/ccache
+          key: ccache-${{ matrix.ros_distro }}-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ matrix.ros_distro }}-
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
+          if [ "${{ matrix.ros_distro }}" = "humble" ]; then
+            apt-get install -y ros-humble-rmw-cyclonedds-cpp
+          fi
+          source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          rosdep update
+          # Same skip-keys as build-and-test: the linters run only in the Jazzy quality job.
+          rosdep install --from-paths src --ignore-src -y \
+            --skip-keys "ament_cmake_clang_tidy ament_cmake_clang_format"
+
+      - name: Build packages
+        env:
+          CCACHE_DIR: /root/.cache/ccache
+          CCACHE_MAXSIZE: 500M
+          CCACHE_SLOPPINESS: pch_defines,time_macros
+        run: |
+          source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          ccache -z
+          # --packages-up-to, not the workspace: the chain reaches the gateway, the fault manager
+          # and ros2_medkit_integration_tests, which is a test dependency and is where the launch
+          # helpers and the demo nodes the end-to-end scenarios start actually live. opcua is not in
+          # that chain, so it needs no explicit skip here.
+          colcon build --symlink-install \
+            --packages-up-to ros2_medkit_graph_watchdog \
+            --cmake-args -DCMAKE_BUILD_TYPE=Release \
+            --event-handlers console_direct+
+          ccache -s
+          ./scripts/ccache_report.sh "${{ matrix.ros_distro }}-graph-watchdog"
+
+      - name: Run graph_watchdog tests
+        timeout-minutes: 45
+        env:
+          # The DDS choice belongs to the distro, not to this package - see the long note in
+          # build-and-test for why humble is forced onto CycloneDDS and lyrical is not.
+          RMW_IMPLEMENTATION: ${{ matrix.ros_distro == 'humble' && 'rmw_cyclonedds_cpp' || '' }}
+        run: |
+          source /opt/ros/${{ matrix.ros_distro }}/setup.bash
+          colcon test --return-code-on-test-failure \
+            --packages-select ros2_medkit_graph_watchdog \
+            --ctest-args -LE linter \
+            --event-handlers console_direct+
+
+      - name: Show test results
+        if: always()
+        run: colcon test-result --verbose
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-graph-watchdog-${{ matrix.ros_distro }}
           path: |
             log/
             build/*/test_results/

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -382,6 +382,11 @@ jobs:
           failed=0
           for pkg_dir in build/ros2_medkit_*/; do
             pkg=$(basename "$pkg_dir")
+            # graph_watchdog is tested in sanitizer-graph-watchdog. Its
+            # end-to-end suite is 24 minutes under instrumentation, which is
+            # more than the headroom left here, and a package that overruns
+            # this step takes every package after it down with it.
+            if [ "$pkg" = "ros2_medkit_graph_watchdog" ]; then continue; fi
             echo "::group::Testing $pkg"
             (cd "$pkg_dir" && ctest -LE "linter" --output-on-failure) || failed=1
             echo "::endgroup::"
@@ -392,6 +397,7 @@ jobs:
         if: always()
         run: |
           for pkg_dir in build/ros2_medkit_*/; do
+            if [ "$(basename "$pkg_dir")" = "ros2_medkit_graph_watchdog" ]; then continue; fi
             colcon test-result --test-result-base "$pkg_dir" --verbose 2>/dev/null || true
           done
 
@@ -500,6 +506,11 @@ jobs:
           failed=0
           for pkg_dir in build/ros2_medkit_*/; do
             pkg=$(basename "$pkg_dir")
+            # graph_watchdog is tested in sanitizer-graph-watchdog. Its
+            # end-to-end suite is 24 minutes under instrumentation, which is
+            # more than the headroom left here, and a package that overruns
+            # this step takes every package after it down with it.
+            if [ "$pkg" = "ros2_medkit_graph_watchdog" ]; then continue; fi
             echo "::group::Testing $pkg"
             (cd "$pkg_dir" && ctest -j1 -LE "linter" --output-on-failure) || failed=1
             echo "::endgroup::"
@@ -510,5 +521,152 @@ jobs:
         if: always()
         run: |
           for pkg_dir in build/ros2_medkit_*/; do
+            if [ "$(basename "$pkg_dir")" = "ros2_medkit_graph_watchdog" ]; then continue; fi
             colcon test-result --test-result-base "$pkg_dir" --verbose 2>/dev/null || true
           done
+
+  # ros2_medkit_graph_watchdog's end-to-end suite runs 24 minutes under
+  # instrumentation, against a 45-minute test budget the rest of the workspace
+  # already spends 22 to 38 of. Testing it here instead of in the workspace
+  # sweeps gives it a budget of its own, and stops a suite that grows with every
+  # new detector from deciding whether the packages behind it get to run at all.
+  # It is not path-filtered: the plugin drives the gateway, the fault manager and
+  # discovery, so the changes most likely to break it are not in its own tree.
+  sanitizer-graph-watchdog:
+    name: Sanitizer ${{ matrix.name }} (graph_watchdog)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sanitizer: asan
+            name: ASan + UBSan
+            cmake_sanitizer: asan,ubsan
+            # Both sizes are the ones the matching workspace job argued for.
+            # This job restores that job's cache and must not evict what it
+            # restored, so it cannot be smaller here.
+            ccache_size: 2G
+          - sanitizer: tsan
+            name: TSan
+            cmake_sanitizer: tsan
+            ccache_size: 1.5G
+    container:
+      image: ubuntu:noble
+      # See sanitizer-asan: the instrumented build tree does not fit the
+      # container overlay on small GitHub runners, so build on /mnt.
+      volumes:
+        - "/mnt:/mnt"
+    # A cold cache builds the chain from scratch, which is the ~20 min the TSan
+    # workspace job measures, before the 45-minute test budget starts.
+    timeout-minutes: 90
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y git
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pre-install ROS 2 apt source
+        uses: ./.github/actions/ros-apt-source
+
+      - name: Set up ROS 2 Jazzy
+        uses: ros-tooling/setup-ros@v0.7
+        with:
+          required-ros-distributions: jazzy
+
+      - name: Install ccache
+        run: apt-get install -y ccache
+
+      - name: Restore ccache
+        # Restore, never save. This job compiles a subset of the sources
+        # sanitizer-${{ matrix.sanitizer }} compiles, with the same flags, so
+        # that job's cache is a superset of what this one needs and serves its
+        # misses. A second copy would buy nothing and would spend the
+        # repository's 10 GB Actions cache quota twice for one set of objects.
+        uses: actions/cache/restore@v4
+        with:
+          path: /root/.cache/ccache
+          key: ccache-jazzy-${{ matrix.sanitizer }}-${{ github.sha }}
+          restore-keys: |
+            ccache-jazzy-${{ matrix.sanitizer }}-
+
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y ros-jazzy-test-msgs
+          source /opt/ros/jazzy/setup.bash
+          rosdep update
+          rosdep install --from-paths src --ignore-src -y
+
+      - name: Redirect heavy build output to /mnt
+        run: |
+          # Same reasoning as the workspace sanitizer jobs, and the same need:
+          # the chain built here still includes the gateway.
+          mkdir -p /mnt/gw/build /mnt/gw/tmp
+          ln -sfn /mnt/gw/build build
+          df -h / /mnt
+
+      - name: Build with ${{ matrix.name }}
+        env:
+          CCACHE_DIR: /root/.cache/ccache
+          CCACHE_MAXSIZE: ${{ matrix.ccache_size }}
+          CCACHE_SLOPPINESS: pch_defines,time_macros
+          TMPDIR: /mnt/gw/tmp
+        run: |
+          source /opt/ros/jazzy/setup.bash
+          ccache -z
+          # --packages-up-to rather than the workspace: the chain reaches the
+          # gateway, the fault manager and ros2_medkit_integration_tests, which
+          # is a test dependency and is where the launch helpers and the demo
+          # nodes the end-to-end scenarios start actually live.
+          colcon build --symlink-install \
+            --packages-up-to ros2_medkit_graph_watchdog \
+            --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+              -DSANITIZER=${{ matrix.cmake_sanitizer }} \
+            --event-handlers console_direct+
+          ccache -s
+          ./scripts/ccache_report.sh jazzy-${{ matrix.sanitizer }}-graph-watchdog
+          df -h / /mnt
+
+      - name: Extend test timeouts for sanitizer overhead
+        run: |
+          # The same generic x3 rewrite the workspace sanitizer jobs apply - see
+          # the comment in sanitizer-asan for why it is not a list of literals.
+          find build/ -name "CTestTestfile.cmake" -exec \
+            perl -pi -e 's/\bTIMEOUT "(\d+)"/sprintf(q{TIMEOUT "%d"}, $1 * 3)/ge' {} +
+          find build/ -name "CTestTestfile.cmake" -exec cat {} + \
+            | grep -oE 'TIMEOUT "[0-9]+"' | sort -t'"' -k2 -n | uniq -c
+
+      - name: Run graph_watchdog tests with ${{ matrix.name }}
+        timeout-minutes: 45
+        env:
+          # Same factor as the ctest TIMEOUT rewrite above, for the wall-clock
+          # budgets tests assert internally - ctest's clock cannot reach those.
+          MEDKIT_TEST_TIME_SCALE: 3
+          # Lets tests size instrumented-only-expensive resources down.
+          MEDKIT_TEST_SANITIZED: 1
+        run: |
+          if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
+            export TSAN_OPTIONS="halt_on_error=0:history_size=4:suppressions=$(pwd)/tsan_suppressions.txt"
+          else
+            # detect_leaks=0: FastDDS allocator leaks on shutdown (not our code)
+            # new_delete_type_mismatch=0: ROS 2 DDS scalar/array new/delete mismatch
+            export ASAN_OPTIONS=halt_on_error=1:detect_leaks=0:new_delete_type_mismatch=0
+            export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+          fi
+          source /opt/ros/jazzy/setup.bash
+          source install/setup.bash
+          cd build/ros2_medkit_graph_watchdog
+          ctest -j1 -LE "linter" --output-on-failure
+
+      - name: Show test results
+        if: always()
+        run: |
+          colcon test-result --test-result-base build/ros2_medkit_graph_watchdog \
+            --verbose 2>/dev/null || true

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -475,6 +475,35 @@ Lower values shorten the worst-case recovery window if a graph event is missed
 but increase idle CPU. The default rarely fires on a stable graph because the
 graph-event poll handles node up/down events directly.
 
+How long a departed node keeps being listed
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once a node has actually left the ROS graph, ``GET /apps`` stops listing it within
+roughly one refresh: at most ``discovery.refresh_debounce_ms`` plus the 100 ms graph
+poll, or ``refresh_interval_ms``, whichever comes first. Nothing is retained behind
+that - every refresh rebuilds the entity set from a live read of the graph - so this
+is the whole of the gateway's share, and it is the only part of a departure the
+gateway can be held to.
+
+Before that point nothing here is promised, and the difference is not small:
+
+* A node that shuts down cleanly unregisters its DDS participant on the way out, and
+  the graph drops it almost at once. Measured at 225 ms from the signal to the node
+  no longer being listed, polling ``GET /apps`` every 200 ms.
+* A node that dies without unregistering - killed outright, or stopped before its
+  shutdown could finish - costs the DDS participant lease instead, because remote
+  participants have nothing to go on but its silence. Measured at 20.07 s, 19.76 s
+  and 19.99 s over three runs, with stock ``rmw_fastrtps_cpp`` and no participant
+  profile override.
+* How long a node takes to shut down is the node's own business. The gateway cannot
+  tell a node that is slow to exit from one that is simply still running, and neither
+  can this bound.
+
+So a caller waiting for a specific node to disappear should watch for its absence
+rather than assume a deadline. Anything that measures a departure should establish
+that the process has actually exited first, and only then hold the gateway to the
+figure above.
+
 Thread Pools
 ------------
 

--- a/src/ros2_medkit_integration_tests/demo_nodes/unreadable_lifecycle_node.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/unreadable_lifecycle_node.cpp
@@ -55,6 +55,16 @@
  * fixture is never driven through a lifecycle transition by anything that reads its
  * result.
  *
+ * `transition_label` (string parameter, default "active") is the label this fixture
+ * announces once it starts answering, on both channels. The default keeps the
+ * GRAPH_NODE_UNREADABLE story unchanged: the node was unreadable, then it is active, then
+ * the fault clears. A NON-active value stages the other sequence a caller may need - the
+ * lifecycle state arriving late and saying the node was never healthy - which is what
+ * distinguishes a node the presence detector may keep from one it has to hand back. The
+ * reported state id follows the label for the two the state machine names ("active" and
+ * "inactive"); anything else reports UNCONFIGURED's id, which is what a caller asking for
+ * an arbitrary label wants a reader to classify as non-active.
+ *
  * `start_answering` (bool parameter, default false) is how the e2e proves the CLEAR
  * half of the story: setting it true - a real `ros2 param set` /
  * `rcl_interfaces/srv/SetParameters` call against this node's own auto-started
@@ -76,6 +86,7 @@
  * calls GetState again to collect that answer unless this event arrives first.
  */
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -93,6 +104,7 @@ class UnreadableLifecycleNode : public rclcpp::Node {
  public:
   UnreadableLifecycleNode() : Node("unreadable_lifecycle") {
     answering_ = this->declare_parameter<bool>("start_answering", false);
+    transition_label_ = this->declare_parameter<std::string>("transition_label", "active");
 
     // Reliable + volatile (the QoS default LifecycleWatcher's own subscription
     // requires - see its "stay volatile" comment), matching how rclcpp_lifecycle
@@ -107,7 +119,7 @@ class UnreadableLifecycleNode : public rclcpp::Node {
           // below), so this callback and the parameter callback that flips
           // `answering_` below can never run concurrently with each other.
           if (answering_) {
-            send_active(header);
+            send_state(header);
             return;
           }
           pending_.push_back(header);  // deliberately leaked for this process's lifetime - see the file doc
@@ -135,7 +147,9 @@ class UnreadableLifecycleNode : public rclcpp::Node {
 
     RCLCPP_INFO(get_logger(),
                 "unreadable_lifecycle started: advertises get_state/change_state like a managed "
-                "lifecycle node, but get_state never answers until start_answering:=true");
+                "lifecycle node, but get_state never answers until start_answering:=true (then it "
+                "reports '%s')",
+                transition_label_.c_str());
   }
 
   ~UnreadableLifecycleNode() override {
@@ -150,10 +164,22 @@ class UnreadableLifecycleNode : public rclcpp::Node {
   UnreadableLifecycleNode & operator=(UnreadableLifecycleNode &&) = delete;
 
  private:
-  void send_active(const std::shared_ptr<rmw_request_id_t> & header) {
+  /// The id the label maps to. Only the two the caller can select matter here; everything
+  /// else answers with UNCONFIGURED's id, which every reader classifies as non-active.
+  static std::uint8_t state_id_for(const std::string & label) {
+    if (label == "active") {
+      return lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+    }
+    if (label == "inactive") {
+      return lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE;
+    }
+    return lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED;
+  }
+
+  void send_state(const std::shared_ptr<rmw_request_id_t> & header) {
     lifecycle_msgs::srv::GetState::Response response;
-    response.current_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
-    response.current_state.label = "active";
+    response.current_state.id = state_id_for(transition_label_);
+    response.current_state.label = transition_label_;
     get_state_service_->send_response(*header, response);
   }
 
@@ -163,7 +189,7 @@ class UnreadableLifecycleNode : public rclcpp::Node {
     }
     answering_ = true;
     for (const auto & header : pending_) {
-      send_active(header);
+      send_state(header);
     }
     pending_.clear();
 
@@ -174,12 +200,13 @@ class UnreadableLifecycleNode : public rclcpp::Node {
     lifecycle_msgs::msg::TransitionEvent event;
     event.start_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED;
     event.start_state.label = "unconfigured";
-    event.goal_state.id = lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
-    event.goal_state.label = "active";
+    event.goal_state.id = state_id_for(transition_label_);
+    event.goal_state.label = transition_label_;
     transition_event_pub_->publish(event);
   }
 
   bool answering_ = false;
+  std::string transition_label_;
   std::vector<std::shared_ptr<rmw_request_id_t>> pending_;
   rclcpp::Service<lifecycle_msgs::srv::GetState>::SharedPtr get_state_service_;
   rclcpp::Service<lifecycle_msgs::srv::ChangeState>::SharedPtr change_state_service_;

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -919,6 +919,96 @@ if(BUILD_TESTING)
     ENV "GATEWAY_TEST_PORT=19520" "WATCHDOG_E2E_SCENARIO=d2_ungated_clear"
       "${_WATCHDOG_E2E_ENV}")
 
+  # === presence-ownership e2e (launch_testing) ===
+  #
+  # Which detector owns the departure of a managed node whose lifecycle state was never
+  # measured. Uses unreadable_lifecycle_node.cpp (advertises get_state / change_state like a
+  # managed node, and never answers GetState until told to), so the unmeasured window is
+  # permanent rather than a race between the GetState seed and the warmup - see
+  # test/e2e/test_presence_ownership_e2e.test.py's own module docstring for the three rows.
+
+  # 60 (arming, app_id-scoped) + 30 (faults-live) + 30 (empty-label poll) + 30 (departure poll)
+  # + 60 (DISAPPEARED raise poll) + 90 (UNREADABLE raise poll, kUnmeasuredHoldTicks is 60 fixed
+  # ticks plus the absence grace) = 300 internal - six independent budgets, not merged. Rounded
+  # to 420 to also cover the launch's own teardown for TWO processes (sigterm 30 + sigkill 15
+  # each, not fully serial).
+  medkit_add_launch_test(test_presence_ownership_e2e_budget_spent_then_owned
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 420
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19540" "WATCHDOG_E2E_SCENARIO=budget_spent_then_owned"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # A crash loop whose uptime is shorter than the warmup: killed, reported, back for less than
+  # one re-warm, killed again. The other restart rows in this package all wait for the returned
+  # node to arm before killing it, so none of them can see a key handed back while it is merely
+  # re-warming. 60 (arming, app_id-scoped, at RESTART_WARMUP_CYCLES) + 30 (faults-live) + 30
+  # (first departure poll) + 60 (first raise poll) + 60 (return poll,
+  # RESTART_RESPAWN_DELAY_SEC + 30) + 30 (un-armed state poll) + 30 (record poll) + 30 (second
+  # departure poll) + 60 (second raise poll) + 10 (no-PASSED window, SILENCE_WINDOW_SEC) = 400
+  # internal - ten independent budgets, not merged. Rounded to 540 to also cover the launch's
+  # own teardown for TWO processes (sigterm 30 + sigkill 15 each, not fully serial).
+  medkit_add_launch_test(test_presence_ownership_e2e_restart_inside_warmup
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 540
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19600" "WATCHDOG_E2E_SCENARIO=restart_inside_warmup"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # The two GROUNDS for ownership, and the only row here that asserts GRAPH_NODE_DISAPPEARED
+  # ABSENT: the fixture is left until its GetState budget is spent (provisional ownership),
+  # then told to announce "inactive", then killed. 60 (arming, app_id-scoped) + 30
+  # (faults-live) + 30 (unread-and-settled poll) + 30 (SetParameters call) + 30 (late-label
+  # poll) + 30 (release poll, node_death's own tracked_count) + 30 (departure poll) + 60
+  # (INACTIVE raise poll) + 10 (silence window, DISAPPEARED, SILENCE_WINDOW_SEC) = 310 internal
+  # - nine independent budgets, not merged. Rounded to 420 to also cover the launch's own
+  # teardown for TWO processes.
+  medkit_add_launch_test(test_presence_ownership_e2e_provisional_yields_to_a_real_label
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 420
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19590" "WATCHDOG_E2E_SCENARIO=provisional_yields_to_a_real_label"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # The same shape in the SHIPPED configuration (no require_active at all), where node_death is
+  # the only detector that can report the death. 60 (arming, app_id-scoped) + 30 (faults-live) +
+  # 30 (empty-label poll) + 30 (departure poll) + 60 (DISAPPEARED raise poll) + 10 (silence
+  # window, UNREADABLE, SILENCE_WINDOW_SEC) = 220 internal. Rounded to 360 to also cover the
+  # launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_presence_ownership_e2e_no_require_active_still_owned
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19570" "WATCHDOG_E2E_SCENARIO=no_require_active_still_owned"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # The reverse transition on a live node: measured "active", then its lifecycle services are
+  # dropped, then it is killed. Uses droppable_lifecycle_node.cpp, the only fixture that can
+  # take a node from measured to unmeasured without killing it. 60 (arming, app_id-scoped) + 30
+  # (faults-live) + 30 (active-label poll) + 30 (SetParameters call) + 30 (null-label poll) + 30
+  # (departure poll) + 60 (DISAPPEARED raise poll) = 270 internal. Rounded to 360 to also cover
+  # the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_presence_ownership_e2e_measured_then_unmeasured
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19580" "WATCHDOG_E2E_SCENARIO=measured_then_unmeasured"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped) + 30 (faults-live) + 30 (empty-label poll) + 30 (SetParameters
+  # call) + 30 (active-label poll) + 30 (departure poll) + 60 (DISAPPEARED raise poll) = 270
+  # internal. Rounded to 360 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_presence_ownership_e2e_answered_then_owned
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19550" "WATCHDOG_E2E_SCENARIO=answered_then_owned"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # test_01: 60 (arming, app_id-scoped) + 30 (empty-label poll) + 60 (PARAM_DRIFT raise poll) =
+  # 150. test_02: 60 (QOS_MISMATCH raise poll). test_03: 60 (ORPHAN raise poll) - 270 internal
+  # across the three cases, not merged. Nothing is killed here, so the only teardown is the
+  # launch's own for TWO processes; rounded to 360 for the same margin as its siblings.
+  medkit_add_launch_test(test_presence_ownership_e2e_gate_unaffected
+    test/e2e/test_presence_ownership_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19560" "WATCHDOG_E2E_SCENARIO=gate_unaffected"
+      "${_WATCHDOG_E2E_ENV}")
+
   ros2_medkit_relax_vendor_warnings()
 
 endif()

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -163,6 +163,7 @@ if(BUILD_TESTING)
     src/detector_registry.cpp
     src/reliability_gate.cpp
     src/lifecycle_watcher.cpp
+    src/detectors/node_death_detector.cpp
     ${LIFECYCLE_STATE_READER_SOURCES})
   target_include_directories(test_graph_watchdog_plugin PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
   medkit_target_dependencies(test_graph_watchdog_plugin
@@ -210,6 +211,60 @@ if(BUILD_TESTING)
   target_include_directories(test_aggregated_fault PRIVATE include)
   medkit_target_dependencies(test_aggregated_fault ros2_medkit_gateway rclcpp ros2_medkit_msgs)
   target_link_libraries(test_aggregated_fault nlohmann_json::nlohmann_json)
+
+  # Pure interface/logic: DetectorContext is only ever default-constructed (every pointer
+  # null), so no rclcpp::init() is needed anywhere in this one.
+  medkit_add_gtest(test_suppressor test/test_suppressor.cpp)
+  target_include_directories(test_suppressor PRIVATE include)
+  medkit_target_dependencies(test_suppressor rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_suppressor nlohmann_json::nlohmann_json)
+
+  # AllowlistSuppressor::suppresses() ignores ctx entirely - same "no rclcpp::init()" shape
+  # as test_suppressor above.
+  medkit_add_gtest(test_allowlist_suppressor test/test_allowlist_suppressor.cpp)
+  target_include_directories(test_allowlist_suppressor PRIVATE include)
+  medkit_target_dependencies(test_allowlist_suppressor rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_allowlist_suppressor nlohmann_json::nlohmann_json)
+
+  # Reads a REAL ReliabilityGate (needs a real rclcpp::Node for its LifecycleWatcher),
+  # driven through set_departed_lifecycle_state_for_test() rather than a live managed node.
+  medkit_add_gtest(test_lifecycle_shutdown_suppressor
+    test/test_lifecycle_shutdown_suppressor.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_lifecycle_shutdown_suppressor PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_lifecycle_shutdown_suppressor ros2_medkit_gateway rclcpp ros2_medkit_msgs lifecycle_msgs)
+  target_link_libraries(test_lifecycle_shutdown_suppressor nlohmann_json::nlohmann_json)
+
+  # Pure logic over hand-built present/armed sets: no rclcpp::Node anywhere in it. Depends
+  # on ros2_medkit_gateway/nlohmann_json only because the D1 case assembles a description
+  # through the real AggregatedFault::describe_ordered(), the same reason
+  # test_lifecycle_expectation_tracker above needs it.
+  medkit_add_gtest(test_node_liveness_tracker test/test_node_liveness_tracker.cpp)
+  target_include_directories(test_node_liveness_tracker PRIVATE include)
+  medkit_target_dependencies(test_node_liveness_tracker ros2_medkit_gateway rclcpp ros2_medkit_msgs)
+  target_link_libraries(test_node_liveness_tracker nlohmann_json::nlohmann_json)
+
+  # Registers a fake /fault_manager/report_fault service like the QoS/orphan/param_drift/
+  # lifecycle_expectation integration tests above, so it shares their RESOURCE_LOCK.
+  medkit_add_gtest(test_node_death_integration
+    test/test_node_death_integration.cpp
+    src/detectors/node_death_detector.cpp
+    src/detector_registry.cpp
+    src/reliability_gate.cpp
+    src/lifecycle_watcher.cpp
+    ${LIFECYCLE_STATE_READER_SOURCES})
+  target_include_directories(test_node_death_integration PRIVATE include ${GATEWAY_SRC_INCLUDE_DIR})
+  medkit_target_dependencies(test_node_death_integration
+    ros2_medkit_gateway rclcpp rcutils ros2_medkit_msgs lifecycle_msgs)
+  target_link_libraries(test_node_death_integration nlohmann_json::nlohmann_json)
+  # N11's churn sweep and the two retention-boundary cases each drive dozens of ticks; none
+  # needs real DDS endpoint discovery (every snapshot is hand-built), so this is generous
+  # against CI slowness rather than against any real per-tick cost.
+  set_tests_properties(test_node_death_integration PROPERTIES TIMEOUT 120)
+  set_property(TEST test_node_death_integration APPEND PROPERTY
+    RESOURCE_LOCK graph_watchdog_integration_domain)
 
   # Real DDS endpoints read through the live graph API. The three that ALSO register a fake
   # /fault_manager/report_fault service share a RESOURCE_LOCK, because they spin real nodes for
@@ -585,6 +640,284 @@ if(BUILD_TESTING)
     test/e2e/test_lifecycle_expectation_e2e.test.py TIMEOUT 600
     LABELS "integration;e2e"
     ENV "GATEWAY_TEST_PORT=19300" "WATCHDOG_E2E_SCENARIO=restart_departed" "${_WATCHDOG_E2E_ENV}")
+
+  # === node_death e2e (launch_testing) ===
+  #
+  # Exercises the node_death detector end to end against a real gateway + fault_manager +
+  # demo-node stack. See test/e2e/test_node_death_e2e.test.py's own module docstring for the
+  # full scenario list and what each row proves.
+
+  # 60 (arming gate, app_id-scoped - already implies presence, so this is not a separate
+  # budget) + 30 (departure poll) + 60 (raise poll) + 30 (entity-scoped fault poll) = 180
+  # internal, plus the two harness self-tests (a handful of seconds against a local
+  # stand-in server, no ROS graph involved). Rounded to 300 to also cover the launch's own
+  # teardown for TWO processes (sigterm 30 + sigkill 15 each, not fully serial).
+  medkit_add_launch_test(test_node_death_e2e_raise
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19310" "WATCHDOG_E2E_SCENARIO=raise" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped - already implies presence) + 30 (departure) + 60 (raise
+  # poll) + 42.5 (presence poll after the respawn: DEPARTURE_TIMEOUT_SEC + RESPAWN_DELAY_SEC)
+  # + 60 (heal poll) = 252.5 internal. Rounded to 420 to also cover the launch's own teardown
+  # for TWO processes.
+  medkit_add_launch_test(test_node_death_e2e_clear_on_return
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 420
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19320" "WATCHDOG_E2E_SCENARIO=clear_on_return" "${_WATCHDOG_E2E_ENV}")
+
+  # Same drive as clear_on_return (60 arming, app_id-scoped + 30 faults-live + 30
+  # departure + 60 raise poll + 42.5 presence-after-respawn = 222.5), plus the persistence
+  # window itself (20, SUSTAINED_WINDOW_SEC) instead of a heal poll = 242.5 internal.
+  # Rounded to 420 to also cover the launch's own teardown for TWO processes - same
+  # budget as clear_on_return since the internal sum is close and both drive one
+  # kill-then-return cycle.
+  medkit_add_launch_test(test_node_death_e2e_no_heal_standalone
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 420
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19330" "WATCHDOG_E2E_SCENARIO=no_heal_standalone" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming) + 30 (faults-live) + 30 (label poll to "active") + 30 (the ChangeState
+  # call itself) + 30 (separate label poll to "inactive") + 20 (silence window) + 15
+  # (end-of-window label check) = 215 internal, 260 with the launch's own teardown for
+  # TWO processes - three independent 30 s budgets, not one combined 30 s.
+  medkit_add_launch_test(test_node_death_e2e_deactivated_not_dead
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19340" "WATCHDOG_E2E_SCENARIO=deactivated_not_dead" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming - proves the hybrid-mode manifest actually loaded rather than silently
+  # degrading to runtime_only) + 30 (faults-live) + 30 (presence poll for the one online
+  # app) + 30 (a SEPARATE presence poll for the never-online app's manifest-derived
+  # snapshot entry) + 20 (silence window) = 170 internal, 215 with the launch's own
+  # teardown for TWO processes - two independent 30 s budgets, not one.
+  medkit_add_launch_test(test_node_death_e2e_manifest_never_online
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 240
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19350" "WATCHDOG_E2E_SCENARIO=manifest_never_online" "${_WATCHDOG_E2E_ENV}")
+
+  # test_01 (load-bearing): 60 (arming) + 30 (faults-live) + three renamed-node arm/kill
+  # cycles (30 presence poll on GET /apps, visible only because this scenario's own
+  # discovery.runtime.filter_internal_nodes is off + 60 app_id-scoped arming poll + 30
+  # departure poll + 15 process-reap budget each = 135 worst case, *3 = 405) + 20 (final
+  # silence window, SUSTAINED_WINDOW_SEC) = 515 internal.
+  # test_02: a constant comparison against the installed ros2cli package - no I/O, no
+  # polling, negligible budget.
+  # Rounded to 660 to also cover the launch's own teardown for the ONE launch-managed
+  # process (the gateway; this scenario declares no demo_nodes), plus however many
+  # renamed `demo_engine_temp_sensor` processes test_01 spawns and reaps itself across
+  # its three cycles (not launch-managed).
+  medkit_add_launch_test(test_node_death_e2e_ros2cli_ignored
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 660
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19360" "WATCHDOG_E2E_SCENARIO=ros2cli_ignored" "${_WATCHDOG_E2E_ENV}")
+
+  # 120 (two app_id-scoped arming gates, 60 each - one per colliding node, each already
+  # implying presence) + 30 (departure poll for the killed one) + 0 (the survivor's
+  # liveness check is a single non-blocking signal-0 probe, not a poll) + 60 (raise poll)
+  # + 5 (the describes-only window, MUTUAL_NAMING_WINDOW_SEC) = 215 internal. Rounded to
+  # 360 to also cover the launch's own teardown for THREE processes.
+  medkit_add_launch_test(test_node_death_e2e_bare_name_collision
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19370" "WATCHDOG_E2E_SCENARIO=bare_name_collision" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming) + 30 (faults-live) + 30 (presence poll) + 20 (silence window) + 5
+  # (end-of-window presence re-check) = 145 internal. Rounded to 240 to also cover the
+  # launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_e2e_fast_tick_floor
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 240
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19380" "WATCHDOG_E2E_SCENARIO=fast_tick_floor" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped - already implies presence) + THREE kill cycles (see
+  # RESTART_LOOP_OCCURRENCES_TARGET's own comment for why three), two of which also
+  # acknowledge and re-arm on the respawned instance (30 departure + 60 occurrence-count
+  # poll + 42.5 app_id-scoped re-arm after the respawn [DEPARTURE_TIMEOUT_SEC +
+  # RESPAWN_DELAY_SEC] = 132.5 each, *2 = 265) plus the third cycle's kill-and-confirm alone
+  # (30 + 60 = 90) + 30 (final record poll) = 445 internal. Rounded to 900, matching
+  # cap_pressure's own budget for a similarly multi-cycle scenario, to also cover the
+  # launch's own teardown for TWO processes plus CI-slowness margin.
+  medkit_add_launch_test(test_node_death_e2e_restart_loop_occurrences
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 900
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19390" "WATCHDOG_E2E_SCENARIO=restart_loop_occurrences" "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped - already implies presence) + 30 (departure) + 60 (raise
+  # poll) + 30 (record poll) = 180 (test_01); 60 (port-down wait) + 90 (global arming gate
+  # after the restart - TARGET_NODE is gone by design here, so this cannot be app_id-scoped
+  # the way test_01's is) + 30 (faults-live, proving the restarted gateway reconnected to
+  # the fault_manager before the persistence window below could mean anything) + 5
+  # (not-present check) + 20 (persistence window) + 30 (record poll) = 235 (test_02) - 415
+  # internal. Rounded to 600, the same budget as the sibling detector's restart_departed
+  # scenario (an identically-shaped gateway-restart test), to also cover the launch's own
+  # teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_e2e_restart_rebaseline
+    test/e2e/test_node_death_e2e.test.py TIMEOUT 600
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19400" "WATCHDOG_E2E_SCENARIO=restart_rebaseline" "${_WATCHDOG_E2E_ENV}")
+
+  # === node_death suppression e2e (launch_testing) ===
+  #
+  # Exercises the node_death detector's suppression framework (allowlist, self-suppression,
+  # pruning) against a real gateway + fault_manager + demo-node stack - see
+  # test/e2e/test_node_death_suppression_e2e.test.py's own module docstring for the full
+  # scenario list and what each row proves.
+
+  # 60 (arming, app_id-scoped) + 30 (faults-live) + 30 (departure poll) + 20 (absence window,
+  # SUSTAINED_WINDOW_SEC) = 140 internal, plus the harness self-test for assert_fault_never_names
+  # (a handful of seconds against a local stand-in server, no ROS graph involved). Rounded to
+  # 240 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_suppression_e2e_allowlist_suppresses
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 240
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19410" "WATCHDOG_E2E_SCENARIO=allowlist_suppresses"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped) + 30 (departure poll) + 60 (raise poll) + 30 (startup-warning
+  # wait on the gateway's own stderr via proc_output, WARNING_TIMEOUT_SEC - unreachable today
+  # since the raise poll above fails first, but written and counted on its own budget) = 180
+  # internal. Rounded to 300 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_suppression_e2e_allowlist_not_named_is_inert
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19420" "WATCHDOG_E2E_SCENARIO=allowlist_not_named_is_inert"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (global arming) + 30 (faults-live) + 60 (watchdog-entity poll, CLEAN_NODE "unconfigured")
+  # + 60 (watchdog-entity poll, KILLED_NODE "active") + 60 (the ChangeState call itself: up to
+  # 30 waiting for the service plus another 30 for the response - _call_change_state_once pays
+  # both, not one) + 30 (watchdog-entity poll, CLEAN_NODE "finalized") + 30 (departure poll,
+  # CLEAN_NODE) + 30 (departure poll, KILLED_NODE) + 60 (raise poll) + 20 (describes-only window,
+  # SUSTAINED_WINDOW_SEC) = 440 internal - ten independent budgets, not merged. Rounded to 720
+  # to also cover the launch's own teardown for THREE processes (gateway plus both lifecycle
+  # fixtures).
+  medkit_add_launch_test(test_node_death_suppression_e2e_lifecycle_clean_shutdown
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 720
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19430" "WATCHDOG_E2E_SCENARIO=lifecycle_clean_shutdown"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped) + 30 (departure poll) + 60 (raise poll) = 150 internal. Rounded
+  # to 240 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_suppression_e2e_suppression_is_opt_in
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 240
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19440" "WATCHDOG_E2E_SCENARIO=suppression_is_opt_in"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # Two independent nodes (TARGET_NODE, allowlisted; SECOND_NODE, not) - see the module
+  # docstring's own note on why a single unsuppressed node cannot exercise pruning at all.
+  # 60+60 (arming, app_id-scoped, one per node) + 30 (faults-live) + 40 (baseline settle,
+  # STABLE_TRACKED_COUNT_TIMEOUT_SEC - node_death's own tick has to catch up to the gate
+  # before the reclaim delta below means anything, see _poll_stable_tracked_count) + 30+30
+  # (departure poll, one per node) + 60 (raise poll, SECOND_NODE) + 60 (reclaim poll on
+  # detectors.node_death.tracked_count via GET /x-medkit-watchdog - PRUNE_GRACE ticks elapse
+  # comfortably inside it) + 20 (describes-only window, SUSTAINED_WINDOW_SEC) = 390 internal.
+  # Rounded to 600 to also cover the launch's own teardown for THREE processes.
+  medkit_add_launch_test(test_node_death_suppression_e2e_prune_no_false_heal
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 600
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19450" "WATCHDOG_E2E_SCENARIO=prune_no_false_heal"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # === node_death boundary, config and instrument e2e (launch_testing) ===
+  #
+  # Exercises the seam between node_death and lifecycle_expectation, plus config/instrument
+  # boundary cases, against a real gateway + fault_manager + demo-node stack - see
+  # test/e2e/test_node_death_boundary_e2e.test.py's own module docstring for the full scenario
+  # list and which rows (B1, B3) are satisfied by lifecycle_expectation alone.
+
+  # 60 (global arming) + 30 (faults-live) + 30 (presence poll) + 60 (raise poll, INACTIVE) + 20
+  # (absence window, DISAPPEARED, SUSTAINED_WINDOW_SEC) + 5 (end-of-window presence recheck) =
+  # 205 internal. Rounded to 300 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b1_inactive_present
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19460" "WATCHDOG_E2E_SCENARIO=b1_inactive_present"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (global arming) + 30 (faults-live) + 60 (tracked_nodes==1 poll) + 30 (departure poll) +
+  # 20 (absence window, INACTIVE, SUSTAINED_WINDOW_SEC) + 60 (raise poll, DISAPPEARED -
+  # unreachable today since the absence window above fails first, but written and counted on
+  # its own budget) = 260 internal. Rounded to 360 to also cover the launch's own teardown for
+  # TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b2_inactive_below_grace_then_gone
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19470" "WATCHDOG_E2E_SCENARIO=b2_inactive_below_grace_then_gone"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (global arming) + 30 (faults-live) + 60 (raise poll, INACTIVE) + 30 (departure poll) + 20
+  # (persistence window, INACTIVE, SUSTAINED_WINDOW_SEC) + 60 (raise poll, DISAPPEARED) = 260
+  # internal. Rounded to 360 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b3_matured_then_gone
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19480" "WATCHDOG_E2E_SCENARIO=b3_matured_then_gone"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped) + 30 (faults-live) + 30 (departure poll) + 20 (absence window,
+  # INACTIVE, SUSTAINED_WINDOW_SEC) + 60 (raise poll, DISAPPEARED) = 200 internal. Rounded to
+  # 300 to also cover the launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b4_healthy_then_gone
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 300
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19490" "WATCHDOG_E2E_SCENARIO=b4_healthy_then_gone"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (global arming) + 30 (faults-live) + 30 (presence poll) + THREE restart cycles (see
+  # B5_CYCLES's own comment for why three), each (30 departure poll + 60 raise poll + 42.5
+  # presence-after-respawn poll [DEPARTURE_TIMEOUT_SEC + B5_RESPAWN_DELAY_SEC] + 60 clear
+  # poll = 192.5), *3 = 577.5, plus the 120 preamble = 697.5 internal - four independent
+  # per-cycle budgets, not one merged figure, times three cycles. B5_RESPAWN_DELAY_SEC
+  # (12.5 s) replaces the launch-wide RESPAWN_DELAY_SEC (1.5 s) for this scenario alone: the
+  # outage has to stay safely above the detector's own wall-clock floor for every cycle to be
+  # reportable by a correct implementation - see that constant's own comment for the margin
+  # arithmetic. Rounded to 1500, well past the 900 this package's own restart-loop-shaped
+  # scenarios already use for a smaller sum, to also cover the launch's own teardown for TWO
+  # processes plus CI-slowness margin.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b5_restart_loop_still_caught
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 1500
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19500" "WATCHDOG_E2E_SCENARIO=b5_restart_loop_still_caught"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (global arming) + 30 (faults-live) + 30 (presence poll) + 60 (tracked_nodes==1 poll) +
+  # 30 (departure poll) + 60 (raise poll, INACTIVE) + 20 (absence window, DISAPPEARED,
+  # SUSTAINED_WINDOW_SEC) = 290 internal. Rounded to 360 to also cover the launch's own
+  # teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_b6_never_armed_below_grace_then_gone
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19530" "WATCHDOG_E2E_SCENARIO=b6_never_armed_below_grace_then_gone"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # 60 (arming, app_id-scoped) + 30 (faults-live) + 30 (departure poll) + 25 (early silence
+  # window, C4_EARLY_WINDOW_SEC, needle-scoped) + 100 (late raise poll,
+  # C4_LATE_RAISE_TIMEOUT_SEC) = 245 internal - five independent budgets, not merged. One
+  # gateway, one target, one domain: rounded to 360 to also cover the launch's own teardown for
+  # TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_c4_config_endpoint_e2e
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 360
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19510" "WATCHDOG_E2E_SCENARIO=c4_config_endpoint_e2e"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # test_01: 60 (arming, app_id-scoped) + 30 (departure poll) + 60 (raise poll) + 30 (record
+  # poll) = 180. test_02: 60 (port-down wait) + 30 (faults-live gate BEFORE the ungated window
+  # opens - a restarted gateway's HTTP server is not up the instant the old port goes down,
+  # confirmed live) + 3.5 (ungated pre-arm window, D2_UNGATED_WATCH_SEC) + 90 (global arming
+  # after the restart - TARGET_NODE is gone by design here, so this cannot be app_id-scoped) +
+  # 30 (faults-live, again, gating the persistence window below) + 5 (not-present check) + 20
+  # (persistence window, SUSTAINED_WINDOW_SEC) + 30 (record poll) = 268.5 - 448.5 internal, nine
+  # independent budgets across both test methods, not merged. Rounded to 660 to also cover the
+  # launch's own teardown for TWO processes.
+  medkit_add_launch_test(test_node_death_boundary_e2e_d2_ungated_clear
+    test/e2e/test_node_death_boundary_e2e.test.py TIMEOUT 660
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19520" "WATCHDOG_E2E_SCENARIO=d2_ungated_clear"
+      "${_WATCHDOG_E2E_ENV}")
 
   ros2_medkit_relax_vendor_warnings()
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/CMakeLists.txt
@@ -320,9 +320,13 @@ if(BUILD_TESTING)
 
   # Registers a fake /fault_manager/report_fault service like orphan/param_drift above, so it
   # shares the same RESOURCE_LOCK (see the comment on the integration block).
+  # Both detectors, because the boundary between them is only observable with both of them on
+  # one gate: what one admits decides what the other latches, and a claim about the handover
+  # cannot be driven from either side alone.
   medkit_add_gtest(test_lifecycle_expectation_integration
     test/test_lifecycle_expectation_integration.cpp
     src/detectors/lifecycle_expectation_detector.cpp
+    src/detectors/node_death_detector.cpp
     src/detector_registry.cpp
     src/reliability_gate.cpp
     src/lifecycle_watcher.cpp
@@ -796,6 +800,16 @@ if(BUILD_TESTING)
     test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 720
     LABELS "integration;e2e"
     ENV "GATEWAY_TEST_PORT=19430" "WATCHDOG_E2E_SCENARIO=lifecycle_clean_shutdown"
+      "${_WATCHDOG_E2E_ENV}")
+
+  # The control for the row above, and the same launch minus one config key, so it carries the
+  # same budget: the suppressed row's "the clean node is never named" cannot tell a working
+  # suppressor from a key node_death never admitted, and this one does by requiring that name.
+  medkit_add_launch_test(test_node_death_suppression_e2e_lifecycle_clean_shutdown_unsuppressed
+    test/e2e/test_node_death_suppression_e2e.test.py TIMEOUT 720
+    LABELS "integration;e2e"
+    ENV "GATEWAY_TEST_PORT=19610"
+      "WATCHDOG_E2E_SCENARIO=lifecycle_clean_shutdown_unsuppressed"
       "${_WATCHDOG_E2E_ENV}")
 
   # 60 (arming, app_id-scoped) + 30 (departure poll) + 60 (raise poll) = 150 internal. Rounded

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -1393,16 +1393,33 @@ the manifest declared - rather than a gap here.
 override lands after `ON_ERROR_FAILURE`/`ON_ERROR_ERROR` out of `errorprocessing` - the
 standard way a driver reports a hardware fault it cannot recover from, which is precisely the
 death an operator needs reported, not silenced. Without an observed transition history the
-departure is unclassified and stays reported - the safe direction. This mechanism is
+departure is unclassified and stays reported - the safe direction. The suppressor itself is
 stateless by construction: a detector's `configure()` (where the suppressor chain is built)
 runs before any per-tick context exists, so it stores nothing at construction and reads the
-gate fresh on every call. Its retention window is not this detector's own to size, either:
-before this detector's own `configure()` has run, the plugin predicts the same
-`prune_ticks_` (`max(prune_grace, miss_grace + 1)`) this detector will compute, then sizes
-the lifecycle watcher's departed-node retention from it with enough margin that a
-clean-shutdown label is still cached at this detector's own reclaim tick, one tick to
-spare - see `GraphWatchdogPlugin::compute_departed_retention_ticks()` for the exact
-arithmetic, which is larger than `prune_ticks_` alone.
+gate fresh on every call.
+
+**The verdict is latched; the evidence is not.** `node_death` remembers that a durable
+suppressor vetoed a given departed key and stops re-asking for as long as that key stays
+tracked and absent. This is not an optimisation. The departed-lifecycle label the suppressor
+reads is retained for a bounded number of ticks, while the veto has to hold all the way to
+`prune()`'s reclaim - which itself needs the veto UNBROKEN for `prune_ticks` consecutive
+ticks. Re-asking every tick made those two windows race, and the retention clock starts at
+the wrong event to win it: it is anchored when the node's lifecycle SERVICES leave the graph,
+while the reclaim tick counts from when its App does, one or more sweeps later. Once the
+label expired mid-veto the suppressor abstained, the streak reset to zero, and with the label
+gone for good the key could never be suppressed again - a cleanly shut-down node named in
+`GRAPH_NODE_DISAPPEARED` for the life of the process. Latching is sound because that is what
+`durable()` means: such a verdict never lifts for a given key, so remembering it cannot
+diverge from asking again. Only positive verdicts from durable suppressors are latched, and
+the entry is dropped the moment the key is present again, so one departure's verdict is never
+carried into the next.
+
+The retention window is still not this detector's own to size: before its `configure()` has
+run, the plugin predicts the same `prune_ticks_` (`max(prune_grace, miss_grace + 1)`) this
+detector will compute and sizes the lifecycle watcher's departed-node retention from it. With
+the verdict latched, all that window has to outlive is the FIRST tick suppression is evaluated
+on; it is left sized to the reclaim tick anyway, as slack against the services-before-App lead
+above - see `GraphWatchdogPlugin::compute_departed_retention_ticks()`.
 
 **Bounded by evidence, not by age.** This detector is zero-config over every armed App in
 the graph - a strictly larger scope than `lifecycle_expectation`'s named `require_active`
@@ -1430,6 +1447,26 @@ sustained pressure from still-maturing churn the departed set may therefore exce
 exists to prevent in the first place. `tracking_saturated` reports exactly this: the departed
 set still exceeds `tracked_node_cap` even after collapsing every confirmed death it safely
 could, because immature entries alone account for the excess.
+
+**What collapsing costs, and why it is not fixed here.** Collapsing DISCARDS the identity: the
+fold is one-way, `collapsed_dead_count_` only ever grows within a tracker's life, and nothing
+decrements it when a collapsed node comes back. Two consequences follow, and both are real.
+The description stops naming those nodes and carries an unattributable `and N more` instead;
+and because the aggregated fault clears only when its dead set is EMPTY, the synthetic
+collapsed entry keeps it non-empty, so once anything has been collapsed
+`GRAPH_NODE_DISAPPEARED` cannot clear again for the life of the process - it ends by operator
+acknowledge (`DELETE /api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED`) or by a
+restart, never by the graph recovering.
+
+Neither is repairable from inside this tracker. Decrementing on return needs the identity the
+collapse threw away, and keeping identities is exactly the unbounded state the cap exists to
+prevent; decaying the count by time would heal a fault by waiting, which this package refuses
+everywhere else (an occurrence is closed by an operator, not by the passage of time). What
+makes it acceptable is what collapsing is allowed to touch: only a MATURED entry, whose death
+has already been reported by name. No departure becomes unreported by being collapsed - the
+fault stays raised, and it is the attribution and the self-healing that are lost, not the
+warning. Reaching the condition at all needs more than `tracked_node_cap` (512 by default)
+distinct dead identities at once, which is a churn problem in its own right.
 
 Unlike `lifecycle_expectation`'s identical-looking cap, a PRESENT/armed key here is never the
 thing evicted to free a slot. `LifecycleExpectationTracker` carries two clocks per node, so a

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -96,7 +96,8 @@ built from it.
 |---|---|
 | Peer-aggregated apps (`app.source` starting `peer:`) | A peer app carries no ROS binding of its own, so `effective_fqn()` is empty for every one of them; tracking them would collapse an entire peer fleet onto one `""` key, and one online peer app would mask every other peer app's departure. |
 | `_ros2cli_<pid>` nodes | Every `ros2` CLI invocation (`ros2 topic echo`, `ros2 param get`, ...) spins up a real, short-lived node under this prefix - rcl's own hidden-node naming convention, matched structurally rather than guessed at. Letting these through would accumulate one permanently "dead" entry per CLI invocation for the life of the gateway. |
-| An App that never comes online | A key is admitted to tracking only once it has been armed by the reliability gate at least once. A manifest App whose binding never starts is never armed and so can never be falsely called dead; a node still inside its `warmup_cycles` window gets the identical protection. Once tracked, though, a node's continued life-or-death judgement rests on PRESENCE alone, not on staying armed - a tracked node that later goes lifecycle-inactive is not thereby mistaken for dead. |
+| An App that never comes online | A key is admitted to tracking only once the reliability gate has said this detector OWNS its departure - armed at least once, and on one of the two GROUNDS ownership can rest on (a lifecycle state read as `active`, or no lifecycle to read at all; the third case, a state nobody could read, is admitted PROVISIONALLY and is described in the row below). A manifest App whose binding never starts is never armed and so can never be falsely called dead; a node still inside its `warmup_cycles` window gets the identical protection. Once tracked, though, a node's continued life-or-death judgement rests on PRESENCE alone, not on staying armed - a tracked node that later goes lifecycle-inactive is not thereby mistaken for dead. |
+| A managed App whose lifecycle state has not been read YET | Not tracked, and only for as long as that is still true. The gate's own raise permission is answered PERMISSIVELY for a managed node whose `GetState` has not answered (`LifecycleWatcher::node_ok()`) - without that, `qos_mismatch`, `orphan` and `param_drift` would all fall silent about a node whose lifecycle service is broken. Permission is not knowledge, though, so tracking is withheld while a measurement may still arrive. `LifecycleWatcher` charges a GetState re-seed budget per node, and only for a read that actually ran, so "still asking" is a fact rather than a guess. Once that budget is spent the node is tracked here after all: nothing will ASK again, and `lifecycle_expectation` looks at nothing unless an operator named the node in `require_active` (empty by default), so withholding it any longer would mean the death is reported by nobody. That admission is PROVISIONAL, not final. The `~/transition_event` subscription outlives the seed budget, so a label can still arrive without being asked for, and one that reads non-active says the node was the lifecycle detector's all along - so the presence detector hands it back on the spot, while it is still alive. Waiting for the budget alone would only have delayed the wrong report, not prevented it. |
 
 Composable/component nodes hosted in one process die together: if the container process
 dies, every node it hosted leaves the snapshot on the same tick, and all of them are folded
@@ -720,8 +721,8 @@ node's SETTLED observation had started, and resets nothing:
 | Settled observation | What sustained absence does |
 |---|---|
 | `inactive`, ALREADY reported under `GRAPH_NODE_INACTIVE` | the streak continues exactly as it did on its last present tick, so the fault stays raised and keeps naming a node that is no longer there |
-| `inactive`, not yet past `grace`, node WAS armed at some point | the streak is HELD - neither advanced (no fault is born while nobody can observe the node) nor erased (a node that returns still inactive resumes rather than re-earning `grace`). The presence detector could report this exact departure instead (`node_death` tracks any node the reliability gate has armed at least once), so this detector does not need to. |
-| `inactive`, not yet past `grace`, node was NEVER armed | the streak keeps climbing on absence exactly as it would on a present tick. `node_death` only ever tracks a node the gate has armed, so a node that never reached that bar is structurally invisible to it no matter what happens afterwards - if this detector held the streak too, the departure would be reported by nothing at all. |
+| `inactive`, not yet past `grace`, node the presence detector OWNED at some point | the streak is HELD - neither advanced (no fault is born while nobody can observe the node) nor erased (a node that returns still inactive resumes rather than re-earning `grace`). The presence detector could report this exact departure instead (`node_death` tracks any node the reliability gate has admitted for presence ownership at least once), so this detector does not need to. |
+| `inactive`, not yet past `grace`, node the presence detector NEVER owned | the streak keeps climbing on absence exactly as it would on a present tick. `node_death` only ever tracks a node the gate has admitted for ownership AND that is online, so a node that never reached that bar - one that never reached `active`, or one whose ROS binding never started - is structurally invisible to it no matter what happens afterwards. If this detector held the streak too, the departure would be reported by nothing at all. |
 | unread label, or no tracked lifecycle | the unmeasured clock keeps climbing under that same cause, so the node is eventually reported under `GRAPH_NODE_UNREADABLE` / `GRAPH_NODE_NOT_MANAGED` |
 | `active` | nothing. Anything the node had started but not corroborated is released, the entry becomes idle and is reclaimed silently |
 
@@ -781,17 +782,22 @@ Where the presence class CAN also report the same departure, that is no longer t
 thing standing between such a node and invisibility: `GRAPH_NODE_DISAPPEARED` (this
 package's `node_death` detector) independently reports it, whether or not the node was
 ever measured not-active first. But `node_death` only ever tracks an App once the
-reliability gate has armed it, and the gate refuses to arm a MANAGED node that is not
-`active` (`LifecycleWatcher::node_ok()`) - so a `require_active` node that never reaches
-`active` is never armed, is never tracked by `node_death`, and its departure can never
-raise `GRAPH_NODE_DISAPPEARED`, whatever kills it. The tracker therefore splits on whether
-a node was EVER armed, read from the reliability gate itself rather than guessed from the
-observed label: once armed, a below-`grace` streak that goes absent is simply HELD -
-maturing it would raise `GRAPH_NODE_INACTIVE` from ticks gathered while nobody could
-observe the node, a fault its presence never earned, and `GRAPH_NODE_DISAPPEARED` is there
-to report the departure instead. A node that was NEVER armed gets no such backstop -
-`GRAPH_NODE_DISAPPEARED` structurally cannot report it - so absence keeps advancing its
-streak exactly as a present tick would, maturing it within the same bound an armed node's
+reliability gate says it OWNS that App's departure, and ownership needs the node's lifecycle
+state either KNOWN not to be a managed-non-active one (no managed record at all, or a record
+reading `active`) or asked for as often as it ever will be. So a `require_active` node that
+never reaches `active` is never tracked by `node_death`, and neither is an app that is not
+online. A managed node whose `GetState` has not answered is withheld only while the watcher is
+still asking: the gate would let it raise throughout (`LifecycleWatcher::node_ok()` treats an
+unread label as permission, deliberately), and once the re-seed budget is spent the node is
+`node_death`'s after all, because nothing else would ever report it. The tracker therefore
+splits on
+whether the presence detector EVER owned a node, read from the reliability gate itself rather
+than guessed from the observed label: once owned, a below-`grace` streak that goes absent is
+simply HELD - maturing it would raise `GRAPH_NODE_INACTIVE` from ticks gathered while nobody
+could observe the node, a fault its presence never earned, and `GRAPH_NODE_DISAPPEARED` is
+there to report the departure instead. A node the presence detector never owned gets no such
+backstop - `GRAPH_NODE_DISAPPEARED` structurally cannot report it - so absence keeps advancing
+its streak exactly as a present tick would, maturing it within the same bound an owned node's
 UNMEASURED clock already has (`grace` + `absence_grace` + 1 ticks). An ALREADY-matured
 streak still continues through absence exactly as before, for either kind of node: two
 codes standing at once for the same node (`GRAPH_NODE_INACTIVE` because it was measured
@@ -1364,6 +1370,21 @@ the lifecycle watcher's cached label for the departed node's LAST observed trans
 | `unconfigured` | No, deliberately - it is also the resting state of a node whose `configure()` failed or that never activated at all, and suppressing on it would hide exactly that startup failure. |
 | Any other label, or no departure on record at all | No (abstains). |
 
+**Which bindings the mechanism can see.** The departed-lifecycle record it reads is written
+when a tracked app's `get_state` path stops appearing in `App::services`, which is what the
+lifecycle watcher builds its managed set from. `App::is_online` plays no part in that, and the
+two do not have to coincide: a manifest-declared App outlives the node it binds, keeping its id
+and fqn while only its runtime-derived collections empty out. That case still works - the
+services go with the node, so the departure is recorded - because a manifest cannot declare
+services at all: `ManifestParser::parse_app` reads `id`, `name`, `description`,
+`is_located_on`, `depends_on`, `tags`, `external` and `ros_binding`, and nothing else, so an
+app's services can only ever come from a live runtime match. The case the mechanism genuinely
+cannot cover is `discovery.inherit_runtime_resources: false`, which restores the manifest's own
+(empty) collections on every sweep: such an app is never lifecycle-tracked in the first place,
+so it has no lifecycle label, `node_ok()` never gates it, and there is nothing for this
+suppressor to classify. That is the documented meaning of the flag - the app exposes only what
+the manifest declared - rather than a gap here.
+
 `finalized` needs the extra corroboration because it is also where a node's `on_error`
 override lands after `ON_ERROR_FAILURE`/`ON_ERROR_ERROR` out of `errorprocessing` - the
 standard way a driver reports a hardware fault it cannot recover from, which is precisely the
@@ -1424,7 +1445,7 @@ present but not active, `GRAPH_NODE_DISAPPEARED` says a node is gone, and an ope
 each has a different repair - reactivate it, or find out why it left. A node CONFIRMED
 `GRAPH_NODE_INACTIVE` that then departs keeps that fault (its description switches to say
 the node has since left the graph) AND now also raises `GRAPH_NODE_DISAPPEARED`, since this
-detector tracks every armed App independently of whatever `lifecycle_expectation` thinks of
+detector tracks every App it owns independently of whatever `lifecycle_expectation` thinks of
 it.
 
 What changed is narrower than that, and it only applies to a node this detector could ever
@@ -1432,17 +1453,19 @@ have tracked. Before this detector existed, `lifecycle_expectation`'s own violat
 let a SUSTAINED absence mature an unconfirmed (below-`grace`) streak into a confirmed
 `GRAPH_NODE_INACTIVE` - the only way a node stuck in a restart loop, never observed long
 enough to cross `grace` while present, would ever be reported at all. Where this detector
-can independently report the same departure - which needs the node to have been ARMED at
-least once, since `node_death` only ever tracks an App the reliability gate has armed, and
-the gate refuses to arm a MANAGED node that is not `active` - that absence-alone maturity is
-gone: absence CONTINUES a violation that has already matured past `grace` (the fault stays
-raised, still naming the node), but no longer CREATES one that has not. A node that was
-briefly non-active and then died is reported as gone (`GRAPH_NODE_DISAPPEARED`) rather than
-also acquiring an inactive fault born from ticks gathered while nobody could observe it. A
-`require_active` node that never reaches `active` is never armed, is never tracked here, and
-its departure can never raise `GRAPH_NODE_DISAPPEARED` - for that one node,
+can independently report the same departure - which needs the presence detector to have OWNED
+the node at least once, since `node_death` only ever tracks an App the reliability gate has
+admitted for ownership, and ownership of a MANAGED node is EARNED only by a lifecycle state
+read as `active` (a state nobody could read earns nothing: it is granted provisionally and given
+up again the moment a label arrives) - that absence-alone maturity is gone: absence CONTINUES a violation that has
+already matured past `grace` (the fault stays raised, still naming the node), but no longer
+CREATES one that has not. A node that was briefly non-active and then died is reported as gone
+(`GRAPH_NODE_DISAPPEARED`) rather than also acquiring an inactive fault born from ticks
+gathered while nobody could observe it. A `require_active` node that never reaches `active` is
+never owned, is never tracked here, and its departure can never raise
+`GRAPH_NODE_DISAPPEARED`; the same holds for an app that is not online. For those,
 `lifecycle_expectation` keeps the older behaviour: absence still matures a below-`grace`
-streak, because it is structurally the only detector that will ever get to report it. See
+streak, because it is structurally the only detector that will ever get to report them. See
 `lifecycle_expectation`'s own "Absence continues the last CORROBORATED observation, it never
 erases" section above for the mechanism.
 
@@ -1484,6 +1507,31 @@ Acknowledging between the two deaths avoids this: `DELETE
 /api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED` closes the first occurrence, so the
 second node's next report reactivates a CLEARED record instead of updating a CONFIRMED one - a
 genuine new occurrence, with its own `occurrence_count` and its own capture.
+
+**A fault outlives a gateway restart even if the node comes back, and only an acknowledgement
+closes it.** Within one process this detector heals on return: the node reappears, the dead set
+empties, a PASSED flows and the fault heals. Across a restart it does not, in either direction.
+The restarted instance may clear `GRAPH_NODE_DISAPPEARED` only once it has ITSELF put a FAILED
+on the wire for it, because until then it cannot tell "the node came back" from "I never saw
+that node" - and clearing on the second reading is the ungated heal the guard exists to
+prevent. So a fault CONFIRMED before a restart stays CONFIRMED afterwards whether or not the
+node returned, and with the sqlite backend it survives every reboot until
+`DELETE /api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED` acknowledges it. That is the
+acknowledge model doing what it is for, not an accident: an occurrence is closed by an
+operator, not by the passage of a restart.
+
+Re-seeding the tracker from the fault store at startup would change it, and today it cannot be
+done. `/fault_manager/list_faults` would tell this detector that a `GRAPH_NODE_DISAPPEARED`
+record is outstanding and that it is among its reporting sources - but not WHICH nodes it
+names, which is the only thing that would make a fresh instance's silence meaningful. The fault
+manager keeps one record per `fault_code`, and this detector folds every dead key into that one
+record's description, capped at `kMaxDescriptionChars` with the remainder collapsed into a
+count, so the key list is not recoverable even by parsing prose. `lifecycle_expectation` has the
+same boundary and resolves it differently (a bounded hold, then the clear flows) because its
+`require_active` set is enumerable from config alone; this detector is zero-config over the
+whole graph and has no such set. The integration test
+`RestartedInstanceNeverClearsAFaultItDidNotRaiseEvenAsTheNodeReturns` pins the behaviour so it
+cannot change silently.
 
 **Test tiers.**
 
@@ -1534,7 +1582,7 @@ genuine new occurrence, with its own `occurrence_count` and its own capture.
    once the pressure passes; and a cap-forced collapse stays raised through a genuine
    recovery but clears once reconfigured, mirroring the ungated-clear guard's own reconfigure
    test for an ordinary (uncollapsed) fault.
-3. **E2e**, three files, each launching its own real gateway + fault_manager + demo-node
+3. **E2e**, four files, each launching its own real gateway + fault_manager + demo-node
    stack:
    - `test/e2e/test_node_death_e2e.test.py` (ten scenarios): raise and name the node; clear
      once it returns; no heal with the fault manager's healing disabled; a lifecycle
@@ -1564,10 +1612,32 @@ genuine new occurrence, with its own `occurrence_count` and its own capture.
      killed raises `GRAPH_NODE_DISAPPEARED` alone; a restart-looping required node is caught
      every cycle regardless of whether it ever matures under `lifecycle_expectation`; a node
      that is NEVER armed, killed while still below `grace`, raises `GRAPH_NODE_INACTIVE`
-     alone instead - `node_death` cannot track a node the gate never armed, so absence has to
-     mature the violation here; a large `miss_grace` delays the report but does not swallow
+     alone instead - `node_death` cannot track a node the gate never admitted for ownership,
+     so absence has to mature the violation here; a large `miss_grace` delays the report but does not swallow
      it; and a restarted gateway's own warmup window never produces a spurious PASSED for a
      node it has not yet re-measured.
+   - `test/e2e/test_presence_ownership_e2e.test.py` (seven scenarios, presence ownership
+     against a node whose `GetState` never answers - the boundary file's B6 row covers the
+     measured-not-active side, where the unread window is a race rather than a permanent
+     state): a managed node the watcher asked and could not read, killed, raises BOTH
+     `GRAPH_NODE_DISAPPEARED` and `GRAPH_NODE_UNREADABLE`; the same death with NO
+     `require_active` entry anywhere - the shipped default, where nothing else is watching -
+     still raises `GRAPH_NODE_DISAPPEARED`, and that pair also rules out an implementation
+     deciding ownership from `require_active` membership; the same node told to start
+     answering, measured `active`, then killed, is reported too, under the identical
+     configuration as the first row so the only variable is the lifecycle state; a node
+     measured `active` that then LOSES its lifecycle services and is killed is still
+     reported; and with an unmeasured managed node in the graph `GRAPH_PARAM_DRIFT` still
+     names it (the one leg of the three that passes through the app-keyed gate at all),
+     while `GRAPH_QOS_MISMATCH` and `GRAPH_ORPHAN`, both keyed by topic, still report too.
+     The sixth is the one that asserts an ABSENCE: the same never-answering node, owned
+     provisionally once the asking stops, is then told to announce `inactive` and killed -
+     `GRAPH_NODE_INACTIVE` names it and `GRAPH_NODE_DISAPPEARED` never appears, which is also
+     the row that rejects a detector wired to the permissive `reliability_allows()`. The
+     seventh is a crash loop shorter than the warmup: killed, reported, back for less than one
+     re-warm, killed again - the second death must still be reported, and no PASSED may be
+     emitted while the node is dead, which is what a key handed back for merely re-warming
+     would produce.
 
 ## Reliability (bringup-quiesce)
 
@@ -1605,7 +1675,72 @@ bringup-quiesce centrally so no individual detector has to reimplement it.
   subscriptions are kept out of the gateway's ROS executor (own callback group,
   own single-threaded executor that the plugin's tick thread drains between
   ticks), so they are only ever created, run and destroyed on that one thread.
-  Non-managed nodes are never gated.
+  Non-managed nodes are never gated. Neither is a managed node whose `GetState`
+  has never answered: its label stays EMPTY, and the gate answers PERMISSIVELY
+  for it on purpose, because gating on an unread label would silence every
+  detector for a node whose lifecycle service is broken - `qos_mismatch`,
+  `orphan` and `param_drift` included. Only a KNOWN non-active label suppresses.
+- **Presence ownership** is a second, stricter question the same gate answers,
+  and only `node_death` and `lifecycle_expectation` ask it. "May this entity
+  raise" is not "will the presence detector be able to report this node's
+  departure". The latter is true for a node with no managed record at all (a
+  plain node) and for one reading `active`. An unread label is ignorance rather
+  than a state, so it answers no - but only while that ignorance can still
+  resolve. `LifecycleWatcher` charges a bounded GetState re-seed budget per node,
+  and charges it only for a read that actually ran, so an empty label with
+  attempts left means "we have not finished asking" and an empty label with the
+  budget spent means "we asked and failed". Past that point the answer flips back
+  to yes, because `lifecycle_expectation` is the only other detector that could
+  report such a node and it looks at nothing unless an operator named the node in
+  `require_active`, which is empty by default: withholding ownership forever
+  would be a silence, not a handover.
+  That readmission is PROVISIONAL, and the distinction is the whole of the rule:
+  **stickiness is earned by knowledge, never by ignorance.** The
+  `~/transition_event` subscription outlives the seed budget, so a label can
+  still arrive without being asked for; one that reads non-active says the node
+  was `lifecycle_expectation`'s all along, and `node_death` releases it while it
+  is still alive rather than reporting a death later. Ownership EARNED from a
+  measurement (or from a node with no lifecycle at all) is never released that
+  way: a node that went `active`, deactivated and then died is still
+  `node_death`'s to report. `lifecycle_expectation` latches only the EARNED
+  ground, and ANDs it with the node being ONLINE, because `node_death` skips an
+  offline app before it ever consults the gate. Both detectors read the one
+  shared answer on the same tick rather than each guessing from a label.
+  The two NEGATIVE answers are kept apart for the same reason the positive ones
+  are: `unclaimed` means nothing is known yet (still warming up, or still being
+  asked about) and `disowned` means the graph has said whose node this is. Only
+  `disowned` may take a key away from a detector already holding it, and the
+  label decides it before arming does - a node that restarts is un-armed for its
+  whole re-warm, and reading that as a verdict would drop the key just in time
+  for the node's next death to be reported by nobody.
+  **The hand-back is not instantaneous, and the gap is stated rather than
+  hidden.** `node_death` releases a provisionally owned key inside its own tick,
+  and only on a tick that still sees the app present, so a node that dies within
+  about one entity-cache refresh of its label arriving is reported by the
+  presence code after all - measured at 210 ms between the label reaching
+  `GET /x-medkit-watchdog` and the release. The report is TRUE (the node did
+  disappear); what the window costs is attribution, and where `require_active`
+  names the node both codes stand, which the boundary already accepts elsewhere.
+  Closing it would mean deciding at REPORT time, and that cannot be done from
+  what survives a departure: the departed record carries only the last label,
+  which reads `inactive` both for a node that was earned and then deactivated
+  (must be reported) and for one that was only ever provisional (must not), so
+  telling them apart needs per-key ownership history outliving the departure -
+  the unbounded state the tracked-key prune exists to prevent.
+  What this does NOT close: an
+  App counts as managed only once the snapshot shows it advertising a
+  `GetState`-typed service, and until then it is indistinguishable from a plain
+  node, so a managed node whose services have not yet been discovered can still
+  be taken for a plain one. That window is bounded by the arming warmup, which
+  already requires several consecutive ticks of presence, and both the node and
+  its services come from the same introspection sweep. The window this DOES
+  close is the unbounded one: a managed node whose state stays unmeasured for as
+  long as its `GetState` goes unanswered, which is not a startup artifact and
+  does not close on its own. Nor does any of it change what arming already
+  decided: a node that appears, lives fewer than `warmup_cycles` ticks and
+  vanishes was never armed, so it is owned by nobody and reported by nobody -
+  the bringup-quiesce trade-off working as designed, not a gap this boundary
+  introduces.
 - **Clock validity.** `ctx.clock->time_is_valid()` flags a paused or absent
   `/clock` (e.g. a bag pauses or a sim crashes under `use_sim_time`). This is
   **detector-consulted, not centrally enforced**: a time-based detector

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -10,10 +10,11 @@ and is driven by the plugin's own executor from the tick thread, never by the ga
 ROS executor.
 
 This package carries the plugin skeleton, the central reliability gate that holds raises
-until the graph has quiesced, and four detectors, `qos_mismatch`, `orphan`,
-`param_drift` and `lifecycle_expectation`. The remaining
-silent-fault classes land in follow-up changes, each against its own issue; their fault
-codes are already reserved in the frozen `GRAPH_*` namespace (see "Fault codes").
+until the graph has quiesced, and five detectors, `qos_mismatch`, `orphan`,
+`param_drift`, `lifecycle_expectation` and `node_death`. Two silent-fault classes remain
+undelivered, `GRAPH_TF_STALE` and `GRAPH_LATENCY_BUDGET`; they land in follow-up changes,
+each against its own issue, and their fault codes are already reserved in the frozen
+`GRAPH_*` namespace (see "Fault codes").
 
 ## Build
 
@@ -53,9 +54,68 @@ id itself is warned about the same way, with the registered ids listed.
 |-----|------|---------|---------|
 | `mode` | string \| bool | `raise` | As above. |
 | `require_active` | string[] | `[]` | Node names that must be in the `active` lifecycle state, each matched against a live node by its `App::id`, its full FQN (`/ns/name`), or the bare leaf of that FQN. A bare name matches that node in EVERY namespace (a fleet-wide "all `controller_server`s must be active"); use a full FQN to pin one robot's. Both the bare and the FQN form match against the node's stable FQN, so they survive the `App::id` renaming that a same-bare-name collision triggers; an entry written as an `App::id` also works, but can stop matching on a multi-robot graph for exactly that reason. Empty = the detector checks nothing and emits nothing. A `require_active` that is not a string array warns and is ignored; an empty-string entry warns and is skipped - never dropped silently, since the operator would go on believing the node is covered. |
-| `grace` | int | `5` | Consecutive not-active ticks a required node tolerates before being reported inactive - bringup time for a managed node to reach `active` (configure + activate) before the expectation is enforced. Counted per NODE, not per matching entry: a node named by both a bare-name and a full-FQN entry still advances its streak once per tick, so mixing the two documented forms cannot halve the grace that was configured. Past the absence grace the streak keeps advancing while the node is ABSENT, so a node that leaves the graph while violating is still confirmed. Accepted range 0..300 - five minutes at the shipped 1 s cadence, and already an extravagant allowance for a managed node to reach `active`. The upper end is a real bound rather than a formality: `grace` also decides how long a node that LEFT the graph while not-active sits unsettled in the tracker, and `GRAPH_NODE_INACTIVE`'s clear is withheld for EVERY node while it does, so at the old maximum of `INT_MAX - 1` the fault could neither raise nor heal for about 24 days. The check runs on the wide integer, so a value that only fits after truncation is rejected rather than silently turned into a hair-trigger. Anything outside the range warns and keeps the default. |
+| `grace` | int | `5` | Consecutive not-active ticks a required node tolerates before being reported inactive - bringup time for a managed node to reach `active` (configure + activate) before the expectation is enforced. Counted per NODE, not per matching entry: a node named by both a bare-name and a full-FQN entry still advances its streak once per tick, so mixing the two documented forms cannot halve the grace that was configured. An ALREADY-CONFIRMED streak keeps its content while the node is ABSENT, so a node that leaves the graph after being confirmed stays confirmed; a streak that has not yet crossed `grace` on a node the presence detector could also report (it was armed at least once) is HELD rather than advanced while absent, so a node is never confirmed out of ticks gathered while nobody could observe it - only a PRESENT tick may still cross `grace` for that node. A node that was NEVER armed gets no such hold: `node_death` can never track it either, so absence keeps advancing its streak too, the same as a present tick would. Accepted range 0..300 - five minutes at the shipped 1 s cadence, and already an extravagant allowance for a managed node to reach `active`. The upper end is a real bound rather than a formality: `grace` decides how long a PRESENT node may go unreported, and how long a node returning from a departure still inactive takes to (re-)mature, so at the old maximum of `INT_MAX - 1` that PRESENT-side silence lasted about 24 days at the shipped cadence with no warning. Whether it also bounds how long a node that leaves the graph BELOW `grace` sits unsettled depends on the same split: for an armed node that lasts for as long as the node stays gone, independent of `grace` (see "Bounded by evidence, not by age" below); for a never-armed one `grace` bounds that too, since absence matures it within `grace + absence_grace + 1` ticks either way. The check runs on the wide integer, so a value that only fits after truncation is rejected rather than silently turned into a hair-trigger. Anything outside the range warns and keeps the default. |
 | `prune_grace` | int | `60` | Consecutive ticks an IDLE tracked node - both clocks at zero and no matured ownership, so nothing to lose - may stay ABSENT from the graph before its bookkeeping is reclaimed. A node carrying evidence is never reclaimed by age at all, however long it stays gone, so this key cannot erase a fault's own state; the map is bounded instead by `tracked_node_cap` (see "Bounded by evidence, not by age"). Injected for every detector at plugin scope and overridable per detector; a value outside 0..3600 warns and this detector keeps its own default of 60. The range check runs on the wide integer, so an out-of-int-range value is rejected rather than truncated. The value is used as written - there is no `grace + 1` clamp, because there is no longer anything for one to protect. |
 | `tracked_node_cap` | int | `512` | The most nodes this detector keeps bookkeeping for at once. It is what bounds the map, since evidence is never reclaimed by age (see "Bounded by evidence, not by age"): at the cap, idle entries are reclaimed first, then entries for DEPARTED nodes are collapsed into a count, and only if every tracked node is PRESENT and carrying evidence is a newly matched node refused - which withholds `GRAPH_NODE_INACTIVE`'s clear and is reported both in the log and on `GET /x-medkit-watchdog`. 512 is comfortably above every node in a realistic graph (a full Nav2 stack plus perception is roughly a hundred nodes; a ten-robot fleet sharing one domain a few hundred), so raising it is only needed where `require_active` legitimately matches more PRESENT nodes than that. Accepted range 1..16384 - 16384 is about 8 MB of bookkeeping at roughly 500 bytes per tracked node, and a deployment needing more distinct required-node identities alive at once has identity churn rather than a large fleet. Anything outside the range, including 0 (a cap of nothing would mean checking nothing), warns and keeps the default; the check runs on the wide integer, so an out-of-int-range value is rejected rather than truncated. |
+
+### `node_death` keys
+
+Zero-config, unlike every detector above: there is no `require_active`-style list of nodes
+to watch, because every armed App in the graph is a candidate.
+
+| Key | Type | Default | Meaning |
+|-----|------|---------|---------|
+| `mode` | string \| bool | `raise` | As above. |
+| `miss_grace` | int | `2` | Consecutive missed ticks a tracked node tolerates before being reported dead - a death is reported once misses EXCEED this, i.e. after `miss_grace + 1` ticks. Accepted range 0..3600, and additionally floored to whatever wall-clock window the configured `tick_interval_ms` needs (see "The wall-clock floor" below); a value below that floor is silently raised to it, with a warning naming the ms window it actually spans. |
+| `prune_grace` | int | `60` | Plugin-injected default (overridable here); how long a key being DURABLY suppressed (see "Suppression" below) may sit unreported before its bookkeeping is reclaimed. Accepted range 0..3600. The value actually used is `max(prune_grace, miss_grace + 1)`, a silent internal floor rather than a rejection: without it, a durably-suppressed key could be reclaimed the very tick it would first have become eligible to report, losing the report rather than merely suppressing it. |
+| `allowlist` | string[] | `[]` | Node identities never reported dead. A dead key matches if it - or a name the same node is also known by - is present verbatim: the key's own fqn, its bare leaf, or (captured while the node was still present) its `App::id`. Has no effect unless named in `suppress`; naming it without a configured list is a no-op. |
+| `suppress` | string[] | `[]` | Suppression mechanisms to activate: `"allowlist"` and `"lifecycle"`. Any other entry warns as unrecognized and is ignored; a non-string or non-array entry warns the same way. |
+| `tracked_node_cap` | int | `512` | The most DEPARTED (not-yet-confirmed-dead or already-collapsed) identities this detector keeps individual bookkeeping for at once - a present/armed node is never counted against it and never refused tracking. Accepted range 1..16384; `0` is refused rather than clamped, since a cap of nothing would mean tracking nothing. See "Bounded by evidence, not by age" below for what it actually bounds and why, unlike the sibling detector's identical-looking cap, a newcomer here is never the thing refused. |
+
+`tick_interval_ms` is not an own key of this detector, but this is the one detector that
+reads the plugin-injected value directly, to compute `miss_grace`'s wall-clock floor below.
+
+**Liveness, and why membership in the snapshot is not enough.** `App::is_online` is what
+this detector tracks, never mere presence in the entity snapshot. In runtime-only discovery
+the two happen to coincide - a dead node's App leaves the snapshot entirely - but a manifest
+keeps a bound App present with only `is_online` cleared once its ROS binding disappears, and
+hybrid discovery inherits that same shape; counting snapshot membership alone would make a
+manifest-declared node immortal. A managed lifecycle node that merely deactivates keeps
+`is_online: true` - its process is still running, only its ROS 2 lifecycle state changed -
+so a deactivation is never mistaken for a death either; that is `lifecycle_expectation`'s
+concern, not this one's (see "The boundary with `lifecycle_expectation`" below).
+
+Tracking is keyed on the STABLE fqn (`App::effective_fqn()`), never `App::id`: an id is
+recomputed every sweep and only gains a namespace prefix once a same-bare-name collision
+currently exists anywhere in the graph, so a live node's id can change out from under a key
+built from it.
+
+**What is never tracked.**
+
+| Excluded | Why |
+|---|---|
+| Peer-aggregated apps (`app.source` starting `peer:`) | A peer app carries no ROS binding of its own, so `effective_fqn()` is empty for every one of them; tracking them would collapse an entire peer fleet onto one `""` key, and one online peer app would mask every other peer app's departure. |
+| `_ros2cli_<pid>` nodes | Every `ros2` CLI invocation (`ros2 topic echo`, `ros2 param get`, ...) spins up a real, short-lived node under this prefix - rcl's own hidden-node naming convention, matched structurally rather than guessed at. Letting these through would accumulate one permanently "dead" entry per CLI invocation for the life of the gateway. |
+| An App that never comes online | A key is admitted to tracking only once it has been armed by the reliability gate at least once. A manifest App whose binding never starts is never armed and so can never be falsely called dead; a node still inside its `warmup_cycles` window gets the identical protection. Once tracked, though, a node's continued life-or-death judgement rests on PRESENCE alone, not on staying armed - a tracked node that later goes lifecycle-inactive is not thereby mistaken for dead. |
+
+Composable/component nodes hosted in one process die together: if the container process
+dies, every node it hosted leaves the snapshot on the same tick, and all of them are folded
+into the one aggregated fault rather than raising one fault each - individually named up to
+the description's 480-character cap and up to 3 at once under `tracked_node_cap` pressure,
+whichever runs out first; past either limit the remainder still count toward the fault, just
+not by name (see "Bounding the tracked-key map" below).
+
+**The wall-clock floor on `miss_grace`.** The entity snapshot a tick reads is not rebuilt
+every tick: runtime discovery rebuilds it off a graph event debounced to about one refresh
+per second, so several consecutive ticks between two refreshes see the IDENTICAL snapshot. A
+`miss_grace` counted purely in ticks does not count independent samples of the graph -
+shorten `tick_interval_ms` enough and one stale cache generation gets re-counted as several
+misses. The floor raises `miss_grace`, for the configured `tick_interval_ms`, to the
+smallest value whose `(miss_grace + 1) * tick_interval_ms` window is still at least 3000 ms -
+one graph-cache refresh cycle plus margin. At the shipped 1000 ms tick the floor is exactly
+the shipped default (`miss_grace: 2`), so the default configuration is unaffected; only a
+faster-than-default tick ever raises the effective grace, and it does so with a warning
+naming the window it actually spans.
 
 ### `orphan` keys
 
@@ -603,8 +663,8 @@ lifecycle state (`inactive`/`unconfigured`/`finalized`), or its lifecycle promis
 not be MEASURED at all - a managed node whose label has never been read, or a node with
 no tracked lifecycle whatsoever. On a Nav2 stack a `controller_server` stuck inactive
 means the robot silently will not act - no crash, no log, nothing on `/diagnostics` or
-`/rosout`. Presence itself is a different fault class (`GRAPH_NODE_DISAPPEARED`, reserved
-in the frozen namespace for a follow-up change): this detector only ever STARTS reporting a
+`/rosout`. Presence itself is a different fault class (`GRAPH_NODE_DISAPPEARED`, this
+package's own `node_death` detector): this detector only ever STARTS reporting a
 node it has measured while PRESENT. A node that leaves the graph having only ever been
 measured healthy is left entirely to the presence class - but one that leaves while already
 under one of these three faults keeps it, because a node the operator declared must-be-
@@ -659,7 +719,9 @@ node's SETTLED observation had started, and resets nothing:
 
 | Settled observation | What sustained absence does |
 |---|---|
-| `inactive` (or any non-active label) | the violation streak keeps climbing, so the node is eventually reported under `GRAPH_NODE_INACTIVE` even though it is gone |
+| `inactive`, ALREADY reported under `GRAPH_NODE_INACTIVE` | the streak continues exactly as it did on its last present tick, so the fault stays raised and keeps naming a node that is no longer there |
+| `inactive`, not yet past `grace`, node WAS armed at some point | the streak is HELD - neither advanced (no fault is born while nobody can observe the node) nor erased (a node that returns still inactive resumes rather than re-earning `grace`). The presence detector could report this exact departure instead (`node_death` tracks any node the reliability gate has armed at least once), so this detector does not need to. |
+| `inactive`, not yet past `grace`, node was NEVER armed | the streak keeps climbing on absence exactly as it would on a present tick. `node_death` only ever tracks a node the gate has armed, so a node that never reached that bar is structurally invisible to it no matter what happens afterwards - if this detector held the streak too, the departure would be reported by nothing at all. |
 | unread label, or no tracked lifecycle | the unmeasured clock keeps climbing under that same cause, so the node is eventually reported under `GRAPH_NODE_UNREADABLE` / `GRAPH_NODE_NOT_MANAGED` |
 | `active` | nothing. Anything the node had started but not corroborated is released, the entry becomes idle and is reclaimed silently |
 
@@ -681,11 +743,13 @@ leaves has corroborated that long before the hold that reports it.
 
 Three consequences worth stating plainly:
 
-- **A departure never heals a fault, within one gateway lifetime.** A node measured
-  not-active, or corroborated as unmeasurable, that then leaves the graph keeps its fault -
-  the operator declared it must be ACTIVE, it was not, and being gone is not an answer. The
-  fault's description switches to saying the node has since left the graph, so nobody is
-  sent looking for it. **Across a gateway restart it does not hold**, and that is a real
+- **A departure never heals a fault it has already earned, within one gateway lifetime.** A
+  node CONFIRMED not-active, or corroborated as unmeasurable, that then leaves the graph
+  keeps its fault - the operator declared it must be ACTIVE, it was not, and being gone is
+  not an answer. The fault's description switches to saying the node has since left the
+  graph, so nobody is sent looking for it. A node that had NOT yet been confirmed when it
+  left earns nothing from leaving either - see "Absence continues the last CORROBORATED
+  observation" above. **Across a gateway restart it does not hold**, and that is a real
   boundary rather than an oversight: the restarted detector has no measurements at all, the
   departed node is not in the graph, and its `require_active` entry therefore matches
   nothing - which is indistinguishable from a misspelt entry, since the only component that
@@ -698,19 +762,41 @@ Three consequences worth stating plainly:
 - **A departure never STARTS one.** A node measured `active` that shuts down raises
   nothing, and neither does one whose lifecycle services went missing from a sweep or two
   immediately before it did. Reporting a healthy node that left is the presence class's job
-  (`GRAPH_NODE_DISAPPEARED`), which still has no detector in this package - the one gap
-  left here, and a much narrower one than "a node absent past the grace is invisible
-  whichever clock it was on".
+  (`GRAPH_NODE_DISAPPEARED`, this package's own `node_death` detector), not this one's -
+  a much narrower boundary than "a node absent past the grace is invisible whichever clock
+  it was on".
 - **A departed node never crowds out a present one.** Entries for departed nodes are
   collapsed into a count when the tracked-node cap needs the slot - see "Bounded by
   evidence, not by age" below.
 
-Why: every erasure horizon is an evasion for a node that touches it periodically. A node
-in a restart loop - start, crash, respawn delay, start - touches absence by construction,
-and that is the node this detector most exists to catch. Discarding its evidence on
-absence let it alternate `(unreadable, absent x N)`, `(not-managed, absent x N)` or
-`(inactive, absent x N)` forever without ever accumulating enough of anything to be
-reported.
+Why, for the two UNMEASURED causes: every erasure horizon is an evasion for a node that
+touches it periodically. A node in a restart loop - start, crash, respawn delay, start -
+touches absence by construction, and discarding its evidence on absence would let it
+alternate `(unreadable, absent x N)` or `(not-managed, absent x N)` forever without ever
+accumulating enough of anything to be reported.
+
+The VIOLATION streak used to need the identical rule for the identical reason - a node
+alternating `(inactive, absent x N)` would otherwise never accumulate `grace` + 1 either.
+Where the presence class CAN also report the same departure, that is no longer the only
+thing standing between such a node and invisibility: `GRAPH_NODE_DISAPPEARED` (this
+package's `node_death` detector) independently reports it, whether or not the node was
+ever measured not-active first. But `node_death` only ever tracks an App once the
+reliability gate has armed it, and the gate refuses to arm a MANAGED node that is not
+`active` (`LifecycleWatcher::node_ok()`) - so a `require_active` node that never reaches
+`active` is never armed, is never tracked by `node_death`, and its departure can never
+raise `GRAPH_NODE_DISAPPEARED`, whatever kills it. The tracker therefore splits on whether
+a node was EVER armed, read from the reliability gate itself rather than guessed from the
+observed label: once armed, a below-`grace` streak that goes absent is simply HELD -
+maturing it would raise `GRAPH_NODE_INACTIVE` from ticks gathered while nobody could
+observe the node, a fault its presence never earned, and `GRAPH_NODE_DISAPPEARED` is there
+to report the departure instead. A node that was NEVER armed gets no such backstop -
+`GRAPH_NODE_DISAPPEARED` structurally cannot report it - so absence keeps advancing its
+streak exactly as a present tick would, maturing it within the same bound an armed node's
+UNMEASURED clock already has (`grace` + `absence_grace` + 1 ticks). An ALREADY-matured
+streak still continues through absence exactly as before, for either kind of node: two
+codes standing at once for the same node (`GRAPH_NODE_INACTIVE` because it was measured
+not-active, `GRAPH_NODE_DISAPPEARED` because it is gone) is not a problem to fix - they say
+different, both-true things.
 
 **Content follows the clocks, not the snapshot.** Whether a node happened to be in this
 tick's matches decides nothing about what it reports: a node whose streak is past `grace`
@@ -792,14 +878,25 @@ at a different N. So:
   in the same tick, never partially. There is no `grace + 1` clamp any more, and none is
   needed: a node carrying evidence is exempt by construction rather than by arithmetic, so
   `prune_grace: 0` means exactly 0.
-- **A non-idle entry is never pruned by age at all.** It cannot grow without bound in time
-  either: past the absence grace its clock advances every tick, so it matures within at most
-  `grace + absence_grace + 1` ticks (a violation streak) or `60 + absence_grace + 1` (an
-  unmeasured clock) and gets reported. Those two numbers are also the longest
-  `GRAPH_NODE_INACTIVE`'s clear can be withheld by one departed node, which is why `grace` is
-  capped at 300 rather than accepted up to the int maximum: at the old maximum the bound was
-  about 24 days at the shipped cadence, i.e. the fault could neither raise nor heal for
-  anybody, with no warning and no way to tell it from a working detector finding nothing.
+- **A non-idle entry is never pruned by age at all.** An entry whose UNMEASURED clock is
+  still climbing cannot grow without bound in time either: past the absence grace it
+  advances every tick, so it matures within at most `60 + absence_grace + 1` ticks and gets
+  reported - the longest `GRAPH_NODE_UNREADABLE` or `GRAPH_NODE_NOT_MANAGED`'s clear can be
+  withheld by one departed node. A below-`grace` VIOLATION streak on a node that was NEVER
+  armed shares that same bound, for the same reason it advances at all while absent: it
+  matures within at most `grace + absence_grace + 1` ticks, because nothing else will ever
+  report that node's departure either. Only once a node HAS been armed does its below-grace
+  streak lose the bound: absence then holds it rather than advancing it, so it neither
+  matures nor becomes idle for as long as the node is away, however long that is. That is
+  not a new way to withhold `GRAPH_NODE_INACTIVE`'s clear - the clear was already gated on
+  every required node's status being settled, so one node this indecisive already blocked
+  it before this design; what changes is only that the fault never NAMES an ARMED node's
+  departure, since that node's evidence belongs to `GRAPH_NODE_DISAPPEARED` instead. `grace`
+  is still capped at 300 rather than accepted up to the int maximum, because it independently
+  bounds how long a PRESENT node may
+  go unreported and how long a returning node takes to re-mature: at the old maximum of
+  `INT_MAX - 1` that PRESENT-side bound was about 24 days at the shipped cadence, with no
+  warning and no way to tell a silently-withheld detector from one finding nothing.
 - **The map is bounded by `tracked_node_cap`** (default 512, accepted range 1..16384). At
   the cap, idle entries are reclaimed first (free - they carry nothing), then entries for
   DEPARTED nodes are collapsed into a count so a PRESENT node always wins a slot; only if
@@ -886,13 +983,14 @@ re-established the node is fine.
 
 What never blocks `GRAPH_NODE_INACTIVE`'s raise: a RAISE is never withheld (a violation
 read from the nodes that did answer is real regardless of the unmeasured ones). An entry
-that HAS matched and later stops matching does not re-enter reason 1 either. Every hold is
-bounded, and every one of them releases by SETTLING the node's status rather than by
-giving up on it: the never-matched hold and both unmeasured-clock causes release after 60
-consecutive ticks (a minute at the shipped 1s cadence), whether the node is present or
-gone; a below-`grace` violation streak releases as soon as the node reads `active` or its
-streak passes `grace` and the fault is raised - which, past the absence grace, happens
-while the node is absent too.
+that HAS matched and later stops matching does not re-enter reason 1 either. The
+never-matched hold and both unmeasured-clock causes are bounded (60 consecutive ticks, a
+minute at the shipped cadence) and release by SETTLING the node's status rather than by
+giving up on it, whether the node is present or gone. A below-`grace` violation streak
+releases the same way - as soon as the node reads `active`, or a PRESENT tick pushes its
+streak past `grace` and the fault is raised - but while the node stays absent that release
+has no timeout of its own: absence holds the streak rather than advancing it, so the hold
+lasts for exactly as long as the node does not return.
 Because a withheld clear is indistinguishable from a detector that is working and
 finding nothing, a hold that lives past 10 consecutive ticks is explained in the log once
 per episode, naming every reason in force and, for the node-keyed ones, how many nodes
@@ -998,12 +1096,20 @@ still fit inside the 480-char cap (`3 * 150 + 2 * 2 = 454 <= 480`).
    read and a not-managed one across absence gaps longer than the absence grace; that the
    violation streak survives non-maturing unmeasured ticks and RESUMES rather than
    restarting (counted exactly, and read through `pending_violation` - the only field that
-   differs during the climbing window); absence CONTINUING whichever clock the node's last
-   real observation started (a blink holds it unchanged; past the blink tolerance it
-   advances, so a node absent long enough matures or crosses grace on absence alone and its
-   detail says the node has left the graph), a matured fault surviving a departure, a node
-   measured ACTIVE that vanishes raising nothing and being reclaimed, and the three
-   `(X, absent x N)` restart-loop shapes for N at the absence grace and past it; the
+   differs during the climbing window); absence CONTINUING an already-matured fault exactly
+   as it was on its last present tick (a blink holds either clock unchanged; past the blink
+   tolerance an unmeasured clock still climbing keeps climbing and matures on absence alone,
+   its detail then saying the node has left the graph, while a below-grace violation streak
+   is instead HELD - neither advanced nor erased - and RESUMES rather than restarts once the
+   node returns, proven both from a single long absence and from many short ones
+   interleaved with matched reads), a matured violation fault surviving a departure, a node
+   measured ACTIVE that vanishes raising nothing and being reclaimed, and the two
+   `(unreadable/not-managed, absent x N)` restart-loop shapes for N at the absence grace and
+   past it (their `inactive` sibling now pinned to the opposite claim, at the same two N: it
+   never crosses grace from absence alone, for a node that was armed at some point - a node
+   that was NEVER armed instead matures from absence alone within `grace + absence_grace + 1`
+   ticks, exactly like the unmeasured clock does, and resumes rather than restarts on return
+   the same way an armed node's held streak does); the
    `pending` set and its per-reason breakdown; new-first ordering for all three
    fault-shaped maps, including the lexicographic tie-break when several cross together;
    the remote-supplied label's own trim budget ahead of the whole-detail backstop, and the
@@ -1037,8 +1143,9 @@ still fit inside the 480-char cap (`3 * 150 + 2 * 2 = 454 <= 480`).
    warning, the withheld-clear guard's releases and its once-per-episode log line, the
    blink-plus-unread-re-seed sequence, the no-match warning, a filler batch sized (from
    the real detail-building code) to exceed the 480-char cap aggregating into one fault
-   with the fresh crossing named first, a PRESENT node crossing on the same tick as a batch
-   of departed ones being named ahead of them (and not truncated away by them), a required
+   with the fresh crossing named first, a PRESENT node crossing grace fresh while a batch of
+   already-departed, already-matured ones sits absent-and-content being named ahead of them
+   (and not truncated away by them), a required
    node appearing mid-run, a re-bind under the same `App::id`, and the
    reconfigure/config-validation edge cases. The
    unmeasured clock's own split is pinned directly, for BOTH codes symmetrically: a
@@ -1058,8 +1165,11 @@ still fit inside the 480-char cap (`3 * 150 + 2 * 2 = 454 <= 480`).
    filler batch, the same new-first ordering; an already-reported node of either cause
    KEEPING its own record once it vanishes (and its description switching to say the node
    has left the graph), a node returning from that absence staying reported with no
-   clear/re-raise churn, each of the three restart-loop shapes raising its own code, the
-   `inactive` <-> `not-managed` alternation across absence gaps, a node measured ACTIVE
+   clear/re-raise churn, each of the two UNMEASURED restart-loop shapes raising its own code
+   from absence alone (their `inactive` sibling instead pinned to counting only real reads,
+   never crossing from any of the interleaved absence gaps), the
+   `inactive` <-> `not-managed` alternation across absence gaps now counting only the
+   MEASURED not-active legs, a node measured ACTIVE
    that vanishes raising nothing under any of the three, and a withheld `GRAPH_NODE_INACTIVE`
    clear releasing when the absent node's clock MATURES into its sibling's content rather
    than when the node is given up on; the two wire strings pinned as hand-typed literals
@@ -1199,6 +1309,266 @@ still fit inside the 480-char cap (`3 * 150 + 2 * 2 = 454 <= 480`).
    crash loop is the case this detector most exists to catch, and it is the one that a
    design discarding evidence on absence makes permanently silent.
 
+#### `node_death` (GRAPH_NODE_DISAPPEARED)
+
+Watches every armed App in the graph for one that goes offline, and raises
+`GRAPH_NODE_DISAPPEARED` naming it. Zero-config, unlike `lifecycle_expectation`'s
+operator-declared `require_active` list: every armed App is a candidate. See the
+`node_death` key table and the "Liveness", "What is never tracked" and "The wall-clock
+floor on `miss_grace`" notes above the `orphan` key table for what counts as alive, what
+this detector never tracks, and why `miss_grace` has a floor - none of that is repeated
+here.
+
+**Suppression.** Nothing is suppressed unless the operator names the mechanism in
+`suppress` - a configured `allowlist` that `suppress` does not name has NO effect, and a
+startup warning says so. Two mechanisms exist, activated independently of each other:
+
+| Name | Mechanism | Durable |
+|---|---|---|
+| `"allowlist"` | `AllowlistSuppressor` over the configured `allowlist` set - the same three-way match (fqn, bare leaf, `App::id`) `lifecycle_expectation`'s `require_active` uses, so an operator who has one working can expect the other to accept the same shapes. Exact match only, never a prefix or a shared suffix. | Yes |
+| `"lifecycle"` | `LifecycleShutdownSuppressor` - suppresses a departure that the reliability gate classifies as a clean managed-lifecycle shutdown. See "Clean-shutdown suppression" below for what counts as clean. | Yes |
+
+Every field is re-validated from scratch on every `configure()` call: a malformed
+`allowlist` entry, an unrecognized `suppress` name, or a `suppress`/`allowlist` entry of the
+wrong type each produce their own named warning rather than being silently dropped. A
+candidate is suppressed the moment ANY active mechanism votes yes, order-independent -
+which one runs first never changes the result. Suppression is independent of `mode`: a
+suppressed key never becomes content in the first place, while `mode` separately decides
+whether non-suppressed content is actually sent (`advisory` observes without sending,
+`off` disables).
+
+**Durability, and why only a durable veto may reclaim bookkeeping.** Whether a suppressor is
+durable answers whether its "yes" is a standing fact about the key rather than a condition
+that can later stop holding. Both mechanisms here are durable: an operator-declared allowlist
+entry does not start matching and then stop on its own, and a departure's observed shutdown
+shape does not change after the fact. Durability is what makes reclaiming a suppressed key's
+tracker bookkeeping (`prune_grace` consecutive suppressed ticks) sound - a NON-durable veto
+could lift later even after its key's bookkeeping was discarded, leaving a live, unsuppressed
+death with nothing left to report it: a false heal that silently outlives the very condition
+that produced it. A durable veto never lifts for a given key once it has fired, so reclaiming
+under it loses nothing. Durable defaults to false, the safe assumption for a suppressor
+nobody has reasoned about yet; both suppressors here override it explicitly to true.
+Reclaiming is re-checked against the durable suppressors specifically, never merely "no
+longer in this tick's report", because a key can be dropped from a tick's report by ANY
+suppressor in the chain while a durable one also happens to cover it - whether a key may be
+reclaimed depends on WHICH suppressor vetoed it, not on whether it survived the filter.
+
+**Clean-shutdown suppression - what counts as clean.** `LifecycleShutdownSuppressor` reads
+the lifecycle watcher's cached label for the departed node's LAST observed transition:
+
+| Last observed label | Suppressed? |
+|---|---|
+| `shuttingdown` | Yes - only reachable via a deliberate SHUTDOWN transition, so the label alone is enough. |
+| `finalized`, with an observed transition and never through the error branch | Yes. |
+| `finalized`, with no observed transition, or reached through the error branch | No. |
+| `unconfigured` | No, deliberately - it is also the resting state of a node whose `configure()` failed or that never activated at all, and suppressing on it would hide exactly that startup failure. |
+| Any other label, or no departure on record at all | No (abstains). |
+
+`finalized` needs the extra corroboration because it is also where a node's `on_error`
+override lands after `ON_ERROR_FAILURE`/`ON_ERROR_ERROR` out of `errorprocessing` - the
+standard way a driver reports a hardware fault it cannot recover from, which is precisely the
+death an operator needs reported, not silenced. Without an observed transition history the
+departure is unclassified and stays reported - the safe direction. This mechanism is
+stateless by construction: a detector's `configure()` (where the suppressor chain is built)
+runs before any per-tick context exists, so it stores nothing at construction and reads the
+gate fresh on every call. Its retention window is not this detector's own to size, either:
+before this detector's own `configure()` has run, the plugin predicts the same
+`prune_ticks_` (`max(prune_grace, miss_grace + 1)`) this detector will compute, then sizes
+the lifecycle watcher's departed-node retention from it with enough margin that a
+clean-shutdown label is still cached at this detector's own reclaim tick, one tick to
+spare - see `GraphWatchdogPlugin::compute_departed_retention_ticks()` for the exact
+arithmetic, which is larger than `prune_ticks_` alone.
+
+**Bounded by evidence, not by age.** This detector is zero-config over every armed App in
+the graph - a strictly larger scope than `lifecycle_expectation`'s named `require_active`
+set - so identity churn (nodes reappearing under ever-new names, one per run or per
+namespace) would grow the tracker's map without a bound if nothing capped it. An
+unsuppressed, still-dead entry is never reclaimed by age - `prune_grace` is the only reclaim
+path there is, and it only ever applies to a durably-suppressed key - so `tracked_node_cap`
+is what actually bounds memory: specifically, the DEPARTED subset of it (identities carrying
+a nonzero miss count). A PRESENT entry never counts against the cap and is never evicted to
+make room for anything, at any map size: it costs nothing to keep (an idle entry is simply
+re-tracked a moment later if it is still armed), and it is bounded by the live graph, not by
+churn, which is bounded by reality rather than by this cap. So a graph carrying far more
+nodes than `tracked_node_cap` is not, by itself, capacity pressure at all - every one of them
+is still tracked and every genuine death among them still reported; only a departed set that
+is itself larger than the cap is.
+
+At that point, the cap collapses departed entries into one synthetic count, keeping at most
+three individually named - but ONLY entries that have actually crossed `miss_grace` (a
+confirmed death). An entry that is merely mid-grace is never a collapse candidate: folding it
+into the count would report a death the node has not earned, permanently, since collapsing
+erases the identity and a node returning cannot un-report what was never real. Under
+sustained pressure from still-maturing churn the departed set may therefore exceed
+`tracked_node_cap` for a few ticks - bounded by how fast new departures arrive times
+`miss_grace`, not by how long the process has been running, which is the growth this cap
+exists to prevent in the first place. `tracking_saturated` reports exactly this: the departed
+set still exceeds `tracked_node_cap` even after collapsing every confirmed death it safely
+could, because immature entries alone account for the excess.
+
+Unlike `lifecycle_expectation`'s identical-looking cap, a PRESENT/armed key here is never the
+thing evicted to free a slot. `LifecycleExpectationTracker` carries two clocks per node, so a
+node can be simultaneously present and mid-violation - a third state this tracker does not
+have, and what makes evicting a present entry there lose nothing (the evidence lives in the
+clocks). `NodeLivenessTracker` carries exactly one piece of per-key state (a miss count), so
+a tracked identity is always either present-and-empty or absent-and-evidential; evicting a
+present one here would only ever discard a key that could simply be re-admitted next tick
+anyway, at the cost of losing any death that happens to land in the eviction window - only
+ONLINE nodes re-enter `armed`, so an evicted-while-present node that then dies is never
+re-admitted at all. The sibling's eviction order does not transfer.
+
+**The boundary with `lifecycle_expectation`.** `GRAPH_NODE_INACTIVE` and
+`GRAPH_NODE_DISAPPEARED` can both be raised for the same node at the same time, and that is
+CORRECT, not a defect this detector removes: `GRAPH_NODE_INACTIVE` says a required node is
+present but not active, `GRAPH_NODE_DISAPPEARED` says a node is gone, and an operator facing
+each has a different repair - reactivate it, or find out why it left. A node CONFIRMED
+`GRAPH_NODE_INACTIVE` that then departs keeps that fault (its description switches to say
+the node has since left the graph) AND now also raises `GRAPH_NODE_DISAPPEARED`, since this
+detector tracks every armed App independently of whatever `lifecycle_expectation` thinks of
+it.
+
+What changed is narrower than that, and it only applies to a node this detector could ever
+have tracked. Before this detector existed, `lifecycle_expectation`'s own violation streak
+let a SUSTAINED absence mature an unconfirmed (below-`grace`) streak into a confirmed
+`GRAPH_NODE_INACTIVE` - the only way a node stuck in a restart loop, never observed long
+enough to cross `grace` while present, would ever be reported at all. Where this detector
+can independently report the same departure - which needs the node to have been ARMED at
+least once, since `node_death` only ever tracks an App the reliability gate has armed, and
+the gate refuses to arm a MANAGED node that is not `active` - that absence-alone maturity is
+gone: absence CONTINUES a violation that has already matured past `grace` (the fault stays
+raised, still naming the node), but no longer CREATES one that has not. A node that was
+briefly non-active and then died is reported as gone (`GRAPH_NODE_DISAPPEARED`) rather than
+also acquiring an inactive fault born from ticks gathered while nobody could observe it. A
+`require_active` node that never reaches `active` is never armed, is never tracked here, and
+its departure can never raise `GRAPH_NODE_DISAPPEARED` - for that one node,
+`lifecycle_expectation` keeps the older behaviour: absence still matures a below-`grace`
+streak, because it is structurally the only detector that will ever get to report it. See
+`lifecycle_expectation`'s own "Absence continues the last CORROBORATED observation, it never
+erases" section above for the mechanism.
+
+**Repeated failures: what `occurrence_count` and the captured evidence answer, and don't.**
+An operator asking "how many times did this node die in the last hour" reads it off the
+fault record itself, not off this detector: `GRAPH_NODE_DISAPPEARED`'s own
+`occurrence_count` (`GET /api/v1/apps/graph_watchdog/faults`, or the scoped
+`GET /api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED`) starts at 1 on the first
+raise and increments by exactly one each time a FAILED report reactivates a record that was
+CLEARED - never merely re-raised while still CONFIRMED, and never merely HEALED. Healing
+(the fault manager's debounce counter crossing `healing_threshold` on clean sweeps, see
+"Closing the loop" above) and clearing are different things: `DELETE
+/api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED` - the fault manager's own
+`~/clear_fault` underneath - is what acknowledges an occurrence and closes its cycle. A
+still-CONFIRMED, or still-HEALED-but-unacknowledged, fault that fires FAILED again is the
+SAME occurrence continuing, not a new one, so restarting the dead node fast enough to heal it
+before anyone acknowledges it will not move the count.
+
+The honest limits, read off this branch's fault-manager storage rather than assumed: the
+per-fault rosbag store enforces `fault_code` as UNIQUE, so a fault can hold at most one
+recording at a time - a later confirmation's capture replaces the earlier one on disk rather
+than accumulating a history. The freeze frame is the same shape: one row per `fault_code`,
+overwritten on every capture, so a fifth occurrence's captured values overwrite the first's.
+What survives every occurrence by default is the count itself; a hash-chained record of
+every raise/clear/heal transition also exists, but only once the fault manager's own
+`audit_log.enabled` is turned on, which it is not by default. Recordings and the freeze
+frame do not accumulate a per-occurrence history either way.
+
+**A second death while the first is still outstanding gets no evidence of its own.** This
+detector folds every currently-affected node into ONE `GRAPH_NODE_DISAPPEARED` record (see
+"The boundary with `lifecycle_expectation`" above) - so a node dying while another's death is
+still CONFIRMED is added to the description, but the report that adds it is a re-report on an
+already-active fault, not a new occurrence: the same distinction "Repeated failures" above
+draws for one node dying twice applies just as much across two different nodes sharing the
+one code. `occurrence_count` does not move, no state transition fires, and - for the same
+reason "The honest limits" above gives - neither a freeze frame nor a recording is captured
+for the second node; only whichever death actually confirmed the record has either.
+Acknowledging between the two deaths avoids this: `DELETE
+/api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED` closes the first occurrence, so the
+second node's next report reactivates a CLEARED record instead of updating a CONFIRMED one - a
+genuine new occurrence, with its own `occurrence_count` and its own capture.
+
+**Test tiers.**
+
+1. **Unit**: `test_node_liveness_tracker.cpp` pins the pure presence/absence state machine -
+   a key present but never armed is never tracked; once armed, presence alone (not
+   continued arming) keeps a tracked key's miss counter at zero; a key is reported dead only
+   once misses exceed `miss_grace`; freshness ordering keeps a brand-new death out of a
+   capped description's blind spot; `prune()` reclaims a key only once it has been
+   suppressed for MORE than `prune_ticks` CONSECUTIVE calls, resets the streak the moment a
+   veto lifts even once, and never reclaims an unsuppressed death no matter how long it
+   stays dead. On the cap: a graph carrying ten times `tracked_node_cap` present keys is
+   never refused or evicted, and every genuine death among them is still individually
+   reported; two entries carrying only a below-grace miss each are never collapsed or
+   reported under cap pressure, however much the departed count exceeds the cap, and
+   `tracking_saturated` reports exactly that condition; matured (confirmed-dead) entries ARE
+   collapsed into a monotonically-accumulating count once the departed set exceeds the cap
+   and no present or immature entry is available to spare; and at `miss_grace: 0`, where
+   every departure matures instantly, saturation never fires at all - a narrower, honestly-
+   scoped property than a blanket "can never saturate" claim. `test_suppressor.cpp`
+   pins the `Suppressor` interface (`durable()` defaults false) and the free
+   `apply_suppressors()` helper (order-independent, null-safe, returns the dropped count) -
+   this detector's own filtering is hand-inlined rather than a call to that helper, because
+   it layers an id-form check the helper's plain string-keyed signature cannot express.
+   `test_allowlist_suppressor.cpp` and `test_lifecycle_shutdown_suppressor.cpp` pin each
+   suppressor's own matching rules independently of any detector.
+2. **Integration** (`test_node_death_integration.cpp`): the full config contract
+   (`miss_grace`, `prune_grace` and `tick_interval_ms` range checks and their floor
+   interaction; malformed `allowlist`/`suppress` entries; `tracked_node_cap` range checks,
+   including a value far past `INT_MAX` rejected rather than wrapped; an unknown top-level
+   key), that a peer-aggregated app and an `is_online: false` app are never tracked, that
+   the tracked count stays bounded and shrinks after a reclaim under sustained identity
+   churn (and, without any suppression configured at all, that `tracked_node_cap` still
+   bounds memory under unsuppressed churn while the fault stays raised), that the
+   `prune_grace` clamp is not merely never-reclaimed-yet but actually reclaims once its
+   clamped horizon passes, that Advisory mode keeps accumulating misses (provable by
+   switching to Raise mode without letting the node return and observing an immediate raise)
+   rather than merely declining to send, that a clean managed-lifecycle departure is
+   suppressed exactly AT the `miss_grace` boundary and stays reclaimed - not re-raised - past
+   the retention window the plugin sizes for it, that the allowlist's id-form suppresses only
+   the colliding node and not its namesake, and the ungated-clear guard's four properties: a
+   stored fault stays unhealed while an unrelated node arms alone, a clear flows once this
+   process instance has itself handed a FAILED request to the fault client, the guard tracks
+   that handoff rather than intent (an attempted-but-never-sent raise never earns a clear),
+   and a reconfigure while the node is absent does not withhold a clear the process had
+   already earned. Three more rows sit past the cap specifically: 513 armed nodes against the
+   default `tracked_node_cap` (512) still report the one that dies; three below-grace entries
+   under `tracked_node_cap: 2` never fabricate a death and still mature into a genuine one
+   once the pressure passes; and a cap-forced collapse stays raised through a genuine
+   recovery but clears once reconfigured, mirroring the ungated-clear guard's own reconfigure
+   test for an ordinary (uncollapsed) fault.
+3. **E2e**, three files, each launching its own real gateway + fault_manager + demo-node
+   stack:
+   - `test/e2e/test_node_death_e2e.test.py` (ten scenarios): raise and name the node; clear
+     once it returns; no heal with the fault manager's healing disabled; a lifecycle
+     DEACTIVATE is never mistaken for a death; a manifest app that never comes online is
+     never called dead; a `_ros2cli_*`-prefixed node is never tracked, checked against
+     ros2cli's own naming constant; a bare-name collision names only the node that actually
+     exited; a fast tick alone, nothing else perturbing the graph, raises nothing; a
+     three-cycle restart loop, acknowledged between cycles, reaches `occurrence_count: 3`;
+     and a fault confirmed before a gateway restart stays CONFIRMED across it.
+   - `test/e2e/test_node_death_suppression_e2e.test.py` (five scenarios): the allowlist
+     suppresses the node it names; the SAME allowlist left unnamed in `suppress` is inert,
+     and a startup warning says so; a managed lifecycle node that reached a clean shutdown
+     is never named while an active sibling that was simply killed still is; naming a node
+     on the allowlist alone, with `suppress` unset, does not suppress it; and an ALLOWLISTED
+     death (the only shape pruning ever applies to - see "Bounded by evidence, not by age")
+     held well past `prune_grace` is actually reclaimed (`tracked_count` on
+     `GET /x-medkit-watchdog` drops to 0, not merely "no fault ever appeared", which a
+     deleted `prune()` would also produce), while never once raising `GRAPH_NODE_DISAPPEARED`
+     for it - proving pruning a suppressed key's bookkeeping is not itself an event the
+     aggregate reacts to.
+   - `test/e2e/test_node_death_boundary_e2e.test.py` (eight scenarios, the seam with
+     `lifecycle_expectation`): a node stuck inactive but never gone is
+     `GRAPH_NODE_INACTIVE`'s alone; the same node, ARMED first, then killed while still below
+     `grace`, raises `GRAPH_NODE_DISAPPEARED` alone, with no `GRAPH_NODE_INACTIVE` ever born
+     from the departure; a node killed AFTER `GRAPH_NODE_INACTIVE` has confirmed raises BOTH
+     codes at once, the confirmed one still naming the node; a healthy node that is simply
+     killed raises `GRAPH_NODE_DISAPPEARED` alone; a restart-looping required node is caught
+     every cycle regardless of whether it ever matures under `lifecycle_expectation`; a node
+     that is NEVER armed, killed while still below `grace`, raises `GRAPH_NODE_INACTIVE`
+     alone instead - `node_death` cannot track a node the gate never armed, so absence has to
+     mature the violation here; a large `miss_grace` delays the report but does not swallow
+     it; and a restarted gateway's own warmup window never produces a spurious PASSED for a
+     node it has not yet re-measured.
+
 ## Reliability (bringup-quiesce)
 
 Silent-fault detectors are prone to bringup noise: a node joining the graph, a
@@ -1323,6 +1693,11 @@ namespace beyond the original six, all raised by `lifecycle_expectation`:
 two share one cause-blind unmeasured clock internally (see the detector section above)
 but are always two DISTINCT codes on the wire - the clock's blindness to which cause it
 is seeing never leaks into which fault code a node ends up reported under.
+
+Of these nine, seven currently have a detector raising them: `qos_mismatch`
+(`GRAPH_QOS_MISMATCH`), `orphan` (`GRAPH_ORPHAN`), `param_drift` (`GRAPH_PARAM_DRIFT`),
+`node_death` (`GRAPH_NODE_DISAPPEARED`), and `lifecycle_expectation`'s three above. Two
+remain undelivered: `GRAPH_TF_STALE` and `GRAPH_LATENCY_BUDGET`.
 
 Splitting the unmeasured cases out of `GRAPH_NODE_INACTIVE` has two consequences nothing
 else states. Anything downstream that filters or correlates on `GRAPH_NODE_INACTIVE`

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/README.md
@@ -33,9 +33,9 @@ With the gateway built and sourced:
 
 | Key | Type | Default | Meaning |
 |-----|------|---------|---------|
-| `tick_interval_ms` | int | `1000` | Detector tick cadence. |
-| `warmup_cycles` | int | `5` | An entity must be continuously present for this many ticks before it arms. A mid-run restart re-warms it. Enforced centrally, see "Reliability (bringup-quiesce)" below. |
-| `prune_grace` | int | `60` | Default injected into every detector's own config before `configure()`; a per-detector `detectors.<id>.prune_grace` overrides it. Used by detectors that keep per-key bookkeeping. |
+| `tick_interval_ms` | int | `1000` | Detector tick cadence. Accepted range 1..`INT_MAX`; the check runs on the wide integer, so a value past `INT_MAX` is rejected rather than truncated back into the band. |
+| `warmup_cycles` | int | `5` | An entity must be continuously present for this many ticks before it arms. A mid-run restart re-warms it. Enforced centrally, see "Reliability (bringup-quiesce)" below. Accepted range 0..`INT_MAX`, checked on the wide integer. |
+| `prune_grace` | int | `60` | Default injected into every detector's own config before `configure()`; a per-detector `detectors.<id>.prune_grace` overrides it. Used by detectors that keep per-key bookkeeping. Accepted range 0..`INT_MAX` here, checked on the wide integer; each detector re-validates it against its own documented range before using it. |
 | `detectors.<id>.mode` | string \| bool | `raise` | `raise` = push faults; `advisory` = observe, do not push; `off` = disabled. Bare `off`/`no` (YAML booleans) also disable; bare `on`/`yes` mean `raise`. |
 | `detectors.<id>.<field>` | any | - | Per-detector thresholds, passed to that detector's `configure()`. |
 
@@ -721,8 +721,8 @@ node's SETTLED observation had started, and resets nothing:
 | Settled observation | What sustained absence does |
 |---|---|
 | `inactive`, ALREADY reported under `GRAPH_NODE_INACTIVE` | the streak continues exactly as it did on its last present tick, so the fault stays raised and keeps naming a node that is no longer there |
-| `inactive`, not yet past `grace`, node the presence detector OWNED at some point | the streak is HELD - neither advanced (no fault is born while nobody can observe the node) nor erased (a node that returns still inactive resumes rather than re-earning `grace`). The presence detector could report this exact departure instead (`node_death` tracks any node the reliability gate has admitted for presence ownership at least once), so this detector does not need to. |
-| `inactive`, not yet past `grace`, node the presence detector NEVER owned | the streak keeps climbing on absence exactly as it would on a present tick. `node_death` only ever tracks a node the gate has admitted for ownership AND that is online, so a node that never reached that bar - one that never reached `active`, or one whose ROS binding never started - is structurally invisible to it no matter what happens afterwards. If this detector held the streak too, the departure would be reported by nothing at all. |
+| `inactive`, not yet past `grace`, node the presence detector currently TRACKS | the streak is HELD - neither advanced (no fault is born while nobody can observe the node) nor erased (a node that returns still inactive resumes rather than re-earning `grace`). `node_death` is tracking this exact departure, so this detector stands back. Note what membership does and does not promise: `node_death` will report the departure unless one of its own suppressors vetoes the key, and a durably suppressed key is reclaimed by `prune()` - at which point it leaves the set and the streak resumes climbing here. Membership is re-read every tick for exactly that reason, so the two detectors cannot disagree about who holds a node. |
+| `inactive`, not yet past `grace`, node the presence detector does NOT track | the streak keeps climbing on absence exactly as it would on a present tick. A node `node_death` never admitted - one that never reached `active`, one whose ROS binding never started, one it handed back on a measured disown - is invisible to it, and so is every node when `node_death` is `off` or `advisory`. If this detector held the streak too, the departure would be reported by nothing at all. |
 | unread label, or no tracked lifecycle | the unmeasured clock keeps climbing under that same cause, so the node is eventually reported under `GRAPH_NODE_UNREADABLE` / `GRAPH_NODE_NOT_MANAGED` |
 | `active` | nothing. Anything the node had started but not corroborated is released, the entry becomes idle and is reclaimed silently |
 
@@ -791,13 +791,17 @@ still asking: the gate would let it raise throughout (`LifecycleWatcher::node_ok
 unread label as permission, deliberately), and once the re-seed budget is spent the node is
 `node_death`'s after all, because nothing else would ever report it. The tracker therefore
 splits on
-whether the presence detector EVER owned a node, read from the reliability gate itself rather
-than guessed from the observed label: once owned, a below-`grace` streak that goes absent is
+whether the presence detector is tracking a node RIGHT NOW, read from the key set that detector
+publishes each sweep rather than from the reliability gate and never latched: while it holds
+the key, a below-`grace` streak that goes absent is
 simply HELD - maturing it would raise `GRAPH_NODE_INACTIVE` from ticks gathered while nobody
 could observe the node, a fault its presence never earned, and `GRAPH_NODE_DISAPPEARED` is
-there to report the departure instead. A node the presence detector never owned gets no such
-backstop - `GRAPH_NODE_DISAPPEARED` structurally cannot report it - so absence keeps advancing
-its streak exactly as a present tick would, maturing it within the same bound an owned node's
+there to report the departure instead. Reading membership instead of remembering it is what
+ends the hold when the claim behind it ends: a key handed back on a measured disown, reclaimed
+after a durable suppression, or collapsed under the cap leaves the set, and the streak resumes.
+A node outside the set gets no such
+backstop - `GRAPH_NODE_DISAPPEARED` will not report it - so absence keeps advancing
+its streak exactly as a present tick would, maturing it within the same bound a tracked node's
 UNMEASURED clock already has (`grace` + `absence_grace` + 1 ticks). An ALREADY-matured
 streak still continues through absence exactly as before, for either kind of node: two
 codes standing at once for the same node (`GRAPH_NODE_INACTIVE` because it was measured
@@ -1462,7 +1466,7 @@ already matured past `grace` (the fault stays raised, still naming the node), bu
 CREATES one that has not. A node that was briefly non-active and then died is reported as gone
 (`GRAPH_NODE_DISAPPEARED`) rather than also acquiring an inactive fault born from ticks
 gathered while nobody could observe it. A `require_active` node that never reaches `active` is
-never owned, is never tracked here, and its departure can never raise
+never admitted, is never tracked here, and its departure can never raise
 `GRAPH_NODE_DISAPPEARED`; the same holds for an app that is not online. For those,
 `lifecycle_expectation` keeps the older behaviour: absence still matures a below-`grace`
 streak, because it is structurally the only detector that will ever get to report them. See
@@ -1525,9 +1529,13 @@ done. `/fault_manager/list_faults` would tell this detector that a `GRAPH_NODE_D
 record is outstanding and that it is among its reporting sources - but not WHICH nodes it
 names, which is the only thing that would make a fresh instance's silence meaningful. The fault
 manager keeps one record per `fault_code`, and this detector folds every dead key into that one
-record's description, capped at `kMaxDescriptionChars` with the remainder collapsed into a
-count, so the key list is not recoverable even by parsing prose. `lifecycle_expectation` has the
-same boundary and resolves it differently (a bounded hold, then the clear flows) because its
+record's description. That description is this detector's own deterministic text, so for a
+record that never hit `kMaxDescriptionChars` the key list could in principle be read back out of
+it - the detector does not, because past the cap the remainder is collapsed into a count and the
+names are gone for good, and a re-seeding rule that works only for small faults is worse than
+none. In practice the operator carries the cost: after a reboot that follows a node death, the
+fault is still CONFIRMED and has to be deleted by hand even though the graph is healthy again.
+`lifecycle_expectation` has the same boundary and resolves it differently (a bounded hold, then the clear flows) because its
 `require_active` set is enumerable from config alone; this detector is zero-config over the
 whole graph and has no such set. The integration test
 `RestartedInstanceNeverClearsAFaultItDidNotRaiseEvenAsTheNodeReturns` pins the behaviour so it
@@ -1594,8 +1602,11 @@ cannot change silently.
      and a fault confirmed before a gateway restart stays CONFIRMED across it.
    - `test/e2e/test_node_death_suppression_e2e.test.py` (five scenarios): the allowlist
      suppresses the node it names; the SAME allowlist left unnamed in `suppress` is inert,
-     and a startup warning says so; a managed lifecycle node that reached a clean shutdown
-     is never named while an active sibling that was simply killed still is; naming a node
+     and a startup warning says so; a managed lifecycle node driven ACTIVE and then all the way
+     down through deactivate, cleanup and shutdown is never named, while an active sibling that
+     was simply killed still is (the node has to be admitted before the suppressor is reached at
+     all, which is why that row starts it active rather than shutting it down from
+     unconfigured); naming a node
      on the allowlist alone, with `suppress` unset, does not suppress it; and an ALLOWLISTED
      death (the only shape pruning ever applies to - see "Bounded by evidence, not by age")
      held well past `prune_grace` is actually reclaimed (`tracked_count` on
@@ -1718,7 +1729,20 @@ bringup-quiesce centrally so no individual detector has to reimplement it.
   and only on a tick that still sees the app present, so a node that dies within
   about one entity-cache refresh of its label arriving is reported by the
   presence code after all - measured at 210 ms between the label reaching
-  `GET /x-medkit-watchdog` and the release. The report is TRUE (the node did
+  `GET /x-medkit-watchdog` and the release. Once the release HAS happened it
+  holds, and that took fixing: a dying managed node loses its lifecycle services
+  from the snapshot a sweep before the App itself goes, and a node with no
+  managed record reads as a plain node, which is `kEarned`. The act of dying was
+  therefore erasing the measurement that disowned the node and walking the key
+  straight back in. A released key now waits for the graph to read `active`
+  again; the disappearance of what disowned it is not news that the node became
+  the presence detector's. That wait is bounded, and has to be: a node that
+  merely STOPPED being managed - dropped its lifecycle services and kept running
+  - shows the same record-less shape forever, and refusing it forever would
+  leave its eventual death reported by nobody. So the refusal lasts
+  `miss_grace + 1` consecutive record-less PRESENT ticks, this detector's own
+  "absent this long means dead" window, which a node that really is dying cannot
+  outlive while still present. The report is TRUE (the node did
   disappear); what the window costs is attribution, and where `require_active`
   names the node both codes stand, which the boundary already accepts elsewhere.
   Closing it would mean deciding at REPORT time, and that cannot be done from

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -83,7 +83,18 @@ Reliability core
     The subscription callback holds only a ``weak_ptr`` to the watcher's shared
     state, so a callback in flight during teardown bails instead of touching
     freed memory. Non-managed nodes are never gated - ``node_ok`` returns true
-    for them unconditionally.
+    for them unconditionally, and so is a managed node whose ``GetState`` has
+    never answered: its label stays empty, and ``node_ok`` reads an unread label
+    as permission on purpose, since gating on it would silence every detector
+    for a node whose lifecycle service is broken. Only a KNOWN non-active label
+    suppresses. ``presence_ownership()`` asks the STRICTER question the presence
+    class needs, without changing that permissive answer, and answers it with a
+    GROUND rather than a boolean: EARNED for a state read as ``active`` or for a
+    node with no lifecycle at all, PROVISIONAL for one whose state was asked for
+    as often as it ever will be and never came (``measurement_pending()``, which
+    reads the per-node GetState re-seed budget charged only for reads that
+    actually ran), and neither while the asking is still going on. Only the first
+    is permanent - see the ``node_death`` section.
 
     Those subscriptions follow the private-callback-group rule described in the
     plugin shell bullet above: created on the shared gateway node, but in the
@@ -418,17 +429,18 @@ at all this tick is ABSENT, a fact separate from any observed state (there is no
 classify). For up to ``absence_grace`` (a fixed 3 ticks) consecutive absent ticks a node's
 whole state is held unchanged - the blink tolerance. Past ``absence_grace`` absence resets
 nothing, but what it ADVANCES depends on whether the node's SETTLED observation is already
-CONTENT, and - for a below-grace violation streak only - on whether the node was ever ARMED: a
-settled-``INACTIVE`` node ALREADY reported under ``GRAPH_NODE_INACTIVE`` keeps its streak
-exactly as it was, so the fault stays raised, regardless of arming. One not yet past ``grace``
-splits on that fact: a node the presence detector COULD have tracked (armed at least once) is
-HELD - neither advanced (no fault born from evidence gathered while nobody could observe the
-node, since ``node_death`` is able to report this exact departure instead) nor erased (it
+CONTENT, and - for a below-grace violation streak only - on whether the presence detector ever
+OWNED the node: a settled-``INACTIVE`` node ALREADY reported under ``GRAPH_NODE_INACTIVE``
+keeps its streak exactly as it was, so the fault stays raised, regardless of ownership. One not
+yet past ``grace`` splits on that fact: a node the presence detector COULD have tracked
+(admitted for ownership at least once) is HELD - neither advanced (no fault born from evidence
+gathered while nobody could observe the node, since ``node_death`` is able to report this exact
+departure instead) nor erased (it
 resumes rather than restarts on return) - while a node the presence detector could NEVER have
 tracked keeps climbing on absence exactly as it would on a present tick, because nothing else
 in the plugin will ever report its departure either. A settled-``UNREADABLE``/``NOT_MANAGED``
 node keeps climbing its unmeasured clock under that same cause regardless of maturity or
-arming - that clock's own absence behaviour is unrelated to this distinction. A
+ownership - that clock's own absence behaviour is unrelated to this distinction. A
 settled-``ACTIVE`` node advances nothing at all - anything it had started but not corroborated
 is released, so the entry becomes idle and is reclaimed silently. So a departure never heals a
 fault it has already earned, and never starts one out of evidence gathered while the node
@@ -473,19 +485,37 @@ alternating ``(INACTIVE, ABSENT x N)`` would otherwise never accumulate ``grace`
 Where the presence class CAN also report the same departure, it no longer does:
 ``GRAPH_NODE_DISAPPEARED`` (this package's own ``node_death`` detector) independently
 reports it, whether or not the node was ever measured not-active first. But ``node_death``
-only ever tracks an App once the reliability gate has armed it, and the gate refuses to arm a
-MANAGED node that is not ``active`` (``LifecycleWatcher::node_ok()``) - so a
-``require_active`` node that never reaches ``active`` is never armed, is never tracked by
-``node_death``, and its departure can never raise ``GRAPH_NODE_DISAPPEARED``, whatever kills
-it. So the split is on whether a node was EVER armed - a fact read from the reliability gate
-itself, not guessed from the observed label: once armed, a below-``grace`` streak that goes
-absent is simply HELD rather than matured on the strength of the absence alone - two codes
-standing at once for the same node is not a problem to fix, it is ``GRAPH_NODE_INACTIVE`` and
-``GRAPH_NODE_DISAPPEARED`` saying different, both-true things. A node that was NEVER armed
-gets no such backstop - ``GRAPH_NODE_DISAPPEARED`` structurally cannot report it - so absence
-keeps advancing its streak exactly as a present tick would. Reporting a HEALTHY node that left
-remains ``GRAPH_NODE_DISAPPEARED``'s job as well, for either kind of node - a healthy
-departure never starts a violation regardless of arming.
+only ever tracks an App once the reliability gate says it OWNS that App's departure, on one of
+one of the two grounds ``ReliabilityGate::presence_ownership()`` accepts - so a ``require_active``
+node that never reaches ``active`` is never tracked by ``node_death``, and neither is a managed
+node whose ``GetState`` has not answered while the watcher is still asking. The gate would
+permit that second one to RAISE - ``LifecycleWatcher::node_ok()`` treats an unread label as
+permission, deliberately, or a broken lifecycle service would silence ``qos_mismatch``,
+``orphan`` and ``param_drift`` too - but permission is not knowledge. Once the asking stops the
+node IS tracked, provisionally, and a label arriving afterwards over ``~/transition_event`` and
+reading non-active takes it straight back out again. A node that is merely RE-WARMING is not
+that: warmup says nothing about who a node belongs to, so the gate distinguishes ``kUnclaimed``
+(nothing known yet) from ``kDisowned`` (measured as another detector's) and only the second
+withdraws a key already held.
+
+That withdrawal happens inside ``node_death``'s own tick, and only on a tick that still sees
+the app present, so it leaves a window of about one entity-cache refresh in which a node that
+dies right after its label arrives is reported by the presence code anyway (measured: 210 ms
+between the label reaching the status route and the release). It is a mis-attribution of a TRUE
+report, not a false positive, and it cannot be closed at report time: the departed record keeps
+only the last label, which reads ``inactive`` both for a node earned and then deactivated - a
+death this detector must report - and for one only ever held provisionally. Separating them
+after the fact needs per-key ownership history surviving the departure, which is the unbounded
+state the tracked-key prune exists to prevent. So
+the split is on whether the presence detector EVER owned the node - a fact read from the
+reliability gate itself, not guessed from the observed label: once owned, a below-``grace``
+streak that goes absent is simply HELD rather than matured on the strength of the absence
+alone - two codes standing at once for the same node is not a problem to fix, it is
+``GRAPH_NODE_INACTIVE`` and ``GRAPH_NODE_DISAPPEARED`` saying different, both-true things. A
+node the presence detector never owned gets no such backstop - ``GRAPH_NODE_DISAPPEARED``
+structurally cannot report it - so absence keeps advancing its streak exactly as a present tick
+would. Reporting a HEALTHY node that left remains ``GRAPH_NODE_DISAPPEARED``'s job as well, for
+either kind of node - a healthy departure never starts a violation regardless of ownership.
 
 **Content follows the clocks, not the snapshot.** Whether a node was in this tick's matches
 decides nothing about what it reports: a node past ``grace`` stays in
@@ -546,15 +576,15 @@ non-idle entry is never pruned by age. An entry whose UNMEASURED clock is still 
 cannot grow without bound in time either: past the absence grace it advances every tick, so
 it matures within at most ``60 + absence_grace + 1`` ticks and is reported - the longest
 ``GRAPH_NODE_UNREADABLE`` or ``GRAPH_NODE_NOT_MANAGED``'s clear can be withheld by one
-departed node. A below-``grace`` VIOLATION streak on a node that was NEVER armed shares that
-same bound, for the same reason it advances at all while absent: it matures within at most
-``grace + absence_grace + 1`` ticks, because nothing else will ever report that node's
-departure either. Only once a node HAS been armed does its below-grace streak lose the
+departed node. A below-``grace`` VIOLATION streak on a node the presence detector never owned
+shares that same bound, for the same reason it advances at all while absent: it matures within
+at most ``grace + absence_grace + 1`` ticks, because nothing else will ever report that node's
+departure either. Only once a node HAS been owned does its below-grace streak lose the
 bound: absence then holds it rather than advancing it, so it neither matures nor becomes
 idle for as long as the node is away. That is not a new way to withhold
 ``GRAPH_NODE_INACTIVE``'s clear - the clear was already gated on every required node's
 status being settled, so one node this indecisive already blocked it; what changes is only
-that the fault never NAMES an ARMED node's departure, since that node's evidence belongs to
+that the fault never NAMES an OWNED node's departure, since that node's evidence belongs to
 ``GRAPH_NODE_DISAPPEARED`` instead. ``grace`` is still capped at 300 instead of being
 accepted up to ``INT_MAX - 1``, because it independently
 bounds how long a PRESENT node may go unreported and how long a returning node takes to
@@ -734,10 +764,10 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    departure, a node measured ACTIVE that vanishes raises nothing and is reclaimed, and the
    two ``(UNREADABLE/NOT_MANAGED, ABSENT x N)`` restart-loop shapes are swept at the
    absence grace and past it (their ``INACTIVE`` sibling pinned to the opposite claim at the
-   same two N: it never crosses grace from absence alone, for a node that was armed at some
-   point - a node that was NEVER armed gets the opposite result instead, maturing from
-   absence alone within ``grace + absence_grace + 1`` ticks exactly like the unmeasured
-   clock does, and resuming rather than restarting on return the same way an armed node's
+   same two N: it never crosses grace from absence alone, for a node the presence detector
+   owned at some point - a node it never owned gets the opposite result instead, maturing
+   from absence alone within ``grace + absence_grace + 1`` ticks exactly like the unmeasured
+   clock does, and resuming rather than restarting on return the same way an owned node's
    held streak does); the ``pending`` set and its
    per-reason breakdown; new-first
    ordering for all three fault-shaped maps; the remote-supplied label's own trim budget
@@ -944,8 +974,37 @@ tracking them would collapse an entire peer fleet onto one ``""`` key. A
 ``_ros2cli_<pid>`` node - rcl's own hidden-node naming convention for every ``ros2`` CLI
 invocation, matched structurally rather than guessed at - is excluded too, or every CLI
 invocation would accumulate one permanently "dead" entry for the life of the gateway. An
-App that never comes online is never armed and so is never admitted to tracking in the
-first place - the identical protection a node still inside ``warmup_cycles`` gets. Once
+App that never comes online is skipped by the ``is_online`` filter above and so is never
+admitted to tracking in the first place - the identical protection a node still inside
+``warmup_cycles`` gets. A MANAGED App whose lifecycle state has not been read YET is excluded
+too, and for a different reason: the gate's raise permission for it is deliberately PERMISSIVE
+(an unread label must not silence ``qos_mismatch``, ``orphan`` or ``param_drift``), but this
+detector reports an ABSENCE and cannot attribute the departure of a node whose state nothing
+has read - so tracking asks ``presence_ownership()`` instead.
+
+That exclusion is BOUNDED, and the readmission that follows it is PROVISIONAL. The watcher
+charges a GetState re-seed budget per node and charges it only for a read that actually ran, so
+an empty label with attempts left is "we have not finished asking" and an empty label with none
+left is "we asked and failed". Past that point the node is admitted here after all - nothing
+will ASK again, and ``lifecycle_expectation`` returns before it looks at anything unless an
+operator named the node in ``require_active``, which defaults to empty, so refusing forever
+would mean a whole class of deaths reported by nobody. But asking is not the only channel: the
+``~/transition_event`` subscription is created independently of the seed budget and is never
+torn down when it runs out, so a label can still arrive unasked. One that reads non-active says
+the node was ``lifecycle_expectation``'s all along, and this detector releases the key while the
+node is still alive rather than reporting a death it was never entitled to. Ownership EARNED
+from a measurement is not released that way: a node that ran and then deactivated is still a
+death when it stops running. Stickiness is earned by knowledge, never by ignorance.
+
+What that does NOT close: an App counts as managed only once the snapshot shows it advertising
+a ``GetState``-typed service, and until then it is indistinguishable from a plain node, so a
+managed node whose services have not yet been discovered can still be taken for one. That
+window is bounded by the arming warmup, which already needs several consecutive ticks of
+presence, and node and services come from the same introspection sweep. Nor does anything here
+close the case of a node that appears, lives fewer than ``warmup_cycles`` ticks and vanishes:
+the gate has always required completed warmup before it arms anything, so such a node is owned
+by nobody and reported by nobody. That is the bringup-quiesce trade-off working as designed,
+not a gap this boundary introduces. Once
 tracked, though, a node's continued life-or-death judgement rests on PRESENCE alone, not
 on staying armed: a tracked node that later goes lifecycle-inactive is not thereby
 mistaken for dead. Composable/component nodes hosted in one process die together - if the
@@ -1059,7 +1118,7 @@ node is present but not active, ``GRAPH_NODE_DISAPPEARED`` says a node is gone, 
 operator facing each has a different repair - reactivate it, or find out why it left. A
 node CONFIRMED ``GRAPH_NODE_INACTIVE`` that then departs keeps that fault (its description
 switches to say the node has since left the graph) AND now also raises
-``GRAPH_NODE_DISAPPEARED``, since this detector tracks every armed App independently of
+``GRAPH_NODE_DISAPPEARED``, since this detector tracks every App it owns independently of
 whatever ``lifecycle_expectation`` thinks of it.
 
 What changed is narrower than that, and it only applies to a node this detector could ever
@@ -1067,19 +1126,22 @@ have tracked. Before this detector existed, ``lifecycle_expectation``'s own viol
 let a SUSTAINED absence mature an unconfirmed (below-``grace``) streak into a confirmed
 ``GRAPH_NODE_INACTIVE`` - the only way a node stuck in a restart loop, never observed long
 enough to cross ``grace`` while present, would ever be reported at all. Where this detector
-can independently report the same departure - which needs the node to have been ARMED at
-least once, since it only ever tracks an App the reliability gate has armed, and the gate
-refuses to arm a MANAGED node that is not ``active`` - that absence-alone maturity is gone:
+can independently report the same departure - which needs the presence detector to have OWNED
+the node at least once, since it only ever tracks an App the reliability gate has admitted for
+ownership, and ownership needs a MANAGED node's lifecycle state known to read ``active`` or
+asked for as often as it ever will be, plus the node being online - that absence-alone maturity
+is gone:
 absence CONTINUES a violation that has already matured past ``grace`` (the fault stays
 raised, still naming the node), but no longer CREATES one that has not. A node that was
 briefly non-active and then died is reported as gone (``GRAPH_NODE_DISAPPEARED``) rather
 than also acquiring an inactive fault born from ticks gathered while nobody could observe
-it. A ``require_active`` node that never reaches ``active`` is never armed, is never
-tracked here, and its departure can never raise ``GRAPH_NODE_DISAPPEARED`` - for that one
-node, ``lifecycle_expectation`` keeps the older behaviour: absence still matures a
-below-``grace`` streak, because it is structurally the only detector that will ever get to
-report it. See ``lifecycle_expectation``'s own "Absence continues the last CORROBORATED
-observation, it never erases" section above for the mechanism this rests on.
+it. A ``require_active`` node that never reaches ``active`` is never owned, is never tracked
+here, and its departure can never raise ``GRAPH_NODE_DISAPPEARED``; the same holds for an app
+that is not online. For those, ``lifecycle_expectation`` keeps the older behaviour: absence
+still matures a below-``grace`` streak, because it is structurally the only detector that will
+ever get to report them. See
+``lifecycle_expectation``'s own "Absence continues the last CORROBORATED observation, it never
+erases" section above for the mechanism this rests on.
 
 **Repeated failures: what** ``occurrence_count`` **and the captured evidence answer, and
 don't.** An operator asking "how many times did this node die in the last hour" reads it
@@ -1181,7 +1243,7 @@ plus the suppression chain the detector shares no code with any sibling for:
    this process instance has genuinely raised, the guard tracks DELIVERY rather than
    intent, and a reconfigure while the node is absent does not withhold a clear the
    process had already earned.
-3. **E2e**, three files, each launching its own real gateway + fault_manager + demo-node
+3. **E2e**, four files, each launching its own real gateway + fault_manager + demo-node
    stack: ``test/e2e/test_node_death_e2e.test.py`` (ten scenarios covering the raise/clear
    round trip, no-heal-standalone, the lifecycle-deactivate/manifest-never-online/ros2cli
    non-cases, a bare-name collision naming only the node that exited, a fast tick alone
@@ -1197,9 +1259,28 @@ plus the suppression chain the detector shares no code with any sibling for:
    ``GRAPH_NODE_DISAPPEARED`` alone, a restart-looping required node is caught every cycle
    regardless of lifecycle maturity, a NEVER-armed node killed below ``grace`` raises
    ``GRAPH_NODE_INACTIVE`` alone instead - node_death cannot track a node the gate never
-   armed, so absence has to mature it here - a large ``miss_grace`` delays but does not
-   swallow the report, and a restarted gateway's warmup window never produces a spurious
-   PASSED).
+   admitted for ownership, so absence has to mature it here - a large ``miss_grace`` delays
+   but does not swallow the report, and a restarted gateway's warmup window never produces a
+   spurious PASSED); and ``test/e2e/test_presence_ownership_e2e.test.py`` (seven scenarios
+   against the fixture whose ``GetState`` never answers, so the unread state is permanent
+   rather than the race the boundary file's B6 row has to live with: a managed node the
+   watcher asked and could not read, killed, raises BOTH ``GRAPH_NODE_DISAPPEARED`` and
+   ``GRAPH_NODE_UNREADABLE``; the same death with no ``require_active`` entry anywhere - the
+   shipped default, where nothing else is watching at all - still raises
+   ``GRAPH_NODE_DISAPPEARED``, and that pair also rules out an implementation deciding
+   ownership from ``require_active`` membership; the SAME node told to start answering,
+   measured ``active``, then killed, IS reported too, under the identical configuration as
+   the first row so the only variable is the lifecycle state; a node measured ``active`` that
+   then LOSES its lifecycle services and is killed is still reported; and with an unmeasured
+   managed node in the graph ``GRAPH_PARAM_DRIFT`` still names it - the one leg of the three
+   that passes through the app-keyed gate at all - while the topic-keyed
+   ``GRAPH_QOS_MISMATCH`` and ``GRAPH_ORPHAN`` still report too; and the one row that asserts
+   an ABSENCE, where the same never-answering node is owned provisionally, then announces
+   ``inactive`` over ~/transition_event, then dies: ``GRAPH_NODE_INACTIVE`` names it and
+   ``GRAPH_NODE_DISAPPEARED`` never appears, which is also what rejects a detector wired to
+   the permissive ``reliability_allows()``; and a crash loop shorter than the warmup, where the
+   node is killed, reported, brought back for less than one re-warm and killed again - the
+   second death must still be reported, and no PASSED may be emitted while it is dead).
 
 
 Status

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -138,8 +138,9 @@ Reliability core
 
 Detectors
 ---------
-``qos_mismatch``, ``orphan``, ``param_drift`` and ``lifecycle_expectation`` are the
-detectors this package ships so far. The remaining silent-fault classes land in
+``qos_mismatch``, ``orphan``, ``param_drift``, ``lifecycle_expectation`` and
+``node_death`` are the detectors this package ships so far. Two silent-fault classes
+remain undelivered, ``GRAPH_TF_STALE`` and ``GRAPH_LATENCY_BUDGET``; they land in
 follow-up changes, each against its own issue.
 
 ``qos_mismatch`` raises ``GRAPH_QOS_MISMATCH``. It
@@ -415,14 +416,24 @@ situation never changed.
 **Absence continues the last CORROBORATED observation, it never erases.** A node not matched
 at all this tick is ABSENT, a fact separate from any observed state (there is no label to
 classify). For up to ``absence_grace`` (a fixed 3 ticks) consecutive absent ticks a node's
-whole state is held unchanged - the blink tolerance. Past ``absence_grace`` absence ADVANCES
-whichever clock the node's SETTLED observation had started, and resets nothing: a
-settled-``INACTIVE`` node keeps climbing its violation streak, a
-settled-``UNREADABLE``/``NOT_MANAGED`` node keeps climbing its unmeasured clock under that
-same cause, and a settled-``ACTIVE`` node advances nothing at all - anything it had started
-but not corroborated is released, so the entry becomes idle and is reclaimed silently. So a
-departure never heals a fault and never starts one; what it changes is the detail phrase,
-which then says the node has since left the graph.
+whole state is held unchanged - the blink tolerance. Past ``absence_grace`` absence resets
+nothing, but what it ADVANCES depends on whether the node's SETTLED observation is already
+CONTENT, and - for a below-grace violation streak only - on whether the node was ever ARMED: a
+settled-``INACTIVE`` node ALREADY reported under ``GRAPH_NODE_INACTIVE`` keeps its streak
+exactly as it was, so the fault stays raised, regardless of arming. One not yet past ``grace``
+splits on that fact: a node the presence detector COULD have tracked (armed at least once) is
+HELD - neither advanced (no fault born from evidence gathered while nobody could observe the
+node, since ``node_death`` is able to report this exact departure instead) nor erased (it
+resumes rather than restarts on return) - while a node the presence detector could NEVER have
+tracked keeps climbing on absence exactly as it would on a present tick, because nothing else
+in the plugin will ever report its departure either. A settled-``UNREADABLE``/``NOT_MANAGED``
+node keeps climbing its unmeasured clock under that same cause regardless of maturity or
+arming - that clock's own absence behaviour is unrelated to this distinction. A
+settled-``ACTIVE`` node advances nothing at all - anything it had started but not corroborated
+is released, so the entry becomes idle and is reclaimed silently. So a departure never heals a
+fault it has already earned, and never starts one out of evidence gathered while the node
+could not be observed AND could be reported some other way; what it changes, for an
+already-raised fault, is the detail phrase, which then says the node has since left the graph.
 
 **What "settled" means, and why an unmeasured reading needs corroborating.** A real
 measurement (``ACTIVE`` or a non-active label) settles at once - a label is a fact about the
@@ -451,15 +462,30 @@ record heals with nothing having been measured. Re-seeding the tracker from the 
 startup would change that and is not implemented; the boundary is pinned by the
 ``restart_departed`` e2e scenario rather than left to be discovered.
 
-Why the erasure went away rather than moving: every erasure horizon is an evasion for a
-node that touches it periodically. A node in a restart loop - start, crash, respawn delay,
-start - touches absence by construction, and that is the node this detector most exists to
-catch, so discarding its evidence let it alternate ``(UNREADABLE, ABSENT x N)``,
-``(NOT_MANAGED, ABSENT x N)`` or ``(INACTIVE, ABSENT x N)`` forever without ever
-accumulating enough of anything to be reported. Reporting a HEALTHY node that left remains
-the presence class's job (``GRAPH_NODE_DISAPPEARED``, still no detector of its own) - the
-single gap this class keeps, and a far narrower one than "a node absent past the grace is
-invisible whichever clock it was on".
+Why the erasure went away rather than moving, for the two UNMEASURED causes: every erasure
+horizon is an evasion for a node that touches it periodically. A node in a restart loop -
+start, crash, respawn delay, start - touches absence by construction, and discarding its
+evidence would let it alternate ``(UNREADABLE, ABSENT x N)`` or ``(NOT_MANAGED, ABSENT x N)``
+forever without ever accumulating enough of anything to be reported.
+
+The VIOLATION streak needed the identical rule for the identical reason once - a node
+alternating ``(INACTIVE, ABSENT x N)`` would otherwise never accumulate ``grace`` + 1 either.
+Where the presence class CAN also report the same departure, it no longer does:
+``GRAPH_NODE_DISAPPEARED`` (this package's own ``node_death`` detector) independently
+reports it, whether or not the node was ever measured not-active first. But ``node_death``
+only ever tracks an App once the reliability gate has armed it, and the gate refuses to arm a
+MANAGED node that is not ``active`` (``LifecycleWatcher::node_ok()``) - so a
+``require_active`` node that never reaches ``active`` is never armed, is never tracked by
+``node_death``, and its departure can never raise ``GRAPH_NODE_DISAPPEARED``, whatever kills
+it. So the split is on whether a node was EVER armed - a fact read from the reliability gate
+itself, not guessed from the observed label: once armed, a below-``grace`` streak that goes
+absent is simply HELD rather than matured on the strength of the absence alone - two codes
+standing at once for the same node is not a problem to fix, it is ``GRAPH_NODE_INACTIVE`` and
+``GRAPH_NODE_DISAPPEARED`` saying different, both-true things. A node that was NEVER armed
+gets no such backstop - ``GRAPH_NODE_DISAPPEARED`` structurally cannot report it - so absence
+keeps advancing its streak exactly as a present tick would. Reporting a HEALTHY node that left
+remains ``GRAPH_NODE_DISAPPEARED``'s job as well, for either kind of node - a healthy
+departure never starts a violation regardless of arming.
 
 **Content follows the clocks, not the snapshot.** Whether a node was in this tick's matches
 decides nothing about what it reports: a node past ``grace`` stays in
@@ -516,14 +542,25 @@ different N. So ``prune_ticks`` (the operator's ``prune_grace``, used as written
 no ``grace + 1`` clamp any more, because there is nothing left for one to protect) reclaims
 IDLE entries only: both clocks at zero and no matured ownership, i.e. nothing to lose, and
 still atomically - ONE map entry per node, gone in the same tick, never partially. A
-non-idle entry is never pruned by age, and cannot grow without bound in time either: past
-the absence grace its clock advances every tick, so it matures within at most
-``grace + absence_grace + 1`` ticks (a violation streak) or ``60 + absence_grace + 1`` (an
-unmeasured clock) and is reported. Those are also the longest ``GRAPH_NODE_INACTIVE``'s clear
-can be withheld by one departed node, which is why ``grace`` is capped at 300 instead of
-being accepted up to ``INT_MAX - 1``: at the old maximum the bound was roughly 24 days at the
-shipped cadence, during which the fault could neither raise nor heal for ANY node - silence
-indistinguishable from a working detector finding nothing.
+non-idle entry is never pruned by age. An entry whose UNMEASURED clock is still climbing
+cannot grow without bound in time either: past the absence grace it advances every tick, so
+it matures within at most ``60 + absence_grace + 1`` ticks and is reported - the longest
+``GRAPH_NODE_UNREADABLE`` or ``GRAPH_NODE_NOT_MANAGED``'s clear can be withheld by one
+departed node. A below-``grace`` VIOLATION streak on a node that was NEVER armed shares that
+same bound, for the same reason it advances at all while absent: it matures within at most
+``grace + absence_grace + 1`` ticks, because nothing else will ever report that node's
+departure either. Only once a node HAS been armed does its below-grace streak lose the
+bound: absence then holds it rather than advancing it, so it neither matures nor becomes
+idle for as long as the node is away. That is not a new way to withhold
+``GRAPH_NODE_INACTIVE``'s clear - the clear was already gated on every required node's
+status being settled, so one node this indecisive already blocked it; what changes is only
+that the fault never NAMES an ARMED node's departure, since that node's evidence belongs to
+``GRAPH_NODE_DISAPPEARED`` instead. ``grace`` is still capped at 300 instead of being
+accepted up to ``INT_MAX - 1``, because it independently
+bounds how long a PRESENT node may go unreported and how long a returning node takes to
+re-mature: at the old maximum that PRESENT-side bound was roughly 24 days at the shipped
+cadence, with no warning - silence indistinguishable from a working detector finding
+nothing.
 
 What bounds the map is ``tracked_node_cap`` (default 512, ``kDefaultTrackedNodeCap``,
 accepted range 1..16384): at the cap idle entries are reclaimed first, then entries for
@@ -583,12 +620,14 @@ started over (a restarted gateway, a reconfigure - ``configure()`` rebuilds the 
 
 Either reason withholds the emission entirely, neither raise nor clear. A raise is never
 withheld: a violation read from the nodes that DID answer is real regardless of the
-unmeasured ones. Every hold is bounded: the never-matched leg and both unmeasured
-causes all release after 60 consecutive ticks (a minute at the shipped cadence,
-mirroring ``param_drift``'s frozen hold), whether the node is present or gone - the pending
-leg releases as soon as the node reads ``active``, or its streak passes grace and the fault
-is raised again, which past the absence grace happens while the node is absent too. Every
-hold releases by SETTLING the node's status, never by giving up on it. Because a correctly
+unmeasured ones. The never-matched leg and both unmeasured causes are bounded: they release
+after 60 consecutive ticks (a minute at the shipped cadence, mirroring ``param_drift``'s
+frozen hold), whether the node is present or gone. The pending leg releases the same
+way - as soon as the node reads ``active``, or a PRESENT tick pushes its streak past grace
+and the fault is raised again - but while the node stays absent that release has no timeout
+of its own: absence holds a below-grace streak rather than advancing it, so the hold lasts
+for exactly as long as the node does not return. Every hold releases by SETTLING the node's
+status, never by giving up on it. Because a correctly
 withheld clear and a detector with nothing to report look identical from outside, a hold
 that lives past 10 consecutive ticks is explained in the log once per episode, naming
 every reason in force and, for the node-keyed ones, the count behind each and one node
@@ -684,13 +723,23 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    alternation this redesign closes - a node alternating between unreadable and
    not-managed, indefinitely and on every single tick, still matures the shared clock;
    the ``INACTIVE``/``NOT_MANAGED`` alternation across absence gaps longer than the
-   absence grace; the violation streak surviving non-maturing unmeasured ticks and
-   RESUMING rather than restarting, counted exactly and read through
-   ``pending_violation``; absence CONTINUING whichever clock the last real observation
-   started - a blink holds it unchanged, past the blink tolerance it advances, a matured
-   fault survives a departure, a node measured ACTIVE that vanishes raises nothing and is
-   reclaimed, and the three ``(X, ABSENT x N)`` restart-loop shapes are swept at the
-   absence grace and past it; the ``pending`` set and its per-reason breakdown; new-first
+   absence grace, now counting only the MEASURED not-active legs; the violation streak
+   surviving non-maturing unmeasured ticks and RESUMING rather than restarting, counted
+   exactly and read through ``pending_violation``; absence CONTINUING an already-matured
+   fault exactly as it was on its last present tick - a blink holds either clock unchanged;
+   past the blink tolerance an unmeasured clock still climbing keeps climbing and matures on
+   absence alone, while a below-grace violation streak is instead HELD and RESUMES rather
+   than restarts once the node returns, proven both from one long absence and from many
+   short ones interleaved with matched reads; a matured violation fault survives a
+   departure, a node measured ACTIVE that vanishes raises nothing and is reclaimed, and the
+   two ``(UNREADABLE/NOT_MANAGED, ABSENT x N)`` restart-loop shapes are swept at the
+   absence grace and past it (their ``INACTIVE`` sibling pinned to the opposite claim at the
+   same two N: it never crosses grace from absence alone, for a node that was armed at some
+   point - a node that was NEVER armed gets the opposite result instead, maturing from
+   absence alone within ``grace + absence_grace + 1`` ticks exactly like the unmeasured
+   clock does, and resuming rather than restarting on return the same way an armed node's
+   held streak does); the ``pending`` set and its
+   per-reason breakdown; new-first
    ordering for all three fault-shaped maps; the remote-supplied label's own trim budget
    ahead of the whole-detail backstop, reapplied to a matured unreadable node's detail
    (which carries no label, only a fqn and a "required by" list); the age horizon
@@ -725,8 +774,9 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    releases and its once-per-episode log line; the blink-plus-unread-re-seed sequence;
    a filler batch sized (from the real detail-building code) to exceed the 480-char cap
    aggregating into one fault with the fresh crossing named first; a PRESENT node crossing
-   on the same tick as a batch of departed ones being named ahead of them rather than
-   truncated away by them; a required node appearing mid-run; a re-bind under the same
+   grace fresh while a batch of already-departed, already-matured ones sits
+   absent-and-content, named ahead of them rather than truncated away by them; a required
+   node appearing mid-run; a re-bind under the same
    ``App::id``; and the reconfigure/config-validation edge cases. The unmeasured clock's own split is pinned directly,
    for BOTH codes symmetrically: a managed node whose ``GetState`` genuinely never
    answers (through ``set_managed_app`` and a real, failing seed - proven by asserting
@@ -744,8 +794,13 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    new-first ordering; an already-reported node of either cause KEEPING its own record
    once it vanishes, with its description switching to say the node has left the graph; a
    node returning from that absence staying reported with no clear/re-raise churn; each of
-   the three restart-loop shapes raising its own code, and the ``inactive``/``not-managed``
-   alternation across absence gaps; a withheld ``GRAPH_NODE_INACTIVE`` clear releasing when
+   the two UNMEASURED restart-loop shapes raising its own code from absence alone (their
+   ``INACTIVE`` sibling instead pinned to counting only real reads, never crossing from any
+   of the interleaved absence gaps), and the ``inactive``/``not-managed``
+   alternation across absence gaps now counting only the MEASURED not-active legs; a
+   below-grace streak surviving the tightest ``prune_grace`` without being confirmed while
+   the node stays absent, and resuming (not restarting) once it returns; a withheld
+   ``GRAPH_NODE_INACTIVE`` clear releasing when
    the absent node's clock MATURES into its sibling's content rather than when the node is
    given up on; the two wire strings pinned as hand-typed literals; and the independence
    claim in both directions.
@@ -761,9 +816,11 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    non-string entries each warning, the unclamped prune horizon reaching idle bookkeeping
    at exactly the configured ``prune_grace`` (0, 1 and 4 - the smallest positive value
    included, since neither documented endpoint sweeps it) while a node carrying evidence
-   survives it - including the ``grace: 0, prune_grace: 0`` corner and a wide ``grace``
-   beside the tightest ``prune_grace``, whose instrument is the CONFIRMATION rather than the
-   map size - ``tracked_node_cap`` validated at both range endpoints and one value past each
+   survives it - including the ``grace: 0, prune_grace: 0`` corner (an UNMEASURED clock, the
+   only kind that keeps climbing while absent) and a wide ``grace`` beside the tightest
+   ``prune_grace`` for a below-grace VIOLATION streak, whose instrument is that it is neither
+   confirmed nor pruned while the node stays absent, and resumes rather than restarts once it
+   returns - ``tracked_node_cap`` validated at both range endpoints and one value past each
    with the key proven IN FORCE at both ends, boundedness under identity churn at the real
    512-node cap by collapsing the departed rather than refusing the live node, and saturation
    reported once per EPISODE with a second episode reported again after the first ends.
@@ -866,9 +923,289 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    detector cannot tell an entry for a departed node from a misspelt one.
 
 
+``node_death`` raises ``GRAPH_NODE_DISAPPEARED``. It watches every ARMED App in the graph
+for one that goes offline - zero-config, unlike ``lifecycle_expectation``'s
+operator-declared ``require_active`` list, because every armed App is a candidate.
+Liveness is ``App::is_online``, never mere membership in the entity snapshot: in
+runtime-only discovery the two happen to coincide (a dead node's App leaves the snapshot
+entirely), but a manifest keeps a bound App present with only ``is_online`` cleared once
+its ROS binding disappears, and hybrid discovery inherits that shape - counting snapshot
+membership alone would make a manifest-declared node immortal. A managed lifecycle node
+that merely deactivates keeps ``is_online: true`` (its process is still running, only its
+ROS 2 lifecycle state changed), so a deactivation is never mistaken for a death either -
+that is ``lifecycle_expectation``'s concern, not this one's. Tracking is keyed on the
+STABLE fqn (``App::effective_fqn()``), never ``App::id``: an id is recomputed every sweep
+and only gains a namespace prefix once a same-bare-name collision currently exists
+anywhere in the graph, so a live node's id can change out from under a key built from it.
+
+**What is never tracked.** A peer-aggregated app (``app.source`` starting ``peer:``)
+carries no ROS binding of its own, so ``effective_fqn()`` is empty for every one of them;
+tracking them would collapse an entire peer fleet onto one ``""`` key. A
+``_ros2cli_<pid>`` node - rcl's own hidden-node naming convention for every ``ros2`` CLI
+invocation, matched structurally rather than guessed at - is excluded too, or every CLI
+invocation would accumulate one permanently "dead" entry for the life of the gateway. An
+App that never comes online is never armed and so is never admitted to tracking in the
+first place - the identical protection a node still inside ``warmup_cycles`` gets. Once
+tracked, though, a node's continued life-or-death judgement rests on PRESENCE alone, not
+on staying armed: a tracked node that later goes lifecycle-inactive is not thereby
+mistaken for dead. Composable/component nodes hosted in one process die together - if the
+container process dies, every node it hosted leaves the snapshot on the same tick, and all
+of them are named in the one aggregated fault rather than raising one fault each.
+
+**The wall-clock floor on** ``miss_grace``. The entity snapshot a tick reads is not
+rebuilt every tick: runtime discovery rebuilds it off a graph event debounced to about one
+refresh per second, so several consecutive ticks between two refreshes see the IDENTICAL
+snapshot. A ``miss_grace`` counted purely in ticks does not count independent samples of
+the graph - shorten ``tick_interval_ms`` enough and one stale cache generation gets
+re-counted as several misses. The floor raises ``miss_grace``, for the configured
+``tick_interval_ms``, to the smallest value whose ``(miss_grace + 1) * tick_interval_ms``
+window is still at least 3000 ms - one graph-cache refresh cycle plus margin. At the
+shipped 1000 ms tick the floor is exactly the shipped default (``miss_grace: 2``), so the
+default configuration is unaffected; only a faster-than-default tick ever raises the
+effective grace, with a warning naming the window it actually spans.
+
+**Suppression: opt-in, and only by name.** Nothing is suppressed unless the operator
+names the mechanism in ``suppress`` - a configured ``allowlist`` that ``suppress`` does
+not name has NO effect, and a startup warning says so. Two mechanisms exist, activated
+independently of each other:
+
+- ``"allowlist"`` builds an ``AllowlistSuppressor`` over the configured ``allowlist`` set
+  - the same three-way match (fqn, bare leaf, ``App::id``) ``lifecycle_expectation``'s
+  ``require_active`` uses, so an operator who has one working can expect the other to
+  accept the same shapes. Exact match only, never a prefix or a shared suffix.
+- ``"lifecycle"`` builds a (stateless) ``LifecycleShutdownSuppressor``: it suppresses a
+  departure the reliability gate classifies as a clean managed-lifecycle shutdown - see
+  "Clean-shutdown suppression" below for what counts as clean.
+
+Every field is re-validated from scratch on every ``configure()`` call, so a malformed
+``allowlist`` entry, an unrecognized ``suppress`` name, or a wrongly-typed entry each
+produce their own named warning rather than being silently dropped. A candidate is
+suppressed the moment ANY active mechanism votes yes, order-independent - which one runs
+first never changes the result. Suppression is independent of ``mode``: a suppressed key
+never becomes content in the first place, while ``mode`` separately decides whether
+non-suppressed content is actually sent.
+
+**Durability, and why only a durable veto may reclaim bookkeeping.** Whether a suppressor
+is durable answers whether its "yes" is a standing fact about the key rather than a
+condition that can later stop holding. Both mechanisms here are durable: an
+operator-declared allowlist entry does not start matching and then stop on its own, and a
+departure's observed shutdown shape does not change after the fact. Durability is what
+makes reclaiming a suppressed key's tracker bookkeeping (``prune_grace`` consecutive
+suppressed ticks) sound - a NON-durable veto could lift later even after its key's
+bookkeeping was discarded, leaving a live, unsuppressed death with nothing left to report
+it: a false heal that silently outlives the very condition that produced it. A durable
+veto never lifts for a given key once it has fired, so reclaiming under it loses nothing.
+``Suppressor::durable()`` defaults to false, the safe assumption for a suppressor nobody
+has reasoned about yet; both suppressors here override it explicitly to true. Reclaiming
+is re-checked against the durable suppressors specifically, never merely "no longer in
+this tick's report", because a key can be dropped from a tick's report by ANY suppressor
+in the chain while a durable one also happens to cover it - whether a key may be reclaimed
+depends on WHICH suppressor vetoed it, not on whether it survived the filter. The generic
+chain is reusable (``Suppressor`` plus the free function ``apply_suppressors()``,
+independently unit-tested), but this detector's own filtering is hand-inlined rather than
+a call to that helper, because it has to interleave the id-form check above - answerable
+only while the node is still present - with the ordinary fqn/leaf dispatch the helper's
+plain string-keyed signature does not have room for.
+
+**Clean-shutdown suppression - what counts as clean.** ``LifecycleShutdownSuppressor``
+reads the lifecycle watcher's cached label for the departed node's LAST observed
+transition. ``shuttingdown`` alone suppresses - it is only reachable via a deliberate
+SHUTDOWN transition, so the label alone is enough. ``finalized`` suppresses only WITH an
+observed transition and never through the error branch; without an observed transition,
+or reached through the error branch, it does not, because ``finalized`` is also where a
+node's ``on_error`` override lands after ``ON_ERROR_FAILURE``/``ON_ERROR_ERROR`` out of
+``errorprocessing`` - the standard way a driver reports a hardware fault it cannot
+recover from, which is precisely the death an operator needs reported, not silenced.
+``unconfigured`` is deliberately excluded even though it looks quiet: it is also the
+resting state of a node whose ``configure()`` failed or that never activated at all, and
+suppressing on it would hide exactly that startup failure. Any other label, or no
+departure on record at all, abstains. The mechanism is stateless by construction - a
+detector's ``configure()`` runs before any per-tick context exists, so it stores nothing
+at construction and reads the gate fresh on every call - and its retention window is not
+this detector's own to size: before this detector's own ``configure()`` has run, the
+plugin predicts the same ``prune_ticks_`` (``max(prune_grace, miss_grace + 1)``) this
+detector will compute, then sizes the lifecycle watcher's departed-node retention from it
+with enough margin that a clean-shutdown label is still cached at this detector's own
+reclaim tick, one tick to spare
+(``GraphWatchdogPlugin::compute_departed_retention_ticks()`` - the resulting window is
+larger than ``prune_ticks_`` alone).
+
+**Bounded by evidence, not by age - and why this cap, unlike the sibling's, cannot
+actually saturate.** This detector is zero-config over every armed App in the graph - a
+strictly larger scope than ``lifecycle_expectation``'s named ``require_active`` set - so
+identity churn would grow the tracker's map without a bound if nothing capped it. An
+unsuppressed, still-dead entry is never reclaimed by age (``prune_grace`` only ever
+reclaims a DURABLY suppressed key), so ``tracked_node_cap`` (default 512, accepted range
+1..16384) is what bounds memory. At the cap: idle entries (present, carrying no evidence)
+are evicted first - free, since a still-armed one is simply re-tracked a moment later -
+then departed entries are collapsed into one synthetic count, keeping at most three
+individually named, and only if even that leaves no room is every departed entry
+collapsed. Unlike ``LifecycleExpectationTracker``, whose two clocks let a node be
+simultaneously present and mid-violation (neither idle nor departed, and so un-evictable -
+exactly what lets ITS cap genuinely saturate and withhold ``GRAPH_NODE_INACTIVE``'s
+clear), ``NodeLivenessTracker`` carries exactly one piece of per-key state, so every
+tracked identity is always either idle or departed; collapsing every departed entry always
+empties enough room, so a newcomer is never actually refused while the cap is at least 1
+(``NodeLivenessTrackerCap.SaturationNeverFiresBecauseEveryKeyIsEitherIdleOrCollapsible``
+pins this directly). ``tracking_saturated`` and ``tracked_node_cap`` still appear in this
+detector's own ``GET /x-medkit-watchdog`` block, in the same shape the sibling reports
+them, but the field is never observed true here - the shared shape exists for consistency
+with the sibling detector, not because saturation is reachable in this one.
+
+**The boundary with** ``lifecycle_expectation``. ``GRAPH_NODE_INACTIVE`` and
+``GRAPH_NODE_DISAPPEARED`` can both be raised for the same node at the same time, and that
+is CORRECT, not a defect this detector removes: ``GRAPH_NODE_INACTIVE`` says a required
+node is present but not active, ``GRAPH_NODE_DISAPPEARED`` says a node is gone, and an
+operator facing each has a different repair - reactivate it, or find out why it left. A
+node CONFIRMED ``GRAPH_NODE_INACTIVE`` that then departs keeps that fault (its description
+switches to say the node has since left the graph) AND now also raises
+``GRAPH_NODE_DISAPPEARED``, since this detector tracks every armed App independently of
+whatever ``lifecycle_expectation`` thinks of it.
+
+What changed is narrower than that, and it only applies to a node this detector could ever
+have tracked. Before this detector existed, ``lifecycle_expectation``'s own violation streak
+let a SUSTAINED absence mature an unconfirmed (below-``grace``) streak into a confirmed
+``GRAPH_NODE_INACTIVE`` - the only way a node stuck in a restart loop, never observed long
+enough to cross ``grace`` while present, would ever be reported at all. Where this detector
+can independently report the same departure - which needs the node to have been ARMED at
+least once, since it only ever tracks an App the reliability gate has armed, and the gate
+refuses to arm a MANAGED node that is not ``active`` - that absence-alone maturity is gone:
+absence CONTINUES a violation that has already matured past ``grace`` (the fault stays
+raised, still naming the node), but no longer CREATES one that has not. A node that was
+briefly non-active and then died is reported as gone (``GRAPH_NODE_DISAPPEARED``) rather
+than also acquiring an inactive fault born from ticks gathered while nobody could observe
+it. A ``require_active`` node that never reaches ``active`` is never armed, is never
+tracked here, and its departure can never raise ``GRAPH_NODE_DISAPPEARED`` - for that one
+node, ``lifecycle_expectation`` keeps the older behaviour: absence still matures a
+below-``grace`` streak, because it is structurally the only detector that will ever get to
+report it. See ``lifecycle_expectation``'s own "Absence continues the last CORROBORATED
+observation, it never erases" section above for the mechanism this rests on.
+
+**Repeated failures: what** ``occurrence_count`` **and the captured evidence answer, and
+don't.** An operator asking "how many times did this node die in the last hour" reads it
+off the fault record itself, not off this detector: ``GRAPH_NODE_DISAPPEARED``'s own
+``occurrence_count`` starts at 1 on the first raise and increments by exactly one each
+time a FAILED report reactivates a record that was CLEARED - never merely re-raised while
+still CONFIRMED, and never merely HEALED. Healing (the fault manager's debounce counter
+crossing ``healing_threshold`` on clean sweeps, see "Closing the loop" in the README) and
+clearing are different things: ``DELETE
+/api/v1/apps/graph_watchdog/faults/GRAPH_NODE_DISAPPEARED`` - the fault manager's own
+``~/clear_fault`` underneath - is what acknowledges an occurrence and closes its cycle. A
+still-CONFIRMED, or still-HEALED-but-unacknowledged, fault that fires FAILED again is the
+SAME occurrence continuing, not a new one, so restarting the dead node fast enough to heal
+it before anyone acknowledges it will not move the count.
+
+The honest limits, read off this branch's fault-manager storage rather than assumed: the
+per-fault rosbag store enforces ``fault_code`` as UNIQUE, so a fault can hold at most one
+recording at a time - a later confirmation's capture replaces the earlier one on disk
+rather than accumulating a history. The freeze frame is the same shape: one row per
+``fault_code``, overwritten on every capture, so a fifth occurrence's captured values
+overwrite the first's. What survives every occurrence by default is the count itself; a
+hash-chained record of every raise/clear/heal transition also exists, but only once the
+fault manager's own ``audit_log.enabled`` is turned on, which it is not by default.
+Recordings and the freeze frame do not accumulate a per-occurrence history either way.
+
+**A second death while the first is still outstanding gets no evidence of its own.** This
+detector folds every currently-affected node into ONE ``GRAPH_NODE_DISAPPEARED`` record via
+``AggregatedFault::emit()`` (see "The boundary with" ``lifecycle_expectation`` above): a
+second node dying while the fault is still CONFIRMED is added to the description on the next
+tick, but the ``ReportFault`` call that carries it lands on ``fault_storage.cpp``'s
+already-CONFIRMED, still-FAILED branch - the same re-report-not-a-new-occurrence path
+"Repeated failures" above describes for one node dying twice, reached here by two different
+nodes sharing one code instead. ``occurrence_count`` does not move, the fault manager
+publishes ``EVENT_UPDATED`` rather than ``EVENT_CONFIRMED``, and ``just_confirmed`` in
+``fault_manager_node.cpp`` stays false - which is what gates ``capture_pool_``, so neither a
+freeze frame nor a recording is captured for the second node. Acknowledging between the two
+deaths avoids this: the DELETE route's ``~/clear_fault`` closes the first occurrence, so the
+second node's next FAILED report reactivates a CLEARED record instead of updating a CONFIRMED
+one - a genuine new occurrence, with its own ``occurrence_count`` and its own capture.
+
+Two fixes were measured and rejected here, so this is not open for reconsideration without
+new evidence:
+
+- **Clear-then-raise from inside the detector does nothing.** ``AggregatedFault`` already has
+  both halves available - ``emit()`` sends a PASSED-shaped ``clear_fault()`` when ``affected``
+  is empty, a FAILED-shaped ``raise_fault()`` otherwise - so sending one right after the other
+  on the same tick looks like a free fix. It is not: ``compute_debounce_status()``'s
+  hysteresis latch holds a CONFIRMED (or HEALED) status until the debounce counter itself
+  crosses the OPPOSITE threshold, and a single PASSED event only moves that counter by one
+  step. Unless the fault happened to sit exactly one step short of ``healing_threshold``
+  already, the clear changes nothing the status can see, and the raise that follows lands
+  right back on the same already-CONFIRMED branch as before.
+- **Calling the real** ``~/clear_fault`` **service instead is worse than doing nothing.**
+  ``SqliteFaultStorage::clear_fault()`` runs ``DELETE FROM snapshots WHERE fault_code = ?`` -
+  it deletes the per-topic readings captured for the fault it clears, keeping only the
+  freeze-frame row. And ``ClearFault.srv``'s own ``skip_correlation_auto_clear`` defaults to
+  false, so clearing a root cause also clears every symptom the correlation engine attributes
+  to it unless the caller explicitly opts out (the gateway's own REST DELETE routes do; a
+  detector reaching for this service directly would have to remember to as well). Having the
+  detector call this automatically the moment a second node dies would destroy the FIRST
+  node's evidence - snapshots and correlated symptoms alike - to chase evidence for the
+  second, before anyone has necessarily seen the first.
+
+A correct fix does not belong in this detector at all: it needs an operation in the fault
+manager that re-confirms a CONFIRMED record - bumping ``occurrence_count``, publishing
+``EVENT_CONFIRMED`` again, and re-arming ``just_confirmed`` for a fresh capture - without
+routing through CLEARED and without deleting anything the first occurrence already earned.
+
+**Test tiers.** Three tiers each prove a different layer, deliberately not overlapping,
+plus the suppression chain the detector shares no code with any sibling for:
+
+1. **Unit** (``test_node_liveness_tracker.cpp``): the pure presence/absence state machine
+   - a key present but never armed is never tracked; once armed, presence alone (not
+   continued arming) keeps a tracked key's miss counter at zero; a key is reported dead
+   only once misses exceed ``miss_grace``; freshness ordering keeps a brand-new death out
+   of a capped description's blind spot; ``prune()`` reclaims a key only once it has been
+   suppressed for MORE than ``prune_ticks`` CONSECUTIVE calls, resets the streak the
+   moment a veto lifts even once, and never reclaims an unsuppressed death no matter how
+   long it stays dead; the cap evicts idle entries before collapsing departed ones, keeps
+   the collapsed count monotone within one tracker lifetime, and - the property most at
+   odds with a naive read of the sibling detector - can never actually report
+   ``tracking_saturated`` at all, since every tracked key here is always either idle or
+   collapsible, never both at once the way the sibling's two clocks allow.
+   ``test_suppressor.cpp`` pins the ``Suppressor`` interface and the free
+   ``apply_suppressors()`` helper (order-independent, null-safe, returns the dropped
+   count); ``test_allowlist_suppressor.cpp`` and ``test_lifecycle_shutdown_suppressor.cpp``
+   pin each suppressor's own matching rules independently of any detector.
+2. **Integration** (``test_node_death_integration.cpp``): the full config contract
+   (``miss_grace``, ``prune_grace`` and ``tick_interval_ms`` range checks and their floor
+   interaction; malformed ``allowlist``/``suppress`` entries; ``tracked_node_cap`` range
+   checks, including a value far past ``INT_MAX`` rejected rather than wrapped; an unknown
+   top-level key), that a peer-aggregated app and an ``is_online: false`` app are never
+   tracked, that the tracked count stays bounded and shrinks after a reclaim under
+   sustained identity churn, that a clean managed-lifecycle departure is suppressed
+   exactly AT the ``miss_grace`` boundary and stays reclaimed - not re-raised - past the
+   retention window the plugin sizes for it, that the allowlist's id-form suppresses only
+   the colliding node and not its namesake, and the ungated-clear guard's four properties:
+   a stored fault stays unhealed while an unrelated node arms alone, a clear flows once
+   this process instance has genuinely raised, the guard tracks DELIVERY rather than
+   intent, and a reconfigure while the node is absent does not withhold a clear the
+   process had already earned.
+3. **E2e**, three files, each launching its own real gateway + fault_manager + demo-node
+   stack: ``test/e2e/test_node_death_e2e.test.py`` (ten scenarios covering the raise/clear
+   round trip, no-heal-standalone, the lifecycle-deactivate/manifest-never-online/ros2cli
+   non-cases, a bare-name collision naming only the node that exited, a fast tick alone
+   raising nothing, a three-cycle restart loop reaching ``occurrence_count: 3``, and a
+   fault surviving a gateway restart); ``test/e2e/test_node_death_suppression_e2e.test.py``
+   (five scenarios covering the allowlist, its inertness when unnamed in ``suppress``, the
+   clean-shutdown/still-active contrast, opt-in suppression, and pruning without a false
+   heal); and ``test/e2e/test_node_death_boundary_e2e.test.py`` (eight scenarios proving
+   the seam with ``lifecycle_expectation`` directly: a node stuck inactive but never gone
+   raises ``GRAPH_NODE_INACTIVE`` alone, an ARMED node killed below ``grace`` raises
+   ``GRAPH_NODE_DISAPPEARED`` alone, a node killed AFTER ``GRAPH_NODE_INACTIVE`` has
+   confirmed raises BOTH at once, a healthy node that is simply killed raises
+   ``GRAPH_NODE_DISAPPEARED`` alone, a restart-looping required node is caught every cycle
+   regardless of lifecycle maturity, a NEVER-armed node killed below ``grace`` raises
+   ``GRAPH_NODE_INACTIVE`` alone instead - node_death cannot track a node the gate never
+   armed, so absence has to mature it here - a large ``miss_grace`` delays but does not
+   swallow the report, and a restarted gateway's warmup window never produces a spurious
+   PASSED).
+
+
 Status
 ---------------
 The plugin loads, ticks the graph, and shuts down cleanly. The reliability core is real
-and already ticking. Four silent-fault detector classes raise through it today,
-``qos_mismatch``, ``orphan``, ``param_drift`` and ``lifecycle_expectation``. The
-remaining classes land in follow-up changes, each against its own issue.
+and already ticking. Five silent-fault detector classes raise through it today,
+``qos_mismatch``, ``orphan``, ``param_drift``, ``lifecycle_expectation`` and
+``node_death``. Two classes remain undelivered, ``GRAPH_TF_STALE`` and
+``GRAPH_LATENCY_BUDGET``; they land in follow-up changes, each against its own issue.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -1092,16 +1092,29 @@ recover from, which is precisely the death an operator needs reported, not silen
 ``unconfigured`` is deliberately excluded even though it looks quiet: it is also the
 resting state of a node whose ``configure()`` failed or that never activated at all, and
 suppressing on it would hide exactly that startup failure. Any other label, or no
-departure on record at all, abstains. The mechanism is stateless by construction - a
+departure on record at all, abstains. The suppressor itself is stateless by construction - a
 detector's ``configure()`` runs before any per-tick context exists, so it stores nothing
-at construction and reads the gate fresh on every call - and its retention window is not
-this detector's own to size: before this detector's own ``configure()`` has run, the
-plugin predicts the same ``prune_ticks_`` (``max(prune_grace, miss_grace + 1)``) this
-detector will compute, then sizes the lifecycle watcher's departed-node retention from it
-with enough margin that a clean-shutdown label is still cached at this detector's own
-reclaim tick, one tick to spare
-(``GraphWatchdogPlugin::compute_departed_retention_ticks()`` - the resulting window is
-larger than ``prune_ticks_`` alone).
+at construction and reads the gate fresh on every call.
+
+**The verdict is latched; the evidence is not.** ``node_death`` remembers that a durable
+suppressor vetoed a given departed key and stops re-asking while that key stays tracked and
+absent. The label the suppressor reads is retained for a bounded number of ticks, while the
+veto must hold to ``prune()``'s reclaim - which needs it UNBROKEN for ``prune_ticks``
+consecutive ticks. Re-asking every tick made those windows race, and the retention clock is
+anchored on the wrong event to win it: it starts when the node's lifecycle SERVICES leave the
+graph, while the reclaim tick counts from when its App does, one or more sweeps later. Once
+the label expired mid-veto the suppressor abstained, the streak reset, and with the label gone
+for good the key could never be suppressed again - a cleanly shut-down node named for the life
+of the process. Latching is sound because that is what ``durable()`` means: the verdict never
+lifts for a given key, so remembering it cannot diverge from asking again. Only positive
+verdicts from durable suppressors are latched, and an entry is dropped the moment its key is
+present again, so one departure's verdict never carries into the next.
+
+The retention window is still not this detector's own to size: the plugin predicts the same
+``prune_ticks_`` (``max(prune_grace, miss_grace + 1)``) and sizes the watcher's departed-node
+retention from it. With the verdict latched, that window only has to outlive the FIRST tick
+suppression is evaluated on; it stays sized to the reclaim tick as slack against the
+services-before-App lead (``GraphWatchdogPlugin::compute_departed_retention_ticks()``).
 
 **Bounded by evidence, not by age - and what the cap actually bounds.** This detector is
 zero-config over every armed App in the graph - a strictly larger scope than
@@ -1122,6 +1135,19 @@ but only entries that have actually crossed ``miss_grace``. An entry still mid-g
 never a collapse candidate, because collapsing erases the identity and would report a death
 the node has not earned, permanently
 (``NodeLivenessTrackerCap.ImmatureDepartedEntriesAreNeverCollapsedOrReportedUnderCapPressure``).
+Collapsing is one-way, and the cost is worth stating plainly: the identity is DISCARDED, the
+collapsed count only grows within a tracker's life, and nothing decrements it when one of those
+nodes returns. So the description stops naming them, and - since the aggregated fault clears
+only on an EMPTY dead set - the synthetic collapsed entry keeps that set non-empty, which means
+``GRAPH_NODE_DISAPPEARED`` cannot clear again for the life of the process once anything has been
+collapsed. It ends by operator acknowledge or by a restart, never by the graph recovering.
+Neither half is repairable here: decrementing needs the identity the collapse threw away, and
+keeping identities is the unbounded state the cap exists to prevent, while decaying the count by
+time would heal a fault by waiting - which this package refuses everywhere else. What bounds the
+damage is what collapsing may touch: only a MATURED entry, whose death has already been reported
+by name, so nothing becomes UNREPORTED by being collapsed. The attribution and the self-healing
+are lost, not the warning.
+
 So saturation IS reachable here: when immature departures alone exceed the cap,
 ``tracking_saturated`` goes true and the departed set stays oversized for a few ticks -
 bounded by how fast departures arrive times ``miss_grace``, not by process uptime, which is

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/design/graph_watchdog.rst
@@ -429,15 +429,15 @@ at all this tick is ABSENT, a fact separate from any observed state (there is no
 classify). For up to ``absence_grace`` (a fixed 3 ticks) consecutive absent ticks a node's
 whole state is held unchanged - the blink tolerance. Past ``absence_grace`` absence resets
 nothing, but what it ADVANCES depends on whether the node's SETTLED observation is already
-CONTENT, and - for a below-grace violation streak only - on whether the presence detector ever
-OWNED the node: a settled-``INACTIVE`` node ALREADY reported under ``GRAPH_NODE_INACTIVE``
-keeps its streak exactly as it was, so the fault stays raised, regardless of ownership. One not
-yet past ``grace`` splits on that fact: a node the presence detector COULD have tracked
-(admitted for ownership at least once) is HELD - neither advanced (no fault born from evidence
-gathered while nobody could observe the node, since ``node_death`` is able to report this exact
-departure instead) nor erased (it
-resumes rather than restarts on return) - while a node the presence detector could NEVER have
-tracked keeps climbing on absence exactly as it would on a present tick, because nothing else
+CONTENT, and - for a below-grace violation streak only - on whether the presence detector is
+CURRENTLY tracking the node: a settled-``INACTIVE`` node ALREADY reported under
+``GRAPH_NODE_INACTIVE`` keeps its streak exactly as it was, so the fault stays raised,
+regardless of ownership. One not yet past ``grace`` splits on that fact, read every tick from
+the key set ``node_death`` publishes and never remembered: a node in that set is HELD - neither
+advanced (no fault born from evidence gathered while nobody could observe the node, since
+``node_death`` is tracking this exact departure) nor erased (it
+resumes rather than restarts on return) - while a node outside it keeps climbing on absence
+exactly as it would on a present tick, because nothing else
 in the plugin will ever report its departure either. A settled-``UNREADABLE``/``NOT_MANAGED``
 node keeps climbing its unmeasured clock under that same cause regardless of maturity or
 ownership - that clock's own absence behaviour is unrelated to this distinction. A
@@ -501,19 +501,33 @@ withdraws a key already held.
 That withdrawal happens inside ``node_death``'s own tick, and only on a tick that still sees
 the app present, so it leaves a window of about one entity-cache refresh in which a node that
 dies right after its label arrives is reported by the presence code anyway (measured: 210 ms
-between the label reaching the status route and the release). It is a mis-attribution of a TRUE
+between the label reaching the status route and the release). A withdrawal that HAS happened
+is final, which needed its own guard: a dying managed node loses its lifecycle services from
+the snapshot before it loses its App entry, and a node with no managed record answers
+``kEarned`` - so dying erased the very measurement that disowned the node and re-admitted the
+key on the tick before it departed. A released key is therefore readmitted on a label
+reading ``active``, never on the mere absence of a label - but the refusal runs for a bounded
+window rather than the node's whole life: after ``miss_grace + 1`` consecutive record-less
+PRESENT ticks (this detector's own "absent this long means dead" span, already floored to
+``kMinNodeDeathWindowMs`` of wall clock) the key is taken back, because a node still present
+past that window is not mid-death, it has simply stopped being managed - and holding the
+refusal open would leave its eventual death reported by nobody at all. It is a mis-attribution of a TRUE
 report, not a false positive, and it cannot be closed at report time: the departed record keeps
 only the last label, which reads ``inactive`` both for a node earned and then deactivated - a
 death this detector must report - and for one only ever held provisionally. Separating them
 after the fact needs per-key ownership history surviving the departure, which is the unbounded
 state the tracked-key prune exists to prevent. So
-the split is on whether the presence detector EVER owned the node - a fact read from the
-reliability gate itself, not guessed from the observed label: once owned, a below-``grace``
-streak that goes absent is simply HELD rather than matured on the strength of the absence
+the split is on whether the presence detector is tracking the node RIGHT NOW - read from the
+key set that detector publishes each sweep, not from the reliability gate and not guessed from
+the observed label: while it holds the key, a below-``grace`` streak that goes absent is simply
+HELD rather than matured on the strength of the absence
 alone - two codes standing at once for the same node is not a problem to fix, it is
-``GRAPH_NODE_INACTIVE`` and ``GRAPH_NODE_DISAPPEARED`` saying different, both-true things. A
-node the presence detector never owned gets no such backstop - ``GRAPH_NODE_DISAPPEARED``
-structurally cannot report it - so absence keeps advancing its streak exactly as a present tick
+``GRAPH_NODE_INACTIVE`` and ``GRAPH_NODE_DISAPPEARED`` saying different, both-true things.
+Reading membership rather than latching it is what makes the hold end when the claim behind it
+does: a key handed back on a measured disown, one reclaimed by ``prune()`` after a durable
+suppression, and one collapsed under the cap all leave the set, and the streak resumes climbing
+for each. A node outside the set gets no backstop - ``GRAPH_NODE_DISAPPEARED``
+will not report it - so absence keeps advancing its streak exactly as a present tick
 would. Reporting a HEALTHY node that left remains ``GRAPH_NODE_DISAPPEARED``'s job as well, for
 either kind of node - a healthy departure never starts a violation regardless of ownership.
 
@@ -576,7 +590,7 @@ non-idle entry is never pruned by age. An entry whose UNMEASURED clock is still 
 cannot grow without bound in time either: past the absence grace it advances every tick, so
 it matures within at most ``60 + absence_grace + 1`` ticks and is reported - the longest
 ``GRAPH_NODE_UNREADABLE`` or ``GRAPH_NODE_NOT_MANAGED``'s clear can be withheld by one
-departed node. A below-``grace`` VIOLATION streak on a node the presence detector never owned
+departed node. A below-``grace`` VIOLATION streak on a node the presence detector is not tracking
 shares that same bound, for the same reason it advances at all while absent: it matures within
 at most ``grace + absence_grace + 1`` ticks, because nothing else will ever report that node's
 departure either. Only once a node HAS been owned does its below-grace streak lose the
@@ -765,7 +779,7 @@ overlapping - plus the shared-watcher seam the re-bind behaviour lives in:
    two ``(UNREADABLE/NOT_MANAGED, ABSENT x N)`` restart-loop shapes are swept at the
    absence grace and past it (their ``INACTIVE`` sibling pinned to the opposite claim at the
    same two N: it never crosses grace from absence alone, for a node the presence detector
-   owned at some point - a node it never owned gets the opposite result instead, maturing
+   is tracking - a node outside its key set gets the opposite result instead, maturing
    from absence alone within ``grace + absence_grace + 1`` ticks exactly like the unmeasured
    clock does, and resuming rather than restarting on return the same way an owned node's
    held streak does); the ``pending`` set and its
@@ -1089,27 +1103,32 @@ reclaim tick, one tick to spare
 (``GraphWatchdogPlugin::compute_departed_retention_ticks()`` - the resulting window is
 larger than ``prune_ticks_`` alone).
 
-**Bounded by evidence, not by age - and why this cap, unlike the sibling's, cannot
-actually saturate.** This detector is zero-config over every armed App in the graph - a
-strictly larger scope than ``lifecycle_expectation``'s named ``require_active`` set - so
-identity churn would grow the tracker's map without a bound if nothing capped it. An
-unsuppressed, still-dead entry is never reclaimed by age (``prune_grace`` only ever
-reclaims a DURABLY suppressed key), so ``tracked_node_cap`` (default 512, accepted range
-1..16384) is what bounds memory. At the cap: idle entries (present, carrying no evidence)
-are evicted first - free, since a still-armed one is simply re-tracked a moment later -
-then departed entries are collapsed into one synthetic count, keeping at most three
-individually named, and only if even that leaves no room is every departed entry
-collapsed. Unlike ``LifecycleExpectationTracker``, whose two clocks let a node be
-simultaneously present and mid-violation (neither idle nor departed, and so un-evictable -
-exactly what lets ITS cap genuinely saturate and withhold ``GRAPH_NODE_INACTIVE``'s
-clear), ``NodeLivenessTracker`` carries exactly one piece of per-key state, so every
-tracked identity is always either idle or departed; collapsing every departed entry always
-empties enough room, so a newcomer is never actually refused while the cap is at least 1
-(``NodeLivenessTrackerCap.SaturationNeverFiresBecauseEveryKeyIsEitherIdleOrCollapsible``
-pins this directly). ``tracking_saturated`` and ``tracked_node_cap`` still appear in this
-detector's own ``GET /x-medkit-watchdog`` block, in the same shape the sibling reports
-them, but the field is never observed true here - the shared shape exists for consistency
-with the sibling detector, not because saturation is reachable in this one.
+**Bounded by evidence, not by age - and what the cap actually bounds.** This detector is
+zero-config over every armed App in the graph - a strictly larger scope than
+``lifecycle_expectation``'s named ``require_active`` set - so identity churn would grow the
+tracker's map without a bound if nothing capped it. An unsuppressed, still-dead entry is
+never reclaimed by age (``prune_grace`` only ever reclaims a DURABLY suppressed key), so
+``tracked_node_cap`` (default 512, accepted range 1..16384) is what bounds memory -
+specifically the DEPARTED subset of the map. A PRESENT/armed key never counts against the
+cap and is never evicted to make room for anything, at any map size
+(``NodeLivenessTrackerCap.PresentEntriesExceedingTheCapAreAllStillIndividuallyReportableOnDeath``):
+it is bounded by the live graph rather than by churn, so a graph far larger than the cap is
+not capacity pressure at all.
+
+Under pressure the cap collapses departed entries into one synthetic count, keeping at most
+three individually named
+(``NodeLivenessTrackerCap.MaturedDepartedEntriesAreCollapsedIntoACountUnderCapPressure``) -
+but only entries that have actually crossed ``miss_grace``. An entry still mid-grace is
+never a collapse candidate, because collapsing erases the identity and would report a death
+the node has not earned, permanently
+(``NodeLivenessTrackerCap.ImmatureDepartedEntriesAreNeverCollapsedOrReportedUnderCapPressure``).
+So saturation IS reachable here: when immature departures alone exceed the cap,
+``tracking_saturated`` goes true and the departed set stays oversized for a few ticks -
+bounded by how fast departures arrive times ``miss_grace``, not by process uptime, which is
+the growth the cap exists to prevent. What differs from ``LifecycleExpectationTracker`` is
+not whether the flag can fire but what it costs: there a refused newcomer withholds
+``GRAPH_NODE_INACTIVE``'s clear, whereas here nothing is refused and no report is lost, the
+map is merely temporarily larger than its target.
 
 **The boundary with** ``lifecycle_expectation``. ``GRAPH_NODE_INACTIVE`` and
 ``GRAPH_NODE_DISAPPEARED`` can both be raised for the same node at the same time, and that
@@ -1135,7 +1154,7 @@ absence CONTINUES a violation that has already matured past ``grace`` (the fault
 raised, still naming the node), but no longer CREATES one that has not. A node that was
 briefly non-active and then died is reported as gone (``GRAPH_NODE_DISAPPEARED``) rather
 than also acquiring an inactive fault born from ticks gathered while nobody could observe
-it. A ``require_active`` node that never reaches ``active`` is never owned, is never tracked
+it. A ``require_active`` node that never reaches ``active`` is never admitted, is never tracked
 here, and its departure can never raise ``GRAPH_NODE_DISAPPEARED``; the same holds for an app
 that is not online. For those, ``lifecycle_expectation`` keeps the older behaviour: absence
 still matures a below-``grace`` streak, because it is structurally the only detector that will
@@ -1220,11 +1239,12 @@ plus the suppression chain the detector shares no code with any sibling for:
    of a capped description's blind spot; ``prune()`` reclaims a key only once it has been
    suppressed for MORE than ``prune_ticks`` CONSECUTIVE calls, resets the streak the
    moment a veto lifts even once, and never reclaims an unsuppressed death no matter how
-   long it stays dead; the cap evicts idle entries before collapsing departed ones, keeps
-   the collapsed count monotone within one tracker lifetime, and - the property most at
-   odds with a naive read of the sibling detector - can never actually report
-   ``tracking_saturated`` at all, since every tracked key here is always either idle or
-   collapsible, never both at once the way the sibling's two clocks allow.
+   long it stays dead; the cap leaves every PRESENT key individually tracked and reportable
+   however far the map is past it, collapses only departed entries that have crossed
+   ``miss_grace``, keeps the collapsed count monotone within one tracker lifetime, and - the
+   property most at odds with a naive read of the sibling detector - reports
+   ``tracking_saturated`` for a departed set that immature entries alone keep oversized,
+   which unlike the sibling's saturation refuses nothing and loses no report.
    ``test_suppressor.cpp`` pins the ``Suppressor`` interface and the free
    ``apply_suppressors()`` helper (order-independent, null-safe, returns the dropped
    count); ``test_allowlist_suppressor.cpp`` and ``test_lifecycle_shutdown_suppressor.cpp``

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/aggregated_fault.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/aggregated_fault.hpp
@@ -29,8 +29,8 @@ namespace ros2_medkit_graph_watchdog {
 /// external entity from its own IntrospectionProvider (graph_watchdog_plugin.cpp).
 ///
 /// It must be an entity the plugin owns, not a borrowed one. Scoping these faults to the
-/// host Component - the obvious choice, and what this used to do - makes them reachable
-/// from NO endpoint: `collect_component_app_fqns` (fault_scope.cpp) only puts a
+/// host Component instead - the obvious-looking alternative - makes them reachable from NO
+/// endpoint: `collect_component_app_fqns` (fault_scope.cpp) only puts a
 /// component's bare id in the scope set when `external` is true, and a runtime host
 /// Component built by HostInfoProvider never sets it, so `/components/<host>/faults` and
 /// the scoped detail route both drop the fault. There is no server-level
@@ -72,16 +72,21 @@ class AggregatedFault {
   AggregatedFault(const char * code, std::uint8_t severity) : code_(code), severity_(severity) {
   }
 
-  void emit(DetectorContext & ctx, const std::map<std::string, std::string> & affected) const {
+  /// Returns whatever ctx.raise_fault()/ctx.clear_fault() returned - true only if the
+  /// request actually reached async_send_request(), never merely because `affected` was
+  /// non-empty. That proves local enqueue, not fault_manager receipt (the client is
+  /// fire-and-forget) - see DetectorContext::raise_fault's own doc for exactly what this
+  /// return value does and does not prove.
+  bool emit(DetectorContext & ctx, const std::map<std::string, std::string> & affected) const {
     const std::string source = graph_source_id(ctx);
     if (affected.empty()) {
-      ctx.clear_fault(code_, source);
-      return;
+      return ctx.clear_fault(code_, source);
     }
-    ctx.raise_fault(code_, severity_, describe(affected), source);
+    return ctx.raise_fault(code_, severity_, describe(affected), source);
   }
 
-  /// emit() with a caller-chosen ORDER for the description.
+  /// emit() with a caller-chosen ORDER for the description. Return value: see emit()'s own
+  /// doc.
   ///
   /// The map overload above lists entities lexicographically, which is fine when every
   /// entry is equally interesting. It is not fine when the set mixes long-standing entries
@@ -89,14 +94,13 @@ class AggregatedFault {
   /// `order` names the keys of `affected` in the order they should appear; any key of
   /// `affected` missing from `order` is appended afterwards, so a caller can never silently
   /// drop an entity by getting the ordering wrong.
-  void emit_ordered(DetectorContext & ctx, const std::map<std::string, std::string> & affected,
+  bool emit_ordered(DetectorContext & ctx, const std::map<std::string, std::string> & affected,
                     const std::vector<std::string> & order) const {
     const std::string source = graph_source_id(ctx);
     if (affected.empty()) {
-      ctx.clear_fault(code_, source);
-      return;
+      return ctx.clear_fault(code_, source);
     }
-    ctx.raise_fault(code_, severity_, describe_ordered(affected, order), source);
+    return ctx.raise_fault(code_, severity_, describe_ordered(affected, order), source);
   }
 
   /// Join the affected entities into one description, capped at kMaxDescriptionChars.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/allowlist_suppressor.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/allowlist_suppressor.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <set>
+#include <string>
+#include <utility>
+
+#include "ros2_medkit_graph_watchdog/suppressor.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Operator-declared veto. Suppresses a key iff it - or a name the SAME entity is also
+/// known by - is present, verbatim, in the configured allow set: never a prefix or a
+/// substring, so allowlisting `/r1/x` can never reach into `/r2/x` on a fleet where the two
+/// share a suffix.
+///
+/// Deliberately mirrors lifecycle_expectation_detector.cpp's own require_active matching
+/// (`id != app.id && id != fqn && id != leaf`) rather than inventing a second convention:
+/// a bare name is the natural operator input, and `App::id` is unstable - it gains a
+/// namespace prefix the moment a same-bare-name collision exists anywhere in the graph -
+/// so the two config surfaces (require_active, allowlist) need to accept the same shapes or
+/// an operator who has one working would reasonably expect the other to behave the same way
+/// and be wrong.
+///
+/// The two surfaces reach that same three-way match through different mechanics, though:
+/// lifecycle_expectation matches while the node is still PRESENT, so `app.id` and its fqn
+/// are both in hand from the very same `ctx.snapshot->apps` entry it is iterating. This
+/// class is asked about a key ONLY after the entity is already gone - present-tense
+/// `ctx.snapshot` cannot answer "what was this dead key's id" at all. suppresses() itself
+/// therefore still only ever sees a single string and covers the two forms derivable from
+/// that string alone (the key verbatim, and its own bare leaf); the id form needs the
+/// caller to have captured `App::id` while the entity was still alive and to re-offer it
+/// through allows() below - see node_death_detector.cpp's tick() for where that capture
+/// happens and why.
+///
+/// Shared by any detector whose candidate keys are plain strings (node_death's are
+/// `App::effective_fqn()`; a future tf_stale conversion would use its own "parent->child"
+/// pair strings) - the exact-match contract does not care which.
+///
+/// The empty string is never treated specially: a caller that means "match nothing" for
+/// an empty entity_key has to actually insert "" into the allow set for that to happen.
+/// Detector configure() code is expected to have already dropped empty entries when
+/// building the set it hands here.
+class AllowlistSuppressor : public Suppressor {
+ public:
+  explicit AllowlistSuppressor(std::set<std::string> allow) : allow_(std::move(allow)) {
+  }
+
+  /// True iff `candidate` is present, verbatim, in the configured allow set. Public (beyond
+  /// what the Suppressor interface requires) so a caller holding a form of an entity's
+  /// identity that suppresses() itself has no way to reach - `App::id`, captured while the
+  /// entity was still present - can still check it against the same set. See the class doc.
+  bool allows(const std::string & candidate) const {
+    return allow_.count(candidate) > 0;
+  }
+
+  /// Matches `entity_key` verbatim, or the bare leaf of it (the substring after the last
+  /// '/', or the whole key if it carries no '/') - the two forms answerable from the key
+  /// alone. The id form is NOT checked here; see allows() and the class doc.
+  bool suppresses(const std::string & entity_key, const DetectorContext & /*ctx*/) const override {
+    if (allows(entity_key)) {
+      return true;
+    }
+    const auto slash = entity_key.rfind('/');
+    if (slash == std::string::npos) {
+      return false;  // entity_key has no '/': it already IS its own bare leaf, checked above
+    }
+    return allows(entity_key.substr(slash + 1));
+  }
+
+  /// An operator-declared entry is a standing fact about that key for as long as this
+  /// configuration is loaded - it does not start matching and then stop on its own, so a
+  /// key it vetoes may safely have its tracker bookkeeping reclaimed.
+  bool durable() const override {
+    return true;
+  }
+
+ private:
+  std::set<std::string> allow_;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 
 #include <nlohmann/json.hpp>
@@ -82,6 +83,23 @@ struct DetectorContext {
   const ros2_medkit_gateway::IntrospectionInput * snapshot =
       nullptr;                                    ///< entities this tick (id + bound_fqn); null in bare-context tests
   const std::atomic<bool> * cancelled = nullptr;  ///< plugin shutdown flag; a long sweep polls it (null => never)
+
+  /// The keys the PRESENCE detector currently tracks, keyed by App::effective_fqn(), as of the
+  /// last tick it completed - or null when nothing is going to report a departure at all
+  /// (node_death absent, Off, or Advisory).
+  ///
+  /// Exists so that "will the presence class report this node's departure" has exactly ONE
+  /// answer in this plugin, given by the detector that decides it. Re-deriving that from the
+  /// gate plus local bookkeeping is what put three copies of the rule in three places, and they
+  /// disagreed on the sweep where a dying node loses its lifecycle record: the gate answers
+  /// kEarned for it, node_death refuses it, and anything mirroring the gate concluded the
+  /// opposite of the truth. A reader asks the owner instead.
+  ///
+  /// One tick stale by construction - it is published after the detectors have run, so a key
+  /// admitted this tick appears next tick. That is deliberate and harmless for the one consumer:
+  /// a sticky "could the presence class ever report this" latch cannot be wrong by being a tick
+  /// late, only by being wrong about a node nobody tracks.
+  const std::set<std::string> * presence_tracked = nullptr;
 
   /// Returns true only once `async_send_request` has actually been called - false for every
   /// suppression path (Advisory/Off, no client, empty source_id, reliability gate, service
@@ -156,6 +174,17 @@ class Detector {
   /// integration tests assert a tracker's map stays bounded under prune without
   /// exposing the tracker itself through the public interface. Default 0 for
   /// detectors with no such tracker.
+  /// The keys whose departure THIS detector would report, keyed by App::effective_fqn(), or
+  /// null for a detector that reports no departures. Only the presence class overrides it; the
+  /// plugin publishes the one non-null view it finds as DetectorContext::presence_tracked, so
+  /// that the question "is this node the presence detector's" has a single owner rather than a
+  /// copy of the rule in every detector that needs the answer.
+  ///
+  /// The returned reference must stay valid until the next tick of the detector that owns it.
+  virtual const std::set<std::string> * tracked_departure_keys() const {
+    return nullptr;
+  }
+
   virtual std::size_t tracked_count_for_test() const {
     return 0;
   }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
@@ -26,6 +26,7 @@
 #include <ros2_medkit_msgs/srv/report_fault.hpp>
 
 #include "ros2_medkit_graph_watchdog/fault_request.hpp"
+#include "ros2_medkit_graph_watchdog/presence_ownership.hpp"
 
 namespace ros2_medkit_gateway {
 struct IntrospectionInput;
@@ -45,6 +46,14 @@ class ReliabilityGate;  // defined in reliability_gate.hpp; only a pointer is st
 // header free of lifecycle_msgs). Defined in reliability_gate.cpp. Returns true when
 // gate is null (not yet wired) or the entity is armed + lifecycle-ok.
 bool reliability_allows(const ReliabilityGate * gate, const std::string & source_id);
+
+// The stricter sibling of reliability_allows(), same null-gate convention, also defined in
+// reliability_gate.cpp: on what GROUNDS the presence detector owns this entity's departure -
+// see ReliabilityGate::presence_ownership() and PresenceOwnership. Where reliability_allows()
+// answers "may this entity raise" and is permissive about a label that has never been read,
+// this answers "whose node is this" and distinguishes an answer earned from a measurement
+// from one granted only because the asking stopped.
+PresenceOwnership presence_ownership(const ReliabilityGate * gate, const std::string & source_id);
 
 /// QoS for subscribing to /tf_static: publishers latch with transient-local
 /// durability, so a late subscriber must match it to receive the static transforms.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector.hpp
@@ -74,10 +74,22 @@ struct DetectorContext {
       nullptr;                                    ///< entities this tick (id + bound_fqn); null in bare-context tests
   const std::atomic<bool> * cancelled = nullptr;  ///< plugin shutdown flag; a long sweep polls it (null => never)
 
-  void raise_fault(const std::string & code, uint8_t severity, const std::string & description,
+  /// Returns true only once `async_send_request` has actually been called - false for every
+  /// suppression path (Advisory/Off, no client, empty source_id, reliability gate, service
+  /// not ready). This proves the request was handed to rclcpp's client library for sending,
+  /// nothing more: the client is deliberately fire-and-forget (see
+  /// GraphWatchdogPlugin::set_context()'s own note on why - nothing consumes the future), so
+  /// a true return does NOT prove fault_manager received or processed the request, only that
+  /// this call was not one of the silent-decline paths above. A caller that needs to
+  /// distinguish "genuinely attempted" from "merely warranted" (report non-empty) - not
+  /// receipt - must use this return value rather than inferring it from its own inputs:
+  /// node_death_detector.cpp's ever_raised_ guard is exactly that caller, and every one of
+  /// these suppression paths is silent by design (no detector should have to duplicate them
+  /// to know whether it may later trust its own silence as a clear).
+  bool raise_fault(const std::string & code, uint8_t severity, const std::string & description,
                    const std::string & source_id) {
     if (!mode_emits(mode) || !fault_client) {
-      return;  // Advisory/Off suppressed, or client not yet wired.
+      return false;  // Advisory/Off suppressed, or client not yet wired.
     }
     if (source_id.empty()) {
       if (gateway_node) {
@@ -85,21 +97,24 @@ struct DetectorContext {
                          "graph_watchdog: dropping fault '%s' with empty source_id (detector contract violation)",
                          code.c_str());
       }
-      return;
+      return false;
     }
     if (!reliability_allows(gate, source_id)) {
-      return;  // entity warming up or lifecycle-inactive: suppressed by the reliability core.
+      return false;  // entity warming up or lifecycle-inactive: suppressed by the reliability core.
     }
     if (!fault_client->service_is_ready()) {
-      return;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
+      return false;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
     }
     fault_client->async_send_request(std::make_shared<ros2_medkit_msgs::srv::ReportFault::Request>(
         make_fault_report(source_id, code, severity, description)));
+    return true;
   }
 
-  void clear_fault(const std::string & code, const std::string & source_id) {
+  /// See raise_fault()'s own doc on the return value - identical contract, minus the
+  /// reliability-gate check clear_fault() has never applied.
+  bool clear_fault(const std::string & code, const std::string & source_id) {
     if (!mode_emits(mode) || !fault_client) {
-      return;  // Advisory/Off suppressed, or client not yet wired.
+      return false;  // Advisory/Off suppressed, or client not yet wired.
     }
     if (source_id.empty()) {
       if (gateway_node) {
@@ -107,13 +122,14 @@ struct DetectorContext {
                          "graph_watchdog: dropping fault-clear '%s' with empty source_id (detector contract violation)",
                          code.c_str());
       }
-      return;
+      return false;
     }
     if (!fault_client->service_is_ready()) {
-      return;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
+      return false;  // fault_manager not reachable yet; avoid unbounded pending_requests_ growth.
     }
     fault_client->async_send_request(
         std::make_shared<ros2_medkit_msgs::srv::ReportFault::Request>(make_fault_clear(source_id, code)));
+    return true;
   }
 };
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/detector_config_keys.hpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <vector>
@@ -48,6 +50,50 @@ inline constexpr double kJumpThreshTickPeriods = 3.0;
 /// Smallest jump threshold that is safe at a given tick period.
 inline constexpr double min_jump_thresh_sec(int tick_interval_ms) {
   return kJumpThreshTickPeriods * static_cast<double>(tick_interval_ms) / 1000.0;
+}
+
+/// Floor for node_death's own `miss_grace`, in milliseconds of wall clock.
+///
+/// The entity cache a detector reads (ctx.snapshot) is not rebuilt every tick: it is
+/// rebuilt on a graph event debounced to about one refresh per second, so every tick
+/// between two refreshes sees the SAME snapshot. A tick-counted miss_grace therefore does
+/// not measure independent samples of the graph - it can re-count one stale cache
+/// generation as several misses - and that collapses silently the moment the tick period
+/// is shortened: at a 200ms tick, a miss_grace of 2 ticks is only 600ms of nominal grace,
+/// well under a single refresh cycle, so one omitted refresh alone can already cross it.
+/// 3000ms is one debounce cycle plus margin, chosen so the shipped default (miss_grace 2 at
+/// the 1000ms default tick) is unaffected and only a faster-than-default tick ever raises
+/// the effective grace.
+inline constexpr int kMinNodeDeathWindowMs = 3000;
+
+/// Ceiling node_death applies to BOTH `miss_grace` and `prune_grace` - ticks-before-
+/// something-happens knobs that, at the 1s default tick, already mean an hour of silence
+/// before either takes effect at 3600; a value past it is a typo or a unit mix-up, not a
+/// real operator choice. Shared (not detector-local) so graph_watchdog_plugin.cpp's own
+/// compute_departed_retention_ticks() - which has to predict node_death's eventual
+/// prune_ticks_ before that detector's own configure() has run - clamps to the IDENTICAL
+/// bound rather than risking a plugin-side window sized for a value the detector will
+/// itself reject.
+inline constexpr std::int64_t kMaxNodeDeathGraceTicks = 3600;
+
+/// Smallest `miss_grace` (in ticks) that keeps kMinNodeDeathWindowMs of wall clock,
+/// whatever `tick_interval_ms` is configured to. A death is reported once misses EXCEED
+/// miss_grace, i.e. after miss_grace + 1 ticks, so the ceiling divides the window by the
+/// tick period and subtracts the one tick that boundary already buys back.
+///
+/// Computed in int64_t throughout: `tick_interval_ms` is validated only against
+/// `> 0 && <= INT_MAX` (node_death_detector.cpp's own configure()), and at that documented-
+/// valid endpoint `kMinNodeDeathWindowMs + tick_interval_ms - 1` overflows a 32-bit int
+/// before the division ever runs - undefined behaviour at a value the config contract
+/// explicitly accepts. The final result is always small (it shrinks as tick_interval_ms
+/// grows), so narrowing it back to int at the end never loses anything.
+inline int min_node_death_miss_grace(int tick_interval_ms) {
+  if (tick_interval_ms <= 0) {
+    return 0;  // not a real cadence; nothing meaningful to floor against
+  }
+  const std::int64_t wide_tick = tick_interval_ms;
+  const std::int64_t window = static_cast<std::int64_t>(kMinNodeDeathWindowMs) + wide_tick - 1;
+  return static_cast<int>(std::max<std::int64_t>(0, window / wide_tick - 1));
 }
 
 /// Append one warning per key in `detector_cfg` that the detector does not read.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
@@ -92,6 +92,15 @@ class GraphWatchdogPlugin : public ros2_medkit_gateway::GatewayPlugin,
   /// clears the pending map as it reads it.
   std::size_t prune_pending_fault_requests_for_test();
 
+  /// Test-only: exposes the otherwise-private compute_departed_retention_ticks() so a unit
+  /// test can drive its config-validation directly (malformed/oversized miss_grace or
+  /// prune_grace) without constructing a full ROS gate/node - it has no ROS dependency of
+  /// its own, only tick_interval_ms_/prune_grace_ (set via configure()+load_parameters())
+  /// and the JSON it is handed.
+  int compute_departed_retention_ticks_for_test(const nlohmann::json & config_snapshot) const {
+    return compute_departed_retention_ticks(config_snapshot);
+  }
+
  private:
   void load_parameters();
   void run_tick_loop();  ///< Body of tick_thread_: tick() + interruptible wait, until shutdown.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/graph_watchdog_plugin.hpp
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 #include <utility>
@@ -171,6 +172,16 @@ class GraphWatchdogPlugin : public ros2_medkit_gateway::GatewayPlugin,
   std::mutex tick_mutex_;  ///< Serializes the get_routes() handler against shutdown()'s member teardown.
 
   std::vector<std::pair<std::unique_ptr<Detector>, DetectorMode>> detectors_;
+  /// The presence class's own tracked-key view, handed to every detector as
+  /// DetectorContext::presence_tracked. A COPY, not a pointer into the owning detector's live
+  /// set: that detector mutates its set inside its own tick(), so a pointer would show a reader
+  /// pre-update or post-update contents depending on where the reader sits in `detectors_`.
+  /// Refreshed at one defined point - the end of the sweep - so every detector in a tick sees
+  /// the same content and none depends on registry order. Empty while no detector both reports
+  /// departures and runs in a mode that emits; `presence_tracked_valid_` is what tells that
+  /// apart from a detector that genuinely tracks nothing. Touched only on the tick thread.
+  std::set<std::string> presence_tracked_;
+  bool presence_tracked_valid_ = false;
 
   std::atomic<uint64_t> tick_count_{0};
   std::atomic<bool> shutdown_requested_{false};  ///< stop signal for the tick loop; set by BOTH the

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
@@ -137,15 +137,19 @@ struct LifecycleMatch {
   std::string entry;  ///< the require_active entry that matched
   std::string fqn;    ///< the node's stable App::effective_fqn()
   std::optional<std::string> state;
-  /// Whether the reliability gate currently allows a fault to be raised for this node's
-  /// App::id - the same predicate node_death's presence detector requires before it will
-  /// ever track a key (NodeLivenessTracker: "a key becomes TRACKED the first time it is
-  /// armed, and stays tracked from then on"). Read off the gate by the caller, not
-  /// re-derived here: whether a MANAGED node counts as armed also depends on
-  /// LifecycleWatcher::node_ok(), which this header has no access to and must not
-  /// reimplement. Defaults true - the narrower of the two behaviours NodeState::ever_armed
-  /// then selects between - so a caller that does not wire this through keeps the
-  /// already-shipped absence handling rather than silently gaining a new reporting path.
+  /// Whether the presence detector will OWN this node's departure. Narrower than "may
+  /// raise": it needs the node's lifecycle state either known not to be a managed-non-active
+  /// one or asked for as often as it ever will be, so a managed node whose state has not
+  /// been read YET answers false here even though the gate would permit it to raise - and
+  /// answers true again once the watcher has stopped asking, since nothing else would report
+  /// that node at all. It also carries the caller's own online check, because node_death
+  /// skips an app that is not online before it consults the gate. Read off the gate and the
+  /// snapshot by the caller, not re-derived here: it composes warmup, the lifecycle watcher's
+  /// record and its re-seed budget, none of which this header has access to or may
+  /// reimplement. Defaults true - the narrower of the two behaviours
+  /// NodeState::ever_armed then selects between - so a caller that does not wire this
+  /// through keeps the already-shipped absence handling rather than silently gaining a new
+  /// reporting path.
   bool armed = true;
 };
 
@@ -327,17 +331,22 @@ struct LifecycleExpectationReport {
 ///   nor erased. Maturing it here would raise GRAPH_NODE_INACTIVE from ticks gathered while
 ///   the node could not be observed at all - evidence the operator's own graph never
 ///   witnessed - and the presence detector is ABLE to report this exact departure instead:
-///   node_death tracks any node the gate has armed at least once (NodeLivenessTracker's own
-///   "a key becomes TRACKED the first time it is armed"), so starting a NEW violation from
-///   a departure nobody here could watch is its job, not this one's. The entry keeps what
-///   it already earned, so a node that RETURNS still inactive resumes its streak rather
-///   than re-earning `grace` from zero.
+///   node_death tracks any node the gate has admitted for presence OWNERSHIP at least once
+///   (NodeLivenessTracker's own "a key becomes TRACKED the first time it is armed"), so
+///   starting a NEW violation from a departure nobody here could watch is its job, not this
+///   one's. The entry keeps what it already earned, so a node that RETURNS still inactive
+///   resumes its streak rather than re-earning `grace` from zero.
 /// - settled kInactive, NOT YET REPORTED, on a node that was NEVER armed: the streak keeps
 ///   climbing on absence exactly as it would on a present tick. The reasoning above
-///   inverts: node_death only ever tracks a node the gate has armed at least once, so one
-///   that never reached that bar - a `require_active` entry that comes up `unconfigured`
-///   and is killed before its own `grace` elapses is exactly this shape - is structurally
-///   invisible to the presence detector no matter what happens to it afterwards. Holding
+///   inverts: node_death only ever tracks a node the gate has admitted for presence
+///   ownership at least once, so one that never reached that bar is structurally invisible
+///   to the presence detector no matter what happens to it afterwards. Two shapes reach
+///   that bar and fail it: a `require_active` entry that comes up `unconfigured` and is
+///   killed before its own `grace` elapses, and a node that is not online, which node_death
+///   skips before it ever asks the gate. A managed node whose state is merely UNREAD is a
+///   third, and a temporary one: the gate withholds ownership while it is still asking, then
+///   grants it PROVISIONALLY once it stops - and that grant is not latched here, because the
+///   presence detector itself gives it up the moment a real label arrives. Holding
 ///   this streak too would mean nothing in the plugin ever reports the departure. This
 ///   keeps the same bound a still-climbing UNMEASURED clock already has regardless of
 ///   arming (see "Bounded by evidence, not by age" below): the streak matures within
@@ -402,18 +411,18 @@ struct LifecycleExpectationReport {
 /// ticks and is reported, which is also the longest GRAPH_NODE_UNREADABLE or
 /// GRAPH_NODE_NOT_MANAGED's clear can be withheld by one departed node.
 ///
-/// A VIOLATION streak on a node that was NEVER armed shares that same bound, for the same
-/// reason it advances at all while absent (see the kInactive case above): it matures within
-/// at most `grace` + `absence_grace` + 1 ticks, because nothing else will ever report that
-/// node's departure either. Only once a node HAS been armed does its below-grace streak
-/// lose the bound: absence then holds it rather than advancing it, so it neither matures
-/// nor becomes idle for as long as the node is away, however long that is. This is not a
-/// new way to withhold GRAPH_NODE_INACTIVE's clear - an aggregate, level-triggered fault
-/// already could not assert "every required node is healthy" while any one of them was
-/// unsettled, whether that unsettled node was HELD (`pending`) or climbing toward CONTENT
-/// (`affected`), so a node this indecisive already blocked the same clear before this
-/// design. What changes is only that GRAPH_NODE_INACTIVE never NAMES an ARMED node's
-/// departure: that node's evidence belongs to GRAPH_NODE_DISAPPEARED, not to an entry
+/// A VIOLATION streak on a node the presence detector was never able to own shares that same
+/// bound, for the same reason it advances at all while absent (see the kInactive case above):
+/// it matures within at most `grace` + `absence_grace` + 1 ticks, because nothing else will
+/// ever report that node's departure either. Only once a node HAS been owned does its
+/// below-grace streak lose the bound: absence then holds it rather than advancing it, so it
+/// neither matures nor becomes idle for as long as the node is away, however long that is.
+/// This is not a new way to withhold GRAPH_NODE_INACTIVE's clear - an aggregate,
+/// level-triggered fault already could not assert "every required node is healthy" while any
+/// one of them was unsettled, whether that unsettled node was HELD (`pending`) or climbing
+/// toward CONTENT (`affected`), so a node this indecisive already blocked the same clear
+/// before this design. What changes is only that GRAPH_NODE_INACTIVE never NAMES an OWNED
+/// node's departure: that node's evidence belongs to GRAPH_NODE_DISAPPEARED, not to an entry
 /// nobody here could measure.
 ///
 /// **A present node always wins a slot.** At the cap the order is: reclaim IDLE entries
@@ -539,9 +548,11 @@ class LifecycleExpectationTracker {
       NodeState & node = *tracked;
       node.absent_ticks = 0;
       node.entries = node_tick.entries;  // refreshed on every matched tick, held through a blink
-      // Sticky: once the gate has armed this node on any one tick, the presence detector
-      // could have picked up its departure from that tick onward, for the rest of this
-      // node's life - see NodeState::ever_armed.
+      // Sticky: once the gate has admitted this node for presence OWNERSHIP on any one tick,
+      // the presence detector could have picked up its departure from that tick onward, for
+      // the rest of this node's life - see NodeState::ever_armed. Latching the stricter fact
+      // is what lets a node that went active, deactivated and then died stay node_death's,
+      // while one whose state was never measured at all never becomes its.
       node.ever_armed = node.ever_armed || node_tick.armed;
 
       const LifecycleObservedState state = classify_observed_state(node_tick.state);
@@ -630,19 +641,21 @@ class LifecycleExpectationTracker {
             // `grace` regardless, see its own "frozen one past itself"), so this call only
             // documents that maturity, once earned, survives a departure. Second,
             // `!node.ever_armed`: who ELSE could ever report this node's departure. A node
-            // the presence detector could have tracked (armed at least once) needs no help
-            // from here even below grace: maturing it would raise GRAPH_NODE_INACTIVE from
-            // ticks gathered while nobody could observe the node, evidence the presence
-            // detector owns instead (node_death tracks any node the gate has armed at least
-            // once - NodeLivenessTracker's own "a key becomes TRACKED the first time it is
-            // armed") - so the streak is left untouched: neither advanced (no fault born
-            // from an absence the presence class will report anyway) nor erased (a node
-            // that RETURNS still inactive resumes from here rather than re-earning `grace`
-            // from zero). A node that was NEVER armed is structurally invisible to the
-            // presence detector no matter what happens to it afterwards, so nothing else in
-            // the plugin will ever report this departure either - absence keeps advancing
-            // the streak for it exactly as a present tick would, the same way it already
-            // does for a still-climbing unmeasured clock below.
+            // the presence detector could have tracked (admitted for ownership at least
+            // once) needs no help from here even below grace: maturing it would raise
+            // GRAPH_NODE_INACTIVE from ticks gathered while nobody could observe the node,
+            // evidence the presence detector owns instead (node_death tracks any node the
+            // gate has admitted for ownership at least once - NodeLivenessTracker's own "a
+            // key becomes TRACKED the first time it is armed") - so the streak is left
+            // untouched: neither advanced (no fault born from an absence the presence class
+            // will report anyway) nor erased (a node that RETURNS still inactive resumes
+            // from here rather than re-earning `grace` from zero). A node that was never
+            // admitted is structurally invisible to the presence detector no matter what
+            // happens to it afterwards - a managed node whose lifecycle state was never
+            // measured is one of them, since ownership needs the state positively known -
+            // so nothing else in the plugin will ever report this departure either: absence
+            // keeps advancing the streak for it exactly as a present tick would, the same
+            // way it already does for a still-climbing unmeasured clock below.
             if (is_content(node) || !node.ever_armed) {
               advance_violation_streak(node, fqn, crossed_violation);
             }
@@ -769,16 +782,16 @@ class LifecycleExpectationTracker {
     /// restart loop, the case this detector most exists to catch) would have its clock
     /// released on every absence and never mature.
     bool ever_measured = false;
-    /// Whether this node has been armed by the reliability gate on at least one matched
-    /// tick, ever. Sticky: once true it stays true, because the fact it stands in for -
-    /// "the presence detector could report this node's departure" - is itself sticky
-    /// (NodeLivenessTracker tracks a key from its first armed tick onward, regardless of
-    /// its arm state afterwards). Read here rather than re-derived from `settled_observed`
-    /// or the live label: this node's LIFECYCLE state alone cannot say whether it is
-    /// armed, since arming also needs warmup, which this class does not track - guessing
-    /// from state would either miss a warming-up node that later arms, or wrongly treat a
-    /// node this class never measured active as armed. See the absence loop's kInactive
-    /// case for the one place this decides anything.
+    /// Whether the reliability gate has admitted this node for presence OWNERSHIP on at
+    /// least one matched tick, ever. Sticky: once true it stays true, because the fact it
+    /// stands in for - "the presence detector could report this node's departure" - is
+    /// itself sticky (NodeLivenessTracker tracks a key from its first admitted tick onward,
+    /// regardless of its arm state afterwards). Read here rather than re-derived from
+    /// `settled_observed` or the live label: this node's LIFECYCLE state alone cannot say
+    /// whether the gate admitted it, since admission also needs warmup, which this class
+    /// does not track - guessing from state would either miss a warming-up node that later
+    /// arms, or wrongly treat a node this class never measured active as owned. See the
+    /// absence loop's kInactive case for the one place this decides anything.
     bool ever_armed = false;
     /// The label of the last kInactive observation, already trimmed to
     /// kMaxLifecycleLabelChars. Kept because the detail for a CONFIRMED violation names the
@@ -884,8 +897,9 @@ class LifecycleExpectationTracker {
   /// has already matured (past `grace`): for a node the presence detector could also have
   /// reported (`ever_armed`), absence does not keep advancing a streak that has not yet
   /// matured (see the kInactive case in update()'s absence loop), so counting one that had
-  /// not crossed `grace` would fabricate a violation the node never earned. A NEVER-armed
-  /// node's below-grace streak is the one case where that is not true - absence keeps
+  /// not crossed `grace` would fabricate a violation the node never earned. The below-grace
+  /// streak of a node the presence detector could never own is the one case where that is
+  /// not true - absence keeps
   /// advancing it too, so left alone it would eventually mature the same way a climbing
   /// unmeasured clock does - but this tally still leaves it uncounted rather than folding
   /// it in: reaching this function with one still below `grace` needs `tracked_node_cap`

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
@@ -137,20 +137,6 @@ struct LifecycleMatch {
   std::string entry;  ///< the require_active entry that matched
   std::string fqn;    ///< the node's stable App::effective_fqn()
   std::optional<std::string> state;
-  /// Whether the presence detector will OWN this node's departure. Narrower than "may
-  /// raise": it needs the node's lifecycle state either known not to be a managed-non-active
-  /// one or asked for as often as it ever will be, so a managed node whose state has not
-  /// been read YET answers false here even though the gate would permit it to raise - and
-  /// answers true again once the watcher has stopped asking, since nothing else would report
-  /// that node at all. It also carries the caller's own online check, because node_death
-  /// skips an app that is not online before it consults the gate. Read off the gate and the
-  /// snapshot by the caller, not re-derived here: it composes warmup, the lifecycle watcher's
-  /// record and its re-seed budget, none of which this header has access to or may
-  /// reimplement. Defaults true - the narrower of the two behaviours
-  /// NodeState::ever_armed then selects between - so a caller that does not wire this
-  /// through keeps the already-shipped absence handling rather than silently gaining a new
-  /// reporting path.
-  bool armed = true;
 };
 
 /// The one observed fact this whole state machine runs on: what a MATCHED node's read
@@ -227,7 +213,13 @@ struct LifecycleExpectationReport {
   /// decision itself, which is `!pending.empty()`. A node can appear in more than one
   /// (e.g. a held violation streak while ALSO climbing the unmeasured clock), so these are
   /// not a partition and must not be summed against `pending.size()`.
-  std::set<std::string> pending_violation;    ///< below-grace violation streak
+  std::set<std::string> pending_violation;  ///< below-grace violation streak
+  /// The subset of `pending_violation` whose nodes have LEFT the graph (absence past the blink
+  /// tolerance). Split out for the withheld-clear log line only: the release conditions a
+  /// present node's hold has - reading active, or the streak crossing grace - are both
+  /// unreachable for a departed one, whose streak absence HOLDS rather than advances, so
+  /// telling an operator to wait for either would point at something that cannot happen.
+  std::set<std::string> pending_violation_departed;
   std::set<std::string> pending_unreadable;   ///< unmeasured clock climbing, cause kUnreadable
   std::set<std::string> pending_not_managed;  ///< unmeasured clock climbing, cause kNotManaged
 
@@ -326,17 +318,14 @@ struct LifecycleExpectationReport {
 ///   still naming a node that is no longer there. That is the honest reading of the
 ///   expectation the operator wrote: the node must be ACTIVE, it was not and was already
 ///   said so, and now it is gone too.
-/// - settled kInactive, NOT YET REPORTED (streak at or below `grace`), on a node that WAS
-///   ARMED at some point (`NodeState::ever_armed`): the streak is HELD, neither advanced
-///   nor erased. Maturing it here would raise GRAPH_NODE_INACTIVE from ticks gathered while
-///   the node could not be observed at all - evidence the operator's own graph never
-///   witnessed - and the presence detector is ABLE to report this exact departure instead:
-///   node_death tracks any node the gate has admitted for presence OWNERSHIP at least once
-///   (NodeLivenessTracker's own "a key becomes TRACKED the first time it is armed"), so
-///   starting a NEW violation from a departure nobody here could watch is its job, not this
-///   one's. The entry keeps what it already earned, so a node that RETURNS still inactive
-///   resumes its streak rather than re-earning `grace` from zero.
-/// - settled kInactive, NOT YET REPORTED, on a node that was NEVER armed: the streak keeps
+/// - settled kInactive, NOT YET REPORTED (streak at or below `grace`), on a node the presence
+///   detector is CURRENTLY tracking (its fqn is in the `presence_owned` set update() is given
+///   this tick): the streak is HELD, neither advanced nor erased. Maturing it here would raise
+///   GRAPH_NODE_INACTIVE from ticks gathered while the node could not be observed at all -
+///   evidence the operator's own graph never witnessed - and that detector is ABLE to report
+///   this exact departure instead. The entry keeps what it already earned, so a node that
+///   RETURNS still inactive resumes its streak rather than re-earning `grace` from zero.
+/// - settled kInactive, NOT YET REPORTED, on a node nobody is tracking: the streak keeps
 ///   climbing on absence exactly as it would on a present tick. The reasoning above
 ///   inverts: node_death only ever tracks a node the gate has admitted for presence
 ///   ownership at least once, so one that never reached that bar is structurally invisible
@@ -494,15 +483,24 @@ class LifecycleExpectationTracker {
     return nodes_.size();
   }
 
-  LifecycleExpectationReport update(const std::vector<LifecycleMatch> & matches) {
+  /// `presence_owned`, when given, is the presence detector's CURRENT set of tracked departure
+  /// keys (fqns), as published by the plugin for this tick. It is consulted, never latched: the
+  /// stickiness this class used to keep for itself lives in that detector's own tracker, which
+  /// keeps a key from its first admitted tick onward, and a second copy here could only ever
+  /// disagree with it. Null (or absent) means nobody has claimed anything, which selects the
+  /// path that keeps reporting - see the kInactive case in the absence loop.
+  LifecycleExpectationReport update(const std::vector<LifecycleMatch> & matches,
+                                    const std::set<std::string> * presence_owned = nullptr) {
     LifecycleExpectationReport report;
+    const auto presence_owns = [presence_owned](const std::string & fqn) {
+      return presence_owned != nullptr && presence_owned->count(fqn) > 0;
+    };
 
     // Collapse the per-(entry, node) matches to one record per NODE before any clock
     // moves - see "Keyed by node, not by config entry" above.
     struct NodeTick {
       std::vector<std::string> entries;  ///< every entry that named this node, in match order
       std::optional<std::string> state;  ///< the label enforced for it this tick
-      bool armed = false;                ///< whether the gate allowed a raise for this node on THIS tick
     };
     std::set<std::string> matched_entries;
     std::map<std::string, NodeTick> nodes;
@@ -522,11 +520,6 @@ class LifecycleExpectationTracker {
           observed_rank(classify_observed_state(match.state)) > observed_rank(classify_observed_state(node.state))) {
         node.state = match.state;
       }
-      // Same app.id, same tick, so every duplicate match necessarily carries the same
-      // arming fact in practice - OR rather than overwrite only so a future caller that
-      // ever legitimately disagrees cannot make this node look LESS armed than any one
-      // match already said it was.
-      node.armed = node.armed || match.armed;
     }
 
     // Clocks that cross their bound on THIS tick. Collected here rather than pushed
@@ -548,13 +541,6 @@ class LifecycleExpectationTracker {
       NodeState & node = *tracked;
       node.absent_ticks = 0;
       node.entries = node_tick.entries;  // refreshed on every matched tick, held through a blink
-      // Sticky: once the gate has admitted this node for presence OWNERSHIP on any one tick,
-      // the presence detector could have picked up its departure from that tick onward, for
-      // the rest of this node's life - see NodeState::ever_armed. Latching the stricter fact
-      // is what lets a node that went active, deactivated and then died stay node_death's,
-      // while one whose state was never measured at all never becomes its.
-      node.ever_armed = node.ever_armed || node_tick.armed;
-
       const LifecycleObservedState state = classify_observed_state(node_tick.state);
       switch (state) {
         case LifecycleObservedState::kActive:
@@ -640,23 +626,23 @@ class LifecycleExpectationTracker {
             // it exactly like any other tick would (advance_violation_streak() no-ops past
             // `grace` regardless, see its own "frozen one past itself"), so this call only
             // documents that maturity, once earned, survives a departure. Second,
-            // `!node.ever_armed`: who ELSE could ever report this node's departure. A node
-            // the presence detector could have tracked (admitted for ownership at least
-            // once) needs no help from here even below grace: maturing it would raise
+            // `!presence_owns(fqn)`: who ELSE could report this node's departure, asked
+            // fresh every tick rather than remembered. A node the presence detector is
+            // tracking RIGHT NOW needs no help from here even below grace: maturing it
+            // would raise
             // GRAPH_NODE_INACTIVE from ticks gathered while nobody could observe the node,
-            // evidence the presence detector owns instead (node_death tracks any node the
-            // gate has admitted for ownership at least once - NodeLivenessTracker's own "a
-            // key becomes TRACKED the first time it is armed") - so the streak is left
+            // evidence the presence detector owns instead - so the streak is left
             // untouched: neither advanced (no fault born from an absence the presence class
             // will report anyway) nor erased (a node that RETURNS still inactive resumes
-            // from here rather than re-earning `grace` from zero). A node that was never
-            // admitted is structurally invisible to the presence detector no matter what
-            // happens to it afterwards - a managed node whose lifecycle state was never
-            // measured is one of them, since ownership needs the state positively known -
-            // so nothing else in the plugin will ever report this departure either: absence
-            // keeps advancing the streak for it exactly as a present tick would, the same
-            // way it already does for a still-climbing unmeasured clock below.
-            if (is_content(node) || !node.ever_armed) {
+            // from here rather than re-earning `grace` from zero). Membership is READ, never
+            // latched, and that is the whole point: a key the presence detector has given
+            // back (a provisional admission its label later disowned), reclaimed (a durably
+            // suppressed death it will file nothing for) or collapsed under its cap is no
+            // longer owned by anybody, and a latch cannot represent any of those - it would
+            // hold the streak for a departure nothing is going to report. When nobody owns
+            // the key, absence keeps advancing the streak exactly as a present tick would,
+            // the same way it already does for a still-climbing unmeasured clock below.
+            if (is_content(node) || !presence_owns(fqn)) {
               advance_violation_streak(node, fqn, crossed_violation);
             }
             break;
@@ -714,6 +700,9 @@ class LifecycleExpectationTracker {
       if (node.violation_streak > 0 && report.affected.count(fqn) == 0) {
         report.pending.insert(fqn);
         report.pending_violation.insert(fqn);
+        if (departed) {
+          report.pending_violation_departed.insert(fqn);
+        }
       }
       if (node.unmeasured_clock > 0) {
         report.pending.insert(fqn);
@@ -782,17 +771,6 @@ class LifecycleExpectationTracker {
     /// restart loop, the case this detector most exists to catch) would have its clock
     /// released on every absence and never mature.
     bool ever_measured = false;
-    /// Whether the reliability gate has admitted this node for presence OWNERSHIP on at
-    /// least one matched tick, ever. Sticky: once true it stays true, because the fact it
-    /// stands in for - "the presence detector could report this node's departure" - is
-    /// itself sticky (NodeLivenessTracker tracks a key from its first admitted tick onward,
-    /// regardless of its arm state afterwards). Read here rather than re-derived from
-    /// `settled_observed` or the live label: this node's LIFECYCLE state alone cannot say
-    /// whether the gate admitted it, since admission also needs warmup, which this class
-    /// does not track - guessing from state would either miss a warming-up node that later
-    /// arms, or wrongly treat a node this class never measured active as owned. See the
-    /// absence loop's kInactive case for the one place this decides anything.
-    bool ever_armed = false;
     /// The label of the last kInactive observation, already trimmed to
     /// kMaxLifecycleLabelChars. Kept because the detail for a CONFIRMED violation names the
     /// state the node is stuck in, and absence carries no label of its own to name. Cleared
@@ -894,11 +872,11 @@ class LifecycleExpectationTracker {
   /// absence advances it every tick and nothing can reset it any more, so it would have
   /// matured under that cause within a bounded number of ticks anyway, and dropping it
   /// instead would let freeing a slot heal a fault. A violation streak counts only once it
-  /// has already matured (past `grace`): for a node the presence detector could also have
-  /// reported (`ever_armed`), absence does not keep advancing a streak that has not yet
+  /// has already matured (past `grace`): for a node the presence detector is tracking,
+  /// absence does not keep advancing a streak that has not yet
   /// matured (see the kInactive case in update()'s absence loop), so counting one that had
   /// not crossed `grace` would fabricate a violation the node never earned. The below-grace
-  /// streak of a node the presence detector could never own is the one case where that is
+  /// streak of a node nobody is tracking is the one case where that is
   /// not true - absence keeps
   /// advancing it too, so left alone it would eventually mature the same way a climbing
   /// unmeasured clock does - but this tally still leaves it uncounted rather than folding

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
@@ -35,9 +35,14 @@ inline constexpr int kDefaultNoMatchWarnTicks = 10;
 /// clocks start moving again. Inside this budget a node's whole state is simply HELD:
 /// zeroing it on the first blink would mean a node dropping out of one snapshot in every
 /// few never accumulates enough consecutive present ticks on either clock below to be
-/// reported at all. PAST this budget absence CONTINUES whatever the node's last real
-/// observation had started - it never restarts a clock and never discards one. See
-/// "Absence continues, it never erases" in LifecycleExpectationTracker's class doc.
+/// reported at all. PAST this budget absence still never DISCARDS a clock, but it may no
+/// longer be the one thing MOVING it either: an already-matured fault CONTINUES exactly as
+/// it did on its last present tick, while a violation streak that has not yet matured is
+/// simply held at whatever it already reached, for a node the presence detector could also
+/// have reported - only a present tick can still advance it there. A node the presence
+/// detector could structurally never report gets no such backstop: absence keeps advancing
+/// its streak too, exactly like a still-climbing unmeasured clock does. See "Absence
+/// continues, it never erases" in LifecycleExpectationTracker's class doc.
 inline constexpr int kDefaultAbsenceGrace = 3;
 
 /// Default bound on how many nodes this tracker keeps state for at once - the operator's
@@ -132,6 +137,16 @@ struct LifecycleMatch {
   std::string entry;  ///< the require_active entry that matched
   std::string fqn;    ///< the node's stable App::effective_fqn()
   std::optional<std::string> state;
+  /// Whether the reliability gate currently allows a fault to be raised for this node's
+  /// App::id - the same predicate node_death's presence detector requires before it will
+  /// ever track a key (NodeLivenessTracker: "a key becomes TRACKED the first time it is
+  /// armed, and stays tracked from then on"). Read off the gate by the caller, not
+  /// re-derived here: whether a MANAGED node counts as armed also depends on
+  /// LifecycleWatcher::node_ok(), which this header has no access to and must not
+  /// reimplement. Defaults true - the narrower of the two behaviours NodeState::ever_armed
+  /// then selects between - so a caller that does not wire this through keeps the
+  /// already-shipped absence handling rather than silently gaining a new reporting path.
+  bool armed = true;
 };
 
 /// The one observed fact this whole state machine runs on: what a MATCHED node's read
@@ -300,23 +315,47 @@ struct LifecycleExpectationReport {
 /// be measured at all. PAST `absence_grace` absence advances whichever clock the node's
 /// `NodeState::settled_observed` says it was on, and resets nothing:
 ///
-/// - settled kInactive: the violation streak keeps climbing, so a node measured not-active
-///   that then vanishes eventually raises GRAPH_NODE_INACTIVE about a node that is no
-///   longer there. That is the honest reading of the expectation the operator wrote: the
-///   node must be ACTIVE, it was not, and now it is gone. Any UNCORROBORATED unmeasured
-///   spell it had also started is dropped here rather than held: nothing is left to read,
-///   and a clock that can never mature would keep the entry non-idle - and therefore
-///   `pending` - for the life of the process.
+/// - settled kInactive, ALREADY REPORTED under GRAPH_NODE_INACTIVE (its streak past
+///   `grace`): the streak continues exactly as it did on its last present tick - frozen at
+///   `grace` + 1 either way, see advance_violation_streak's own "frozen one past itself" -
+///   so a node measured not-active and confirmed that then vanishes keeps its fault raised,
+///   still naming a node that is no longer there. That is the honest reading of the
+///   expectation the operator wrote: the node must be ACTIVE, it was not and was already
+///   said so, and now it is gone too.
+/// - settled kInactive, NOT YET REPORTED (streak at or below `grace`), on a node that WAS
+///   ARMED at some point (`NodeState::ever_armed`): the streak is HELD, neither advanced
+///   nor erased. Maturing it here would raise GRAPH_NODE_INACTIVE from ticks gathered while
+///   the node could not be observed at all - evidence the operator's own graph never
+///   witnessed - and the presence detector is ABLE to report this exact departure instead:
+///   node_death tracks any node the gate has armed at least once (NodeLivenessTracker's own
+///   "a key becomes TRACKED the first time it is armed"), so starting a NEW violation from
+///   a departure nobody here could watch is its job, not this one's. The entry keeps what
+///   it already earned, so a node that RETURNS still inactive resumes its streak rather
+///   than re-earning `grace` from zero.
+/// - settled kInactive, NOT YET REPORTED, on a node that was NEVER armed: the streak keeps
+///   climbing on absence exactly as it would on a present tick. The reasoning above
+///   inverts: node_death only ever tracks a node the gate has armed at least once, so one
+///   that never reached that bar - a `require_active` entry that comes up `unconfigured`
+///   and is killed before its own `grace` elapses is exactly this shape - is structurally
+///   invisible to the presence detector no matter what happens to it afterwards. Holding
+///   this streak too would mean nothing in the plugin ever reports the departure. This
+///   keeps the same bound a still-climbing UNMEASURED clock already has regardless of
+///   arming (see "Bounded by evidence, not by age" below): the streak matures within
+///   `grace` + `absence_grace` + 1 ticks, never staying unsettled forever the way an ARMED
+///   node's below-grace streak may.
+///
+///   Either way, any UNCORROBORATED unmeasured spell the node had also started is dropped
+///   here rather than held: nothing is left to read, and a clock that can never mature
+///   would keep the entry non-idle - and therefore `pending` - for the life of the process.
 /// - settled kUnreadable or kNotManaged: the unmeasured clock keeps climbing, under the
 ///   cause that observation set - absence carries no label, so it cannot change one.
 /// - settled kActive: nothing advances, and anything the node had started but not
 ///   corroborated is released, so the entry becomes idle and is reclaimed silently. An
 ///   entry that is already CONTENT (a matured unmeasured clock, or a streak past `grace`)
 ///   is never released - a departure heals nothing. Starting a NEW violation from a healthy
-///   departure is the presence class's job (GRAPH_NODE_DISAPPEARED), which still has no
-///   detector in this package and is still out of scope - the single remaining gap here,
-///   and a far narrower one than "a node absent past the grace is invisible whichever clock
-///   it was on".
+///   departure is the presence class's job (GRAPH_NODE_DISAPPEARED, this package's own
+///   node_death detector), not this class's - a far narrower boundary than "a node absent
+///   past the grace is invisible whichever clock it was on".
 ///
 /// **What "settled" means, and the alternatives rejected for it.** A real measurement
 /// (kActive or kInactive) settles IMMEDIATELY: a lifecycle label is a fact about the node,
@@ -350,17 +389,32 @@ struct LifecycleExpectationReport {
 /// ABSENT x N)` forever and never accumulate enough of anything to be reported, which is
 /// precisely the node this detector most exists to catch.
 ///
-/// **Bounded by evidence, not by age.** Since absence no longer erases anything, an entry
-/// carrying a live clock is never reclaimed by age either - the two are the same defect
-/// seen twice, and moving the horizon rather than removing it would leave the evasion in
-/// place at a different N. `prune_ticks` therefore reclaims only IDLE entries (both clocks
-/// zero, no matured ownership), which carry nothing to lose. What bounds the map instead is
-/// `tracked_node_cap`. A non-idle entry cannot grow without bound in time either way: past
-/// `absence_grace` its clock advances every tick, so it matures within at most
-/// `grace` + `absence_grace` + 1 ticks (violation) or `unmeasured_hold_ticks` +
-/// `absence_grace` + 1 (unmeasured) and is reported. Both bounds are why the detector caps
-/// the `grace` it accepts: they are also the longest GRAPH_NODE_INACTIVE's clear can be
-/// withheld by one departed node.
+/// **Bounded by evidence, not by age.** Since absence no longer erases anything a MATURED
+/// entry carries, that entry is never reclaimed by age - a departure must not heal what it
+/// cannot un-happen. `prune_ticks` therefore reclaims only IDLE entries (both clocks zero,
+/// no matured ownership, no live-but-unmatured streak), which carry nothing to lose. What
+/// bounds the map's SIZE instead is `tracked_node_cap`.
+///
+/// A node whose UNMEASURED clock is still climbing keeps the bound this class shipped with:
+/// past `absence_grace` it advances every tick regardless of maturity - unlike the violation
+/// streak above, this clock's own absence behaviour did not change, see the two unmeasured
+/// causes above - so it matures within at most `unmeasured_hold_ticks` + `absence_grace` + 1
+/// ticks and is reported, which is also the longest GRAPH_NODE_UNREADABLE or
+/// GRAPH_NODE_NOT_MANAGED's clear can be withheld by one departed node.
+///
+/// A VIOLATION streak on a node that was NEVER armed shares that same bound, for the same
+/// reason it advances at all while absent (see the kInactive case above): it matures within
+/// at most `grace` + `absence_grace` + 1 ticks, because nothing else will ever report that
+/// node's departure either. Only once a node HAS been armed does its below-grace streak
+/// lose the bound: absence then holds it rather than advancing it, so it neither matures
+/// nor becomes idle for as long as the node is away, however long that is. This is not a
+/// new way to withhold GRAPH_NODE_INACTIVE's clear - an aggregate, level-triggered fault
+/// already could not assert "every required node is healthy" while any one of them was
+/// unsettled, whether that unsettled node was HELD (`pending`) or climbing toward CONTENT
+/// (`affected`), so a node this indecisive already blocked the same clear before this
+/// design. What changes is only that GRAPH_NODE_INACTIVE never NAMES an ARMED node's
+/// departure: that node's evidence belongs to GRAPH_NODE_DISAPPEARED, not to an entry
+/// nobody here could measure.
 ///
 /// **A present node always wins a slot.** At the cap the order is: reclaim IDLE entries
 /// (they carry nothing); then collapse DEPARTED entries - lexicographically last first,
@@ -439,6 +493,7 @@ class LifecycleExpectationTracker {
     struct NodeTick {
       std::vector<std::string> entries;  ///< every entry that named this node, in match order
       std::optional<std::string> state;  ///< the label enforced for it this tick
+      bool armed = false;                ///< whether the gate allowed a raise for this node on THIS tick
     };
     std::set<std::string> matched_entries;
     std::map<std::string, NodeTick> nodes;
@@ -458,6 +513,11 @@ class LifecycleExpectationTracker {
           observed_rank(classify_observed_state(match.state)) > observed_rank(classify_observed_state(node.state))) {
         node.state = match.state;
       }
+      // Same app.id, same tick, so every duplicate match necessarily carries the same
+      // arming fact in practice - OR rather than overwrite only so a future caller that
+      // ever legitimately disagrees cannot make this node look LESS armed than any one
+      // match already said it was.
+      node.armed = node.armed || match.armed;
     }
 
     // Clocks that cross their bound on THIS tick. Collected here rather than pushed
@@ -479,6 +539,10 @@ class LifecycleExpectationTracker {
       NodeState & node = *tracked;
       node.absent_ticks = 0;
       node.entries = node_tick.entries;  // refreshed on every matched tick, held through a blink
+      // Sticky: once the gate has armed this node on any one tick, the presence detector
+      // could have picked up its departure from that tick onward, for the rest of this
+      // node's life - see NodeState::ever_armed.
+      node.ever_armed = node.ever_armed || node_tick.armed;
 
       const LifecycleObservedState state = classify_observed_state(node_tick.state);
       switch (state) {
@@ -532,12 +596,16 @@ class LifecycleExpectationTracker {
     }
 
     // Absence loop: every tracked node NOT matched this tick. Inside absence_grace_
-    // everything is HELD unchanged (a blink). Past it, absence CONTINUES whichever clock
-    // the node's last REAL observation had started, and resets nothing - see "Absence
-    // continues, it never erases" in the class doc. A node last measured kActive continues
-    // nothing: a healthy node shutting down is GRAPH_NODE_DISAPPEARED's business, which
-    // still has no detector in this package and stays out of scope. Only IDLE bookkeeping
-    // is reclaimed by age, because only an idle entry has nothing to lose.
+    // everything is HELD unchanged (a blink). Past it, absence resets nothing but no longer
+    // advances everything either - see "Absence continues, it never erases" in the class
+    // doc. A node last measured kInactive continues an ALREADY-matured violation exactly as
+    // it was, but a below-grace one is simply held, never matured on the strength of absence
+    // alone. A node last measured kUnreadable/kNotManaged keeps climbing its unmeasured
+    // clock regardless of maturity - that clock's own absence behaviour did not change. A node
+    // last measured kActive continues nothing: a healthy node shutting down is
+    // GRAPH_NODE_DISAPPEARED's business, which this package's node_death detector now
+    // covers. Only IDLE bookkeeping is reclaimed by age, because only an idle entry has
+    // nothing to lose.
     for (auto it = nodes_.begin(); it != nodes_.end();) {
       const std::string & fqn = it->first;
       NodeState & node = it->second;
@@ -555,7 +623,29 @@ class LifecycleExpectationTracker {
             // the node: there is nothing left to read, and a clock that can never mature
             // would keep this entry non-idle - and therefore `pending` - forever.
             node.unmeasured_clock = 0;
-            advance_violation_streak(node, fqn, crossed_violation);
+            // Two independent questions decide whether this tick may advance the streak.
+            // First, is_content(node): "has this node's violation already been reported",
+            // not "how many ticks has it accumulated" - already reported, absence continues
+            // it exactly like any other tick would (advance_violation_streak() no-ops past
+            // `grace` regardless, see its own "frozen one past itself"), so this call only
+            // documents that maturity, once earned, survives a departure. Second,
+            // `!node.ever_armed`: who ELSE could ever report this node's departure. A node
+            // the presence detector could have tracked (armed at least once) needs no help
+            // from here even below grace: maturing it would raise GRAPH_NODE_INACTIVE from
+            // ticks gathered while nobody could observe the node, evidence the presence
+            // detector owns instead (node_death tracks any node the gate has armed at least
+            // once - NodeLivenessTracker's own "a key becomes TRACKED the first time it is
+            // armed") - so the streak is left untouched: neither advanced (no fault born
+            // from an absence the presence class will report anyway) nor erased (a node
+            // that RETURNS still inactive resumes from here rather than re-earning `grace`
+            // from zero). A node that was NEVER armed is structurally invisible to the
+            // presence detector no matter what happens to it afterwards, so nothing else in
+            // the plugin will ever report this departure either - absence keeps advancing
+            // the streak for it exactly as a present tick would, the same way it already
+            // does for a still-climbing unmeasured clock below.
+            if (is_content(node) || !node.ever_armed) {
+              advance_violation_streak(node, fqn, crossed_violation);
+            }
             break;
           case LifecycleObservedState::kUnreadable:
           case LifecycleObservedState::kNotManaged:
@@ -679,6 +769,17 @@ class LifecycleExpectationTracker {
     /// restart loop, the case this detector most exists to catch) would have its clock
     /// released on every absence and never mature.
     bool ever_measured = false;
+    /// Whether this node has been armed by the reliability gate on at least one matched
+    /// tick, ever. Sticky: once true it stays true, because the fact it stands in for -
+    /// "the presence detector could report this node's departure" - is itself sticky
+    /// (NodeLivenessTracker tracks a key from its first armed tick onward, regardless of
+    /// its arm state afterwards). Read here rather than re-derived from `settled_observed`
+    /// or the live label: this node's LIFECYCLE state alone cannot say whether it is
+    /// armed, since arming also needs warmup, which this class does not track - guessing
+    /// from state would either miss a warming-up node that later arms, or wrongly treat a
+    /// node this class never measured active as armed. See the absence loop's kInactive
+    /// case for the one place this decides anything.
+    bool ever_armed = false;
     /// The label of the last kInactive observation, already trimmed to
     /// kMaxLifecycleLabelChars. Kept because the detail for a CONFIRMED violation names the
     /// state the node is stuck in, and absence carries no label of its own to name. Cleared
@@ -779,8 +880,19 @@ class LifecycleExpectationTracker {
   /// unmeasured clock STILL CLIMBING counts under its cause rather than being dropped:
   /// absence advances it every tick and nothing can reset it any more, so it would have
   /// matured under that cause within a bounded number of ticks anyway, and dropping it
-  /// instead would let freeing a slot heal a fault. An idle entry contributes nothing -
-  /// idle entries are reclaimed before this ever runs.
+  /// instead would let freeing a slot heal a fault. A violation streak counts only once it
+  /// has already matured (past `grace`): for a node the presence detector could also have
+  /// reported (`ever_armed`), absence does not keep advancing a streak that has not yet
+  /// matured (see the kInactive case in update()'s absence loop), so counting one that had
+  /// not crossed `grace` would fabricate a violation the node never earned. A NEVER-armed
+  /// node's below-grace streak is the one case where that is not true - absence keeps
+  /// advancing it too, so left alone it would eventually mature the same way a climbing
+  /// unmeasured clock does - but this tally still leaves it uncounted rather than folding
+  /// it in: reaching this function with one still below `grace` needs `tracked_node_cap`
+  /// genuinely saturated by departed identities, and losing that one entry's evidence is
+  /// the safer direction to be incomplete in than risking a wrong count for every OTHER
+  /// entry this function has to keep classifying correctly. An idle entry, or a
+  /// live-but-unmatured streak, contributes nothing.
   void count_collapsed(const NodeState & node) {
     if (node.unmeasured_matured || node.unmeasured_clock > 0) {
       if (node.cause == LifecycleUnmeasuredCause::kUnreadable) {
@@ -788,7 +900,7 @@ class LifecycleExpectationTracker {
       } else {
         ++collapsed_not_managed_;
       }
-    } else if (node.violation_streak > 0) {
+    } else if (node.violation_streak > grace_) {
       ++collapsed_inactive_;
     }
   }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_shutdown_suppressor.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_shutdown_suppressor.hpp
@@ -1,0 +1,77 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <string>
+
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"  // DepartedLifecycle
+#include "ros2_medkit_graph_watchdog/suppressor.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+/// Self-suppression: a managed lifecycle node that reached a clean shutdown before it left
+/// the graph was stopped on purpose, so node_death must not report its departure. Reads
+/// `ReliabilityGate::departed_lifecycle_state_of(fqn)` - the seam that header documents for
+/// exactly this - rather than owning any state of its own.
+///
+/// A departure counts as clean only for two labels, and one of them still needs corroborating
+/// evidence:
+///   - `shuttingdown`: only reachable via a deliberate SHUTDOWN transition, so the label alone
+///     is enough.
+///   - `finalized`: NOT enough on its own. It is also where a node's on_error override lands
+///     after ON_ERROR_FAILURE/ON_ERROR_ERROR out of `errorprocessing` - the standard way a
+///     driver reports a hardware fault it cannot recover from, which is precisely the death
+///     an operator needs reported, not silenced. So `finalized` only counts when the watcher
+///     actually saw a transition into it (`saw_transition`) and never saw it pass through the
+///     error branch (`!error_terminated`). Without an observed transition history the
+///     departure is unclassified and stays reported.
+///
+/// `unconfigured` is deliberately excluded: it is also the resting state of a node whose
+/// configure() failed or that never activated at all, and suppressing on it would hide exactly
+/// that startup failure.
+///
+/// Stateless by design: a detector's own `configure()` (where the suppressor chain is built)
+/// runs before any DetectorContext exists, so this class stores nothing at construction and
+/// reads the gate fresh on every call instead.
+class LifecycleShutdownSuppressor : public Suppressor {
+ public:
+  bool suppresses(const std::string & fqn, const DetectorContext & ctx) const override {
+    if (ctx.gate == nullptr) {
+      return false;  // not yet wired (e.g. a bare-context test) -> nothing to read, abstain
+    }
+    const auto departed = ctx.gate->departed_lifecycle_state_of(fqn);
+    if (!departed.has_value()) {
+      return false;  // never departed within retention, or this fqn was never lifecycle-tracked
+    }
+    if (departed->label == "shuttingdown") {
+      return true;
+    }
+    if (departed->label == "finalized") {
+      return departed->saw_transition && !departed->error_terminated;
+    }
+    return false;
+  }
+
+  /// A departure's shutdown shape does not change after the fact - once a fqn's last
+  /// observed transition qualifies as clean, it stays clean for as long as the gate's
+  /// retention window remembers it at all. Reclaiming a suppressed key's tracker
+  /// bookkeeping is therefore sound PROVIDED that window outlives node_death's own reclaim
+  /// tick, which is what GraphWatchdogPlugin::compute_departed_retention_ticks() sizes it
+  /// for.
+  bool durable() const override {
+    return true;
+  }
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
@@ -64,10 +64,18 @@ struct DepartedLifecycle {
 /// Concretely, `update()` and `pump_events()` MUST be called from one and the same thread
 /// (the plugin's tick thread), and `reset()`/the destructor MUST NOT run while either is
 /// in flight (the plugin joins its tick thread before tearing the gate down). The const
-/// readers - node_ok(), state_of(), departed_state_of() - are the only members safe to
-/// call from another thread; they take the shared-state mutex and touch no ROS entity.
+/// readers - node_ok(), state_of(), measurement_pending(), departed_state_of() - are the
+/// only members safe to call from another thread; they take the shared-state mutex and
+/// touch no ROS entity.
 class LifecycleWatcher {
  public:
+  /// How many extra GetState re-seeds a tracked-but-non-active node gets to self-heal a
+  /// missed activation. Two ticks of coverage comfortably outlast the tens-of-ms DDS
+  /// endpoint-matching window; after that a matched subscription catches every transition.
+  /// Public because it is also the bound on how long an unmeasured node's ignorance can
+  /// still resolve - see measurement_pending().
+  static constexpr int kReseedAttempts = 2;
+
   LifecycleWatcher(rclcpp::Node * gateway_node, std::mutex * node_mutex,
                    int departed_retention_ticks = kDefaultDepartedRetentionTicks);
   ~LifecycleWatcher();
@@ -95,6 +103,19 @@ class LifecycleWatcher {
 
   bool node_ok(const std::string & app_id) const;  // true if untracked or "active"
   std::optional<std::string> state_of(const std::string & app_id) const;
+  /// True while `app_id` is a tracked managed node whose state is not measured YET and
+  /// still can be: the label is empty and the GetState self-heal budget has attempts left.
+  ///
+  /// This is what separates transient ignorance from settled ignorance, and the two must
+  /// not be treated alike. `reseeds_remaining` is charged only for a read that actually
+  /// ran (see update()), so it answers "have we finished asking" rather than "how many
+  /// ticks have passed". False for an untracked node, false for one carrying a real label,
+  /// and false once the budget is spent: at that point nothing in this class will ever
+  /// issue another GetState for it, so the label can only still change through a
+  /// ~/transition_event the node may never publish. A caller deciding who OWNS such a
+  /// node's departure must treat that as settled and take it, or the node is reported by
+  /// nobody - see ReliabilityGate::presence_ownership().
+  bool measurement_pending(const std::string & app_id) const;
   /// Last cached lifecycle label of a node that WAS tracked but is no longer present in
   /// the snapshot (departed within `departed_retention_ticks` ticks of "now"), keyed by
   /// its stable fqn (App::effective_fqn(), NOT App::id - mirrors node_death's own keying,
@@ -107,7 +128,12 @@ class LifecycleWatcher {
   /// it too, and it is idempotent.
   void reset();
 
-  void set_state_for_test(const std::string & app_id, const std::string & label);
+  /// Test seam: stage a tracked entry directly. `reseeds_remaining` defaults to the same
+  /// budget a freshly discovered node gets, so an injected EMPTY label reads as transient
+  /// ignorance (the state a node is in right after discovery); pass 0 to stage the settled
+  /// form a node reaches once its GetState has been asked and never answered.
+  void set_state_for_test(const std::string & app_id, const std::string & label,
+                          int reseeds_remaining = kReseedAttempts);
   /// Test-only: how much of the bounded GetState self-heal budget a tracked node has left.
   /// -1 if the node is not tracked. Lets a test assert that a re-seed job cut by the per-tick
   /// blocking budget was not charged for a read it never issued.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
@@ -311,6 +311,16 @@ class NodeLivenessTracker {
     return departed_count() > static_cast<std::size_t>(tracked_key_cap_);
   }
 
+  /// One-way, and that is the whole cost of the cap. The identity is DISCARDED, the count only
+  /// ever grows within this tracker's life, and nothing decrements it when a collapsed node
+  /// returns - decrementing would need the identity that was just thrown away, and keeping
+  /// identities is the unbounded state the cap exists to prevent. Downstream that means the
+  /// caller's aggregated fault, which clears only on an EMPTY dead set, can never clear again
+  /// once anything has been collapsed: the synthetic collapsed entry keeps the set non-empty
+  /// until an operator acknowledges the fault or the process restarts. Bounded by what this
+  /// may touch: only a MATURED entry, whose death has already been reported by name, so being
+  /// collapsed never turns a reported departure into an unreported one.
+  ///
   /// Fold MATURED departed entries (misses_ > miss_grace_) into collapsed_dead_count_ until
   /// at most `keep_named` remain individually tracked. NEVER touches an immature departed
   /// entry (0 < misses_ <= miss_grace_) or a present one - collapsing either would report

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
@@ -55,13 +55,22 @@ struct NodeDeathReport {
 ///
 /// Each call to update() is handed two sets over the SAME key space:
 ///   present - every key visible in this tick's graph snapshot (the liveness signal)
-///   armed   - the subset the reliability gate currently allows a raise for
+///   armed   - the subset whose departure the reliability gate says this detector OWNS: it
+///             allows a raise for them AND their lifecycle state is either known not to be a
+///             managed-non-active one or has been asked for as often as it ever will be
+///             (ReliabilityGate::presence_ownership), so a managed node whose state is
+///             unread but still being asked for is deliberately not in this set
 ///
 /// A key becomes TRACKED (added to `known_`) the first time it is armed, and stays tracked
 /// from then on regardless of its later arm state - so a node that is present but not
 /// currently armed (still warming up, or lifecycle-inactive) is never mistaken for dead:
 /// presence alone keeps a tracked key's miss counter at zero. A key is reported dead once
 /// its consecutive-miss counter exceeds `miss_grace`.
+///
+/// That stickiness is the right default for a key admitted on knowledge, and the wrong one
+/// for a key admitted only because nothing was known about it - see PresenceOwnership.
+/// release() is how the caller undoes the second kind, and it is the caller's job to know
+/// which kind it granted: this class is handed sets, not grounds.
 ///
 /// update() never removes a key BY AGE. An unsuppressed, still-dead entry has to stay
 /// reported for as long as it is actually dead - the alternative is a detector that quietly
@@ -146,6 +155,25 @@ class NodeLivenessTracker {
 
   explicit NodeLivenessTracker(int miss_grace, int prune_ticks = kNoPrune, int tracked_key_cap = kDefaultTrackedKeyCap)
     : miss_grace_(miss_grace), prune_ticks_(prune_ticks), tracked_key_cap_(tracked_key_cap < 1 ? 1 : tracked_key_cap) {
+  }
+
+  /// Undo the admission of a key that is still PRESENT and whose ground for being tracked
+  /// has been withdrawn: a node admitted on PresenceOwnership::kProvisional whose lifecycle
+  /// label finally arrived and answered kDisowned, so the graph has said the node belongs to
+  /// another detector. Those are the only two grounds involved - kUnclaimed is not one of
+  /// them, because it says nothing has been measured, and a node that is merely re-warming
+  /// after a restart reads exactly like that.
+  ///
+  /// Only ever call this for a key the caller can see in this tick's snapshot. A present key
+  /// carries `misses_ == 0`, so dropping it loses no evidence: it is exactly the state a key
+  /// would be in if it had never been admitted at all. Calling it for an ABSENT key would be
+  /// a different act entirely - erasing an in-flight or already-matured death - and this
+  /// class deliberately offers no way to do that by age (see the class doc); prune() is the
+  /// one path that reclaims a departed key, and it demands a durable suppressor's veto first.
+  void release(const std::string & key) {
+    known_.erase(key);
+    misses_.erase(key);
+    suppressed_streak_.erase(key);
   }
 
   NodeDeathReport update(const std::set<std::string> & present, const std::set<std::string> & armed) {

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/node_liveness_tracker.hpp
@@ -1,0 +1,327 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ros2_medkit_graph_watchdog {
+
+/// One sweep's verdict. `dead` maps every reported key to a human-readable detail phrase;
+/// `keys_by_freshness` names the same keys ordered by MISS COUNT ascending - the most
+/// recently departed key first, with the collapsed-count synthetic entry (see
+/// NodeLivenessTracker::kCollapsedKey) always first of all when present.
+///
+/// The ordering matters because the description built from `dead` is capped
+/// (AggregatedFault::kMaxDescriptionChars) while `dead` itself is a std::map and so walks
+/// lexicographically. On a graph carrying several long-dead entries, a fresh death whose
+/// key sorts late alphabetically would otherwise be cut from the text - and, being fresh,
+/// it is also the one thing the operator has not already been told. Freshest-first is what
+/// keeps a capped description still naming the thing that just happened.
+struct NodeDeathReport {
+  std::map<std::string, std::string> dead;
+  std::vector<std::string> keys_by_freshness;
+  /// LEVEL: true on every tick the DEPARTED (misses_ > 0) subset of the tracked map still
+  /// exceeds `tracked_key_cap` after collapsing every entry it safely could - i.e. entries
+  /// still mid-grace, which collapsing must never touch (see collapse_matured()'s own doc),
+  /// are alone enough to keep it over the cap. Stays true for as long as the condition
+  /// lasts. NOT the same condition LifecycleExpectationReport::tracking_saturated names for
+  /// the sibling tracker: an ARMED/PRESENT key is never refused here (see the class doc), so
+  /// this can no longer mean "a newly-armed key went unwatched."
+  bool tracking_saturated = false;
+  /// EDGE: the first tick of a saturation episode, for a caller's one-time warning. Re-arms
+  /// when the episode ends.
+  bool saturation_started = false;
+};
+
+/// Pure presence/absence state machine for "armed nodes that vanish."
+///
+/// Each call to update() is handed two sets over the SAME key space:
+///   present - every key visible in this tick's graph snapshot (the liveness signal)
+///   armed   - the subset the reliability gate currently allows a raise for
+///
+/// A key becomes TRACKED (added to `known_`) the first time it is armed, and stays tracked
+/// from then on regardless of its later arm state - so a node that is present but not
+/// currently armed (still warming up, or lifecycle-inactive) is never mistaken for dead:
+/// presence alone keeps a tracked key's miss counter at zero. A key is reported dead once
+/// its consecutive-miss counter exceeds `miss_grace`.
+///
+/// update() never removes a key BY AGE. An unsuppressed, still-dead entry has to stay
+/// reported for as long as it is actually dead - the alternative is a detector that quietly
+/// stops saying so once enough time has passed, which is the one failure mode this exists
+/// to rule out. prune() reclaims a key only once it has been DURABLY suppressed for long
+/// enough (see its own doc below); ordinary, unsuppressed churn - unique identities that
+/// arm once and are never seen again, which this detector's zero-config "every armed App is
+/// a candidate" scope makes the common case on any fleet with per-run or per-namespace
+/// names - has no age-based or suppression-based removal path at all. `tracked_key_cap` is
+/// what bounds the map against exactly that growth.
+///
+/// **What the cap bounds, and why it differs from its own past shape.** The unbounded
+/// growth is entirely in DEPARTED keys: a dead node's entry is never
+/// reclaimed by anything but a durable suppressor, so unique dead identities accumulate for
+/// the life of the process. A PRESENT key does not have that problem - its count at any
+/// instant is bounded by the live graph, which is bounded by reality (a large single-robot
+/// graph runs to roughly a hundred nodes, a ten-robot fleet to a few hundred - see
+/// kDefaultTrackedKeyCap) - and it carries no state worth reclaiming anyway (misses_ == 0).
+/// So the cap here bounds only the DEPARTED subset (misses_ > 0): admission of an
+/// ARMED/PRESENT key is therefore NEVER refused and never evicts anything, at any map size.
+/// A tracked_key_cap smaller than the live graph is consequently not saturation - the extra
+/// present entries simply coexist with a full departed set - only a departed set that stays
+/// oversized even after every eligible collapse is.
+///
+/// Collapsing (folding a departed identity into the one collapsed_dead_count_, see
+/// collapse_matured()) may ONLY apply to an entry that has ACTUALLY crossed `miss_grace_` -
+/// a confirmed death. Collapsing one that is merely mid-grace would report a death the node
+/// has not earned, permanently (the identity is erased, so the node returning cannot un-ring
+/// it) - the exact fabrication an earlier shape of this cap produced. An immature departed
+/// entry is therefore never evicted by the cap either: it is kept, tracked exactly like any
+/// other departed entry, until it either matures (and becomes a collapse candidate) or the
+/// node returns (and the entry goes idle again). Under sustained pressure from still-maturing
+/// churn the departed set may consequently exceed tracked_key_cap_ for a few ticks - bounded
+/// by recent churn rate times miss_grace_, not by how long the process has been running,
+/// which is the growth this cap exists to prevent in the first place.
+///
+/// Why this differs from LifecycleExpectationTracker's make_room(), despite looking
+/// parallel: that tracker keeps TWO clocks per key (a violation streak and an unmeasured
+/// clock), so one node's entry can be PRESENT and carrying evidence at the same time - that
+/// third state is what makes its idle/collapsible/present-and-evidential three-way eviction
+/// order meaningful, and is also why IT can evict a present entry without losing anything
+/// (the evidence lives in the clocks, not in presence). This tracker keeps exactly one piece
+/// of per-key state (`misses_`), so a key is always either present-and-empty (idle) or
+/// absent-and-evidential (departed) - there is no third state, and evicting a present entry
+/// here would only ever throw away a key that could simply be re-admitted next tick anyway,
+/// at the cost of losing any death that happens to land in the eviction window (only ONLINE
+/// nodes re-enter `armed`, so an evicted-while-present node that then dies is never
+/// re-admitted at all). The sibling's shape does not transfer.
+class NodeLivenessTracker {
+ public:
+  /// Sentinel `prune_ticks` meaning "never reclaim anything." The default for callers that
+  /// only care about update()'s presence/absence bookkeeping (short-lived tests, mostly);
+  /// real wiring (NodeDeathDetector::configure()) always passes an explicit, clamped value.
+  static constexpr int kNoPrune = std::numeric_limits<int>::max();
+
+  /// Default `tracked_key_cap` - same value, for the same reason, as
+  /// LifecycleExpectationTracker::kDefaultTrackedNodeCap: a large single-robot ROS 2 graph
+  /// runs to roughly a hundred nodes, a ten-robot fleet sharing one domain to a few hundred,
+  /// so even an operator whose graph is entirely in scope (every App here, versus only
+  /// require_active's named subset there) stays comfortably under it at a cost of a few
+  /// hundred KB. Growth past it can only come from DEPARTED identity churn, which is exactly
+  /// what the cap exists to bound - a present key never counts against it at all (see the
+  /// class doc).
+  static constexpr int kDefaultTrackedKeyCap = 512;
+
+  /// Most DEPARTED, matured (confirmed dead) entries kept individually named when the
+  /// departed set has to be shrunk; the rest are collapsed into the one count. Mirrors
+  /// LifecycleExpectationTracker::kMaxNamedDepartedEntries and its reasoning: past three, a
+  /// name is pure cost (AggregatedFault::kMaxDescriptionChars cannot fit a fourth alongside
+  /// the freshest entries this tracker already prioritises).
+  static constexpr int kMaxNamedDepartedEntries = 3;
+
+  /// Key for the collapsed-departed synthetic report entry. '!' sorts below every character
+  /// a real key can start with here ('/'), matching LifecycleExpectationTracker's identical
+  /// convention - though this class additionally puts it FIRST in keys_by_freshness itself
+  /// (see update()) rather than relying on describe_ordered()'s map-order fallback: unlike
+  /// the sibling's `newly_*` lists (only entries crossing THIS tick), keys_by_freshness here
+  /// already names every CURRENTLY dead key every tick, so leaving the collapsed entry out
+  /// of it would place it last, not first, and a capped description could cut the one line
+  /// that tells the operator identities are being lost to capacity pressure at all.
+  static constexpr const char * kCollapsedKey = "!collapsed";
+
+  explicit NodeLivenessTracker(int miss_grace, int prune_ticks = kNoPrune, int tracked_key_cap = kDefaultTrackedKeyCap)
+    : miss_grace_(miss_grace), prune_ticks_(prune_ticks), tracked_key_cap_(tracked_key_cap < 1 ? 1 : tracked_key_cap) {
+  }
+
+  NodeDeathReport update(const std::set<std::string> & present, const std::set<std::string> & armed) {
+    NodeDeathReport report;
+    // Unconditional: a PRESENT/armed key is never refused a slot and never costs an
+    // existing entry its own - see the class doc for why this differs from the sibling.
+    for (const auto & key : armed) {
+      known_.insert(key);  // no-op if already tracked
+    }
+
+    for (const auto & key : known_) {
+      if (present.count(key) > 0) {
+        misses_[key] = 0;
+      } else {
+        ++misses_[key];
+      }
+    }
+
+    // Bounds the DEPARTED subset only, and only by collapsing entries that have ACTUALLY
+    // matured - never a present or still-immature one. Runs BEFORE the report below is
+    // built, so a just-collapsed identity never simultaneously appears both individually and
+    // inside the collapsed count.
+    report.tracking_saturated = enforce_departed_cap();
+
+    std::vector<std::pair<int, std::string>> by_miss_count;
+    for (const auto & key : known_) {
+      const int misses = misses_.at(key);
+      if (misses > miss_grace_) {
+        report.dead[key] = "node " + key + " disappeared (" + std::to_string(misses) + " missed cycles)";
+        by_miss_count.emplace_back(misses, key);
+      }
+    }
+    // Fewest misses first (freshest death first); the key itself breaks ties so the
+    // ordering - and so the capped description - does not reshuffle tick to tick on its
+    // own.
+    std::sort(by_miss_count.begin(), by_miss_count.end());
+    report.keys_by_freshness.reserve(by_miss_count.size() + 1);
+    // See kCollapsedKey's own doc for why this goes first rather than through
+    // describe_ordered()'s map-order fallback.
+    if (collapsed_dead_count_ > 0) {
+      report.dead[kCollapsedKey] = "and " + std::to_string(collapsed_dead_count_) +
+                                   " more node(s) disappeared; not named individually (tracked_key_cap is full)";
+      report.keys_by_freshness.emplace_back(kCollapsedKey);
+    }
+    for (auto & entry : by_miss_count) {
+      report.keys_by_freshness.push_back(std::move(entry.second));
+    }
+    report.saturation_started = report.tracking_saturated && !saturated_last_tick_;
+    saturated_last_tick_ = report.tracking_saturated;
+    return report;
+  }
+
+  /// Reclaim bookkeeping for a key in `suppressed` once it has been suppressed on more than
+  /// `prune_ticks_` CONSECUTIVE calls. Call this after update() each tick, with the set of
+  /// keys a detector's DURABLE suppressors currently vote to suppress - never the raw
+  /// "removed from this tick's report" set, and never a non-durable suppressor's verdict
+  /// (see suppressor.hpp's own doc on why only a durable veto makes reclaiming sound).
+  ///
+  /// A key missing from `suppressed` has its streak reset to zero on this same call - not
+  /// merely left alone - so a veto that lifts even once starts the count over rather than
+  /// merely pausing it. A key that is never suppressed therefore has streak zero forever
+  /// and can never be reclaimed no matter how long it stays dead: this asymmetry is what
+  /// makes an unsuppressed death permanent-until-acknowledged while still letting a
+  /// permanently-vetoed one stop costing memory.
+  void prune(const std::set<std::string> & suppressed) {
+    for (auto it = known_.begin(); it != known_.end();) {
+      const auto & key = *it;
+      int & streak = suppressed_streak_[key];
+      streak = suppressed.count(key) > 0 ? streak + 1 : 0;
+      if (streak > prune_ticks_) {
+        suppressed_streak_.erase(key);
+        misses_.erase(key);
+        it = known_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  /// How many keys are currently tracked (known_/misses_ size) - a test seam so a suite can
+  /// assert the map stays bounded under churn without exposing the map itself. Never
+  /// counts collapsed-departed identities: they no longer have one to count. Includes
+  /// present entries, which are not bounded by tracked_key_cap_ at all (see the class doc).
+  std::size_t tracked_count() const {
+    return known_.size();
+  }
+
+  /// The keys currently tracked. A read-only view, not a copy of any mutable state a caller
+  /// could corrupt - used by a detector that keeps its OWN per-key bookkeeping alongside
+  /// this tracker's (e.g. a remembered App::id for allowlist matching after a key dies) and
+  /// needs to reclaim it in step with prune() without this class exposing prune()'s own
+  /// internal streak bookkeeping to do it.
+  const std::set<std::string> & known_keys() const {
+    return known_;
+  }
+
+ private:
+  /// How many known_ keys currently carry evidence (misses_ > 0) - present (idle) entries
+  /// never count. What tracked_key_cap_ actually bounds; see the class doc.
+  std::size_t departed_count() const {
+    std::size_t n = 0;
+    for (const auto & [key, misses] : misses_) {
+      (void)key;
+      if (misses > 0) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+  /// Shrinks the DEPARTED subset of known_ to at most tracked_key_cap_ where it safely can,
+  /// by collapsing MATURED entries (misses_ > miss_grace_) - never a present or immature
+  /// one; see the class doc for why. Two stages, mirroring
+  /// LifecycleExpectationTracker::make_room()'s identical shape for the same reason: first
+  /// collapse down to kMaxNamedDepartedEntries (keeping a few individually named when that
+  /// alone is enough to clear the cap), and only if the departed set is STILL over cap -
+  /// meaning immature entries alone already account for the excess - collapse the rest of
+  /// the matured ones too, since every one collapsed still reduces the pressure even when it
+  /// cannot fully relieve it.
+  ///
+  /// Returns true when the departed set remains over tracked_key_cap_ even after collapsing
+  /// every matured entry available - i.e. immature (still mid-grace) entries alone exceed
+  /// the cap. That condition is left standing rather than forced down: an immature entry is
+  /// never a collapse candidate, so there is nothing further this function may safely do
+  /// about it.
+  bool enforce_departed_cap() {
+    if (departed_count() <= static_cast<std::size_t>(tracked_key_cap_)) {
+      return false;
+    }
+    collapse_matured(kMaxNamedDepartedEntries);
+    if (departed_count() <= static_cast<std::size_t>(tracked_key_cap_)) {
+      return false;
+    }
+    collapse_matured(0);
+    return departed_count() > static_cast<std::size_t>(tracked_key_cap_);
+  }
+
+  /// Fold MATURED departed entries (misses_ > miss_grace_) into collapsed_dead_count_ until
+  /// at most `keep_named` remain individually tracked. NEVER touches an immature departed
+  /// entry (0 < misses_ <= miss_grace_) or a present one - collapsing either would report
+  /// (or lose) a death the node has not actually earned yet. Lexicographically LAST first,
+  /// so the survivors are a stable prefix and the same graph always keeps the same names -
+  /// mirrors LifecycleExpectationTracker::collapse_departed's identical choice.
+  void collapse_matured(std::size_t keep_named) {
+    std::vector<std::string> matured;
+    for (const auto & [key, misses] : misses_) {
+      if (misses > miss_grace_) {
+        matured.push_back(key);
+      }
+    }
+    for (std::size_t i = matured.size(); i > keep_named; --i) {
+      const std::string & key = matured[i - 1];
+      ++collapsed_dead_count_;
+      known_.erase(key);
+      misses_.erase(key);
+      suppressed_streak_.erase(key);
+    }
+  }
+
+  int miss_grace_;
+  int prune_ticks_;
+  int tracked_key_cap_;  ///< clamped to at least 1 in the constructor; bounds departed_count() only
+  std::set<std::string> known_;
+  std::map<std::string, int> misses_;
+  std::map<std::string, int> suppressed_streak_;
+  bool saturated_last_tick_ = false;  ///< for the saturation EDGE (see NodeDeathReport)
+  /// Departed, MATURED entries folded into a count to shrink the departed set back toward
+  /// tracked_key_cap_. Monotone within one tracker lifetime by design, mirroring the
+  /// sibling: a gateway restart or a detector reconfigure both replace this object wholesale
+  /// (see node_death_detector.cpp's own configure()), which is the only thing that ever
+  /// resets it. A collapsed identity returning does not decrement it - the identity itself
+  /// is gone, so there is no way to tell which of possibly-several collapsed departures came
+  /// back - the aggregate fault this count keeps raised clears only via a reconfigure (which
+  /// also re-baselines whatever is present at that point) or an operator's explicit
+  /// acknowledgement.
+  int collapsed_dead_count_ = 0;
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/presence_ownership.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/presence_ownership.hpp
@@ -1,0 +1,52 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstdint>
+
+namespace ros2_medkit_graph_watchdog {
+
+/// On what GROUNDS the presence detector (node_death) owns an entity's departure. The two
+/// positive answers are not interchangeable, and collapsing them into one boolean is what
+/// makes a node the graph later proves inactive stay owned by the wrong detector.
+///
+/// Stickiness is earned by KNOWLEDGE, never by IGNORANCE:
+///
+///   - kEarned survives anything the node does afterwards. It was granted because the node's
+///     lifecycle state was read and said so, or because the node carries no lifecycle at all,
+///     and a later deactivate does not hand the node back - that is the boundary this plugin
+///     has always drawn (a node that ran and then stopped running is a death, whatever state
+///     it stopped in).
+///   - kProvisional is granted for the opposite reason: nothing is known, and nothing more
+///     will be asked, so leaving the node unowned would mean nobody reports it at all. That
+///     ground evaporates the instant a real label arrives, because the label tells us who
+///     the node belongs to. A provisional owner must therefore hand the node back while it
+///     is still alive, rather than discover at its death that it never had a claim.
+///
+/// The two NEGATIVE answers are just as different from each other, and conflating them is its
+/// own defect: kUnclaimed says nothing is known yet, kDisowned says the graph has said whose
+/// node this is. Only the second may take a key away from a caller that already holds it. A
+/// node that is merely re-warming after a restart answers kUnclaimed, and treating that as a
+/// verdict releases a key the detector must keep - its next death would then be reported by
+/// nobody, and the detector would call an outage healthy every tick it lasted.
+///
+/// See ReliabilityGate::presence_ownership() for the exact per-state mapping.
+enum class PresenceOwnership : std::uint8_t {
+  kUnclaimed,    ///< nothing known either way yet: still warming up, or still being asked about
+  kDisowned,     ///< measured, and measured as a state this detector does not report - another detector's
+  kProvisional,  ///< owned only because the asking stopped with no answer; withdrawn as soon as one arrives
+  kEarned,       ///< owned on a measurement, or on the absence of any lifecycle to measure; never withdrawn
+};
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/reliability_gate.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/reliability_gate.hpp
@@ -24,15 +24,19 @@
 
 #include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"  // IntrospectionInput
 #include "ros2_medkit_graph_watchdog/lifecycle_watcher.hpp"
+#include "ros2_medkit_graph_watchdog/presence_ownership.hpp"
 #include "ros2_medkit_graph_watchdog/warmup_tracker.hpp"
 
 namespace ros2_medkit_graph_watchdog {
 
 /// Central gate composing per-entity warmup (WarmupTracker) with ROS lifecycle state
 /// (LifecycleWatcher). An entity is allowed to raise a fault once it has been armed
-/// (continuously present for warmup_cycles ticks) and its lifecycle state (if managed)
-/// is "active". Unknown source_ids (e.g. topics, not tracked apps) fall back to a
-/// global bringup grace period keyed off the first tick the graph was non-empty.
+/// (continuously present for warmup_cycles ticks) and its lifecycle state is not a KNOWN
+/// non-active one: a managed node whose GetState has never answered still passes, because
+/// gating on an unread label would silence every detector for it (LifecycleWatcher::node_ok()).
+/// Unknown source_ids (e.g. topics, not tracked apps) fall back to a global bringup grace
+/// period keyed off the first tick the graph was non-empty. presence_ownership() below asks
+/// the narrower question the presence class needs, without moving this one.
 class ReliabilityGate {
  public:
   ReliabilityGate(int warmup_cycles, rclcpp::Node * gateway_node, std::mutex * node_mutex,
@@ -52,6 +56,39 @@ class ReliabilityGate {
   /// and lifecycle-ok; unknown entities fall back to the global warmup window.
   bool allows_raise(const std::string & source_id) const;
 
+  /// On what grounds the PRESENCE detector (node_death) owns this source's departure, listed
+  /// in the order the cases are decided, because that order is itself load-bearing:
+  ///
+  ///   1. a label that is neither empty nor "active"  -> kDisowned    (measured elsewhere)
+  ///   2. not allowed to raise                        -> kUnclaimed   (warming up)
+  ///   3. no managed record at all (a plain node)     -> kEarned
+  ///   4. empty label, GetState attempts still to run -> kUnclaimed   (still asking)
+  ///   5. empty label, every attempt spent            -> kProvisional (asked, and failed)
+  ///   6. the label reads "active"                    -> kEarned
+  ///
+  /// Case 1 is deliberately decided BEFORE arming, and not merely for tidiness: node_ok()
+  /// already refuses a managed non-active node, so asking allows_raise() first would answer
+  /// the same for a node the graph has measured as inactive and for one that has simply not
+  /// armed yet. A caller that gives up a key on the negative answer would then drop every
+  /// node that restarts, since a returning node is un-armed for its whole re-warm - see
+  /// PresenceOwnership for why only kDisowned may take a key away.
+  ///
+  /// Narrower than allows_raise(), and deliberately so. allows_raise() answers "may this
+  /// entity raise", and for a managed node whose label has never been read it answers yes,
+  /// because gating every detector on an unread label would silence a node whose GetState
+  /// never answers (see LifecycleWatcher::node_ok()). Ownership needs knowledge rather than
+  /// permission, so an unread label answers kUnclaimed while that ignorance can still resolve.
+  ///
+  /// It does NOT stay kUnclaimed forever: `lifecycle_expectation` is the only other detector
+  /// that could report such a node's departure, and it looks at nothing unless an operator
+  /// named the node in `require_active`, which defaults to empty. So once the watcher has
+  /// stopped asking, the answer becomes kProvisional - owned, because otherwise nobody
+  /// reports this death, and provisional, because the label may still arrive over
+  /// ~/transition_event (that subscription outlives the seed budget) and would then say the
+  /// node was never this detector's. See PresenceOwnership for what each caller owes the
+  /// distinction.
+  PresenceOwnership presence_ownership(const std::string & source_id) const;
+
   /// Raw lifecycle state label for `app_id` (delegates to the internal
   /// LifecycleWatcher), or nullopt if `app_id` is not a tracked managed lifecycle
   /// node. Additive, const, plugin-internal seam for detectors that need the raw
@@ -67,8 +104,11 @@ class ReliabilityGate {
   /// plugin-internal seam for LifecycleShutdownSuppressor.
   std::optional<DepartedLifecycle> departed_lifecycle_state_of(const std::string & fqn) const;
 
-  /// SOVD `x-medkit-watchdog` extension payload: schema_version, warmup_cycles,
-  /// global_state, and per-entity state/armed/lifecycle.
+  /// SOVD `x-medkit-watchdog` extension payload: schema_version, warmup_cycles, global_state,
+  /// and per entity id/first_seen_tick/armed/state/lifecycle/measurement_pending. The last two
+  /// are a pair on purpose: `lifecycle` is null for a node with no managed record and "" for
+  /// one whose GetState has not answered, and `measurement_pending` says whether that second
+  /// case is still being asked about - which nothing else on the route distinguishes.
   nlohmann::json status_json() const;
 
   /// Drop lifecycle subscriptions (shutdown path).
@@ -76,8 +116,17 @@ class ReliabilityGate {
 
   /// Test seam: inject a lifecycle state label for `app_id` so a test can drive the
   /// composed warmup + lifecycle path (an armed entity whose lifecycle is non-active)
-  /// through allows_raise()/status_json() without a live managed node.
-  void set_lifecycle_state_for_test(const std::string & app_id, const std::string & label);
+  /// through allows_raise()/status_json() without a live managed node. `reseeds_remaining`
+  /// stages the OTHER half of an unmeasured node's state (see
+  /// LifecycleWatcher::measurement_pending): the default is what a freshly discovered node
+  /// carries, and 0 is the settled form.
+  void set_lifecycle_state_for_test(const std::string & app_id, const std::string & label,
+                                    int reseeds_remaining = LifecycleWatcher::kReseedAttempts);
+
+  /// Test seam: GetState re-seed budget the internal LifecycleWatcher has left for
+  /// `app_id`, or -1 if it is not tracked. Lets a test tie the ownership answer to the
+  /// budget actually running out rather than to a tick count that happens to correlate.
+  int lifecycle_reseeds_remaining_for_test(const std::string & app_id) const;
 
   /// Test-only seam: inject a departed-lifecycle entry directly (delegates to the
   /// internal LifecycleWatcher) so a suppressor unit test can drive
@@ -91,8 +140,9 @@ class ReliabilityGate {
   // thread. warmup_ (an unordered_map) and the scalars below have no internal lock, so
   // gate_mutex_ serializes the writer (update) against the cross-thread reader
   // (status_json). lifecycle_ is separately self-synchronized and is deliberately updated
-  // OUTSIDE gate_mutex_ (it does blocking reads); allows_raise() is a reader that only
-  // runs on the tick thread (sequentially after update), so it needs no lock.
+  // OUTSIDE gate_mutex_ (it does blocking reads); allows_raise() and presence_ownership()
+  // are readers that only run on the tick thread (sequentially after update), so they need no
+  // lock - the lifecycle_ reads inside them take that class's own mutex.
   mutable std::mutex gate_mutex_;
   WarmupTracker warmup_;
   LifecycleWatcher lifecycle_;

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/suppressor.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/suppressor.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <cstddef>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_graph_watchdog/detector.hpp"  // DetectorContext
+
+namespace ros2_medkit_graph_watchdog {
+
+/// One vote on whether a single candidate entity should be dropped from an aggregated
+/// fault this tick. A detector holds a CHAIN of these and drops a candidate the moment
+/// any of them votes yes - see apply_suppressors() below.
+///
+/// Pure by contract: an implementation reads only the key it is asked about and the
+/// DetectorContext it is handed (gate, snapshot, clock), and never raises or clears a
+/// fault itself. The interface exists so more than one detector can share the same
+/// suppression mechanism (AllowlistSuppressor already serves node_death and tf_stale)
+/// without either one owning the other's config surface.
+class Suppressor {
+ public:
+  virtual ~Suppressor() = default;
+
+  /// True to suppress `entity_key` this tick; false to abstain (say nothing about it).
+  virtual bool suppresses(const std::string & entity_key, const DetectorContext & ctx) const = 0;
+
+  /// Whether a "yes" from this suppressor is a standing fact about the key rather than a
+  /// condition that can later stop holding.
+  ///
+  /// This is what a detector's own pruning may safely rely on: reclaiming a tracked key's
+  /// bookkeeping while it is suppressed only avoids a false report FOR AS LONG AS the
+  /// suppression keeps holding. A veto that CAN lift (a live condition on the current
+  /// graph, say) offers no such guarantee - the moment it lifts, the key would be a live,
+  /// unsuppressed death with no tracking left to report it, which is a false heal that
+  /// silently outlives the very condition that caused it. A veto that is durable never
+  /// lifts for a given key once it has fired, so reclaiming under it loses nothing: the
+  /// key would never be reported again regardless of whether its bookkeeping survives.
+  ///
+  /// Defaults to false, which is the safe assumption for a suppressor nobody has reasoned
+  /// about yet. Override to true only for a suppressor whose "yes" is permanent per key.
+  virtual bool durable() const {
+    return false;
+  }
+};
+
+/// Drop every key in `affected` that any suppressor in `chain` votes to suppress.
+///
+/// Order-independent: a key survives only if EVERY suppressor abstains, so which one
+/// happens to run first never changes the result. Returns how many keys were dropped, for
+/// callers that want to know without re-diffing `affected` themselves.
+inline std::size_t apply_suppressors(std::map<std::string, std::string> & affected,
+                                     const std::vector<const Suppressor *> & chain, const DetectorContext & ctx) {
+  if (chain.empty()) {
+    return 0;
+  }
+  std::size_t dropped = 0;
+  for (auto it = affected.begin(); it != affected.end();) {
+    bool suppressed = false;
+    for (const Suppressor * s : chain) {
+      if (s != nullptr && s->suppresses(it->first, ctx)) {
+        suppressed = true;
+        break;
+      }
+    }
+    if (suppressed) {
+      it = affected.erase(it);
+      ++dropped;
+    } else {
+      ++it;
+    }
+  }
+  return dropped;
+}
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
@@ -320,16 +320,37 @@ class LifecycleExpectationDetector : public Detector {
         if (state.has_value()) {
           entry_has_managed_match.insert(id);
         }
-        // Whether the gate currently allows a fault to be raised for this SAME app.id - the
-        // exact predicate node_death's own presence detector uses to decide whether it will
-        // ever be able to track this node at all (reliability_allows(), see
-        // node_death_detector.cpp's identical call). Reading it here, from the one gate both
-        // detectors share on the same tick, is what makes "armed" trustworthy rather than a
-        // guess: it is not derived from this node's own lifecycle label, it IS the fact the
-        // presence detector would itself consult if asked right now. The tracker needs it to
-        // tell a node the presence detector could someday report from one it structurally
-        // never can - see LifecycleExpectationTracker's own class doc.
-        const bool armed = reliability_allows(ctx.gate, app.id);
+        // Whether the gate says the presence detector OWNS this node's departure, for this
+        // SAME app.id. It is what node_death's tracking decision consults, not the whole of
+        // it: that detector applies its own filters first (peer-aggregated apps, apps that
+        // are not online, an empty fqn, ros2cli helper names - see node_death_detector.cpp),
+        // so a true answer here means the GATE would let it track this node, not that it
+        // will. Reading it from the one gate both detectors share on the same tick is what
+        // makes "armed" trustworthy rather than a guess: it is not derived from this node's
+        // own lifecycle label, it IS the fact the presence detector would itself consult if
+        // asked right now. The tracker needs it to tell a node the presence detector could
+        // someday report from one it structurally never can - see LifecycleExpectationTracker's
+        // own class doc. Deliberately NOT reliability_allows(): that one is permissive about a
+        // managed node whose lifecycle label has never been read, so taking its permission for
+        // ownership would switch this detector's absence path off for a node the presence class
+        // does not actually hold - either because the watcher has not finished asking about it,
+        // or because it asked, gave up, and then a label arrived and took the node back.
+        //
+        // kEarned only, and the two exclusions are for different reasons.
+        //
+        // A PROVISIONAL grant is deliberately not enough: the tracker latches this value for
+        // the node's whole life, and a provisional grant is the one node_death itself gives up
+        // the moment a real label arrives. Latching it here would leave this detector believing
+        // the presence class had a node it had already handed back - the same silence in the
+        // opposite direction.
+        //
+        // ANDed with is_online because node_death skips an app that is not online before it
+        // ever consults the gate, and the gate has no notion of online-ness: a manifest app
+        // whose node never started is armed, carries no lifecycle record, and would otherwise
+        // read as owned by a detector that will never look at it. The remaining filters
+        // node_death applies need no mirror here: a peer-aggregated app and one with no binding
+        // both have an empty fqn and are already skipped above.
+        const bool armed = app.is_online && presence_ownership(ctx.gate, app.id) == PresenceOwnership::kEarned;
         // One match per (entry, node): the tracker keys violations by NODE, so two
         // namesakes are both reported instead of one silently replacing the other.
         matches.push_back(LifecycleMatch{id, fqn, state, armed});

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
@@ -11,9 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <iterator>
 #include <limits>
 #include <map>
 #include <optional>
@@ -320,40 +322,9 @@ class LifecycleExpectationDetector : public Detector {
         if (state.has_value()) {
           entry_has_managed_match.insert(id);
         }
-        // Whether the gate says the presence detector OWNS this node's departure, for this
-        // SAME app.id. It is what node_death's tracking decision consults, not the whole of
-        // it: that detector applies its own filters first (peer-aggregated apps, apps that
-        // are not online, an empty fqn, ros2cli helper names - see node_death_detector.cpp),
-        // so a true answer here means the GATE would let it track this node, not that it
-        // will. Reading it from the one gate both detectors share on the same tick is what
-        // makes "armed" trustworthy rather than a guess: it is not derived from this node's
-        // own lifecycle label, it IS the fact the presence detector would itself consult if
-        // asked right now. The tracker needs it to tell a node the presence detector could
-        // someday report from one it structurally never can - see LifecycleExpectationTracker's
-        // own class doc. Deliberately NOT reliability_allows(): that one is permissive about a
-        // managed node whose lifecycle label has never been read, so taking its permission for
-        // ownership would switch this detector's absence path off for a node the presence class
-        // does not actually hold - either because the watcher has not finished asking about it,
-        // or because it asked, gave up, and then a label arrived and took the node back.
-        //
-        // kEarned only, and the two exclusions are for different reasons.
-        //
-        // A PROVISIONAL grant is deliberately not enough: the tracker latches this value for
-        // the node's whole life, and a provisional grant is the one node_death itself gives up
-        // the moment a real label arrives. Latching it here would leave this detector believing
-        // the presence class had a node it had already handed back - the same silence in the
-        // opposite direction.
-        //
-        // ANDed with is_online because node_death skips an app that is not online before it
-        // ever consults the gate, and the gate has no notion of online-ness: a manifest app
-        // whose node never started is armed, carries no lifecycle record, and would otherwise
-        // read as owned by a detector that will never look at it. The remaining filters
-        // node_death applies need no mirror here: a peer-aggregated app and one with no binding
-        // both have an empty fqn and are already skipped above.
-        const bool armed = app.is_online && presence_ownership(ctx.gate, app.id) == PresenceOwnership::kEarned;
         // One match per (entry, node): the tracker keys violations by NODE, so two
         // namesakes are both reported instead of one silently replacing the other.
-        matches.push_back(LifecycleMatch{id, fqn, state, armed});
+        matches.push_back(LifecycleMatch{id, fqn, state});
       }
     }
     std::set<std::string> matched_entries;
@@ -407,7 +378,20 @@ class LifecycleExpectationDetector : public Detector {
       }
     }
 
-    auto report = tracker_.update(matches);
+    // Who owns a departure is ASKED of the presence detector on every tick, never mirrored and
+    // never remembered. node_death decides it from its own admission rule - the gate's answer
+    // plus what it remembers handing back - and every attempt to re-derive that here has
+    // disagreed with it somewhere: the sweep in which a dying node loses its lifecycle record
+    // answers kEarned at the gate while node_death refuses the key, and a mirror once latched a
+    // handover to a detector that was never going to report. Passing that detector's own current
+    // key set makes the two agree by construction, and passing it EVERY tick (rather than
+    // latching the first true answer) is what keeps a key it has since given back, reclaimed or
+    // collapsed from holding a streak nobody will ever mature.
+    //
+    // A null view means no detector will report a departure at all (none present, or the one
+    // that would is running Advisory or Off). The tracker reads that as "nobody owns anything",
+    // which keeps this detector's own report rather than holding it for a fault nobody files.
+    auto report = tracker_.update(matches, ctx.presence_tracked);
     // Published for GET /x-medkit-watchdog. Written here on the plugin's tick thread and
     // read by status_json() on an HTTP handler thread, which holds no lock this detector
     // takes - hence atomics rather than plain members.
@@ -484,8 +468,8 @@ class LifecycleExpectationDetector : public Detector {
     // node cannot assert that every required node is healthy, for as long as it keeps
     // declining.
     if (report.affected.empty() && (!report.pending.empty() || unmatched_blocking || report.tracking_saturated)) {
-      report_withheld_clear(ctx, report.pending_violation, report.pending_unreadable, report.pending_not_managed,
-                            unmatched_blocking, report.tracking_saturated);
+      report_withheld_clear(ctx, report.pending_violation, report.pending_violation_departed, report.pending_unreadable,
+                            report.pending_not_managed, unmatched_blocking, report.tracking_saturated);
       return;  // GRAPH_NODE_INACTIVE: nothing measured - and a young streak - is not the same as healthy
     }
     withheld_ticks_ = 0;
@@ -524,6 +508,7 @@ class LifecycleExpectationDetector : public Detector {
   /// `violation` releases either into content (GRAPH_NODE_INACTIVE itself) or into health,
   /// so the three cannot share one sentence.
   void report_withheld_clear(const DetectorContext & ctx, const std::set<std::string> & pending_violation,
+                             const std::set<std::string> & pending_violation_departed,
                              const std::set<std::string> & pending_unreadable,
                              const std::set<std::string> & pending_not_managed, bool unmatched, bool saturated) {
     ++withheld_ticks_;
@@ -563,11 +548,23 @@ class LifecycleExpectationDetector : public Detector {
           " unanswered ticks that hold releases by itself and the node is reported under "
           "GRAPH_NODE_UNREADABLE instead)");
     }
-    if (!pending_violation.empty()) {
-      add(std::to_string(pending_violation.size()) +
+    // Split by whether the node is still THERE, because the two have different exits and only
+    // one of them is something an operator can wait for.
+    std::vector<std::string> present_violation;
+    std::set_difference(pending_violation.begin(), pending_violation.end(), pending_violation_departed.begin(),
+                        pending_violation_departed.end(), std::back_inserter(present_violation));
+    if (!present_violation.empty()) {
+      add(std::to_string(present_violation.size()) +
           " required node(s) are measured not-active but still within grace " + "(starting with '" +
-          *pending_violation.begin() + "'; that hold releases as soon as the node reads active or " +
+          present_violation.front() + "'; that hold releases as soon as the node reads active or " +
           "its streak passes grace)");
+    }
+    if (!pending_violation_departed.empty()) {
+      add(std::to_string(pending_violation_departed.size()) +
+          " required node(s) were measured not-active below grace and have since LEFT the graph " + "(starting with '" +
+          *pending_violation_departed.begin() +
+          "'; absence holds that streak rather than advancing it, so the hold lasts until the node " +
+          "comes back - it will not time out, and the presence detector reports the departure itself)");
     }
     RCLCPP_WARN(ctx.gateway_node->get_logger(),
                 "graph_watchdog lifecycle_expectation: nothing is reported inactive, but GRAPH_NODE_INACTIVE is "

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
@@ -60,14 +60,26 @@ constexpr int kDefaultGrace = 5;
 // that reports a node on its very first not-active tick, with no warning and no default.
 //
 // The upper end used to be INT_MAX - 1, which is not a wide tolerance but an off switch with
-// no warning attached. `grace` bounds two things at once: how long a node may read not-active
-// before being reported, AND how long a node that LEFT the graph while not-active sits in the
-// tracker's pending set - during which GRAPH_NODE_INACTIVE's clear is withheld for every
-// node, so the fault can neither raise nor heal for anybody. At INT_MAX - 1 that is roughly
-// 24 days at the shipped cadence; five minutes is already an extravagant allowance for a
-// managed node to reach `active`, and it makes the worst-case withhold something an operator
-// can reason about. A deployment that genuinely needs longer wants a slower tick, not a
-// detector that is silent for weeks.
+// no warning attached. `grace` bounds how long a node that STAYS IN THE GRAPH may read
+// not-active before being reported, and how long a node that returns from a departure still
+// inactive takes to (re-)mature - both advance on present ticks, which this value directly
+// caps. At INT_MAX - 1 that is roughly 24 days at the shipped cadence either way; five minutes
+// is already an extravagant allowance for a managed node to reach `active`, and it makes the
+// worst-case PRESENT withhold something an operator can reason about. A deployment that
+// genuinely needs longer wants a slower tick, not a detector that is silent for weeks.
+//
+// Whether it also bounds a node that leaves the graph before its streak matures depends on
+// whether that node was ever ARMED (see LifecycleExpectationTracker's own class doc). For one
+// the reliability gate has armed at least once, `grace` does NOT bound it: absence holds a
+// below-grace streak rather than advancing it, so that entry sits in the tracker's pending
+// set for as long as the node stays gone, however long that is - GRAPH_NODE_DISAPPEARED can
+// report that departure instead, so nothing here needs to hurry it. That is not a new way to
+// withhold GRAPH_NODE_INACTIVE's clear for every OTHER node - the clear was already gated on
+// every required node's status being settled, so one node this indecisive already blocked it
+// before this bound existed. For a node that was NEVER armed - node_death only ever tracks a
+// node the gate has armed, so this is the one departure nothing else can report - `grace`
+// DOES still bound it: absence keeps advancing the streak too, so it matures within `grace` +
+// `absence_grace` + 1 ticks either way.
 constexpr std::int64_t kMaxGrace = 300;
 /// Consecutive ticks an entry must match ONLY unmanaged nodes before the typo warning
 /// fires. One transient tick is not evidence: discover_apps() wraps the per-node service
@@ -308,9 +320,19 @@ class LifecycleExpectationDetector : public Detector {
         if (state.has_value()) {
           entry_has_managed_match.insert(id);
         }
+        // Whether the gate currently allows a fault to be raised for this SAME app.id - the
+        // exact predicate node_death's own presence detector uses to decide whether it will
+        // ever be able to track this node at all (reliability_allows(), see
+        // node_death_detector.cpp's identical call). Reading it here, from the one gate both
+        // detectors share on the same tick, is what makes "armed" trustworthy rather than a
+        // guess: it is not derived from this node's own lifecycle label, it IS the fact the
+        // presence detector would itself consult if asked right now. The tracker needs it to
+        // tell a node the presence detector could someday report from one it structurally
+        // never can - see LifecycleExpectationTracker's own class doc.
+        const bool armed = reliability_allows(ctx.gate, app.id);
         // One match per (entry, node): the tracker keys violations by NODE, so two
         // namesakes are both reported instead of one silently replacing the other.
-        matches.push_back(LifecycleMatch{id, fqn, state});
+        matches.push_back(LifecycleMatch{id, fqn, state, armed});
       }
     }
     std::set<std::string> matched_entries;

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
@@ -211,7 +211,11 @@ class NodeDeathDetector : public Detector {
     // just rebuilt (or dropped) that allowlist above, so a value captured under the OLD
     // config would misrepresent the new one - clear rather than carry it forward.
     id_allowlisted_.clear();
-    // Deliberately NOT reset here, unlike id_allowlisted_ above: ever_raised_ is a fact about
+    // Same reasoning for the latched durable verdicts: each one was reached by a suppressor
+    // that build_suppressor_chain() has just rebuilt or dropped, so carrying it forward would
+    // let a key stay suppressed under a configuration that no longer suppresses it.
+    durably_suppressed_.clear();
+    // Deliberately NOT reset here, unlike the two maps above: ever_raised_ is a fact about
     // this PROCESS's history ("has this instance ever put a genuine FAILED on the wire"),
     // not about the current config. A live reconfigure (an operator editing the allowlist,
     // say) can run with a death still outstanding and absent; resetting the flag would make
@@ -283,6 +287,10 @@ class NodeDeathDetector : public Detector {
     std::set<std::string> present;
     std::set<std::string> armed;
     std::set<std::string> handed_back;  // provisionally admitted, and the ground has gone
+    // Keys the snapshot carries AT ALL this tick, online or not. A superset of `present`, and
+    // the right lifetime for bookkeeping about a node that has not left the graph - see the
+    // `released_` cleanup at the end of this function.
+    std::set<std::string> seen;
     for (const auto & app : ctx.snapshot->apps) {
       // A peer-aggregated app carries no ROS binding of its own (PeerClient::parse_app
       // never reads x-medkit.ros2.node), so effective_fqn() is empty for every one of
@@ -291,16 +299,19 @@ class NodeDeathDetector : public Detector {
       if (app.source.rfind("peer:", 0) == 0) {
         continue;
       }
-      // Liveness is the bound node actually running, not mere presence in the snapshot -
-      // see the class doc for why membership alone would make a manifest node immortal.
-      if (!app.is_online) {
-        continue;
-      }
       // Keyed on the STABLE fqn, not App::id: id is recomputed every sweep and only gets a
       // namespace prefix once a bare-name collision currently exists anywhere in the
       // graph, so a live node's id can change out from under a key built from it.
       const std::string key = app.effective_fqn();
       if (key.empty() || is_ros2cli_node(key)) {
+        continue;
+      }
+      seen.insert(key);
+      // Liveness is the bound node actually running, not mere presence in the snapshot -
+      // see the class doc for why membership alone would make a manifest node immortal.
+      // Computed AFTER the key, because "not tracked this tick" and "left the graph" are
+      // different facts and one piece of bookkeeping below needs the second one.
+      if (!app.is_online) {
         continue;
       }
       present.insert(key);
@@ -437,15 +448,29 @@ class NodeDeathDetector : public Detector {
     for (auto it = earned_.begin(); it != earned_.end();) {
       it = tracked_keys.count(*it) == 0 ? earned_.erase(it) : std::next(it);
     }
-    // `released_` answers a different question with a different lifetime: it is the set of
-    // PRESENT keys this detector has refused, and a released key is by definition not in the
-    // tracker at all, so it cannot be bounded by known_keys() - it is bounded by the live graph
-    // instead, since every member of it is a key present this tick. It goes when the node does;
+    // `released_` answers a different question with a different lifetime: it is the set of keys
+    // this detector has refused, and a released key is by definition not in the tracker at all,
+    // so it cannot be bounded by known_keys() - it is bounded by the live graph instead, since
+    // every member of it is a key the snapshot carried this tick. It goes when the node does;
     // the incarnation that returns is re-derived from whatever the gate then says about it. The
     // no-record counter beside it answers only about keys in `released_`, so it is pruned with
     // it rather than separately.
+    //
+    // Against `seen`, NOT `present`: an App whose process stopped keeps its snapshot entry with
+    // is_online cleared (a manifest or hybrid App does exactly this), and that node has not left
+    // the graph - it is merely not trackable this tick. Pruning on the narrower set threw the
+    // withheld key and its window away on the offline tick, so the first tick back online
+    // readmitted it outright, with none of the record-less present ticks the window promises. A
+    // node whose lifecycle services vanished as it died and whose App flickered online once
+    // would then be reported here after being handed to lifecycle_expectation.
+    //
+    // The counter is neither advanced nor reset by an offline tick, only carried: it counts
+    // ticks in which the node was OBSERVED present-and-unmanaged, and an offline tick observes
+    // nothing of the kind. Counting those would let a window that exists to establish "this node
+    // is alive and no longer managed" be satisfied by ticks in which the node was not running -
+    // ignorance standing in for the evidence the window is asking for.
     for (auto it = released_.begin(); it != released_.end();) {
-      if (present.count(*it) != 0) {
+      if (seen.count(*it) != 0) {
         ++it;
         continue;
       }
@@ -464,11 +489,32 @@ class NodeDeathDetector : public Detector {
     // key was still present. The id form bypasses chain_ dispatch entirely rather than
     // going through Suppressor::suppresses() - see allowlist_suppressor.hpp for why.
     for (auto it = report.dead.begin(); it != report.dead.end();) {
-      bool suppressed = id_allowlisted_.count(it->first) > 0;
+      // A durable verdict already reached for this key stands without re-asking. That is not a
+      // shortcut, it is the only way the verdict can outlive the EVIDENCE behind it:
+      // LifecycleShutdownSuppressor reads the lifecycle watcher's departed record, which is
+      // retained for a bounded number of ticks and then dropped, while the veto it produces has
+      // to hold until prune() reclaims the key - and prune() needs the veto UNBROKEN for
+      // prune_ticks consecutive ticks to get there. Re-asking on every tick made those two
+      // windows race, and the retention clock starts at the wrong event to win it: it is
+      // anchored when the node's lifecycle SERVICES leave the graph, while the reclaim tick
+      // counts from when its App does, one or more sweeps later. Every tick of that lead came
+      // out of the single tick of margin the window is sized with; past one, the record expired
+      // first, the veto lifted, the streak reset to zero, and - the record now gone for good -
+      // the key could never be suppressed again, so a cleanly shut-down node stayed named for
+      // the life of the process.
+      //
+      // Latching is sound here for the same reason `durable()` exists: a durable suppressor's
+      // answer for a given key never lifts, so remembering it can never diverge from asking
+      // again - it only survives the evidence being garbage-collected. Only POSITIVE verdicts
+      // are latched, and only from durable suppressors; nothing here remembers a "no".
+      bool suppressed = id_allowlisted_.count(it->first) > 0 || durably_suppressed_.count(it->first) > 0;
       if (!suppressed) {
         for (const Suppressor * s : chain_) {
           if (s != nullptr && s->suppresses(it->first, ctx)) {
             suppressed = true;
+            if (s->durable()) {
+              durably_suppressed_.insert(it->first);
+            }
             break;
           }
         }
@@ -492,7 +538,7 @@ class NodeDeathDetector : public Detector {
       if (report.dead.count(key) > 0) {
         continue;  // survived the filter - nothing suppressed it this tick
       }
-      if (id_allowlisted_.count(key) > 0) {
+      if (id_allowlisted_.count(key) > 0 || durably_suppressed_.count(key) > 0) {
         suppressed_for_prune.insert(key);
         continue;
       }
@@ -511,6 +557,14 @@ class NodeDeathDetector : public Detector {
     // identity churn is exactly the failure N11 exists to rule out for tracker_ itself).
     for (auto it = id_allowlisted_.begin(); it != id_allowlisted_.end();) {
       it = tracker_.known_keys().count(*it) > 0 ? std::next(it) : id_allowlisted_.erase(it);
+    }
+    // Bound the latched verdicts to keys that are BOTH still tracked and still gone. Dropping a
+    // key the moment it is present again is what keeps the latch honest: the verdict describes
+    // one departure, and a node that came back and later dies a second time must be judged on
+    // that second departure - which may not be clean at all.
+    for (auto it = durably_suppressed_.begin(); it != durably_suppressed_.end();) {
+      const bool still_relevant = tracker_.known_keys().count(*it) > 0 && present.count(*it) == 0;
+      it = still_relevant ? std::next(it) : durably_suppressed_.erase(it);
     }
     // Published once per sweep, after prune() has settled this tick's count - see
     // status_json()'s own doc for why this is the only cross-thread-safe way to read it.
@@ -709,6 +763,12 @@ class NodeDeathDetector : public Detector {
   /// Pruned to the live graph every tick.
   std::set<std::string> earned_;
   std::set<std::string> id_allowlisted_;
+  /// Departed keys a DURABLE suppressor has already vetoed at least once. Consulted before the
+  /// chain and fed to prune() exactly like an id-form allowlist match, so a veto outlives the
+  /// evidence that produced it - see the suppression filter in tick() for why it has to. Bounded
+  /// to keys that are still tracked AND still absent, so it can neither outlive the tracker's own
+  /// map nor carry one departure's verdict into the next.
+  std::set<std::string> durably_suppressed_;
   /// Whether THIS detector instance has itself genuinely raised GRAPH_NODE_DISAPPEARED at
   /// least once - the ungated-clear guard. See tick()'s own comment for why this, and not
   /// tracker_.tracked_count(), is the right granularity.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
@@ -1,0 +1,541 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <ros2_medkit_msgs/msg/fault.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+#include "ros2_medkit_graph_watchdog/allowlist_suppressor.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+#include "ros2_medkit_graph_watchdog/lifecycle_shutdown_suppressor.hpp"
+#include "ros2_medkit_graph_watchdog/node_liveness_tracker.hpp"
+#include "ros2_medkit_graph_watchdog/suppressor.hpp"
+
+namespace ros2_medkit_graph_watchdog {
+
+namespace {
+// Fault severity scale: SEVERITY_WARN=1, SEVERITY_ERROR=2 (ros2_medkit_msgs/msg/Fault.msg).
+// A dead node is a total, silent loss of whatever it provided - as severe as QoS starvation.
+constexpr std::uint8_t kNodeDeathSeverity = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
+
+// Ticks a tracked node may be absent before it is reported dead. Mirrors
+// GraphWatchdogPlugin's own kDefaultNodeDeathMissGrace, which needs this value before
+// this detector's own configure() has run (see that plugin's
+// compute_departed_retention_ticks()).
+constexpr int kDefaultMissGrace = 2;
+
+// Standalone fallback only. A real launch always injects "prune_grace" (the plugin's own
+// default, also 60) once wired through GraphWatchdogPlugin::set_context() - this only
+// matters for a bare configure() call that never goes through the plugin, e.g. a unit test.
+constexpr int kDefaultPruneGrace = 60;
+
+// Bounds for detectors.node_death.tracked_node_cap - same range, same reasoning, as
+// lifecycle_expectation_detector.cpp's identical kMinTrackedNodeCap/kMaxTrackedNodeCap: the
+// range check runs on the WIDE integer before narrowing, for the same reason miss_grace and
+// prune_grace above do. Zero is refused rather than clamped: a cap of nothing means this
+// detector tracks nothing, which is exactly the silence it exists to prevent.
+constexpr std::int64_t kMinTrackedNodeCap = 1;
+constexpr std::int64_t kMaxTrackedNodeCap = 16384;
+
+/// Whether `fqn`'s leaf is one of ROS 2's own short-lived CLI helper nodes.
+///
+/// `ros2 topic echo`, `ros2 param get` and every other `ros2` CLI invocation spin up a
+/// real node named `_ros2cli_<pid>` - there is no hidden-node filter in discovery, so the
+/// gateway turns each one into an ordinary App. A few seconds of one of those is enough to
+/// arm it, and the moment the CLI process exits looks exactly like a death; because every
+/// invocation gets a fresh pid, letting these through would accumulate one permanently
+/// "dead" entry per CLI invocation for the life of the gateway. The prefix is rcl's own
+/// naming convention for hidden nodes, so matching it is an exact structural check, not a
+/// heuristic over operator-chosen names.
+bool is_ros2cli_node(const std::string & fqn) {
+  const auto slash = fqn.rfind('/');
+  const std::string leaf = slash == std::string::npos ? fqn : fqn.substr(slash + 1);
+  return leaf.rfind("_ros2cli_", 0) == 0;
+}
+}  // namespace
+
+/// Watches every App the graph carries for one that was armed and then vanishes, and
+/// raises GRAPH_NODE_DISAPPEARED naming it. Zero-config: unlike lifecycle_expectation's
+/// operator-declared require_active list, every App in scope is a candidate - see the
+/// package design note this mirrors.
+///
+/// Liveness is `App::is_online`, never mere membership in the snapshot. In runtime
+/// discovery a dead node's App leaves the snapshot entirely, so the two happen to
+/// coincide; but a manifest keeps a bound App present with only `is_online` cleared once
+/// its node disappears, so counting membership alone would make a manifest node immortal.
+/// A managed lifecycle node that merely deactivates keeps `is_online=true` (its process is
+/// still alive; only its ROS 2 lifecycle state changed), so that is never mistaken for
+/// death either - lifecycle state is lifecycle_expectation's concern, not this one's.
+///
+/// A key is tracked - and so can ever be reported dead - only once it has been armed by
+/// the reliability gate at least once. A manifest App that never comes online starts
+/// `is_online=false` and so is never armed, so it can never be falsely called dead; a node
+/// still inside its warmup window gets the same protection.
+///
+/// Composable/component nodes hosted in one process die together: if the container
+/// process dies, every node it hosted vanishes from the snapshot on the same tick, and all
+/// of them are folded into the one aggregated fault rather than one fault each (see
+/// AggregatedFault) - individually named up to AggregatedFault::kMaxDescriptionChars and
+/// NodeLivenessTracker::kMaxNamedDepartedEntries, whichever runs out first; past either
+/// limit the remainder are still counted, just not named (see NodeLivenessTracker's own
+/// collapsed-count doc).
+class NodeDeathDetector : public Detector {
+ public:
+  std::string id() const override {
+    return "node_death";
+  }
+
+  void configure(const nlohmann::json & config) override {
+    std::vector<std::string> warnings;
+
+    // tick_interval_ms is plugin plumbing (see plugin_injected_detector_keys()), but the
+    // miss_grace floor below is computed FROM it, so a malformed value here would corrupt
+    // that derivation silently unless it too is validated and named.
+    int tick_interval_ms = kDefaultTickIntervalMs;
+    if (config.contains("tick_interval_ms")) {
+      const auto & value = config["tick_interval_ms"];
+      // ROS parameters are int64: get the wide value and range-check it BEFORE narrowing,
+      // or a value above INT_MAX wraps back into the accepted band and passes silently.
+      const std::int64_t wide = value.is_number_integer() ? value.get<std::int64_t>() : 0;
+      if (wide > 0 && wide <= std::numeric_limits<int>::max()) {
+        tick_interval_ms = static_cast<int>(wide);
+      } else {
+        warnings.push_back("'tick_interval_ms' must be a positive integer up to " +
+                           std::to_string(std::numeric_limits<int>::max()) + "; keeping " +
+                           std::to_string(tick_interval_ms));
+      }
+    }
+
+    int miss_grace = kDefaultMissGrace;
+    if (config.contains("miss_grace")) {
+      const auto & value = config["miss_grace"];
+      const std::int64_t wide = value.is_number_integer() ? value.get<std::int64_t>() : -1;
+      if (wide >= 0 && wide <= kMaxNodeDeathGraceTicks) {
+        miss_grace = static_cast<int>(wide);
+      } else {
+        warnings.push_back("'miss_grace' must be an integer in 0.." + std::to_string(kMaxNodeDeathGraceTicks) +
+                           "; keeping " + std::to_string(kDefaultMissGrace));
+      }
+    }
+    // The wall-clock floor: a death is reported once misses EXCEED miss_grace, i.e. after
+    // miss_grace + 1 ticks, so raise the tick count until that window spans at least
+    // kMinNodeDeathWindowMs - and say so, since a silently-shortened tolerance is exactly
+    // how a fast tick turns one stale graph-cache generation into an immediate false death.
+    const int floor = min_node_death_miss_grace(tick_interval_ms);
+    if (miss_grace < floor) {
+      warnings.push_back("'miss_grace' " + std::to_string(miss_grace) + " spans only " +
+                         std::to_string((miss_grace + 1) * tick_interval_ms) + "ms at a " +
+                         std::to_string(tick_interval_ms) + "ms tick, under the " +
+                         std::to_string(kMinNodeDeathWindowMs) + "ms floor one graph-cache refresh needs; using " +
+                         std::to_string(floor));
+      miss_grace = floor;
+    }
+
+    int prune_grace = kDefaultPruneGrace;
+    if (config.contains("prune_grace")) {
+      const auto & value = config["prune_grace"];
+      const std::int64_t wide = value.is_number_integer() ? value.get<std::int64_t>() : -1;
+      if (wide >= 0 && wide <= kMaxNodeDeathGraceTicks) {
+        prune_grace = static_cast<int>(wide);
+      } else {
+        warnings.push_back("'prune_grace' must be an integer in 0.." + std::to_string(kMaxNodeDeathGraceTicks) +
+                           "; keeping " + std::to_string(kDefaultPruneGrace));
+      }
+    }
+
+    // The hard bound on how many keys tracker_ keeps state for at once. Same validation
+    // shape as miss_grace/prune_grace above; see NodeLivenessTracker::kDefaultTrackedKeyCap
+    // for why 512 is comfortable even against this detector's full-graph scope.
+    int tracked_node_cap = NodeLivenessTracker::kDefaultTrackedKeyCap;
+    if (config.contains("tracked_node_cap")) {
+      const auto & value = config["tracked_node_cap"];
+      const std::int64_t wide = value.is_number_integer() ? value.get<std::int64_t>() : -1;
+      if (wide >= kMinTrackedNodeCap && wide <= kMaxTrackedNodeCap) {
+        tracked_node_cap = static_cast<int>(wide);
+      } else {
+        warnings.push_back("'tracked_node_cap' must be an integer in " + std::to_string(kMinTrackedNodeCap) + ".." +
+                           std::to_string(kMaxTrackedNodeCap) + "; keeping the default (" +
+                           std::to_string(NodeLivenessTracker::kDefaultTrackedKeyCap) + ")");
+      }
+    }
+
+    build_suppressor_chain(config, warnings);
+    // A remembered id-match belongs to the allowlist that computed it; build_suppressor_chain
+    // just rebuilt (or dropped) that allowlist above, so a value captured under the OLD
+    // config would misrepresent the new one - clear rather than carry it forward.
+    id_allowlisted_.clear();
+    // Deliberately NOT reset here, unlike id_allowlisted_ above: ever_raised_ is a fact about
+    // this PROCESS's history ("has this instance ever put a genuine FAILED on the wire"),
+    // not about the current config. A live reconfigure (an operator editing the allowlist,
+    // say) can run with a death still outstanding and absent; resetting the flag would make
+    // the freshly-rebuilt tracker unable to ever re-create evidence for a node that is not
+    // currently online and armed, so the standing fault would get neither a further FAILED
+    // NOR a PASSED once the node genuinely returns - stuck for the rest of the process's
+    // life. A real process restart needs no reset either: it gets a brand-new
+    // NodeDeathDetector object, and ever_raised_'s own member initializer already starts
+    // false - see tick()'s own comment for the guard this flag drives.
+    collect_unknown_detector_keys(config, known_keys(), warnings);
+    warnings_ = std::move(warnings);
+    warnings_logged_ = false;
+
+    // A death can only ever be reported once misses_ exceeds miss_grace, so prune_ticks
+    // must be at least miss_grace + 1 - otherwise a durably-suppressed key could be
+    // reclaimed the very tick it would first have been reported, and the report would be
+    // silently lost rather than silently suppressed.
+    const int prune_ticks = std::max(prune_grace, miss_grace + 1);
+    tracker_ = NodeLivenessTracker(miss_grace, prune_ticks, tracked_node_cap);
+    tracked_node_cap_.store(tracked_node_cap);
+  }
+
+  std::size_t tracked_count_for_test() const override {
+    return tracked_count_.load();
+  }
+
+  /// status_json() runs on an HTTP handler thread concurrently with tick() on the plugin's
+  /// tick thread (see the base class doc), and NodeLivenessTracker itself carries no
+  /// synchronization of its own - reading tracker_ directly from here would race tick()'s
+  /// writes to it. tick() publishes into these atomics once per sweep instead, so this
+  /// method touches nothing tick() also touches.
+  ///
+  /// `tracking_saturated` is the one an operator acts on: it means the number of DEPARTED
+  /// (not yet confirmed dead, or already collapsed) identities exceeds tracked_node_cap even
+  /// after collapsing every confirmed death it safely could - so a newly confirmed death
+  /// among them may not get an individual name, only a place in the collapsed count. An
+  /// armed/present key is never refused tracking by this cap (see NodeLivenessTracker's own
+  /// class doc), so this is never "a node is going unchecked." The fix is a
+  /// require_active-style narrower allowlist entry set is not available here (this detector
+  /// is zero-config by design), so it is either less simultaneous departure churn or a larger
+  /// tracked_node_cap - both of which need tracked_count/tracked_node_cap alongside it to
+  /// reason about.
+  nlohmann::json status_json() const override {
+    return {{"tracked_count", tracked_count_.load()},
+            {"tracking_saturated", saturated_.load()},
+            {"tracked_node_cap", tracked_node_cap_.load()}};
+  }
+
+  void tick(DetectorContext & ctx) override {
+    if (!ctx.snapshot) {
+      return;
+    }
+    log_warnings_once(ctx);
+
+    std::set<std::string> present;
+    std::set<std::string> armed;
+    for (const auto & app : ctx.snapshot->apps) {
+      // A peer-aggregated app carries no ROS binding of its own (PeerClient::parse_app
+      // never reads x-medkit.ros2.node), so effective_fqn() is empty for every one of
+      // them. Tracking them would collapse the whole peer fleet onto a single "" key: one
+      // online peer app would mask every other peer app's departure.
+      if (app.source.rfind("peer:", 0) == 0) {
+        continue;
+      }
+      // Liveness is the bound node actually running, not mere presence in the snapshot -
+      // see the class doc for why membership alone would make a manifest node immortal.
+      if (!app.is_online) {
+        continue;
+      }
+      // Keyed on the STABLE fqn, not App::id: id is recomputed every sweep and only gets a
+      // namespace prefix once a bare-name collision currently exists anywhere in the
+      // graph, so a live node's id can change out from under a key built from it.
+      const std::string key = app.effective_fqn();
+      if (key.empty() || is_ros2cli_node(key)) {
+        continue;
+      }
+      present.insert(key);
+      if (reliability_allows(ctx.gate, app.id)) {  // the gate is keyed by App::id
+        armed.insert(key);
+      }
+      // Capture the allowlist's id-form verdict WHILE the entity is still present and
+      // app.id is in hand - suppresses() alone can never do this for a dead key, since by
+      // the time one is checked below the entity has already left ctx.snapshot entirely.
+      // See allowlist_suppressor.hpp's class doc. Overwritten every tick rather than
+      // latched, so a key whose id later stops colliding (and so stops matching) does not
+      // stay exempt on a stale reading - App::id, unlike the fqn, is not stable.
+      if (allowlist_ != nullptr) {
+        if (allowlist_->allows(app.id)) {
+          id_allowlisted_.insert(key);
+        } else {
+          id_allowlisted_.erase(key);
+        }
+      }
+    }
+
+    auto report = tracker_.update(present, armed);
+
+    std::set<std::string> keys_before_suppression;
+    for (const auto & [key, detail] : report.dead) {
+      (void)detail;
+      keys_before_suppression.insert(key);
+    }
+    // Suppress via the generic chain_ (each suppressor gets just the fqn key - covers
+    // AllowlistSuppressor's own fqn/leaf forms and LifecycleShutdownSuppressor's fqn-keyed
+    // departed-state lookup) OR via a remembered allowlist id-match captured above while the
+    // key was still present. The id form bypasses chain_ dispatch entirely rather than
+    // going through Suppressor::suppresses() - see allowlist_suppressor.hpp for why.
+    for (auto it = report.dead.begin(); it != report.dead.end();) {
+      bool suppressed = id_allowlisted_.count(it->first) > 0;
+      if (!suppressed) {
+        for (const Suppressor * s : chain_) {
+          if (s != nullptr && s->suppresses(it->first, ctx)) {
+            suppressed = true;
+            break;
+          }
+        }
+      }
+      if (suppressed) {
+        it = report.dead.erase(it);
+      } else {
+        ++it;
+      }
+    }
+
+    // Only a DURABLE suppressor's veto may feed prune() (see suppressor.hpp). Re-checking
+    // against durable_chain_ specifically - rather than simply "no longer in report.dead"
+    // - is required because a non-durable suppressor could remove a key from this tick's
+    // report even while chain_ also carries a durable one; durability is a property of
+    // WHICH suppressor vetoed a key, not of whether the key survived the filter. The id-form
+    // allowlist match is exactly as durable as its fqn/leaf forms (both read the same
+    // AllowlistSuppressor::durable()==true), so it feeds prune() the same way.
+    std::set<std::string> suppressed_for_prune;
+    for (const auto & key : keys_before_suppression) {
+      if (report.dead.count(key) > 0) {
+        continue;  // survived the filter - nothing suppressed it this tick
+      }
+      if (id_allowlisted_.count(key) > 0) {
+        suppressed_for_prune.insert(key);
+        continue;
+      }
+      for (const Suppressor * s : durable_chain_) {
+        if (s != nullptr && s->suppresses(key, ctx)) {
+          suppressed_for_prune.insert(key);
+          break;
+        }
+      }
+    }
+    tracker_.prune(suppressed_for_prune);
+    // Bound id_allowlisted_ the same way tracker_ itself is bounded: drop any key the
+    // tracker no longer knows about at all, so a key reclaimed by prune() above does not
+    // leave a same-tick orphan entry that would otherwise sit here forever (this map is
+    // never itself consulted for a key outside known_keys(), but an unbounded map under
+    // identity churn is exactly the failure N11 exists to rule out for tracker_ itself).
+    for (auto it = id_allowlisted_.begin(); it != id_allowlisted_.end();) {
+      it = tracker_.known_keys().count(*it) > 0 ? std::next(it) : id_allowlisted_.erase(it);
+    }
+    // Published once per sweep, after prune() has settled this tick's count - see
+    // status_json()'s own doc for why this is the only cross-thread-safe way to read it.
+    tracked_count_.store(tracker_.tracked_count());
+    saturated_.store(report.tracking_saturated);
+    if (report.saturation_started && ctx.gateway_node) {
+      // Once per EPISODE, not once per process: the latch re-arms when saturation ends (see
+      // NodeLivenessTracker's own saturated_last_tick_), so a later, real saturation is not
+      // silent because an earlier one already spent the warning. Mirrors
+      // lifecycle_expectation_detector.cpp's identical saturation_started handling.
+      RCLCPP_WARN(ctx.gateway_node->get_logger(),
+                  "graph_watchdog node_death: %d departed identities exceed tracked_node_cap even after "
+                  "collapsing every confirmed death - a newly confirmed death may not be named "
+                  "individually until some of these clear or are collapsed in turn. Every armed/present "
+                  "node is still being checked; raise 'tracked_node_cap' if this graph genuinely churns "
+                  "this many simultaneous departures at once",
+                  tracked_node_cap_.load());
+    }
+
+    // ctx.clear_fault(), unlike ctx.raise_fault(), carries no reliability-gate check of its
+    // own, so a level-triggered "affected is empty" reaches the fault manager as a genuine
+    // PASSED unconditionally the moment the fault client is ready - and this detector is
+    // zero-config, so unlike lifecycle_expectation's require_active it has no fixed,
+    // enumerable set of entries to ask "have I re-observed all of them yet" before trusting
+    // its own silence. ever_raised_ stands in for that: this process may only clear
+    // GRAPH_NODE_DISAPPEARED once it has ITSELF actually handed a FAILED request for it to
+    // the fault client at least once - not merely decided one was warranted. See
+    // DetectorContext::raise_fault's own doc for exactly what that return value does and
+    // does not prove.
+    //
+    // Tracked-key COUNT is deliberately not the signal, though it may look like an equally
+    // good proxy: any App elsewhere in the graph - the gateway's own node included - tends
+    // to arm within a tick or two of startup, which would make tracker_.tracked_count() go
+    // non-zero long before the SPECIFIC node a stored, outstanding fault names has been
+    // re-observed at all. A guard keyed on that count would open on an unrelated node's
+    // arming and clear a fault this process has not actually re-verified - exactly the
+    // silent, ungated heal this guard exists to rule out. report.dead's own emptiness says
+    // nothing that specific either (every dead key is merged into one aggregate), which is
+    // why the guard is keyed on whether THIS instance has raised at all, not on what it
+    // currently knows about.
+    if (report.dead.empty() && !ever_raised_) {
+      return;
+    }
+    // emit_ordered()'s own return is what earns ever_raised_, not report.dead's mere
+    // non-emptiness: raise_fault() can still decline to send even with a non-empty report -
+    // Advisory/Off mode, no client wired yet, or (concretely) the fault_manager service not
+    // being ready right at this tick, none of which are visible from here without reading
+    // the return value. Setting the flag from intent rather than delivery is the exact
+    // shape of false-clear this guard exists to rule out, one level deeper: kill a node
+    // while the service is down, wait past miss_grace, restore the service, let the node
+    // return - a flag set from "the report was non-empty" would already be true by then
+    // though async_send_request() had never actually been called for it, and the empty
+    // report on return would then emit a PASSED for an occurrence never even attempted.
+    // Retried
+    // every tick the report stays non-empty (emit_ordered() runs unconditionally above the
+    // guard once report.dead is non-empty, whether or not ever_raised_ is already true), so
+    // a raise that fails here is simply attempted again next tick rather than lost.
+    const bool sent = aggregated_.emit_ordered(ctx, report.dead, report.keys_by_freshness);
+    if (!report.dead.empty() && sent) {
+      ever_raised_ = true;
+    }
+  }
+
+ private:
+  static const std::set<std::string> & known_keys() {
+    static const std::set<std::string> keys{"allowlist", "miss_grace",       "prune_grace",
+                                            "suppress",  "tick_interval_ms", "tracked_node_cap"};
+    return keys;
+  }
+
+  void log_warnings_once(const DetectorContext & ctx) {
+    if (warnings_.empty() || warnings_logged_ || !ctx.gateway_node) {
+      return;
+    }
+    for (const auto & warning : warnings_) {
+      RCLCPP_WARN(ctx.gateway_node->get_logger(), "graph_watchdog node_death: %s", warning.c_str());
+    }
+    warnings_logged_ = true;
+  }
+
+  /// Rebuild owned_suppressors_/chain_/durable_chain_ from this detector's own config
+  /// slice. `suppress` is a list of mechanism names, dispatched here:
+  ///   "allowlist"  - an AllowlistSuppressor over the configured `allowlist` set.
+  ///   "lifecycle"  - a (stateless) LifecycleShutdownSuppressor.
+  ///   anything else - named but unrecognised; warned about, not built.
+  ///
+  /// Both mechanisms are opt-in: a configured `allowlist` that `suppress` never names has
+  /// NO effect, and says so - naming an entry on the list is not, by itself, a request to
+  /// suppress it. Every field is re-validated from scratch on every call (type, then array
+  /// element shape), and every rejection is named rather than silently dropped, so a typo'd
+  /// key or a malformed entry never reads as "working" from the operator's side.
+  ///
+  /// Rebuilds all three containers unconditionally, so a re-configure() never leaves
+  /// chain_/durable_chain_ holding a pointer into a freed owned_suppressors_ entry.
+  void build_suppressor_chain(const nlohmann::json & config, std::vector<std::string> & warnings) {
+    std::set<std::string> allow_set;
+    if (config.contains("allowlist")) {
+      const auto & value = config["allowlist"];
+      if (value.is_array()) {
+        for (const auto & entry : value) {
+          if (entry.is_string() && !entry.get<std::string>().empty()) {
+            allow_set.insert(entry.get<std::string>());
+          } else {
+            warnings.push_back("'allowlist' entries must be non-empty strings; skipping " + entry.dump());
+          }
+        }
+      } else {
+        warnings.push_back("'allowlist' must be an array of strings; ignoring it");
+      }
+    }
+
+    owned_suppressors_.clear();
+    chain_.clear();
+    durable_chain_.clear();
+    allowlist_ = nullptr;  // owned_suppressors_.clear() just freed whatever this pointed to
+
+    bool allowlist_named = false;
+    if (config.contains("suppress")) {
+      const auto & value = config["suppress"];
+      if (value.is_array()) {
+        for (const auto & entry : value) {
+          if (!entry.is_string()) {
+            warnings.push_back("'suppress' entries must be strings; skipping " + entry.dump());
+            continue;
+          }
+          const std::string name = entry.get<std::string>();
+          if (name == "allowlist") {
+            allowlist_named = true;
+          } else if (name == "lifecycle") {
+            owned_suppressors_.push_back(std::make_unique<LifecycleShutdownSuppressor>());
+          } else {
+            warnings.push_back("unknown 'suppress' entry '" + name + "'; ignoring it");
+          }
+        }
+      } else {
+        warnings.push_back("'suppress' must be an array of strings; ignoring it");
+      }
+    }
+
+    if (allowlist_named) {
+      auto suppressor = std::make_unique<AllowlistSuppressor>(std::move(allow_set));
+      // Kept as a second, typed pointer alongside the polymorphic chain_ entry below -
+      // node_death_detector.cpp's own tick() needs to call allows() directly (an
+      // AllowlistSuppressor-specific method, not part of the generic Suppressor interface)
+      // while an entity is still present. See tick()'s own comment and
+      // allowlist_suppressor.hpp's class doc for why.
+      allowlist_ = suppressor.get();
+      owned_suppressors_.push_back(std::move(suppressor));
+    } else if (!allow_set.empty()) {
+      // A configured allowlist that suppress does not name has no effect - naming it in
+      // suppress is what opts it in, matching every other suppression mechanism this
+      // framework carries.
+      warnings.push_back("'allowlist' has " + std::to_string(allow_set.size()) + " entr" +
+                         (allow_set.size() == 1 ? std::string("y") : std::string("ies")) +
+                         " configured but 'suppress' does not name \"allowlist\"; the list is inert");
+    }
+
+    for (const auto & s : owned_suppressors_) {
+      chain_.push_back(s.get());
+      if (s->durable()) {
+        durable_chain_.push_back(s.get());
+      }
+    }
+  }
+
+  NodeLivenessTracker tracker_{kDefaultMissGrace};
+  std::vector<std::string> warnings_;
+  bool warnings_logged_ = false;
+  AggregatedFault aggregated_{graph_fault_codes::kNodeDisappeared, kNodeDeathSeverity};
+  std::vector<std::unique_ptr<Suppressor>> owned_suppressors_;
+  std::vector<const Suppressor *> chain_;
+  std::vector<const Suppressor *> durable_chain_;  ///< Subset of chain_ safe to feed prune(). See tick().
+  /// Non-owning; points into owned_suppressors_ when "allowlist" is named in suppress, null
+  /// otherwise. Typed (not just another chain_ entry) because tick() needs allows(), which
+  /// is not part of the generic Suppressor interface - see allowlist_suppressor.hpp.
+  AllowlistSuppressor * allowlist_ = nullptr;
+  /// fqn -> "the last App::id observed for this key, while present, matched the allowlist".
+  /// Refreshed every tick a key is present (see tick()); the value from its last live tick
+  /// is what a dead key is judged by, since id is unavailable once the entity has left
+  /// ctx.snapshot. Bounded to tracker_.known_keys() at the end of every tick.
+  std::set<std::string> id_allowlisted_;
+  /// Whether THIS detector instance has itself genuinely raised GRAPH_NODE_DISAPPEARED at
+  /// least once - the ungated-clear guard. See tick()'s own comment for why this, and not
+  /// tracker_.tracked_count(), is the right granularity.
+  bool ever_raised_ = false;
+  std::atomic<std::size_t> tracked_count_{0};  ///< Cross-thread-safe mirror of tracker_.tracked_count().
+  std::atomic<bool> saturated_{false};         ///< tracked_node_cap refused a key on the last tick
+  std::atomic<int> tracked_node_cap_{NodeLivenessTracker::kDefaultTrackedKeyCap};  ///< as of the last configure()
+};
+
+REGISTER_DETECTOR(NodeDeathDetector, "node_death")
+
+}  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
@@ -93,10 +93,20 @@ bool is_ros2cli_node(const std::string & fqn) {
 /// still alive; only its ROS 2 lifecycle state changed), so that is never mistaken for
 /// death either - lifecycle state is lifecycle_expectation's concern, not this one's.
 ///
-/// A key is tracked - and so can ever be reported dead - only once it has been armed by
-/// the reliability gate at least once. A manifest App that never comes online starts
-/// `is_online=false` and so is never armed, so it can never be falsely called dead; a node
-/// still inside its warmup window gets the same protection.
+/// A key is tracked - and so can ever be reported dead - only once the reliability gate has
+/// said this detector OWNS its departure, which needs it armed AND its lifecycle state
+/// either known not to be a managed-non-active one or asked for as often as it ever will be.
+/// A manifest App that never comes online starts `is_online=false` and is skipped above
+/// regardless, so it can never be falsely called dead; a node still inside its warmup window
+/// gets the same protection; and a MANAGED node whose state has not been read YET is left to
+/// lifecycle_expectation while the watcher still has GetState attempts to spend on it. Once
+/// those are spent the node comes back here, because nothing will ASK again and
+/// lifecycle_expectation looks at nothing unless an operator named it in `require_active`.
+/// That last admission is PROVISIONAL: the ~/transition_event subscription outlives the seed
+/// budget, so an unasked-for label can still arrive, and one that reads non-active means the
+/// node was never this detector's - it is released while still alive rather than reported dead
+/// afterwards. The gate itself stays permissive about an unread label throughout (see
+/// LifecycleWatcher::node_ok()), so this whole decision is made here, not there.
 ///
 /// Composable/component nodes hosted in one process die together: if the container
 /// process dies, every node it hosted vanishes from the snapshot on the same tick, and all
@@ -247,6 +257,7 @@ class NodeDeathDetector : public Detector {
 
     std::set<std::string> present;
     std::set<std::string> armed;
+    std::set<std::string> handed_back;  // provisionally admitted, and the ground has gone
     for (const auto & app : ctx.snapshot->apps) {
       // A peer-aggregated app carries no ROS binding of its own (PeerClient::parse_app
       // never reads x-medkit.ros2.node), so effective_fqn() is empty for every one of
@@ -268,8 +279,57 @@ class NodeDeathDetector : public Detector {
         continue;
       }
       present.insert(key);
-      if (reliability_allows(ctx.gate, app.id)) {  // the gate is keyed by App::id
-        armed.insert(key);
+      // Tracking follows OWNERSHIP rather than permission, and the two are not the same
+      // question: the gate answers "may this entity raise" permissively for a managed node
+      // whose lifecycle label has never been read. What the gate returns here is the GROUND,
+      // and the ground decides whether admission is permanent. kEarned came from a
+      // measurement (or from a node with no lifecycle to measure) and is latched exactly as
+      // this detector has always latched an armed key. kProvisional came only from the
+      // watcher giving up on asking, so it holds only while that stays true: if a label
+      // arrives afterwards - the ~/transition_event subscription outlives the seed budget -
+      // the node turns out to have been another detector's all along, and it is handed back
+      // below rather than reported dead later. The two NEGATIVE grounds are just as different
+      // from each other: kDisowned is that measurement arriving, and kUnclaimed is the absence
+      // of any measurement at all, which is what a re-warming node answers - so only the first
+      // withdraws a key. The gate is keyed by App::id.
+      switch (presence_ownership(ctx.gate, app.id)) {
+        case PresenceOwnership::kEarned:
+          earned_.insert(key);  // knowledge, once had, is never withdrawn
+          armed.insert(key);
+          break;
+        case PresenceOwnership::kProvisional:
+          armed.insert(key);
+          break;
+        case PresenceOwnership::kDisowned:
+          // The graph has measured this node as another detector's. If this detector never
+          // earned it, hand it back while it is still alive. A key that WAS earned keeps its
+          // admission - a node that ran and then deactivated is still a death when it stops
+          // running.
+          //
+          // This runs inside the per-app loop, so the hand-back needs a tick on which the app
+          // is BOTH still present and already disowned. A node that dies within one such tick
+          // of its label arriving is reported by this detector after all - measured at 210 ms
+          // between the label reaching the status route and the release, against a ~1 s entity
+          // cache refresh. The window cannot be closed by deciding at REPORT time instead: by
+          // then the key has departed, `earned_` has been pruned for it (that prune is what
+          // bounds this map against identity churn), and the departed record carries only the
+          // LAST label - which reads "inactive" both for a node that was earned and then
+          // deactivated, which must be reported, and for one that was only ever provisional,
+          // which must not. Telling those apart at report time needs per-key ownership history
+          // that survives the departure, which is the unbounded state the prune exists to
+          // prevent. The window is stated in the README rather than papered over.
+          if (earned_.count(key) == 0) {
+            handed_back.insert(key);
+          }
+          break;
+        case PresenceOwnership::kUnclaimed:
+          // Nothing is known about this node yet - it is warming up, or the watcher is still
+          // asking. That is not a reason to admit it, and it is emphatically not a reason to
+          // give up a key already admitted: a node that dies, is reported, comes back and dies
+          // again inside its re-warm window reads exactly like this on the tick it returns, and
+          // releasing it there means its second death is tracked by nothing and every tick of
+          // the outage reports PASSED.
+          break;
       }
       // Capture the allowlist's id-form verdict WHILE the entity is still present and
       // app.id is in hand - suppresses() alone can never do this for a dead key, since by
@@ -284,6 +344,20 @@ class NodeDeathDetector : public Detector {
           id_allowlisted_.erase(key);
         }
       }
+    }
+
+    // Before update(), so a key handed back this tick cannot appear in this tick's report:
+    // the whole point is that it is not this detector's node, and a death it was never
+    // entitled to report must not be reported once on the way out either.
+    for (const auto & key : handed_back) {
+      tracker_.release(key);
+    }
+    // `earned_` is a fact about keys in the CURRENT graph, so it is pruned to them: a key
+    // that departs and later returns is a new incarnation, and it re-earns (or does not) from
+    // whatever the gate then says. Without the prune this would grow with identity churn for
+    // the life of the process, which is the growth the tracker's own cap exists to bound.
+    for (auto it = earned_.begin(); it != earned_.end();) {
+      it = present.count(*it) == 0 ? earned_.erase(it) : std::next(it);
     }
 
     auto report = tracker_.update(present, armed);
@@ -526,6 +600,11 @@ class NodeDeathDetector : public Detector {
   /// Refreshed every tick a key is present (see tick()); the value from its last live tick
   /// is what a dead key is judged by, since id is unavailable once the entity has left
   /// ctx.snapshot. Bounded to tracker_.known_keys() at the end of every tick.
+  /// Keys whose ownership the gate granted on kEarned grounds while they were present. Read
+  /// only by the kDisowned branch in tick(), which is the one place the difference between an
+  /// admission earned from a measurement and one granted provisionally decides anything.
+  /// Pruned to the live graph every tick.
+  std::set<std::string> earned_;
   std::set<std::string> id_allowlisted_;
   /// Whether THIS detector instance has itself genuinely raised GRAPH_NODE_DISAPPEARED at
   /// least once - the ungated-clear guard. See tick()'s own comment for why this, and not

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/node_death_detector.cpp
@@ -73,6 +73,17 @@ constexpr std::int64_t kMaxTrackedNodeCap = 16384;
 /// "dead" entry per CLI invocation for the life of the gateway. The prefix is rcl's own
 /// naming convention for hidden nodes, so matching it is an exact structural check, not a
 /// heuristic over operator-chosen names.
+/// Whether the gate can currently read this app's lifecycle label as "active" - the one
+/// positive measurement that says a node is the presence detector's. Distinct from a kEarned
+/// answer, which is also given to a node that carries no lifecycle at all.
+bool reads_active(const ReliabilityGate * gate, const std::string & app_id) {
+  if (gate == nullptr) {
+    return true;  // not wired (a bare-context test): every other predicate here is permissive
+  }
+  const auto label = gate->lifecycle_state_of(app_id);
+  return label.has_value() && *label == "active";
+}
+
 bool is_ros2cli_node(const std::string & fqn) {
   const auto slash = fqn.rfind('/');
   const std::string leaf = slash == std::string::npos ? fqn : fqn.substr(slash + 1);
@@ -219,8 +230,22 @@ class NodeDeathDetector : public Detector {
     // reclaimed the very tick it would first have been reported, and the report would be
     // silently lost rather than silently suppressed.
     const int prune_ticks = std::max(prune_grace, miss_grace + 1);
+    // How long a RELEASED key may keep showing "no lifecycle record at all" while still PRESENT
+    // before this detector takes it back. Derived from miss_grace rather than picked, and the
+    // derivation is the argument: miss_grace + 1 ticks is this detector's own definition of
+    // "absent long enough to be dead", already floored to span at least kMinNodeDeathWindowMs
+    // of wall clock whatever the tick rate. A node that really is dying is GONE inside that
+    // window - its App follows its lifecycle services within one entity-cache refresh - so a
+    // node still present past it is not mid-death, it has simply stopped being managed.
+    released_no_record_hold_ticks_ = miss_grace + 1;
     tracker_ = NodeLivenessTracker(miss_grace, prune_ticks, tracked_node_cap);
     tracked_node_cap_.store(tracked_node_cap);
+  }
+
+  /// This detector IS the presence class, so the set it tracks is the answer every other
+  /// reader needs - see DetectorContext::presence_tracked for why they ask rather than re-derive.
+  const std::set<std::string> * tracked_departure_keys() const override {
+    return &tracker_.known_keys();
   }
 
   std::size_t tracked_count_for_test() const override {
@@ -279,6 +304,12 @@ class NodeDeathDetector : public Detector {
         continue;
       }
       present.insert(key);
+      // Any lifecycle record at all - whatever it says - ends a "no record" run, so the hold
+      // below only ever counts CONSECUTIVE record-less ticks. Only asked for a key that is
+      // actually withheld: nothing else can have an entry, and this is a watcher lookup.
+      if (released_.count(key) != 0 && ctx.gate != nullptr && ctx.gate->lifecycle_state_of(app.id).has_value()) {
+        released_no_record_ticks_.erase(key);
+      }
       // Tracking follows OWNERSHIP rather than permission, and the two are not the same
       // question: the gate answers "may this entity raise" permissively for a managed node
       // whose lifecycle label has never been read. What the gate returns here is the GROUND,
@@ -294,10 +325,40 @@ class NodeDeathDetector : public Detector {
       // withdraws a key. The gate is keyed by App::id.
       switch (presence_ownership(ctx.gate, app.id)) {
         case PresenceOwnership::kEarned:
+          // kEarned has two grounds and only one of them is a measurement: "the label reads
+          // active" is, "there is no managed record at all" is not. For a key this detector has
+          // already handed back that difference decides everything, because a dying managed
+          // node produces the second shape on its way out - its lifecycle services leave the
+          // snapshot a sweep before the App does, the watcher drops the record, and a node with
+          // no record reads exactly like a plain one. Re-admitting on that would let the act of
+          // dying erase the measurement that disowned the node, and the death would be reported
+          // by the detector the label had already disqualified. So a released key waits for the
+          // graph to say ACTIVE again; the disappearance of what disowned it is not news that
+          // the node became ours.
+          //
+          // The wait is bounded, and it has to be. Refusing on "no record" for as long as the
+          // condition lasts means a node that merely STOPPED being managed - dropped its
+          // lifecycle services and kept running as an ordinary node - is refused for the rest of
+          // its life, and its eventual death is reported by nobody: this detector has no key,
+          // and lifecycle_expectation only ever looks at require_active entries. So the refusal
+          // runs for released_no_record_hold_ticks_ consecutive record-less PRESENT ticks (see
+          // configure()), which is this detector's own "gone means dead" window; past it the
+          // node has outlived any plausible death and is taken back.
+          if (released_.count(key) != 0 && !reads_active(ctx.gate, app.id) &&
+              ++released_no_record_ticks_[key] <= released_no_record_hold_ticks_) {
+            break;
+          }
+          released_.erase(key);
+          released_no_record_ticks_.erase(key);
           earned_.insert(key);  // knowledge, once had, is never withdrawn
           armed.insert(key);
           break;
         case PresenceOwnership::kProvisional:
+          // Same rule, same reason: the asking starting over on a re-bound entry is the absence
+          // of knowledge, not the arrival of it, so it cannot readmit a key already handed back.
+          if (released_.count(key) != 0) {
+            break;
+          }
           armed.insert(key);
           break;
         case PresenceOwnership::kDisowned:
@@ -320,6 +381,7 @@ class NodeDeathDetector : public Detector {
           // prevent. The window is stated in the README rather than papered over.
           if (earned_.count(key) == 0) {
             handed_back.insert(key);
+            released_.insert(key);
           }
           break;
         case PresenceOwnership::kUnclaimed:
@@ -352,15 +414,44 @@ class NodeDeathDetector : public Detector {
     for (const auto & key : handed_back) {
       tracker_.release(key);
     }
-    // `earned_` is a fact about keys in the CURRENT graph, so it is pruned to them: a key
-    // that departs and later returns is a new incarnation, and it re-earns (or does not) from
-    // whatever the gate then says. Without the prune this would grow with identity churn for
-    // the life of the process, which is the growth the tracker's own cap exists to bound.
-    for (auto it = earned_.begin(); it != earned_.end();) {
-      it = present.count(*it) == 0 ? earned_.erase(it) : std::next(it);
-    }
-
     auto report = tracker_.update(present, armed);
+
+    // Pruned AFTER update(), because update() is what admits this tick's keys: running it before
+    // means pruning against a tracker that has not seen them yet, which on a key's very first
+    // tick throws away the ground it was just admitted on.
+    //
+    // `earned_` is bookkeeping about a TRACKED KEY, so it lives exactly as long as the tracker
+    // keeps that key - which is what known_keys() is for, and what bounds it. Note what that
+    // bound actually is: tracked_key_cap governs the DEPARTED subset only (a present, armed key
+    // is admitted unconditionally and never evicted - see NodeLivenessTracker's class doc), so
+    // known_keys() is bounded by the live graph PLUS the cap, not by the cap alone. Neither term
+    // grows with uptime, which is what matters here: a churned identity is present only while
+    // its process runs, and once it departs and matures it becomes a collapse candidate that
+    // enforce_departed_cap() erases outright, so identity churn cannot accumulate. Pruning
+    // `earned_` to the PRESENT graph
+    // instead threw the ground away during an outage, and a crash-looping node came back at
+    // "unconfigured" - which is where a respawned lifecycle node always starts, since nothing
+    // re-drives it - with nothing left to say it had ever been this detector's. It was handed
+    // back on the return, its fault healed, and every death after the first went unreported.
+    const auto & tracked_keys = tracker_.known_keys();
+    for (auto it = earned_.begin(); it != earned_.end();) {
+      it = tracked_keys.count(*it) == 0 ? earned_.erase(it) : std::next(it);
+    }
+    // `released_` answers a different question with a different lifetime: it is the set of
+    // PRESENT keys this detector has refused, and a released key is by definition not in the
+    // tracker at all, so it cannot be bounded by known_keys() - it is bounded by the live graph
+    // instead, since every member of it is a key present this tick. It goes when the node does;
+    // the incarnation that returns is re-derived from whatever the gate then says about it. The
+    // no-record counter beside it answers only about keys in `released_`, so it is pruned with
+    // it rather than separately.
+    for (auto it = released_.begin(); it != released_.end();) {
+      if (present.count(*it) != 0) {
+        ++it;
+        continue;
+      }
+      released_no_record_ticks_.erase(*it);
+      it = released_.erase(it);
+    }
 
     std::set<std::string> keys_before_suppression;
     for (const auto & [key, detail] : report.dead) {
@@ -600,6 +691,18 @@ class NodeDeathDetector : public Detector {
   /// Refreshed every tick a key is present (see tick()); the value from its last live tick
   /// is what a dead key is judged by, since id is unavailable once the entity has left
   /// ctx.snapshot. Bounded to tracker_.known_keys() at the end of every tick.
+  /// Consecutive PRESENT ticks a released key has shown no lifecycle record at all. Bounded to
+  /// `released_` (pruned with it every tick), which is itself bounded by the live graph.
+  std::map<std::string, int> released_no_record_ticks_;
+  /// How many such ticks a released key is refused before this detector takes it back. Set from
+  /// the configured miss_grace - see configure() for why that is the right window.
+  int released_no_record_hold_ticks_ = kDefaultMissGrace + 1;
+  /// Keys this detector handed back on a measured disown and has not been given back by a
+  /// measurement since. Read only by the two admission branches in tick(), where it is what
+  /// stops the loss of a lifecycle record - which is what dying looks like from the snapshot -
+  /// counting as the node becoming this detector's. Cleared by a label reading "active", and
+  /// pruned to the live graph every tick.
+  std::set<std::string> released_;
   /// Keys whose ownership the gate granted on kEarned grounds while they were present. Read
   /// only by the kDisowned branch in tick(), which is the one place the difference between an
   /// admission earned from a measurement and one granted provisionally decides anything.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <set>
 #include <string>
@@ -35,6 +36,7 @@
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"  // kGraphWatchdogEntityId
 #include "ros2_medkit_graph_watchdog/detector_config.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"  // min_node_death_miss_grace
 #include "ros2_medkit_graph_watchdog/detector_registry.hpp"
 #include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
 
@@ -72,6 +74,43 @@ typename rclcpp::Client<ServiceT>::SharedPtr create_client_in_group(rclcpp::Node
 #else
   return node->create_client<ServiceT>(name, rmw_qos_profile_services_default, group);
 #endif
+}
+
+/// What node_death's own configure() will resolve `prune_grace` to, mirroring that
+/// detector's exact validation (a non-negative integer no larger than
+/// kMaxNodeDeathGraceTicks) so this function and the config actually injected into
+/// node_death's own dcfg (set_context()'s detector loop, below) can never disagree - both
+/// call this, so there is exactly one place that decision is made.
+///
+/// Falls back to `plugin_prune_grace` (clamped into node_death's own accepted range - a
+/// defensive clamp, not another validation pass: load_parameters() only checks
+/// `>= 0` for its own field) exactly when node_death's own configure() would ALSO fall back:
+/// the per-detector value is absent, the wrong JSON type, negative, or past
+/// kMaxNodeDeathGraceTicks. Before this existed, the plugin's own retention math used this
+/// same fallback while set_context() injected the plugin default only when the per-detector
+/// key was ABSENT - so a PRESENT but malformed `detectors.node_death.prune_grace` reached
+/// node_death's configure() unfiltered, which falls back to ITS OWN hardcoded default
+/// instead of `plugin_prune_grace`. The two fallbacks coincide at their shared default (60)
+/// and only diverge when an operator's plugin-scope `prune_grace` differs from it - which is
+/// exactly the gap a test that never varies the plugin-scope value off 60 cannot catch.
+int resolve_node_death_prune_grace(const nlohmann::json & config_snapshot, int plugin_prune_grace) {
+  if (config_snapshot.contains("detectors") && config_snapshot["detectors"].is_object()) {
+    const auto & detectors = config_snapshot["detectors"];
+    if (detectors.contains("node_death") && detectors["node_death"].is_object()) {
+      const auto & node_death_cfg = detectors["node_death"];
+      // ROS/JSON integers are wide: read int64_t and range-check it BEFORE narrowing to int,
+      // mirroring node_death_detector.cpp's own identical read of this same field. A value
+      // above kMaxNodeDeathGraceTicks (or above INT_MAX) narrowed first can wrap back into
+      // an accepted-looking band and pass silently.
+      if (node_death_cfg.contains("prune_grace") && node_death_cfg["prune_grace"].is_number_integer()) {
+        const std::int64_t wide = node_death_cfg["prune_grace"].get<std::int64_t>();
+        if (wide >= 0 && wide <= kMaxNodeDeathGraceTicks) {
+          return static_cast<int>(wide);
+        }
+      }
+    }
+  }
+  return std::min(plugin_prune_grace, static_cast<int>(kMaxNodeDeathGraceTicks));
 }
 }  // namespace
 
@@ -144,31 +183,42 @@ int GraphWatchdogPlugin::compute_departed_retention_ticks(const nlohmann::json &
   // configure() has not run yet at the point set_context() needs this value, so its
   // own kDefaultMissGrace/clamping cannot be reused directly here.
   int node_death_miss_grace = kDefaultNodeDeathMissGrace;
-  int node_death_prune_grace = prune_grace_;
   if (config_snapshot.contains("detectors") && config_snapshot["detectors"].is_object()) {
     const auto & detectors = config_snapshot["detectors"];
     if (detectors.contains("node_death") && detectors["node_death"].is_object()) {
       const auto & node_death_cfg = detectors["node_death"];
+      // ROS/JSON integers are wide: read int64_t and range-check it BEFORE narrowing to int,
+      // mirroring node_death_detector.cpp's own identical read of this same field. A
+      // value above kMaxNodeDeathGraceTicks (or above INT_MAX) narrowed first can wrap back
+      // into an accepted-looking band and pass the ">= 0" check silently - node_death's own
+      // configure() would reject that same value and keep its default, so a plugin that
+      // narrowed first would size this window from a number the detector never actually
+      // uses, under- or over-running the retention this function exists to get right.
       if (node_death_cfg.contains("miss_grace") && node_death_cfg["miss_grace"].is_number_integer()) {
-        const int candidate = node_death_cfg["miss_grace"].get<int>();
-        if (candidate >= 0) {
-          node_death_miss_grace = candidate;
-        }
-      }
-      // Same reason we read miss_grace here: prune_grace is a per-detector key whose
-      // plugin-scope value is only a default, so the retention window must be computed from
-      // whatever node_death will ACTUALLY clamp its prune_ticks_ to. Reading prune_grace_
-      // unconditionally would under-run the retention whenever an operator raises
-      // detectors.node_death.prune_grace, and node_death would then re-raise a
-      // cleanly-shut-down node it should have silently reclaimed (see the formula below).
-      if (node_death_cfg.contains("prune_grace") && node_death_cfg["prune_grace"].is_number_integer()) {
-        const int candidate = node_death_cfg["prune_grace"].get<int>();
-        if (candidate >= 0) {
-          node_death_prune_grace = candidate;
+        const std::int64_t wide = node_death_cfg["miss_grace"].get<std::int64_t>();
+        if (wide >= 0 && wide <= kMaxNodeDeathGraceTicks) {
+          node_death_miss_grace = static_cast<int>(wide);
         }
       }
     }
   }
+  // prune_grace is a per-detector key whose plugin-scope value is only a default, so the
+  // retention window must be computed from whatever node_death will ACTUALLY clamp its
+  // prune_ticks_ to - see resolve_node_death_prune_grace()'s own doc for why this must be
+  // the SAME function set_context() uses to inject node_death's own dcfg, not a parallel
+  // re-derivation of the same rule.
+  const int node_death_prune_grace = resolve_node_death_prune_grace(config_snapshot, prune_grace_);
+  // node_death's own configure() unconditionally raises miss_grace to its wall-clock floor
+  // (min_node_death_miss_grace(), detector_config_keys.hpp) whenever the configured tick is fast
+  // enough to need it - "unconditionally" because that floor applies to node_death's
+  // DEFAULT miss_grace too, not only an operator-set one. A fast tick is exactly this
+  // plugin's own tick_interval_ms_, already loaded by the time set_context() calls this
+  // (load_parameters() runs first). Applied here too, and outside the "detectors.node_death
+  // exists" check above: mirroring only the RAW config value - or only flooring it when an
+  // operator happened to configure node_death at all - would leave this window sized for a
+  // miss_grace smaller than the one node_death will actually use, which is the exact
+  // under-run the rest of this function's comment describes.
+  node_death_miss_grace = std::max(node_death_miss_grace, min_node_death_miss_grace(tick_interval_ms_));
   // prune_ticks mirrors node_death's OWN prune_ticks_ clamp (node_death_detector.cpp's
   // configure()): max(prune_grace, miss_grace + 1). The departed-lifecycle label must
   // survive not just past the FIRST tick node_death evaluates suppression on
@@ -177,14 +227,14 @@ int GraphWatchdogPlugin::compute_departed_retention_ticks(const nlohmann::json &
   // node_death's own RECLAIM tick (T_depart + miss_grace + prune_ticks): only a durable
   // suppressor (lifecycle_clean_shutdown IS one, see suppressor.hpp) may feed
   // NodeLivenessTracker::prune(), and that reclaim can only happen while the suppressor
-  // still actively vetoes the id - i.e. while the label is still cached. If the label
-  // expired even one tick earlier (the old `max(prune_grace, miss_grace + 1)` retention
-  // - the SAME length as prune_ticks, but anchored miss_grace ticks later at
-  // T_depart instead of T_death), the suppressor would abstain right at the reclaim
-  // tick, node_death would RAISE instead of silently reclaiming, and - because the
-  // label is now gone for good - the id could never be suppressed again: a permanent
-  // false GRAPH_NODE_DISAPPEARED for a cleanly-shut-down node. The extra "+1" keeps one
-  // full tick of margin past the reclaim tick itself. See
+  // still actively vetoes the id - i.e. while the label is still cached. A retention window
+  // anchored at T_depart instead and merely as long as prune_ticks itself (`max(prune_grace,
+  // miss_grace + 1)`, with no `+ node_death_miss_grace + 1` on top) would expire miss_grace
+  // ticks too early: the suppressor would then abstain right at the reclaim tick, node_death
+  // would RAISE instead of silently reclaiming, and - because the label is now gone for good
+  // - the id could never be suppressed again: a permanent false GRAPH_NODE_DISAPPEARED for a
+  // cleanly-shut-down node. The extra "+1" below keeps one full tick of margin past the
+  // reclaim tick itself. See
   // test_node_death_integration.cpp's CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention
   // for the regression this formula fixes.
   const int prune_ticks = std::max(node_death_prune_grace, node_death_miss_grace + 1);
@@ -267,6 +317,17 @@ void GraphWatchdogPlugin::set_context(ros2_medkit_gateway::PluginContext & conte
       // unconditionally silently discarded the per-detector setting.
       if (!dcfg.contains("prune_grace")) {
         dcfg["prune_grace"] = prune_grace_;
+      }
+      if (id == "node_death") {
+        // node_death is the one detector this plugin also predicts the behaviour of BEFORE
+        // configure() runs (compute_departed_retention_ticks(), above, sizes the lifecycle
+        // watcher's own retention off it) - so what actually reaches its configure() here
+        // must be byte-for-byte the value that prediction assumed, not merely "the operator's
+        // value when well-formed, else whatever node_death happens to default to on its own."
+        // Re-resolving (rather than trusting the injection above) also covers a PRESENT but
+        // malformed detectors.node_death.prune_grace, which the absence check above leaves
+        // untouched even though node_death's own configure() will still reject it.
+        dcfg["prune_grace"] = resolve_node_death_prune_grace(config_snapshot, prune_grace_);
       }
       detector->configure(dcfg);
     } catch (const std::exception & e) {

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <limits>
 #include <set>
 #include <string>
 #include <utility>
@@ -150,31 +151,34 @@ void GraphWatchdogPlugin::configure(const nlohmann::json & config) {
 
 void GraphWatchdogPlugin::load_parameters() {
   std::lock_guard<std::mutex> lock(config_mutex_);
-  if (config_.contains("tick_interval_ms") && config_["tick_interval_ms"].is_number_integer()) {
-    const int candidate = config_["tick_interval_ms"].get<int>();
-    if (candidate > 0) {
-      tick_interval_ms_ = candidate;
-    } else {
-      log_warn("ignoring non-positive tick_interval_ms=" + std::to_string(candidate) + "; keeping " +
-               std::to_string(tick_interval_ms_));
+  // Every read here is WIDE, range-checked, and only then narrowed. JSON (and the ROS
+  // parameters these values arrive from) carry 64-bit integers, so get<int>() first is an
+  // implementation-defined narrowing that lands a huge value back inside the accepted band:
+  // tick_interval_ms 4294968296 narrows to 1000 and passes "> 0" as though the operator had
+  // asked for the default, and 2147483648 narrows to a negative and is merely "ignored" with a
+  // warning naming a number nobody typed. compute_departed_retention_ticks() below already
+  // reads node_death's own miss_grace this way, for the identical reason.
+  const auto read_wide = [this](const char * key, std::int64_t lo, std::int64_t hi, int & out) {
+    if (!config_.contains(key) || !config_[key].is_number_integer()) {
+      return;
     }
-  }
-  if (config_.contains("warmup_cycles") && config_["warmup_cycles"].is_number_integer()) {
-    const int candidate = config_["warmup_cycles"].get<int>();
-    if (candidate >= 0) {
-      warmup_cycles_ = candidate;
-    } else {
-      log_warn("ignoring negative warmup_cycles=" + std::to_string(candidate));
+    const std::int64_t candidate = config_[key].get<std::int64_t>();
+    if (candidate >= lo && candidate <= hi) {
+      out = static_cast<int>(candidate);
+      return;
     }
-  }
-  if (config_.contains("prune_grace") && config_["prune_grace"].is_number_integer()) {
-    const int candidate = config_["prune_grace"].get<int>();
-    if (candidate >= 0) {
-      prune_grace_ = candidate;
-    } else {
-      log_warn("ignoring negative prune_grace=" + std::to_string(candidate));
-    }
-  }
+    log_warn("ignoring out-of-range " + std::string(key) + "=" + std::to_string(candidate) + " (accepted " +
+             std::to_string(lo) + ".." + std::to_string(hi) + "); keeping " + std::to_string(out));
+  };
+  // The bands are the ones this plugin already documented, now actually enforced: the only
+  // change is WHERE the value is checked, never which values are legal. INT_MAX is the real
+  // ceiling in each case - min_node_death_miss_grace() is written to stay defined right up to
+  // it, and a plugin-scope prune_grace is re-validated against each detector's own 0..3600
+  // before it takes effect anywhere.
+  constexpr std::int64_t kIntMax = std::numeric_limits<int>::max();
+  read_wide("tick_interval_ms", 1, kIntMax, tick_interval_ms_);
+  read_wide("warmup_cycles", 0, kIntMax, warmup_cycles_);
+  read_wide("prune_grace", 0, kIntMax, prune_grace_);
 }
 
 int GraphWatchdogPlugin::compute_departed_retention_ticks(const nlohmann::json & config_snapshot) const {
@@ -486,10 +490,38 @@ void GraphWatchdogPlugin::tick() {
     dctx.fault_client = fault_client_;
     dctx.snapshot = &snapshot;
     dctx.cancelled = &shutdown_requested_;
+    dctx.presence_tracked = presence_tracked_valid_ ? &presence_tracked_ : nullptr;
     try {
       detector->tick(dctx);
     } catch (const std::exception & e) {
       log_error("detector '" + detector->id() + "' threw: " + e.what());
+    }
+  }
+
+  // COPIED at one defined point: after every detector has ticked, so the content is the owner's
+  // set as it stood at the END of this sweep. A pointer into that set would not be a view at all
+  // - the owner mutates it inside its own tick(), so a reader registered before it would see the
+  // previous tick's contents and one registered after would see this tick's, which is exactly
+  // the registry-order dependence this seam exists to remove. The end of the sweep is the right
+  // point because it is the only one at which no detector is mid-update: taking it at the start
+  // would publish the same content one tick later without removing the hazard, since a reader
+  // still cannot tell whether the owner has run yet. Cost is one string-set copy per tick, sized
+  // by the live graph.
+  //
+  // Only a detector that will actually REPORT a departure may speak for the presence class: one
+  // running Advisory or Off tracks keys it will never raise for, and a reader treating that as
+  // "somebody has this covered" would hold back its own report for a fault nobody is going to
+  // file.
+  presence_tracked_.clear();
+  presence_tracked_valid_ = false;
+  for (const auto & [detector, mode] : detectors_) {
+    if (!mode_emits(mode)) {
+      continue;
+    }
+    if (const auto * keys = detector->tracked_departure_keys()) {
+      presence_tracked_ = *keys;
+      presence_tracked_valid_ = true;
+      break;
     }
   }
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/graph_watchdog_plugin.cpp
@@ -224,23 +224,25 @@ int GraphWatchdogPlugin::compute_departed_retention_ticks(const nlohmann::json &
   // under-run the rest of this function's comment describes.
   node_death_miss_grace = std::max(node_death_miss_grace, min_node_death_miss_grace(tick_interval_ms_));
   // prune_ticks mirrors node_death's OWN prune_ticks_ clamp (node_death_detector.cpp's
-  // configure()): max(prune_grace, miss_grace + 1). The departed-lifecycle label must
-  // survive not just past the FIRST tick node_death evaluates suppression on
-  // (T_depart + miss_grace, see test_node_death_integration.cpp's
-  // CleanShutdownDepartureAtMissGraceBoundaryIsSuppressed), but all the way through
-  // node_death's own RECLAIM tick (T_depart + miss_grace + prune_ticks): only a durable
-  // suppressor (lifecycle_clean_shutdown IS one, see suppressor.hpp) may feed
-  // NodeLivenessTracker::prune(), and that reclaim can only happen while the suppressor
-  // still actively vetoes the id - i.e. while the label is still cached. A retention window
-  // anchored at T_depart instead and merely as long as prune_ticks itself (`max(prune_grace,
-  // miss_grace + 1)`, with no `+ node_death_miss_grace + 1` on top) would expire miss_grace
-  // ticks too early: the suppressor would then abstain right at the reclaim tick, node_death
-  // would RAISE instead of silently reclaiming, and - because the label is now gone for good
-  // - the id could never be suppressed again: a permanent false GRAPH_NODE_DISAPPEARED for a
-  // cleanly-shut-down node. The extra "+1" below keeps one full tick of margin past the
-  // reclaim tick itself. See
-  // test_node_death_integration.cpp's CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention
-  // for the regression this formula fixes.
+  // configure()): max(prune_grace, miss_grace + 1). What the departed-lifecycle label must
+  // outlive is the FIRST tick node_death evaluates suppression on (T_depart + miss_grace, see
+  // test_node_death_integration.cpp's CleanShutdownDepartureAtMissGraceBoundaryIsSuppressed).
+  // That is the whole requirement, because node_death LATCHES a durable suppressor's verdict
+  // per departed key and stops re-asking - see the suppression filter in its tick().
+  //
+  // The window is sized well past that anyway, out to node_death's own RECLAIM tick
+  // (T_depart + miss_grace + prune_ticks) plus one, and that generosity is deliberate rather
+  // than vestigial: sizing it to the first evaluation alone would leave nothing for the gap
+  // between the two events this arithmetic straddles. The retention clock starts when a dying
+  // node's lifecycle SERVICES leave the graph, while every T_depart above counts from when its
+  // App does - one or more sweeps later - so a window with no slack loses whatever that lead
+  // costs. Before the latch existed that lead came straight out of the single tick of margin
+  // here, and past one tick of it the label expired mid-veto: the suppressor abstained, the
+  // consecutive-suppression streak prune() depends on reset to zero, and with the label then
+  // gone for good the key could never be suppressed again - a permanent false
+  // GRAPH_NODE_DISAPPEARED for a cleanly-shut-down node. See that scenario in
+  // test_node_death_integration.cpp's CleanShutdownIsStillSuppressedWhenItsServicesLeaveBeforeItsApp,
+  // and CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention for the reclaim boundary itself.
   const int prune_ticks = std::max(node_death_prune_grace, node_death_miss_grace + 1);
   return prune_ticks + node_death_miss_grace + 1;
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
@@ -42,11 +42,6 @@ constexpr int kMaxGetStateSeedsPerTick = 8;
 /// timeout (~500 ms), never N of them; async ~/transition_event keeps state fresh meanwhile.
 constexpr std::chrono::milliseconds kGetStateBudgetPerTick{150};
 
-/// How many extra GetState re-seeds a tracked-but-non-active node gets to self-heal a
-/// missed activation. Two ticks of coverage comfortably outlast the tens-of-ms DDS
-/// endpoint-matching window; after that a matched subscription catches every transition.
-constexpr int kReseedAttempts = 2;
-
 /// The error branch of the default lifecycle state machine. A node reaches it from any
 /// primary state via ON_ERROR, and leaves it either back to `unconfigured` (ON_ERROR_SUCCESS,
 /// the default on_error) or into `finalized` (ON_ERROR_FAILURE / ON_ERROR_ERROR).
@@ -289,7 +284,7 @@ void LifecycleWatcher::update(const ros2_medkit_gateway::IntrospectionInput & sn
         options);
     auto & tracked = state_->tracked[id];
     tracked.sub = std::move(sub);
-    tracked.reseeds_remaining = kReseedAttempts;
+    tracked.reseeds_remaining = LifecycleWatcher::kReseedAttempts;
     const auto seed_it = seeded.find(id);
     tracked.state_label = (seed_it != seeded.end()) ? seed_it->second : "";
     // Captured at first sighting: current_fqns is built from the same snapshot pass
@@ -361,6 +356,19 @@ bool LifecycleWatcher::node_ok(const std::string & app_id) const {
   return it->second.state_label.empty() || it->second.state_label == "active";
 }
 
+bool LifecycleWatcher::measurement_pending(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(state_->mutex);
+  const auto it = state_->tracked.find(app_id);
+  if (it == state_->tracked.end()) {
+    return false;
+  }
+  // Both conjuncts matter. A non-empty label is a measurement, however stale. An empty one
+  // with no attempts left is a measurement that will never arrive: update() only queues a
+  // re-seed while `reseeds_remaining > 0`, so nothing here will issue another GetState for
+  // this entry for the rest of its tracked life.
+  return it->second.state_label.empty() && it->second.reseeds_remaining > 0;
+}
+
 std::optional<std::string> LifecycleWatcher::state_of(const std::string & app_id) const {
   std::lock_guard<std::mutex> lock(state_->mutex);
   const auto it = state_->tracked.find(app_id);
@@ -408,10 +416,12 @@ int LifecycleWatcher::reseeds_remaining_for_test(const std::string & app_id) con
   return it == state_->tracked.end() ? -1 : it->second.reseeds_remaining;
 }
 
-void LifecycleWatcher::set_state_for_test(const std::string & app_id, const std::string & label) {
+void LifecycleWatcher::set_state_for_test(const std::string & app_id, const std::string & label,
+                                          int reseeds_remaining) {
   std::lock_guard<std::mutex> lock(state_->mutex);
   auto & tracked = state_->tracked[app_id];
   tracked.state_label = label;
+  tracked.reseeds_remaining = reseeds_remaining;
   // This seam stands in for a live ~/transition_event round-trip, so it must record the same
   // thing that callback does: we WATCHED the node reach this label. Leaving saw_transition false
   // would make every shim-driven departure look like a node found already sitting in its final

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/reliability_gate.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/reliability_gate.cpp
@@ -73,6 +73,40 @@ bool ReliabilityGate::allows_raise(const std::string & source_id) const {
   return (last_tick_ - graph_first_tick_) >= static_cast<uint64_t>(warmup_cycles_);
 }
 
+PresenceOwnership ReliabilityGate::presence_ownership(const std::string & source_id) const {
+  // Read without gate_mutex_, for the same reason allows_raise() takes none: lifecycle_ is
+  // separately self-synchronized, and both run on the tick thread, sequentially after update().
+  // Two reads rather than one combined lock: the only transition either can observe mid-call is
+  // an empty label becoming a real one, and both orderings of that give the same answer here.
+  const auto label = lifecycle_.state_of(source_id);
+
+  // Decided BEFORE arming, and that order is the point. A measured non-active label is
+  // knowledge about who the node belongs to, and it is the only negative answer a caller may
+  // act on by giving a key up. Warmup is not: an entity that has not armed yet, or has gone
+  // back to warming after a restart, has been measured as nothing at all. Asking allows_raise()
+  // first would collapse the two, because node_ok() already refuses a managed non-active node -
+  // so every re-warming node would read exactly like a node the graph had disowned.
+  if (label.has_value() && !label->empty() && *label != "active") {
+    return PresenceOwnership::kDisowned;
+  }
+  if (!allows_raise(source_id)) {
+    return PresenceOwnership::kUnclaimed;
+  }
+  if (!label.has_value()) {
+    // No managed record: a plain node. Nothing about it can ever say it belonged elsewhere,
+    // so this is knowledge, not a gap in it.
+    return PresenceOwnership::kEarned;
+  }
+  if (label->empty()) {
+    // Ignorance, and it is bounded. While the watcher still has GetState attempts to spend, a
+    // measurement may be one tick away and taking ownership now would race it. Once they are
+    // spent, nothing here will ASK again - but ~/transition_event is still subscribed and can
+    // still deliver a label, so the grant is provisional rather than final.
+    return lifecycle_.measurement_pending(source_id) ? PresenceOwnership::kUnclaimed : PresenceOwnership::kProvisional;
+  }
+  return PresenceOwnership::kEarned;  // "active", the one label that says this node is ours
+}
+
 nlohmann::json ReliabilityGate::status_json() const {
   // Reader side of gate_mutex_ (see update()). Held across the lifecycle_ reads too - they
   // take the lifecycle SharedState mutex (order gate_mutex_ -> lifecycle mutex, never the
@@ -87,7 +121,12 @@ nlohmann::json ReliabilityGate::status_json() const {
                         {"first_seen_tick", entry.first_seen},
                         {"armed", armed},
                         {"state", suppressed ? "warming_up" : "armed"},
-                        {"lifecycle", lc.has_value() ? nlohmann::json(*lc) : nlohmann::json(nullptr)}});
+                        {"lifecycle", lc.has_value() ? nlohmann::json(*lc) : nlohmann::json(nullptr)},
+                        // The other half of an unread label, and the half no caller can infer
+                        // from elapsed time: whether the watcher still intends to ask. Without
+                        // it an operator (and a test) cannot tell a node that is about to be
+                        // measured from one that never will be - see measurement_pending().
+                        {"measurement_pending", lifecycle_.measurement_pending(id)}});
   }
   const bool global_armed = graph_seen_ && (last_tick_ - graph_first_tick_) >= static_cast<uint64_t>(warmup_cycles_);
   return {{"x-medkit-watchdog",
@@ -111,8 +150,14 @@ void ReliabilityGate::reset() {
   lifecycle_.reset();
 }
 
-void ReliabilityGate::set_lifecycle_state_for_test(const std::string & app_id, const std::string & label) {
-  lifecycle_.set_state_for_test(app_id, label);
+void ReliabilityGate::set_lifecycle_state_for_test(const std::string & app_id, const std::string & label,
+                                                   int reseeds_remaining) {
+  lifecycle_.set_state_for_test(app_id, label, reseeds_remaining);
+}
+
+int ReliabilityGate::lifecycle_reseeds_remaining_for_test(const std::string & app_id) const {
+  std::lock_guard<std::mutex> lock(gate_mutex_);
+  return lifecycle_.reseeds_remaining_for_test(app_id);
 }
 
 void ReliabilityGate::set_departed_lifecycle_state_for_test(const std::string & fqn, const std::string & label,
@@ -122,6 +167,14 @@ void ReliabilityGate::set_departed_lifecycle_state_for_test(const std::string & 
 
 bool reliability_allows(const ReliabilityGate * gate, const std::string & source_id) {
   return gate == nullptr || gate->allows_raise(source_id);
+}
+
+PresenceOwnership presence_ownership(const ReliabilityGate * gate, const std::string & source_id) {
+  // A null gate is not yet wired (a bare-context test), and every other predicate here treats
+  // that as fully permissive. kEarned rather than kProvisional: there is no watcher to ever
+  // withdraw the grant, so a provisional answer would leave a caller waiting for news that
+  // cannot come.
+  return gate == nullptr ? PresenceOwnership::kEarned : gate->presence_ownership(source_id);
 }
 
 }  // namespace ros2_medkit_graph_watchdog

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -585,18 +585,229 @@ def assert_fault_absent_throughout(test_case, port, code, duration, interval=0.5
         f'>= interval ({interval}s)')
 
 
+def assert_fault_persists_throughout(test_case, port, code, duration, interval=0.5):
+    """Fail unless `code` is present on EVERY poll for `duration` seconds.
+
+    The mirror of assert_fault_absent_throughout, and it owes the same proof: a fault
+    surface that stops answering must fail the assertion rather than satisfy it. Poll the
+    same endpoint the same way; a request error, a non-200, or a body that does not parse
+    is a failure, not a skipped sample. Waiting for a single sighting
+    (``assertIsNotNone(poll_faults(...))``) proves the fault appeared once, not that it
+    stayed - it returns on the first match and says nothing about a channel that goes dark
+    on poll three of twenty. Use this for every scenario whose claim is sustained presence
+    over a window, not merely "present right now".
+
+    Parameters
+    ----------
+    test_case : unittest.TestCase
+        Used for the actual assertion calls, so a failure here reports through the normal
+        unittest failure path rather than a bare ``AssertionError`` from a free function.
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` that must be present on every poll.
+    duration : float
+        Total seconds to keep polling.
+    interval : float
+        Sleep between polls in seconds.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + duration
+    polls = 0
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', timeout=5)
+        except requests.exceptions.RequestException as exc:
+            test_case.fail(
+                f'/faults became unreachable {polls} poll(s) into a {duration}s persistence '
+                f'window (could not ask, which is not the same as "asked, and {code} is '
+                f'still there"): {exc}')
+            return
+        if response.status_code != 200:
+            test_case.fail(
+                f'/faults answered HTTP {response.status_code} {polls} poll(s) into a '
+                f'{duration}s persistence window - the channel died mid-window, which this '
+                'assertion must not read as "still there"')
+            return
+        codes = {item.get('fault_code') for item in response.json().get('items', [])}
+        test_case.assertIn(
+            code, codes,
+            f'{code} was missing {polls} poll(s) into a {duration}s window that was supposed '
+            'to stay confirmed the whole way through')
+        polls += 1
+        time.sleep(interval)
+    test_case.assertGreater(
+        polls, 0,
+        f'the {duration}s persistence window never actually polled /faults - duration must '
+        f'be >= interval ({interval}s)')
+
+
+def assert_fault_describes_only(
+        test_case, port, code, required, forbidden, duration, interval=0.5):
+    """Fail unless `code` is present with a matching description on every poll.
+
+    On every poll for `duration` seconds, `code` must be present and its description must
+    contain every needle in `required` and none in `forbidden`. `required` and `forbidden`
+    are iterables of plain substrings. The aggregated fault
+    names several entities in one description, so this is how a scenario says "this node is
+    named and that one is not" without depending on ordering. Polls the whole window, not a
+    single sample: a description this assertion must hold true FOR THE DURATION (one node
+    named, a sibling never named) is exactly the kind of claim a channel that goes dark
+    mid-window can falsely satisfy if only checked once.
+
+    Parameters
+    ----------
+    test_case : unittest.TestCase
+        Used for the actual assertion calls, so a failure here reports through the normal
+        unittest failure path rather than a bare ``AssertionError`` from a free function.
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` that must be present, with a matching description, on every poll.
+    required : iterable of str
+        Substrings that must all appear in the fault's description on every poll.
+    forbidden : iterable of str
+        Substrings that must never appear in the fault's description on any poll.
+    duration : float
+        Total seconds to keep polling.
+    interval : float
+        Sleep between polls in seconds.
+
+    """
+    required = list(required)
+    forbidden = list(forbidden)
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + duration
+    polls = 0
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', timeout=5)
+        except requests.exceptions.RequestException as exc:
+            test_case.fail(
+                f'/faults became unreachable {polls} poll(s) into a {duration}s description '
+                f'window (could not ask, which is not the same as "asked, and the '
+                f'description still holds"): {exc}')
+            return
+        if response.status_code != 200:
+            test_case.fail(
+                f'/faults answered HTTP {response.status_code} {polls} poll(s) into a '
+                f'{duration}s description window - the channel died mid-window, which this '
+                'assertion must not read as "the description still holds"')
+            return
+        items = {item.get('fault_code'): item for item in response.json().get('items', [])}
+        fault = items.get(code)
+        if fault is None:
+            test_case.fail(
+                f'{code} was missing {polls} poll(s) into a {duration}s window that was '
+                'supposed to keep describing it')
+        description = fault.get('description', '')
+        for needle in required:
+            test_case.assertIn(
+                needle, description,
+                f"{code}'s description dropped required text {needle!r} {polls} poll(s) "
+                f'into a {duration}s window: {description!r}')
+        for needle in forbidden:
+            test_case.assertNotIn(
+                needle, description,
+                f"{code}'s description carries forbidden text {needle!r} {polls} poll(s) "
+                f'into a {duration}s window: {description!r}')
+        polls += 1
+        time.sleep(interval)
+    test_case.assertGreater(
+        polls, 0,
+        f'the {duration}s description window never actually polled /faults - duration must '
+        f'be >= interval ({interval}s)')
+
+
+def assert_fault_never_names(test_case, port, code, forbidden, duration, interval=0.5):
+    """Fail if `code`'s description EVER names a forbidden needle, whatever `code` itself does.
+
+    Distinct from the three assertions above in what it does NOT require: it takes no position
+    on whether `code` is raised at all. ``assert_fault_absent_throughout`` is too strong for a
+    claim like "no disappearance names THIS node" - a correct detector raising `code` for some
+    OTHER entity would trip it for a reason that has nothing to do with the node under test.
+    ``assert_fault_describes_only`` is too strong the other way: it REQUIRES `code` present on
+    every poll, which is wrong for a scenario where the code staying fully absent is itself a
+    correct outcome. This is the narrower claim in between: whenever `code` happens to be
+    present, on any poll, none of `forbidden` may appear in its description; `code` being absent
+    on a given poll is not a failure.
+
+    Same channel-alive discipline as the other window assertions: a request error or a non-200
+    is a failure naming which poll and why, never a silently-skipped sample.
+
+    Parameters
+    ----------
+    test_case : unittest.TestCase
+        Used for the actual assertion calls, so a failure here reports through the normal
+        unittest failure path rather than a bare ``AssertionError`` from a free function.
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` whose description must never name a forbidden needle. Its own
+        presence or absence is not judged.
+    forbidden : iterable of str
+        Substrings that must never appear in `code`'s description, on any poll where `code` is
+        present.
+    duration : float
+        Total seconds to keep polling.
+    interval : float
+        Sleep between polls in seconds.
+
+    """
+    forbidden = list(forbidden)
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + duration
+    polls = 0
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', timeout=5)
+        except requests.exceptions.RequestException as exc:
+            test_case.fail(
+                f'/faults became unreachable {polls} poll(s) into a {duration}s window (could '
+                f'not ask, which is not the same as "asked, and {code} never named a forbidden '
+                f'entity"): {exc}')
+            return
+        if response.status_code != 200:
+            test_case.fail(
+                f'/faults answered HTTP {response.status_code} {polls} poll(s) into a '
+                f'{duration}s window - the channel died mid-window, which this assertion must '
+                'not read as "never named a forbidden entity"')
+            return
+        items = {item.get('fault_code'): item for item in response.json().get('items', [])}
+        fault = items.get(code)
+        if fault is not None:
+            description = fault.get('description', '')
+            for needle in forbidden:
+                test_case.assertNotIn(
+                    needle, description,
+                    f"{code}'s description named forbidden text {needle!r} {polls} poll(s) "
+                    f'into a {duration}s window: {description!r}')
+        polls += 1
+        time.sleep(interval)
+    test_case.assertGreater(
+        polls, 0,
+        f'the {duration}s window never actually polled /faults - duration must be >= interval '
+        f'({interval}s)')
+
+
 class _FlakyFaultsHandler(http.server.BaseHTTPRequestHandler):
     """Stands in for a gateway whose ``GET /faults`` answers normally, then dies.
 
-    Answers 200 with an empty fault list for the first ``healthy_polls`` requests to
-    ``{API_BASE_PATH}/faults`` (this class's own attribute, set per instantiation via
-    ``make_handler``), then drops the connection with no response at all for every
+    Answers 200 with ``{'items': healthy_items}`` for the first ``healthy_polls`` requests
+    to ``{API_BASE_PATH}/faults`` (both class attributes, set per instantiation via
+    `_FlakyFaultsServer`), then drops the connection with no response at all for every
     request after that - the same "channel gone" shape a crashed or hung fault_manager
     produces, distinct from an ordinary 503 (also exercised via ``dead_status``).
+    `healthy_items` defaults to empty (a healthy-but-silent fault surface, what the
+    absence proof needs); the persistence and describes-only proofs set it to a list
+    holding the fault they poll for, so the same handler can stand in for a surface that
+    is healthy AND SAYING SOMETHING before it goes dark.
     """
 
     healthy_polls = 2
     dead_status = None  # None = drop the connection; an int = answer with that status instead
+    healthy_items = []  # the `items` list served while healthy
 
     def do_GET(self):
         if self.path != f'{API_BASE_PATH}/faults':
@@ -611,14 +822,14 @@ class _FlakyFaultsHandler(http.server.BaseHTTPRequestHandler):
             self.send_response(type(self).dead_status)
             self.end_headers()
             return
-        body = json.dumps({'items': []}).encode()
+        body = json.dumps({'items': type(self).healthy_items}).encode()
         self.send_response(200)
         self.send_header('Content-Type', 'application/json')
         self.send_header('Content-Length', str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
-    def log_message(self, log_format, *args):
+    def log_message(self, format, *args):  # noqa: A002 - matches the base class's own name
         pass  # keep test output quiet - this is expected traffic, not diagnostics
 
 
@@ -626,15 +837,16 @@ class _FlakyFaultsServer:
     """Context manager for a local `_FlakyFaultsHandler` HTTP server.
 
     Starts on a free port in a daemon thread and tears itself down on exit - the
-    boilerplate every leg of `prove_silence_proof_catches_a_dead_fault_surface` below
-    needs, factored out once so each leg reads as the claim it is checking rather than
-    server plumbing.
+    boilerplate every leg of `prove_silence_proof_catches_a_dead_fault_surface` (and its
+    persistence/describes-only siblings) below needs, factored out once so each leg reads
+    as the claim it is checking rather than server plumbing.
     """
 
-    def __init__(self, healthy_polls, dead_status):
+    def __init__(self, healthy_polls, dead_status, healthy_items=None):
         handler = type(
             '_Handler', (_FlakyFaultsHandler,),
-            {'healthy_polls': healthy_polls, 'dead_status': dead_status})
+            {'healthy_polls': healthy_polls, 'dead_status': dead_status,
+             'healthy_items': [] if healthy_items is None else healthy_items})
         self._server = http.server.HTTPServer(('127.0.0.1', 0), handler)
         self.port = self._server.server_address[1]
         self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
@@ -699,6 +911,171 @@ def prove_silence_proof_catches_a_dead_fault_surface(test_case):
     with _FlakyFaultsServer(healthy_polls=10_000, dead_status=None) as fake:
         assert_fault_absent_throughout(
             test_case, fake.port, 'GRAPH_NODE_INACTIVE', duration=1.0, interval=0.2)
+
+
+def prove_persistence_proof_catches_a_dead_fault_surface(test_case):
+    """Prove `assert_fault_persists_throughout` catches a `/faults` that dies mid-window.
+
+    The mirror of `prove_silence_proof_catches_a_dead_fault_surface`, for the opposite
+    claim: a fault that must stay CONFIRMED for a whole window, not one that must stay
+    absent. Self-contained, same stand-in server, same three-part proof:
+
+    (1) the naive pattern this fix replaces - `poll_faults` + `assertIsNotNone` - actually
+    DOES pass against a `/faults` that answers healthily a couple of times and then dies:
+    it returns the moment `code` is first seen, before the channel goes dark, so it never
+    observes the death at all; (2) `assert_fault_persists_throughout` raises against the
+    SAME dying channel, for both dead-channel shapes (a dropped connection and a 503); (3)
+    a channel that never dies, and keeps answering `code` present the whole time, does NOT
+    trip the fixed helper - otherwise the RED result above would be meaningless.
+
+    Raises whatever `test_case`'s own assertions raise on failure; callers use it from
+    inside a test method exactly like any other assertion helper.
+    """
+    code = 'GRAPH_NODE_INACTIVE'
+    healthy_items = [{'fault_code': code, 'description': f'{code} present'}]
+    for dead_status, label in ((None, 'a dropped connection'), (503, 'a 503 response')):
+        with _FlakyFaultsServer(healthy_polls=2, dead_status=dead_status,
+                                healthy_items=healthy_items) as fake:
+            # (1) The OLD pattern this fix replaces: prove it actually passes on this
+            # exact dying channel - it returns on the first sighting, before the death.
+            test_case.assertIsNotNone(
+                poll_faults(fake.port, code, timeout=2.0, interval=0.2),
+                f'the OLD pattern (poll_faults + assertIsNotNone) did NOT pass against a '
+                f'/faults that later died via {label} - this self-test no longer '
+                'demonstrates the hole the fix closes')
+            # (2) The fixed helper must fail against the identical dying channel.
+            with test_case.assertRaises(
+                    AssertionError,
+                    msg=f'assert_fault_persists_throughout did not fail when /faults died '
+                        f'mid-window via {label} - it would pass on the exact '
+                        'channel-death this fix exists to catch'):
+                assert_fault_persists_throughout(
+                    test_case, fake.port, code, duration=2.0, interval=0.2)
+
+    # (3) The companion proof: a channel that never dies, and keeps answering `code`
+    # present, must not trip the assertion, or the RED result above would be meaningless.
+    with _FlakyFaultsServer(healthy_polls=10_000, dead_status=None,
+                            healthy_items=healthy_items) as fake:
+        assert_fault_persists_throughout(test_case, fake.port, code, duration=1.0, interval=0.2)
+
+
+def prove_describes_only_proof_catches_a_dead_fault_surface(test_case):
+    """Prove `assert_fault_describes_only` catches a `/faults` that dies mid-window.
+
+    Same shape as the silence and persistence self-tests above, for the third claim this
+    package's scenarios rely on: a description that must hold ("names alpha, never beta")
+    for a whole window, not merely on one lucky read before the channel goes dark.
+
+    (1) `poll_fault_describing` (the existing single-shot reader) DOES pass against a
+    `/faults` that answers correctly a couple of times and then dies - it returns the
+    moment the description matches, never observing the death; (2)
+    `assert_fault_describes_only` raises against the SAME dying channel, for both
+    dead-channel shapes; (3) a channel that never dies, and keeps describing the fault
+    correctly the whole time, does NOT trip the fixed helper.
+    """
+    code = 'GRAPH_NODE_INACTIVE'
+    healthy_items = [{'fault_code': code, 'description': 'alpha is gone, beta is fine'}]
+    for dead_status, label in ((None, 'a dropped connection'), (503, 'a 503 response')):
+        with _FlakyFaultsServer(healthy_polls=2, dead_status=dead_status,
+                                healthy_items=healthy_items) as fake:
+            # (1) The OLD pattern this fix replaces: a single successful description read
+            # proves nothing about the rest of the window.
+            found, _description = poll_fault_describing(
+                fake.port, code, ['alpha'], timeout=2.0, interval=0.2)
+            test_case.assertTrue(
+                found,
+                f'the OLD pattern (poll_fault_describing) did NOT pass against a /faults '
+                f'that later died via {label} - this self-test no longer demonstrates the '
+                'hole the fix closes')
+            # (2) The fixed helper must fail against the identical dying channel.
+            with test_case.assertRaises(
+                    AssertionError,
+                    msg=f'assert_fault_describes_only did not fail when /faults died '
+                        f'mid-window via {label} - it would pass on the exact '
+                        'channel-death this fix exists to catch'):
+                assert_fault_describes_only(
+                    test_case, fake.port, code, required=['alpha'], forbidden=['gamma'],
+                    duration=2.0, interval=0.2)
+
+    # (3) The companion proof: a channel that never dies, and keeps the description
+    # correct the whole time, must not trip the assertion.
+    with _FlakyFaultsServer(healthy_polls=10_000, dead_status=None,
+                            healthy_items=healthy_items) as fake:
+        assert_fault_describes_only(
+            test_case, fake.port, code, required=['alpha'], forbidden=['gamma'],
+            duration=1.0, interval=0.2)
+
+
+def prove_never_names_proof_catches_a_wrongly_scoped_absence(test_case):
+    """Prove `assert_fault_never_names` succeeds where a whole-code absence check would not.
+
+    The gap this closes: a claim like "no disappearance names THIS node" is not the same claim
+    as "this code never appears at all". A correct detector raising `code` for some OTHER entity
+    should leave a "never names X" assertion GREEN - it is exactly the case
+    `assert_fault_absent_throughout` cannot tell apart from a real defect, since it only ever
+    looks at whether the code is present, never at what it names.
+
+    (1) A `/faults` that answers healthily throughout, with `code` present but naming only an
+    unrelated entity, fails the OLD pattern (`assert_fault_absent_throughout` on the bare code) -
+    the concrete false failure this fix replaces, demonstrated rather than asserted in prose. (2)
+    The SAME server does not trip `assert_fault_never_names`. (3) A server whose `code` DOES name
+    the forbidden entity at some point trips the new helper - or it would never fail on the
+    actual defect it exists to catch. (4) The same channel-alive discipline the other three
+    window assertions already carry: a dead channel mid-window fails this one too.
+
+    Raises whatever `test_case`'s own assertions raise on failure; callers use it from inside a
+    test method exactly like any other assertion helper.
+    """
+    code = 'GRAPH_NODE_DISAPPEARED'
+    forbidden_entity = '/target/allowlisted'
+    unrelated_items = [
+        {'fault_code': code, 'description': f'{code}: node /other/unrelated is gone'}]
+    naming_items = [
+        {'fault_code': code, 'description': f'{code}: node {forbidden_entity} is gone'}]
+
+    with _FlakyFaultsServer(healthy_polls=10_000, dead_status=None,
+                            healthy_items=unrelated_items) as fake:
+        # (1) The OLD pattern this fix replaces: a whole-code absence check trips on a raise for
+        # an unrelated entity - the false failure this fix exists to stop, demonstrated rather
+        # than asserted.
+        with test_case.assertRaises(
+                AssertionError,
+                msg='assert_fault_absent_throughout did NOT fail against a code raised for an '
+                    'unrelated entity - this self-test no longer demonstrates the false failure '
+                    'the fix replaces'):
+            assert_fault_absent_throughout(test_case, fake.port, code, duration=1.0, interval=0.2)
+
+        # (2) The fixed helper must NOT fail on the identical server: the code is present, but
+        # never names the forbidden entity.
+        assert_fault_never_names(
+            test_case, fake.port, code, forbidden=[forbidden_entity], duration=1.0, interval=0.2)
+
+    with _FlakyFaultsServer(healthy_polls=10_000, dead_status=None,
+                            healthy_items=naming_items) as fake:
+        # (3) The fixed helper MUST fail once the description actually names the forbidden
+        # entity - or it would never catch the defect it exists for.
+        with test_case.assertRaises(
+                AssertionError,
+                msg='assert_fault_never_names did not fail when the description named the '
+                    'forbidden entity - it would pass on the exact defect this fix exists to '
+                    'catch'):
+            assert_fault_never_names(
+                test_case, fake.port, code, forbidden=[forbidden_entity],
+                duration=1.0, interval=0.2)
+
+    # (4) Channel-alive discipline, matching the other three window assertions: a dead channel
+    # mid-window must fail this one too, not be read as "never named a forbidden entity".
+    for dead_status, label in ((None, 'a dropped connection'), (503, 'a 503 response')):
+        with _FlakyFaultsServer(healthy_polls=2, dead_status=dead_status,
+                                healthy_items=unrelated_items) as fake:
+            with test_case.assertRaises(
+                    AssertionError,
+                    msg=f'assert_fault_never_names did not fail when /faults died mid-window '
+                        f'via {label} - it would pass on the exact channel-death this fix '
+                        'exists to catch'):
+                assert_fault_never_names(
+                    test_case, fake.port, code, forbidden=[forbidden_entity],
+                    duration=2.0, interval=0.2)
 
 
 def poll_cleared(port, code, timeout=30.0, interval=0.5):

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -50,40 +50,31 @@ from ros2_medkit_test_utils.launch_helpers import (
 
 API_BASE_PATH = '/api/v1'
 
-# ---- What "the node is gone" costs, and who promises which part -------------------------
+# ---- What "the node is gone" costs, and what these tests may hold the gateway to --------
 #
-# Read this before writing another assertion about a killed node disappearing. "A SIGTERM'd
-# node is absent from GET /apps within N seconds" is three quantities in a trench coat, and
-# only the last one is a promise anybody makes:
+# The bound itself is NOT stated here. It belongs to the gateway and is written down in its
+# own configuration reference, docs/config/server.rst, under "How long a departed node keeps
+# being listed" - including the measurements behind it. Read that first; this note only says
+# what the tests in this package do about it, and the constants below only exist so those
+# tests can be sized against it.
 #
-#   1. signal -> the node stops announcing itself on DDS. NOBODY PROMISES THIS. It is the
-#      node's own shutdown path, and how long a node takes to shut down is the node's own
-#      business. Measured at 225 ms for a demo node on an uninstrumented box; under a
-#      sanitizer every step of that teardown is instrumented and it is unbounded as far as
-#      any test here is concerned.
-#   2. participant gone -> the ROS graph drops the node. Free if the participant
-#      unregistered cleanly. If it did not - the process died without completing its
-#      shutdown - remote participants must wait out the Fast DDS PARTICIPANT LEASE, measured
-#      at 19.8-20.1 s over three runs on this stack (stock rmw_fastrtps_cpp, no profile
-#      override anywhere in this repo).
-#   3. graph drops it -> GET /apps stops listing it. THIS ONE THE GATEWAY PROMISES, and it
-#      is the only bound of the three: at most `discovery.refresh_debounce_ms` (1000 by
-#      default) plus one 100 ms graph-check tick, and create_gateway_node additionally pins
-#      `refresh_interval_ms` to 1000 as an unconditional backstop. There is no retention
-#      anywhere behind it - RuntimeLayer rebuilds from scratch and discover_apps() reads
-#      get_node_names_and_namespaces() live.
+# The short of it: "a SIGTERM'd node is absent from GET /apps within N seconds" is three
+# quantities, and only the last is the gateway's.
 #
-# So a test may hold the gateway to term 3 and to nothing else. Term 1 must be OBSERVED, not
-# budgeted for - assert_process_exited() below is how - because budgeting for it produces a
-# failure that blames a component whose own bound is one second. Term 2 is the reason the
-# post-exit budgets here are tens of seconds rather than the ~1 s term 3 would suggest.
+#   1. signal -> the node stops announcing itself on DDS. Nobody promises this, so it is
+#      OBSERVED here rather than budgeted for - assert_process_exited() below is how.
+#      Budgeting for it produces a failure that blames a component whose own bound is about
+#      a second, which is how four sanitizer runs came to accuse the gateway of a node that
+#      had not finished dying.
+#   2. participant gone -> the graph drops it. Free after a clean unregister, the full DDS
+#      participant lease after an unclean death. This is why the post-exit budgets here are
+#      tens of seconds rather than the ~1 s term 3 alone would suggest.
+#   3. graph drops it -> GET /apps stops listing it. The gateway's share, and the only one
+#      of the three a test may hold it to.
 #
-# The two measurements above were taken with the gateway and a demo node on this stack,
-# polling GET /apps at 200 ms: SIGTERM gone in 225 ms, SIGKILL (no unregister) gone in
-# 20073 / 19762 / 19989 ms.
-
-# The Fast DDS participant lease, from the measurement above. What an UNCLEAN death costs
-# before the graph drops the participant - the worst case, not the typical one.
+# The Fast DDS participant lease - what an UNCLEAN death costs before the graph drops the
+# participant, and the worst case rather than the typical one. Figure and measurement in
+# docs/config/server.rst.
 PARTICIPANT_LEASE_SEC = 20.0
 # The gateway's own graph-to-/apps latency: refresh_debounce_ms (1000) + one 100 ms tick.
 GATEWAY_GRAPH_TO_APPS_SEC = 1.1
@@ -94,9 +85,9 @@ GATEWAY_GRAPH_TO_APPS_SEC = 1.1
 DEPARTURE_AFTER_EXIT_SEC = PARTICIPANT_LEASE_SEC + GATEWAY_GRAPH_TO_APPS_SEC  # 21.1
 
 # How long assert_process_exited() waits. NOT derived from anything, because term 1 above is
-# not promised by anyone: this is a diagnostic ceiling, chosen at the same magnitude the
-# departure budgets already used so no existing budget grows. It is scaled like every other
-# give-up bound here because the thing being waited on is instrumented in the sanitizer jobs.
+# nobody's promise: a diagnostic ceiling, chosen at the same magnitude the departure budgets
+# already used so no existing budget grows. Scaled like every other give-up bound here
+# because the thing being waited on is instrumented in the sanitizer jobs.
 NODE_EXIT_TIMEOUT_SEC = 30.0 * get_time_scale()
 
 
@@ -151,10 +142,11 @@ def assert_process_exited(test_case, pid, label, timeout=None):
 
     Every "the node left GET /apps" assertion in this suite is downstream of this one, and
     before it existed those assertions blamed the gateway for a node that had not finished
-    dying. See the "What 'the node is gone' costs" note at the top of this module: the time
-    from a signal to a process actually stopping is the one term in that chain nobody
-    promises, so it is OBSERVED here rather than folded into a budget and charged to a
-    component whose own bound is one second.
+    dying. The time from a signal to a process actually stopping is the one term in that
+    chain nobody promises, so it is OBSERVED here rather than folded into a budget and
+    charged to a component whose own bound is about a second. The gateway's own share, and
+    the measurements either side of it, are in docs/config/server.rst under "How long a
+    departed node keeps being listed".
 
     Call it immediately after the signal and before polling GET /apps. On failure the
     message says the node never died, which is both true and the thing worth knowing; the

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/harness.py
@@ -41,7 +41,7 @@ from launch import LaunchDescription
 from launch.actions import TimerAction
 import launch_testing.actions
 import requests
-from ros2_medkit_test_utils.constants import get_test_port
+from ros2_medkit_test_utils.constants import get_test_port, get_time_scale
 from ros2_medkit_test_utils.launch_helpers import (
     create_demo_nodes,
     create_fault_manager_node,
@@ -49,6 +49,126 @@ from ros2_medkit_test_utils.launch_helpers import (
 )
 
 API_BASE_PATH = '/api/v1'
+
+# ---- What "the node is gone" costs, and who promises which part -------------------------
+#
+# Read this before writing another assertion about a killed node disappearing. "A SIGTERM'd
+# node is absent from GET /apps within N seconds" is three quantities in a trench coat, and
+# only the last one is a promise anybody makes:
+#
+#   1. signal -> the node stops announcing itself on DDS. NOBODY PROMISES THIS. It is the
+#      node's own shutdown path, and how long a node takes to shut down is the node's own
+#      business. Measured at 225 ms for a demo node on an uninstrumented box; under a
+#      sanitizer every step of that teardown is instrumented and it is unbounded as far as
+#      any test here is concerned.
+#   2. participant gone -> the ROS graph drops the node. Free if the participant
+#      unregistered cleanly. If it did not - the process died without completing its
+#      shutdown - remote participants must wait out the Fast DDS PARTICIPANT LEASE, measured
+#      at 19.8-20.1 s over three runs on this stack (stock rmw_fastrtps_cpp, no profile
+#      override anywhere in this repo).
+#   3. graph drops it -> GET /apps stops listing it. THIS ONE THE GATEWAY PROMISES, and it
+#      is the only bound of the three: at most `discovery.refresh_debounce_ms` (1000 by
+#      default) plus one 100 ms graph-check tick, and create_gateway_node additionally pins
+#      `refresh_interval_ms` to 1000 as an unconditional backstop. There is no retention
+#      anywhere behind it - RuntimeLayer rebuilds from scratch and discover_apps() reads
+#      get_node_names_and_namespaces() live.
+#
+# So a test may hold the gateway to term 3 and to nothing else. Term 1 must be OBSERVED, not
+# budgeted for - assert_process_exited() below is how - because budgeting for it produces a
+# failure that blames a component whose own bound is one second. Term 2 is the reason the
+# post-exit budgets here are tens of seconds rather than the ~1 s term 3 would suggest.
+#
+# The two measurements above were taken with the gateway and a demo node on this stack,
+# polling GET /apps at 200 ms: SIGTERM gone in 225 ms, SIGKILL (no unregister) gone in
+# 20073 / 19762 / 19989 ms.
+
+# The Fast DDS participant lease, from the measurement above. What an UNCLEAN death costs
+# before the graph drops the participant - the worst case, not the typical one.
+PARTICIPANT_LEASE_SEC = 20.0
+# The gateway's own graph-to-/apps latency: refresh_debounce_ms (1000) + one 100 ms tick.
+GATEWAY_GRAPH_TO_APPS_SEC = 1.1
+# What a departure may cost once the process is PROVEN gone: the two real terms, added.
+# Every per-file DEPARTURE_TIMEOUT_SEC in this suite is 30 s * the time scale, which already
+# clears this with room to spare, so this constant is here to be compared against rather
+# than to replace them.
+DEPARTURE_AFTER_EXIT_SEC = PARTICIPANT_LEASE_SEC + GATEWAY_GRAPH_TO_APPS_SEC  # 21.1
+
+# How long assert_process_exited() waits. NOT derived from anything, because term 1 above is
+# not promised by anyone: this is a diagnostic ceiling, chosen at the same magnitude the
+# departure budgets already used so no existing budget grows. It is scaled like every other
+# give-up bound here because the thing being waited on is instrumented in the sanitizer jobs.
+NODE_EXIT_TIMEOUT_SEC = 30.0 * get_time_scale()
+
+
+def process_is_running(pid):
+    """Whether `pid` is still a LIVE process - a zombie counts as gone.
+
+    The distinction matters and is not pedantry. A launch-spawned node that has exited but
+    not yet been reaped by the launch service is a zombie: it holds no DDS participant, has
+    stopped announcing, and is therefore gone as far as every question this suite asks - but
+    ``os.kill(pid, 0)`` still succeeds for it, so a naive liveness check would wait for a
+    reap that may not happen until launch shuts down at the end of the test.
+
+    Reads /proc directly for that reason. The state character sits after the comm field,
+    which is parenthesised and may itself contain spaces and parentheses, so the split is on
+    the LAST ')' rather than on whitespace. Falls back to a signal probe where /proc is not
+    available.
+    """
+    try:
+        with open(f'/proc/{pid}/stat', 'rb') as handle:
+            raw = handle.read()
+    except FileNotFoundError:
+        return False
+    except (PermissionError, ProcessLookupError):
+        return False
+    except OSError:
+        raw = None
+    if raw is None:  # no /proc: fall back to a signal probe, which cannot see zombies
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            return False
+        return True
+    close = raw.rfind(b')')
+    if close < 0:
+        return False  # unparseable: treat as gone rather than wait forever on a guess
+    state = raw[close + 2:close + 3].decode('ascii', 'replace')
+    return state != 'Z'
+
+
+def wait_until_process_exits(pid, timeout, interval=0.1):
+    """Poll until `pid` is no longer a live process. ``True`` once it is gone."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not process_is_running(pid):
+            return True
+        time.sleep(interval)
+    return not process_is_running(pid)
+
+
+def assert_process_exited(test_case, pid, label, timeout=None):
+    """Fail unless `pid` has actually exited - the precondition for any departure claim.
+
+    Every "the node left GET /apps" assertion in this suite is downstream of this one, and
+    before it existed those assertions blamed the gateway for a node that had not finished
+    dying. See the "What 'the node is gone' costs" note at the top of this module: the time
+    from a signal to a process actually stopping is the one term in that chain nobody
+    promises, so it is OBSERVED here rather than folded into a budget and charged to a
+    component whose own bound is one second.
+
+    Call it immediately after the signal and before polling GET /apps. On failure the
+    message says the node never died, which is both true and the thing worth knowing; the
+    departure poll after it then only has to cover the two terms that are real.
+    """
+    timeout = NODE_EXIT_TIMEOUT_SEC if timeout is None else timeout
+    test_case.assertTrue(
+        wait_until_process_exits(pid, timeout=timeout),
+        f'{label} (pid {pid}) was still a live process {timeout}s after the signal, so it '
+        'had not stopped announcing itself on DDS and no departure could possibly have been '
+        'observed downstream. This is the node failing to shut down, not the graph failing '
+        'to notice: nothing here promises how long a shutdown takes, and under a sanitizer '
+        'every step of it is instrumented.',
+    )
 
 
 def create_watchdog_test_launch(

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
@@ -151,7 +151,11 @@ from harness import (  # noqa: E402, I100
     watchdog_detector_status,
 )
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.constants import (  # noqa: E402
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
 from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
 from ros2_medkit_test_utils.launch_helpers import DEMO_NODE_REGISTRY  # noqa: E402
 
@@ -161,6 +165,25 @@ from ros2_medkit_test_utils.launch_helpers import DEMO_NODE_REGISTRY  # noqa: E4
 # together into one scenario and still report 1/1 passed. A KeyError is loud.
 SCENARIO = os.environ['WATCHDOG_E2E_SCENARIO']
 PORT = get_test_port()
+
+# Every GIVE-UP bound below is multiplied by MEDKIT_TEST_TIME_SCALE, which the sanitizer jobs
+# set to the same factor they apply to each declared CTest timeout. A deadline asserted INSIDE
+# a test is invisible to that rewrite, so an instrumented build that takes longer to notice a
+# departure blows a poll here and the failure reads as a detector that never reported - the
+# exact red this suite exists to produce for a real defect. Unset elsewhere, so the normal jobs
+# keep the tight budgets that give these assertions their falsifying edge.
+#
+# Deliberately NOT scaled, and each for its own reason: the sustained-observation windows
+# (SILENT_WINDOW_SEC, UNREADABLE_INACTIVE_SILENCE_SEC, MUTUAL_EXCLUSION_WINDOW_SEC,
+# CAP_WITHHOLD_WINDOW_SEC), because watching for silence longer buys no confidence; the enforced
+# launch delays (HEALING_RESPAWN_DELAY_SEC, RESTART_LOOP_RESPAWN_DELAY_SEC,
+# CAP_REFUSED_NODE_DELAY_SEC), because they are floors the launch imposes rather than bounds
+# this file waits out; the deliberate settles (DEPARTURE_SETTLE_SEC); the HTTP per-request
+# timeouts inside this file's own helpers, which bound one call and not a wait; and every
+# quantity that MEASURES a detector window rather than budgeting for one - the absence-grace
+# arithmetic in _blink() above all, since scaling that would stop the blink proving it stayed
+# inside the grace at all.
+TIME_SCALE = get_time_scale()
 
 # Fast tick cadence + short warmup so the whole story (gateway/fault_manager startup,
 # demo-node discovery, lifecycle label seeding, global bringup grace) comfortably fits
@@ -253,7 +276,7 @@ UNREADABLE_INACTIVE_SILENCE_SEC = 10.0
 # demo_delay, DDS discovery, entity-cache debounce) the sibling scenarios' 60 s "raise
 # poll" budgets already carry for a MUCH smaller expected cost - kept here rather than
 # tightened, since CI slowness is the variable this margin exists for, not the tick math.
-UNREADABLE_RAISE_TIMEOUT_SEC = 60.0
+UNREADABLE_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 
 # The "departure_keeps" scenario's own budgets, for what a DEPARTURE does to an
 # already-reported unmeasured fault: nothing. A SIGTERM's DDS "participant left" propagates
@@ -261,8 +284,8 @@ UNREADABLE_RAISE_TIMEOUT_SEC = 60.0
 # healing_threshold defines it: giving the entity cache room to reflect a kill quickly)
 # bounds the entity-cache catch-up. The generous margin below is the same CI-slowness
 # allowance every other poll budget in this file carries, not a measurement of that cost.
-ABSENCE_DEPARTURE_TIMEOUT_SEC = 30.0
-ABSENCE_CLEAR_TIMEOUT_SEC = 30.0
+ABSENCE_DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+ABSENCE_CLEAR_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Slept after a departure has been CONFIRMED on GET /apps, before asserting the fault
 # survived it. Long enough to cover every horizon that could have discarded the node's
 # evidence at this scenario's 100 ms cadence: the tracker's absence grace (3 ticks),
@@ -300,7 +323,7 @@ RESTART_LOOP_RESPAWN_DELAY_SEC = 1.0
 # been seen, so ~61 ticks (6.1 s) plus the held blink ticks is the real expected cost; this
 # is several times that, and a detector that discarded evidence on absence stays silent for
 # all of it however many cycles fit.
-RESTART_LOOP_WINDOW_SEC = 45.0
+RESTART_LOOP_WINDOW_SEC = 45.0 * TIME_SCALE
 # Kills the loop must have completed before a sighting of the fault is accepted. Three, so
 # the run is unambiguously a LOOP rather than one departure, and so the fault is proven to
 # survive the restarts that follow its first appearance. At ~3.5 s per cycle that is ~11 s,
@@ -322,12 +345,12 @@ FAULT_CODE_NOT_MANAGED = 'GRAPH_NODE_NOT_MANAGED'
 # and NOT_MANAGED needs no blocking GetState round trips at all (there is no lifecycle
 # service to call), so if anything this scenario's real cost is lower, not higher - the same
 # generous CI-slowness margin is kept rather than tightened.
-NOT_MANAGED_RAISE_TIMEOUT_SEC = 60.0
+NOT_MANAGED_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # Same margins as ABSENCE_DEPARTURE_TIMEOUT_SEC / ABSENCE_CLEAR_TIMEOUT_SEC above, for the
 # same OTHER way an unmeasured code clears: an already-reported node leaving the graph and
 # staying away past the absence grace, never by being read (there is nothing to read here).
-NOT_MANAGED_DEPARTURE_TIMEOUT_SEC = 30.0
-NOT_MANAGED_CLEAR_TIMEOUT_SEC = 30.0
+NOT_MANAGED_DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+NOT_MANAGED_CLEAR_TIMEOUT_SEC = 30.0 * TIME_SCALE
 
 # The detector id its own status block is filed under on GET /x-medkit-watchdog.
 DETECTOR_ID = 'lifecycle_expectation'
@@ -354,14 +377,14 @@ CAP_REFUSED_NODE_DELAY_SEC = 10.0
 # Long enough for the unmeasured hold (60 ticks, fixed) to run out after the tracked node's
 # lifecycle services are dropped, plus the usual CI-slowness margin every raise poll here
 # carries: 61 * 0.1 = 6.1 s of tick cadence.
-CAP_NOT_MANAGED_RAISE_TIMEOUT_SEC = 60.0
+CAP_NOT_MANAGED_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long GRAPH_NODE_INACTIVE's clear must stay withheld while a required node is refused.
 # ~100 ticks at this cadence, and the fault_manager runs at healing_threshold 1 here, so a
 # single spurious PASSED anywhere in the window is enough to fail the assertion.
 CAP_WITHHOLD_WINDOW_SEC = 10.0
 # Budget for the refused node to be admitted and confirmed once the departed entry is
 # collapsed: absence grace (3 ticks) + grace (3 ticks) + the report reaching the store.
-CAP_ADMISSION_TIMEOUT_SEC = 60.0
+CAP_ADMISSION_TIMEOUT_SEC = 60.0 * TIME_SCALE
 
 # ---- the "unsettled_departure" scenario: what ONE bad sweep may decide ----------------
 #
@@ -386,7 +409,7 @@ UNSETTLED_SETTLED_HOLD_TICKS = 10
 # The unmeasured hold (60 ticks, fixed) plus the absence grace, at this cadence: 63 * 0.5 =
 # 31.5 s, plus the usual margin. Both legs are measured against this same budget - the
 # settled one must raise inside it, the blinking one must never raise at all.
-UNSETTLED_RAISE_TIMEOUT_SEC = 90.0
+UNSETTLED_RAISE_TIMEOUT_SEC = 90.0 * TIME_SCALE
 # Sped up from the gateway's own 1000 ms default so the entity cache reflects a kill quickly
 # relative to the settling budget the blink leg has to stay inside.
 UNSETTLED_REFRESH_DEBOUNCE_MS = 300
@@ -402,7 +425,7 @@ WIDE_GRACE_TICK_INTERVAL_MS = 100
 WIDE_GRACE_VALUE = 2147483646
 # The raise poll's budget. With the value refused and the documented default (5) in force,
 # the node is confirmed within a handful of ticks; the margin is the usual bringup allowance.
-WIDE_GRACE_RAISE_TIMEOUT_SEC = 60.0
+WIDE_GRACE_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 
 # ---- the "restart_departed" scenario: what a gateway RESTART does ---------------------
 #
@@ -415,7 +438,7 @@ RESTART_TICK_INTERVAL_MS = 100
 # kDefaultUnmeasuredHoldTicks (60, fixed): the never-matched hold's own bound, after which
 # the clear is released. 60 * 0.1 = 6 s, plus healing at healing_threshold 1 and the usual
 # CI margin.
-RESTART_HEAL_TIMEOUT_SEC = 90.0
+RESTART_HEAL_TIMEOUT_SEC = 90.0 * TIME_SCALE
 
 
 def generate_test_description():
@@ -684,7 +707,7 @@ def _droppable_node(name, state_label):
     )
 
 
-def _fault_record(port, code, timeout=30.0, interval=0.5):
+def _fault_record(port, code, timeout=30.0 * TIME_SCALE, interval=0.5):
     """Poll ``GET /faults?status=all`` until `code` appears, whatever its status.
 
     ``poll_faults`` uses the default (pending+confirmed) filter, so a fault that
@@ -710,7 +733,7 @@ def _fault_record(port, code, timeout=30.0, interval=0.5):
     return None
 
 
-def _poll_fault_description_contains(port, code, needle, timeout=30.0, interval=0.5):
+def _poll_fault_description_contains(port, code, needle, timeout=30.0 * TIME_SCALE, interval=0.5):
     """Poll ``GET /faults?status=all`` until `code`'s description contains `needle`.
 
     A single read of the description is a snapshot of whatever the last emitted tick said,
@@ -733,7 +756,7 @@ def _poll_fault_description_contains(port, code, needle, timeout=30.0, interval=
     return False
 
 
-def _wait_until_port_is_down(port, timeout=60.0, interval=0.2):
+def _wait_until_port_is_down(port, timeout=60.0 * TIME_SCALE, interval=0.2):
     """Wait until the gateway's HTTP port stops answering. True once it does."""
     base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
     deadline = time.monotonic() + timeout
@@ -746,7 +769,7 @@ def _wait_until_port_is_down(port, timeout=60.0, interval=0.2):
     return False
 
 
-def _poll_watchdog_entity(port, app_id, lifecycle, timeout=30.0, interval=0.5):
+def _poll_watchdog_entity(port, app_id, lifecycle, timeout=30.0 * TIME_SCALE, interval=0.5):
     """Poll GET /x-medkit-watchdog until `app_id` appears with this lifecycle label.
 
     The absence scenarios need one fact wait_until_watchdog_armed cannot give them:
@@ -787,7 +810,7 @@ def _poll_watchdog_entity(port, app_id, lifecycle, timeout=30.0, interval=0.5):
     return None
 
 
-def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
+def _poll_apps_absent(port, app_id, timeout=30.0 * TIME_SCALE, interval=0.5):
     """Poll ``GET /apps`` until `app_id` is no longer listed. ``True`` once it is gone.
 
     The "departure_keeps" scenario's own gate: confirms the fixture process it just
@@ -838,7 +861,7 @@ def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
     return False
 
 
-def _poll_apps_present(port, app_id, timeout=30.0, interval=0.5):
+def _poll_apps_present(port, app_id, timeout=30.0 * TIME_SCALE, interval=0.5):
     """Poll ``GET /apps`` until `app_id` IS listed. ``True`` once it appears.
 
     The "not_managed" scenario's own gate: `calibration` is launched via a delayed
@@ -869,7 +892,7 @@ def _poll_apps_present(port, app_id, timeout=30.0, interval=0.5):
     return False
 
 
-def _set_bool_parameter(client_node, service_name, param_name, value, timeout=30.0):
+def _set_bool_parameter(client_node, service_name, param_name, value, timeout=30.0 * TIME_SCALE):
     """Set one bool parameter on a REMOTE node via its own ``~/set_parameters`` service.
 
     Drives ``unreadable_lifecycle_node.cpp``'s ``start_answering`` parameter at a time
@@ -940,7 +963,8 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         cls._client_node.destroy_node()
         rclpy.shutdown()
 
-    def _call_transition(self, transition_id, reached_label, timeout=30.0, attempts=3):
+    def _call_transition(self, transition_id, reached_label,
+                         timeout=30.0 * TIME_SCALE, attempts=3):
         """Drive one real lifecycle transition, retrying a call that never comes back.
 
         The whole scenario hangs off two of these, and a single-shot call makes one lost
@@ -991,7 +1015,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
             'attempt - the node refused a transition that must be valid from where it was',
         )
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, reached_label, timeout=10.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, reached_label, timeout=10.0 * TIME_SCALE),
             f'ChangeState (transition {transition_id}) was rejected after a retry and '
             f'{TARGET_NODE} is not in "{reached_label}" either - the transition neither '
             'applied on the lost attempt nor succeeded on the retry',
@@ -1008,7 +1032,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # loaded and the tick loop ran, so a bringup failure dies here naming itself
         # instead of as a 60 s poll timeout blaming the detector.
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'raise below could mean anything',
@@ -1016,7 +1040,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
 
         # managed_lifecycle launches unconfigured: present in the graph, alive, but not
         # active. That alone must raise once it persists past the configured grace.
-        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0 * TIME_SCALE)
         self.assertIsNotNone(
             fault,
             f'{FAULT_CODE} never raised while {TARGET_NODE} stayed unconfigured',
@@ -1027,7 +1051,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # entity-scoped surface proves an operator can OPEN it somewhere (see
         # test_qos_e2e.test.py's identical rationale for the same entity).
         self.assertIsNotNone(
-            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE, timeout=30.0),
+            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE, timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE} is not reachable at /apps/graph_watchdog/faults - the '
             'entity the plugin publishes does not own the fault it raises',
         )
@@ -1039,7 +1063,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # "configured" as good enough would heal it here.
         self._call_transition(Transition.TRANSITION_CONFIGURE, reached_label='inactive')
 
-        fault = poll_faults(PORT, FAULT_CODE, timeout=30.0)
+        fault = poll_faults(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             fault,
             f'{FAULT_CODE} did not stay raised once {TARGET_NODE} reached "inactive"',
@@ -1068,7 +1092,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         and is never unset, so it catches a single spurious clear whether or not it
         ever reached HEALED.
         """
-        before = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        before = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             before,
             f'{FAULT_CODE} is not in the store before the restart, so there is nothing '
@@ -1084,7 +1108,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         old_pid = gateway_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _wait_until_port_is_down(PORT, timeout=60.0),
+            _wait_until_port_is_down(PORT, timeout=60.0 * TIME_SCALE),
             f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing was '
             'restarted, so the rest of this test would measure the original process',
         )
@@ -1093,7 +1117,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # globally armed again: a raise (or a clear) is only possible past that point,
         # so measuring before it would measure a stack that had not started detecting.
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=90.0),
+            wait_until_watchdog_armed(PORT, timeout=90.0 * TIME_SCALE),
             'the gateway never came back armed after the restart',
         )
         new_pid = gateway_node.process_details['pid']
@@ -1107,7 +1131,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # fault_manager needs healing_threshold (default 3) PASSED reports to heal.
         time.sleep(max(4.0, (GRACE + 8) * TICK_INTERVAL_MS / 1000.0))
 
-        after = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        after = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             after,
             f'{FAULT_CODE} vanished from the store entirely after the restart',
@@ -1127,7 +1151,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # And the fault is still on the operator-visible active list, i.e. the withhold
         # preserved it rather than merely delaying the damage.
         self.assertIsNotNone(
-            poll_faults(PORT, FAULT_CODE, timeout=30.0),
+            poll_faults(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE} is no longer an active fault after the gateway restart',
         )
 
@@ -1139,7 +1163,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # is a heal of a proven-present fault (same pairing as
         # test_param_drift_e2e.test.py's heal leg).
         self.assertIsNotNone(
-            poll_faults(PORT, FAULT_CODE, timeout=30.0),
+            poll_faults(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE} is not active at the start of the heal test, so there is '
             'nothing here that could heal and the clear below would pass without '
             'measuring anything',
@@ -1154,13 +1178,13 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # label arrived but the clear never flowed, poll_cleared below is the one that
         # fails.
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0, app_id=TARGET_NODE),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE, app_id=TARGET_NODE),
             f'the gate never armed {TARGET_NODE} after a successful ACTIVATE - the '
             'live lifecycle machinery (transition_event / GetState) never delivered '
             'the "active" label to the watcher',
         )
 
-        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0)
+        cleared = poll_cleared(PORT, FAULT_CODE, timeout=60.0 * TIME_SCALE)
         self.assertTrue(
             cleared,
             f'{FAULT_CODE} did not heal after {TARGET_NODE} reached "active"',
@@ -1173,7 +1197,7 @@ class TestLifecycleExpectationMain(unittest.TestCase):
         # Pin that the node is still present and reading "active" once the clear was
         # observed.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'active', timeout=15.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'active', timeout=15.0 * TIME_SCALE),
             f'{TARGET_NODE} is no longer present and reading "active" once the clear was '
             'observed - the clear could have come from the absence path (a fixture exit) '
             'rather than the ACTIVATE that this test is actually about',
@@ -1188,7 +1212,7 @@ class TestLifecycleExpectationDefaultConfig(unittest.TestCase):
         # same "no fault" result, and every bringup failure mode on this launch still
         # exits 0 (see the harness docstring).
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load or its tick loop never ran, so an absent fault proves nothing',
         )
@@ -1198,7 +1222,7 @@ class TestLifecycleExpectationDefaultConfig(unittest.TestCase):
         # poll_faults swallows that and returns None, and the absence assertion passes
         # for the one reason it must never pass.
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so an absent fault proves nothing about the '
             'detector',
@@ -1207,7 +1231,7 @@ class TestLifecycleExpectationDefaultConfig(unittest.TestCase):
         # node AND read its non-active label. Without this the silence below could just
         # as well mean the label never arrived.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0 * TIME_SCALE),
             f'the gate never reported {TARGET_NODE} with lifecycle "unconfigured" - '
             'the node was not discovered or its label was never read, so the silence '
             'below would be vacuous',
@@ -1224,7 +1248,7 @@ class TestLifecycleExpectationDefaultConfig(unittest.TestCase):
         # check and invisible to the tracker (a departed node is the presence class's
         # problem), which would leave 2 s of trigger and 18 s of empty graph.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=15.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=15.0 * TIME_SCALE),
             f'{TARGET_NODE} is no longer reported as "unconfigured" at the END of the '
             'silence window - the trigger did not survive it, so most of the window '
             'proved nothing',
@@ -1252,7 +1276,7 @@ class TestLifecycleExpectationNegativeControl(unittest.TestCase):
         # .so loaded, the tick loop ran, the node was discovered, its warmup elapsed,
         # and the watcher considers it ok.
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0, app_id=ACTIVE_NODE),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE, app_id=ACTIVE_NODE),
             f'graph_watchdog never reported {ACTIVE_NODE} as an armed entity - the '
             'plugin did not load, its tick loop never ran, or the gateway never '
             'discovered the node, so an absent fault proves nothing',
@@ -1263,7 +1287,7 @@ class TestLifecycleExpectationNegativeControl(unittest.TestCase):
         # never DDS-matched - leaves GET /faults answering 503, which poll_faults
         # swallows into exactly the None the assertion below wants.
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so a wrong raise would have been lost rather '
             'than caught',
@@ -1272,7 +1296,7 @@ class TestLifecycleExpectationNegativeControl(unittest.TestCase):
         # label, and the tracker treats unread as benign - a run whose label never
         # arrived would stay silent for the wrong reason. Pin that "active" was READ.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, ACTIVE_NODE, 'active', timeout=30.0),
+            _poll_watchdog_entity(PORT, ACTIVE_NODE, 'active', timeout=30.0 * TIME_SCALE),
             f'the gate never reported {ACTIVE_NODE} with lifecycle "active" - its '
             'label was never read, so the silence below would be vacuous',
         )
@@ -1286,7 +1310,7 @@ class TestLifecycleExpectationNegativeControl(unittest.TestCase):
         # window: a node that exited early leaves an empty graph, which is silent for a
         # reason that has nothing to do with the detector being right.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, ACTIVE_NODE, 'active', timeout=15.0),
+            _poll_watchdog_entity(PORT, ACTIVE_NODE, 'active', timeout=15.0 * TIME_SCALE),
             f'{ACTIVE_NODE} is no longer reported as "active" at the END of the silence '
             'window - the required node did not survive it, so most of the window was '
             'not exercising an active node at all',
@@ -1339,13 +1363,13 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         # bringup failure must die here, naming itself, instead of as a raise-poll
         # timeout that blames the detector.
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'assertion below could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so a wrong raise would have been lost rather '
             'than caught',
@@ -1356,7 +1380,7 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         # - LifecycleWatcher seeded it once and nothing has answered since (see
         # _poll_watchdog_entity's docstring for why "" is not "no data yet").
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=30.0),
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=30.0 * TIME_SCALE),
             f'the gate never reported {UNREADABLE_NODE} with an empty (never-read) '
             'lifecycle label - the fixture was not discovered as a managed node, or its '
             'GetState answered when it must not have, so nothing below would prove '
@@ -1373,7 +1397,7 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         # And the node must still be genuinely unread at the END of the window, or the
         # silence above measured an empty graph rather than a real unreadable node.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=15.0),
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=15.0 * TIME_SCALE),
             f'{UNREADABLE_NODE} no longer reads an empty (never-read) lifecycle label '
             'at the end of the silence window - the trigger did not survive it, so '
             'most of the window proved nothing',
@@ -1404,14 +1428,15 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         # entity-scoped surface proves an operator can OPEN it somewhere (see
         # TestLifecycleExpectationMain.test_01's identical rationale for the sibling code).
         self.assertIsNotNone(
-            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE_UNREADABLE, timeout=30.0),
+            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE_UNREADABLE,
+                               timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE_UNREADABLE} is not reachable at /apps/graph_watchdog/faults - '
             'the entity the plugin publishes does not own the fault it raises',
         )
 
     def test_04_answering_active_clears_it(self):
         self.assertIsNotNone(
-            poll_faults(PORT, FAULT_CODE_UNREADABLE, timeout=30.0),
+            poll_faults(PORT, FAULT_CODE_UNREADABLE, timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE_UNREADABLE} is not active at the start of the heal test, so '
             'there is nothing here that could heal and the clear below would pass '
             'without measuring anything',
@@ -1420,7 +1445,7 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         self.assertTrue(
             _set_bool_parameter(
                 type(self)._client_node, f'/{UNREADABLE_NODE}/set_parameters',
-                'start_answering', True, timeout=30.0),
+                'start_answering', True, timeout=30.0 * TIME_SCALE),
             f'setting start_answering:=true on /{UNREADABLE_NODE}/set_parameters '
             'never succeeded - the fixture never got the signal to start answering '
             'GetState, so no heal below could mean anything',
@@ -1431,13 +1456,13 @@ class TestLifecycleExpectationUnreadable(unittest.TestCase):
         # this node: node_ok() was already true while unread (an unread label defaults
         # open, see lifecycle_watcher.cpp), so this is the read itself, not the gate.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNREADABLE_NODE, 'active', timeout=30.0),
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, 'active', timeout=30.0 * TIME_SCALE),
             f'the gate never reported {UNREADABLE_NODE} with lifecycle "active" after '
             'start_answering:=true - the fixture accepted the parameter but its '
             'GetState still never delivered "active" to the watcher',
         )
 
-        cleared = poll_cleared(PORT, FAULT_CODE_UNREADABLE, timeout=30.0)
+        cleared = poll_cleared(PORT, FAULT_CODE_UNREADABLE, timeout=30.0 * TIME_SCALE)
         self.assertTrue(
             cleared,
             f'{FAULT_CODE_UNREADABLE} did not heal after {UNREADABLE_NODE} started '
@@ -1530,7 +1555,7 @@ class TestLifecycleExpectationHealingThreshold(unittest.TestCase):
         # including the absence duration below, describes a node the tracker never saw
         # leave. GET /apps carries no such retention.
         self.assertTrue(
-            _poll_apps_present(PORT, TARGET_NODE, timeout=15.0),
+            _poll_apps_present(PORT, TARGET_NODE, timeout=15.0 * TIME_SCALE),
             f'blink {blink_number}: {TARGET_NODE} never came back into GET /apps - the '
             'respawn or its rediscovery did not complete, so this blink cannot be trusted '
             'to have stayed inside the absence grace',
@@ -1576,19 +1601,19 @@ class TestLifecycleExpectationHealingThreshold(unittest.TestCase):
 
     def test_repeated_blinks_do_not_heal_a_still_violating_fault(self, target_node):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state for the '
             'healing_threshold scenario - no assertion below could mean anything',
         )
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never read "unconfigured" - the false-positive trigger this '
             'test needs was never actually present',
         )
 
-        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0 * TIME_SCALE)
         self.assertIsNotNone(fault, f'{FAULT_CODE} never raised for the stuck {TARGET_NODE}')
-        before = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        before = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(before, f'{FAULT_CODE} is not in the store before the blinks')
         self.assertIsNone(
             before.get('last_passed'),
@@ -1652,7 +1677,7 @@ class TestLifecycleExpectationHealingThreshold(unittest.TestCase):
             sse_response.close()
             sse_pump.join(timeout=5)
 
-        after = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        after = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             after, f'{FAULT_CODE} vanished from the store entirely after the blinks')
         self.assertIsNone(
@@ -1670,7 +1695,7 @@ class TestLifecycleExpectationHealingThreshold(unittest.TestCase):
         # And the node is still genuinely stuck, so the outcome above measured something
         # real rather than an empty graph.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=15.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=15.0 * TIME_SCALE),
             f'{TARGET_NODE} is no longer reading "unconfigured" at the end of the test - '
             'the trigger did not survive the blinks, so the assertions above proved '
             'nothing',
@@ -1783,19 +1808,19 @@ class TestLifecycleExpectationDepartureKeeps(unittest.TestCase):
 
     def test_01_present_and_unread_before_anything_else(self):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'assertion below could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so a wrong raise would have been lost rather '
             'than caught',
         )
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=30.0),
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=30.0 * TIME_SCALE),
             f'the gate never reported {UNREADABLE_NODE} with an empty (never-read) '
             'lifecycle label - the fixture was not discovered as a managed node, or its '
             'GetState answered when it must not have, so nothing below would prove '
@@ -1829,7 +1854,7 @@ class TestLifecycleExpectationDepartureKeeps(unittest.TestCase):
         # evidence on absence has had every opportunity to do so.
         time.sleep(DEPARTURE_SETTLE_SEC)
 
-        record = _fault_record(PORT, FAULT_CODE_UNREADABLE, timeout=30.0)
+        record = _fault_record(PORT, FAULT_CODE_UNREADABLE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             record,
             f'{FAULT_CODE_UNREADABLE} vanished from the store entirely after '
@@ -1852,7 +1877,8 @@ class TestLifecycleExpectationDepartureKeeps(unittest.TestCase):
         # describe a graph it left.
         self.assertIn(
             'has since left the graph',
-            _fault_record(PORT, FAULT_CODE_UNREADABLE, timeout=10.0).get('description', ''),
+            _fault_record(PORT, FAULT_CODE_UNREADABLE,
+                          timeout=10.0 * TIME_SCALE).get('description', ''),
             f'{FAULT_CODE_UNREADABLE} still describes {UNREADABLE_NODE} as a present '
             'node whose state cannot be read, after it left the graph',
         )
@@ -1897,13 +1923,13 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
 
     def test_01_present_and_not_managed_before_anything_else(self):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'assertion below could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so a wrong raise would have been lost rather '
             'than caught',
@@ -1915,7 +1941,7 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
         # statement about ABSENCE of tracking, which GET /apps + the raise below prove
         # together more directly than a nullable JSON field would.
         self.assertTrue(
-            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0),
+            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0 * TIME_SCALE),
             f'{NOT_MANAGED_NODE} never appeared on GET /apps - the fixture never came up, '
             'so nothing below would prove anything about NOT-MANAGED',
         )
@@ -1943,7 +1969,8 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
             self, PORT, FAULT_CODE_UNREADABLE, MUTUAL_EXCLUSION_WINDOW_SEC)
 
         self.assertIsNotNone(
-            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE_NOT_MANAGED, timeout=30.0),
+            poll_entity_faults(PORT, 'apps/graph_watchdog', FAULT_CODE_NOT_MANAGED,
+                               timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE_NOT_MANAGED} is not reachable at /apps/graph_watchdog/faults - '
             'the entity the plugin publishes does not own the fault it raises',
         )
@@ -1967,7 +1994,7 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
         )
         time.sleep(DEPARTURE_SETTLE_SEC)
 
-        record = _fault_record(PORT, FAULT_CODE_NOT_MANAGED, timeout=30.0)
+        record = _fault_record(PORT, FAULT_CODE_NOT_MANAGED, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             record,
             f'{FAULT_CODE_NOT_MANAGED} vanished from the store entirely after '
@@ -1987,7 +2014,8 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
         )
         self.assertIn(
             'has since left the graph',
-            _fault_record(PORT, FAULT_CODE_NOT_MANAGED, timeout=10.0).get('description', ''),
+            _fault_record(PORT, FAULT_CODE_NOT_MANAGED,
+                          timeout=10.0 * TIME_SCALE).get('description', ''),
             f'{FAULT_CODE_NOT_MANAGED} still describes {NOT_MANAGED_NODE} as a present '
             'node, after it left the graph',
         )
@@ -2032,14 +2060,14 @@ class TestLifecycleExpectationRestartLoop(unittest.TestCase):
         old_pid = node_action.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, NOT_MANAGED_NODE, timeout=30.0, interval=0.05),
+            _poll_apps_absent(PORT, NOT_MANAGED_NODE, timeout=30.0 * TIME_SCALE, interval=0.05),
             f'cycle {cycle}: {NOT_MANAGED_NODE} (pid {old_pid}) was never observed absent '
             'from GET /apps after the SIGTERM - this cycle never crossed the absence '
             'horizon it exists to cross',
         )
         absence_observed = time.monotonic()
         self.assertTrue(
-            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0, interval=0.05),
+            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0 * TIME_SCALE, interval=0.05),
             f'cycle {cycle}: {NOT_MANAGED_NODE} never came back after the SIGTERM - launch '
             'did not respawn it, so this is a single departure, not a restart loop',
         )
@@ -2057,18 +2085,18 @@ class TestLifecycleExpectationRestartLoop(unittest.TestCase):
 
     def test_crash_looping_node_is_reported(self, target_node):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'assertion below could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the '
             'fault_manager in this launch, so a missing fault would prove nothing',
         )
         self.assertTrue(
-            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0),
+            _poll_apps_present(PORT, NOT_MANAGED_NODE, timeout=30.0 * TIME_SCALE),
             f'{NOT_MANAGED_NODE} never appeared on GET /apps - the fixture never came up, '
             'so there is no node here to crash-loop',
         )
@@ -2152,13 +2180,13 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
 
     def test_01_the_refused_node_is_reported_as_saturation(self):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state - the plugin did not '
             'load, its tick loop never ran, or the bringup grace never elapsed, so no '
             'assertion below could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the fault_manager '
             'in this launch',
         )
@@ -2166,24 +2194,26 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
         # refused" would just be "one of them never came up".
         for node_id in (CAP_TRACKED_NODE, CAP_REFUSED_NODE):
             self.assertTrue(
-                _poll_apps_present(PORT, node_id, timeout=30.0),
+                _poll_apps_present(PORT, node_id, timeout=30.0 * TIME_SCALE),
                 f'{node_id} never appeared on GET /apps - with only one required node '
                 'present the cap of one is not full and nothing is refused',
             )
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, CAP_TRACKED_NODE, 'unconfigured', timeout=30.0),
+            _poll_watchdog_entity(PORT, CAP_TRACKED_NODE, 'unconfigured',
+                                  timeout=30.0 * TIME_SCALE),
             f'{CAP_TRACKED_NODE} never read "unconfigured" - the node that must win the '
             'single slot was never measured as a violation at all',
         )
 
-        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0)
+        fault = poll_faults(PORT, FAULT_CODE, timeout=60.0 * TIME_SCALE)
         self.assertIsNotNone(
             fault, f'{FAULT_CODE} never raised for {CAP_TRACKED_NODE}, which holds the one slot')
         self.assertIn(CAP_TRACKED_NODE, fault.get('description', ''))
 
         # The refusal itself, on the operator-visible surface.
         self.assertTrue(
-            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', True, timeout=30.0),
+            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', True,
+                                 timeout=30.0 * TIME_SCALE),
             'GET /x-medkit-watchdog never reported the lifecycle_expectation tracked-node '
             f'cap as saturated while {CAP_REFUSED_NODE} was present, required and refused - '
             'a required node is going unchecked and nothing an operator can read says so',
@@ -2196,7 +2226,7 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
             f'configured ({CAP_NODE_CAP}) - the key did not reach the detector: {block}')
 
     def test_02_a_refused_node_withholds_the_clear(self):
-        before = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        before = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             before, f'{FAULT_CODE} is not in the store, so there is nothing a clear could heal')
         self.assertIsNone(
@@ -2213,7 +2243,7 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
         self.assertTrue(
             _set_bool_parameter(
                 type(self)._client_node, f'/{CAP_TRACKED_NODE}/set_parameters',
-                'drop_services', True, timeout=30.0),
+                'drop_services', True, timeout=30.0 * TIME_SCALE),
             f'setting drop_services:=true on /{CAP_TRACKED_NODE}/set_parameters never '
             'succeeded, so the state this test needs was never reached',
         )
@@ -2224,7 +2254,7 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
             f'{FAULT_CODE} still has content and the withhold below would prove nothing',
         )
         time.sleep(CAP_WITHHOLD_WINDOW_SEC)
-        after = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        after = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(after, f'{FAULT_CODE} vanished from the store entirely')
         self.assertIsNone(
             after.get('last_passed'),
@@ -2241,7 +2271,8 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
         # unmeasured clock is evidence), so it kept the single slot the whole way through and
         # the other required node was never admitted behind our back.
         self.assertTrue(
-            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', True, timeout=15.0),
+            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', True,
+                                 timeout=15.0 * TIME_SCALE),
             'the cap stopped reporting itself saturated once the tracked node went '
             'not-managed - the refused node was admitted, so the window above was not about '
             'a withheld clear at all',
@@ -2251,12 +2282,12 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
         old_pid = tracked_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, CAP_TRACKED_NODE, timeout=30.0),
+            _poll_apps_absent(PORT, CAP_TRACKED_NODE, timeout=30.0 * TIME_SCALE),
             f'{CAP_TRACKED_NODE} (pid {old_pid}) is still listed on GET /apps after SIGTERM '
             '- it never left the graph, so its entry was never a DEPARTED one',
         )
         self.assertTrue(
-            _poll_apps_present(PORT, CAP_REFUSED_NODE, timeout=30.0),
+            _poll_apps_present(PORT, CAP_REFUSED_NODE, timeout=30.0 * TIME_SCALE),
             f'{CAP_REFUSED_NODE} is not on GET /apps - the node that must now be admitted '
             'is not even present',
         )
@@ -2272,13 +2303,14 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
         )
         # And the refusal is over, so the latch that reports it has re-armed for a later one.
         self.assertTrue(
-            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', False, timeout=30.0),
+            poll_detector_status(PORT, DETECTOR_ID, 'tracking_saturated', False,
+                                 timeout=30.0 * TIME_SCALE),
             'the cap still reports itself saturated after the departed entry was collapsed '
             'and the present node admitted - a later, real saturation would be indistinguishable',
         )
         # The departed node's own fault is not healed by its departure: its evidence lives on
         # as a count, which is what keeps that code's content non-empty.
-        record = _fault_record(PORT, FAULT_CODE_NOT_MANAGED, timeout=30.0)
+        record = _fault_record(PORT, FAULT_CODE_NOT_MANAGED, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(
             record, f'{FAULT_CODE_NOT_MANAGED} vanished from the store after the departure')
         self.assertIsNone(
@@ -2288,7 +2320,7 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
             'slot threw its evidence away instead of keeping it as a count',
         )
         # Nothing anywhere in this run ever cleared GRAPH_NODE_INACTIVE.
-        final = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        final = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNone(
             final.get('last_passed'),
             f'{FAULT_CODE} was reported PASSED at some point in this run '
@@ -2339,25 +2371,25 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
         self.assertTrue(
             _set_bool_parameter(
                 type(self)._client_node, f'/{node_id}/set_parameters',
-                'drop_services', True, timeout=30.0),
+                'drop_services', True, timeout=30.0 * TIME_SCALE),
             f'setting drop_services:=true on /{node_id}/set_parameters never succeeded - '
             'the node never stopped looking like a managed lifecycle node',
         )
 
     def test_01_both_required_nodes_are_present_and_healthy(self):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state, so no assertion below '
             'could mean anything',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the fault_manager '
             'in this launch, so an absent fault would prove nothing',
         )
         for node_id in (UNSETTLED_BLINK_NODE, UNSETTLED_SETTLED_NODE):
             self.assertIsNotNone(
-                _poll_watchdog_entity(PORT, node_id, 'active', timeout=30.0),
+                _poll_watchdog_entity(PORT, node_id, 'active', timeout=30.0 * TIME_SCALE),
                 f'{node_id} never read lifecycle "active" - it was not discovered as a '
                 'managed node, so it cannot be a HEALTHY managed node whose services then '
                 'disappear',
@@ -2370,14 +2402,15 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
         # the watchdog route reports a null lifecycle exactly when the watcher no longer
         # tracks the id, which is what the tracker classifies as kNotManaged.
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNSETTLED_BLINK_NODE, None, timeout=15.0),
+            _poll_watchdog_entity(PORT, UNSETTLED_BLINK_NODE, None, timeout=15.0 * TIME_SCALE),
             f'{UNSETTLED_BLINK_NODE} never lost its tracked lifecycle state after its '
             'services were dropped - this leg never produced the unmeasured observation it '
             'is about',
         )
         os.kill(blink_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, UNSETTLED_BLINK_NODE, timeout=30.0, interval=0.05),
+            _poll_apps_absent(PORT, UNSETTLED_BLINK_NODE,
+                              timeout=30.0 * TIME_SCALE, interval=0.05),
             f'{UNSETTLED_BLINK_NODE} never left GET /apps after SIGTERM')
         unmanaged_for = time.monotonic() - dropped_at
         settle_budget_sec = (UNSETTLED_SETTLE_TICKS * UNSETTLED_TICK_INTERVAL_MS) / 1000.0
@@ -2392,7 +2425,7 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
     def test_03_a_settled_not_managed_departure_is_still_reported(self, settled_node):
         self._drop_services(UNSETTLED_SETTLED_NODE)
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, UNSETTLED_SETTLED_NODE, None, timeout=15.0),
+            _poll_watchdog_entity(PORT, UNSETTLED_SETTLED_NODE, None, timeout=15.0 * TIME_SCALE),
             f'{UNSETTLED_SETTLED_NODE} never lost its tracked lifecycle state after its '
             'services were dropped',
         )
@@ -2401,7 +2434,7 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
         time.sleep((UNSETTLED_SETTLED_HOLD_TICKS * UNSETTLED_TICK_INTERVAL_MS) / 1000.0)
         os.kill(settled_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, UNSETTLED_SETTLED_NODE, timeout=30.0),
+            _poll_apps_absent(PORT, UNSETTLED_SETTLED_NODE, timeout=30.0 * TIME_SCALE),
             f'{UNSETTLED_SETTLED_NODE} never left GET /apps after SIGTERM')
 
         fault = poll_faults(PORT, FAULT_CODE_NOT_MANAGED, timeout=UNSETTLED_RAISE_TIMEOUT_SEC)
@@ -2418,7 +2451,7 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
         # have matured the blinker's own one-sweep reading has been passed on this same
         # stack: it dropped its services first and left the graph first.
         for code in (FAULT_CODE_NOT_MANAGED, FAULT_CODE_UNREADABLE, FAULT_CODE):
-            record = _fault_record(PORT, code, timeout=5.0)
+            record = _fault_record(PORT, code, timeout=5.0 * TIME_SCALE)
             description = (record or {}).get('description', '')
             self.assertNotIn(
                 UNSETTLED_BLINK_NODE, description,
@@ -2453,17 +2486,17 @@ class TestLifecycleExpectationWideGrace(unittest.TestCase):
 
     def test_01_an_out_of_range_grace_is_refused_and_the_default_applies(self):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state, so a missing fault would '
             'prove nothing',
         )
         self.assertTrue(
-            wait_until_faults_endpoint_live(PORT, timeout=30.0),
+            wait_until_faults_endpoint_live(PORT, timeout=30.0 * TIME_SCALE),
             'GET /faults never answered 200 - the gateway never reached the fault_manager, '
             'so a missing fault would prove nothing',
         )
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never read "unconfigured" - the violation this test needs was '
             'never present',
         )
@@ -2482,15 +2515,15 @@ class TestLifecycleExpectationWideGrace(unittest.TestCase):
     def test_02_the_fault_survives_the_node_leaving(self, target_node):
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0),
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
         self.assertTrue(
             _poll_fault_description_contains(
-                PORT, FAULT_CODE, 'has since left the graph', timeout=30.0),
+                PORT, FAULT_CODE, 'has since left the graph', timeout=30.0 * TIME_SCALE),
             f'{FAULT_CODE} still describes {TARGET_NODE} as a present node after it left '
             'the graph',
         )
-        record = _fault_record(PORT, FAULT_CODE, timeout=10.0)
+        record = _fault_record(PORT, FAULT_CODE, timeout=10.0 * TIME_SCALE)
         self.assertIsNone(
             record.get('last_passed'),
             f'{FAULT_CODE} was reported PASSED once {TARGET_NODE} left the graph '
@@ -2530,21 +2563,21 @@ class TestLifecycleExpectationRestartDeparted(unittest.TestCase):
 
     def test_01_the_fault_raises_and_survives_the_node_leaving(self, target_node):
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=60.0),
+            wait_until_watchdog_armed(PORT, timeout=60.0 * TIME_SCALE),
             'graph_watchdog never reported an armed global state')
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0),
+            _poll_watchdog_entity(PORT, TARGET_NODE, 'unconfigured', timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never read "unconfigured"')
         self.assertIsNotNone(
-            poll_faults(PORT, FAULT_CODE, timeout=60.0),
+            poll_faults(PORT, FAULT_CODE, timeout=60.0 * TIME_SCALE),
             f'{FAULT_CODE} never raised for the stuck {TARGET_NODE}')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
-            _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0),
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
         time.sleep(max(4.0, (GRACE + 8) * RESTART_TICK_INTERVAL_MS / 1000.0))
-        record = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        record = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(record, f'{FAULT_CODE} vanished from the store')
         self.assertIsNone(
             record.get('last_passed'),
@@ -2557,10 +2590,10 @@ class TestLifecycleExpectationRestartDeparted(unittest.TestCase):
         old_pid = gateway_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _wait_until_port_is_down(PORT, timeout=60.0),
+            _wait_until_port_is_down(PORT, timeout=60.0 * TIME_SCALE),
             f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing restarted')
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=90.0),
+            wait_until_watchdog_armed(PORT, timeout=90.0 * TIME_SCALE),
             'the gateway never came back armed after the restart')
         self.assertNotEqual(
             gateway_node.process_details['pid'], old_pid,
@@ -2577,7 +2610,7 @@ class TestLifecycleExpectationRestartDeparted(unittest.TestCase):
             'stopped being bounded or something now re-seeds the tracker at startup - '
             'either way the documented scope of the promise needs rewriting, not this test',
         )
-        record = _fault_record(PORT, FAULT_CODE, timeout=30.0)
+        record = _fault_record(PORT, FAULT_CODE, timeout=30.0 * TIME_SCALE)
         self.assertIsNotNone(record, f'{FAULT_CODE} vanished from the store entirely')
         self.assertIsNotNone(
             record.get('last_passed'),

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
@@ -287,11 +287,11 @@ UNREADABLE_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # allowance every other poll budget in this file carries, not a measurement of that cost.
 # Unchanged, and now it only has to cover what it can actually be held to. Every call site
 # proves the process EXITED first (assert_process_exited), so the two terms left are the ones
-# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
-# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
-# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
-# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
-# is gone' costs" note for who promises which term.
+# somebody owns: the DDS participant lease an unclean death costs before the graph drops the
+# participant, plus the gateway's own graph-to-/apps latency - 20 + 1.1 = 21.1 s. 30 s clears
+# that with room for the sanitizer jobs, so nothing here needed widening. Both figures, and
+# who promises which term, are in the gateway's docs/config/server.rst under "How long a
+# departed node keeps being listed".
 ABSENCE_DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 ABSENCE_CLEAR_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Slept after a departure has been CONFIRMED on GET /apps, before asserting the fault

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
@@ -140,6 +140,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import (  # noqa: E402, I100
     API_BASE_PATH,
     assert_fault_absent_throughout,
+    assert_process_exited,
     create_watchdog_test_launch,
     poll_cleared,
     poll_detector_status,
@@ -284,6 +285,13 @@ UNREADABLE_RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # healing_threshold defines it: giving the entity cache room to reflect a kill quickly)
 # bounds the entity-cache catch-up. The generous margin below is the same CI-slowness
 # allowance every other poll budget in this file carries, not a measurement of that cost.
+# Unchanged, and now it only has to cover what it can actually be held to. Every call site
+# proves the process EXITED first (assert_process_exited), so the two terms left are the ones
+# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
+# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
+# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
+# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
+# is gone' costs" note for who promises which term.
 ABSENCE_DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 ABSENCE_CLEAR_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Slept after a departure has been CONFIRMED on GET /apps, before asserting the fault
@@ -1532,6 +1540,7 @@ class TestLifecycleExpectationHealingThreshold(unittest.TestCase):
         """
         old_pid = node_action.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, TARGET_NODE)
 
         # This scenario is named for a departure that stays INSIDE the tracker's
         # absence grace (kDefaultAbsenceGrace, 3 ticks - fixed, not configurable) - not
@@ -1841,6 +1850,7 @@ class TestLifecycleExpectationDepartureKeeps(unittest.TestCase):
     def test_03_killed_node_confirmed_gone_and_the_fault_survives_it(self, target_node):
         old_pid = target_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, UNREADABLE_NODE)
 
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=ABSENCE_DEPARTURE_TIMEOUT_SEC),
@@ -1985,6 +1995,7 @@ class TestLifecycleExpectationNotManaged(unittest.TestCase):
 
         old_pid = target_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, NOT_MANAGED_NODE)
 
         self.assertTrue(
             _poll_apps_absent(PORT, NOT_MANAGED_NODE, timeout=NOT_MANAGED_DEPARTURE_TIMEOUT_SEC),
@@ -2059,6 +2070,7 @@ class TestLifecycleExpectationRestartLoop(unittest.TestCase):
         """SIGTERM the node, prove it left the graph past the absence grace, wait it back."""
         old_pid = node_action.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, NOT_MANAGED_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, NOT_MANAGED_NODE, timeout=30.0 * TIME_SCALE, interval=0.05),
             f'cycle {cycle}: {NOT_MANAGED_NODE} (pid {old_pid}) was never observed absent '
@@ -2281,6 +2293,7 @@ class TestLifecycleExpectationCapPressure(unittest.TestCase):
     def test_03_a_departed_entry_is_collapsed_so_the_present_node_is_checked(self, tracked_node):
         old_pid = tracked_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, CAP_TRACKED_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, CAP_TRACKED_NODE, timeout=30.0 * TIME_SCALE),
             f'{CAP_TRACKED_NODE} (pid {old_pid}) is still listed on GET /apps after SIGTERM '
@@ -2408,6 +2421,7 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
             'is about',
         )
         os.kill(blink_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, blink_node.process_details['pid'], UNSETTLED_BLINK_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNSETTLED_BLINK_NODE,
                               timeout=30.0 * TIME_SCALE, interval=0.05),
@@ -2433,6 +2447,7 @@ class TestLifecycleExpectationUnsettledDeparture(unittest.TestCase):
         # node leaves - the difference, and the only difference, from the blink leg above.
         time.sleep((UNSETTLED_SETTLED_HOLD_TICKS * UNSETTLED_TICK_INTERVAL_MS) / 1000.0)
         os.kill(settled_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, settled_node.process_details['pid'], UNSETTLED_SETTLED_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNSETTLED_SETTLED_NODE, timeout=30.0 * TIME_SCALE),
             f'{UNSETTLED_SETTLED_NODE} never left GET /apps after SIGTERM')
@@ -2514,6 +2529,7 @@ class TestLifecycleExpectationWideGrace(unittest.TestCase):
 
     def test_02_the_fault_survives_the_node_leaving(self, target_node):
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -2573,6 +2589,7 @@ class TestLifecycleExpectationRestartDeparted(unittest.TestCase):
             f'{FAULT_CODE} never raised for the stuck {TARGET_NODE}')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=30.0 * TIME_SCALE),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -163,6 +163,7 @@ from harness import (  # noqa: E402, I100
     assert_fault_describes_only,
     assert_fault_never_names,
     assert_fault_persists_throughout,
+    assert_process_exited,
     create_watchdog_test_launch,
     poll_cleared,
     poll_detector_status,
@@ -267,6 +268,13 @@ TIME_SCALE = get_time_scale()
 ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
 FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+# Unchanged, and now it only has to cover what it can actually be held to. Every call site
+# proves the process EXITED first (assert_process_exited), so the two terms left are the ones
+# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
+# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
+# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
+# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
+# is gone' costs" note for who promises which term.
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE
@@ -890,6 +898,7 @@ class TestBoundaryInactiveBelowGraceThenGone(unittest.TestCase):
         )
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -986,6 +995,7 @@ class TestBoundaryMaturedThenGone(unittest.TestCase):
         self.assertIn(TARGET_NODE, fault.get('description', ''))
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -1028,6 +1038,7 @@ class TestBoundaryHealthyThenGone(unittest.TestCase):
             'GET /faults never answered 200 - nothing below would prove anything')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], ACTIVE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, ACTIVE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{ACTIVE_NODE} never left GET /apps after SIGTERM')
@@ -1091,6 +1102,7 @@ class TestBoundaryRestartLoopStillCaught(unittest.TestCase):
         pid = target_node.process_details['pid']
         for cycle in range(1, B5_CYCLES + 1):
             os.kill(pid, signal.SIGTERM)
+            assert_process_exited(self, pid, TARGET_NODE)
             self.assertTrue(
                 _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
                 f'cycle {cycle}: {TARGET_NODE} never left GET /apps after SIGTERM',
@@ -1207,6 +1219,7 @@ class TestBoundaryNeverArmedBelowGraceThenGone(unittest.TestCase):
         )
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -1254,6 +1267,7 @@ class TestBoundaryConfigEndpointE2E(unittest.TestCase):
             'GET /faults never answered 200 - nothing below would prove anything')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], C4_TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, C4_TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{C4_TARGET_NODE} never left GET /apps after SIGTERM')
@@ -1290,6 +1304,7 @@ class TestBoundaryUngatedClear(unittest.TestCase):
             f'graph_watchdog never reported {D2_TARGET_NODE} armed')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], D2_TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, D2_TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{D2_TARGET_NODE} never left GET /apps after SIGTERM')

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -171,7 +171,11 @@ from harness import (  # noqa: E402, I100
     wait_until_watchdog_armed,
 )
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.constants import (  # noqa: E402
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
 from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
 from ros2_medkit_test_utils.launch_helpers import DEMO_NODE_REGISTRY  # noqa: E402
 
@@ -243,12 +247,23 @@ B5_MISS_GRACE = 16
 # by 1200 ms - worst-case observed window 12500 - 1100 = 11400 ms, 3.35x the nominal grace.
 B5_RESPAWN_DELAY_SEC = 12.5
 
-ARM_TIMEOUT_SEC = 60.0
-FAULTS_LIVE_TIMEOUT_SEC = 30.0
-PRESENCE_TIMEOUT_SEC = 30.0
-DEPARTURE_TIMEOUT_SEC = 30.0
-RAISE_TIMEOUT_SEC = 60.0
-CLEAR_TIMEOUT_SEC = 60.0
+# The budgets below are scaled by MEDKIT_TEST_TIME_SCALE, which the sanitizer jobs set to the
+# same factor they apply to every declared CTest timeout. A deadline asserted INSIDE a test is
+# invisible to that rewrite, so an instrumented graph that takes longer to forget a departed
+# node blows a budget here and the failure reads as a detector that never reported - the exact
+# red this suite exists to produce for a real defect. Unset elsewhere, so the normal jobs keep
+# the tight budgets that give these assertions their falsifying edge.
+#
+# Poll intervals, enforced respawn delays and the sustained-observation windows are NOT scaled.
+# Those are not give-up bounds: stretching a window a scenario watches for silence buys no
+# confidence and spends the whole package's test budget to do it.
+TIME_SCALE = get_time_scale()
+ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
+FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
+CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long an absent or a persisting fault is watched for - measured from the arming gate, not
 # process start, so bringup cannot eat it. Matches test_node_death_e2e.test.py's identical
 # constant.
@@ -285,7 +300,7 @@ C4_EARLY_WINDOW_SEC = 25.0
 # Measured from the END of C4_EARLY_WINDOW_SEC, not from the kill: comfortably covers the
 # remaining ~75s to C4_MISS_GRACE_LARGE's own nominal grace-crossing point plus reporting
 # latency.
-C4_LATE_RAISE_TIMEOUT_SEC = 100.0
+C4_LATE_RAISE_TIMEOUT_SEC = 100.0 * TIME_SCALE
 
 # ---- "d2_ungated_clear" scenario's own fixtures -------------------------------------------------
 D2_TARGET_NODE = 'calibration'
@@ -321,11 +336,11 @@ def _lifecycle_node_action(
     here explicitly rather than inferred from it. Defaults to whether `name` is ACTIVE_NODE -
     the historical convention every scenario but B3/B5 relies on - but a caller launching
     TARGET_NODE (managed_lifecycle) for a scenario that needs it to actually ARM for
-    node_death passes `auto_activate=True` explicitly: node_death only ever tracks a node it
-    has seen armed at least once (reliability_allows() requires "active" for a managed node -
-    LifecycleWatcher::node_ok()), so a require_active node that never activates is invisible
-    to it no matter what happens to it afterwards. See TestBoundaryMaturedThenGone and
-    TestBoundaryRestartLoopStillCaught's own class docstrings.
+    node_death passes `auto_activate=True` explicitly: node_death only ever tracks a node whose
+    departure the gate has said it OWNS at least once (presence_ownership() needs a
+    MANAGED node's lifecycle state positively known to read "active"), so a require_active node
+    that never activates is invisible to it no matter what happens to it afterwards. See
+    TestBoundaryMaturedThenGone and TestBoundaryRestartLoopStillCaught's own class docstrings.
     """
     executable, ros_name, namespace = DEMO_NODE_REGISTRY[name]
     if auto_activate is None:
@@ -774,9 +789,9 @@ class TestBoundaryInactiveBelowGraceThenGone(unittest.TestCase):
 
     Both of this row's claims are satisfiable together, which took getting the arming gate
     wrong once to learn: the target must reach "active" FIRST, or GRAPH_NODE_DISAPPEARED can
-    never report its death, whatever kills it - reliability_allows() requires "active" for a
-    MANAGED node (LifecycleWatcher::node_ok()), so a managed_lifecycle instance that stays
-    "unconfigured" its whole life is structurally invisible to node_death, exactly as
+    never report its death, whatever kills it - presence_ownership() needs a MANAGED
+    node's lifecycle state positively known to read "active", so a managed_lifecycle instance
+    that stays "unconfigured" its whole life is structurally invisible to node_death, exactly as
     TestBoundaryMaturedThenGone's own docstring explains for its target. The launch therefore
     drives TARGET_NODE through "active" first, THEN a real DEACTIVATE transition - the same two
     steps B3 takes - but where B3 leaves the node inactive long enough to CONFIRM (past
@@ -898,12 +913,13 @@ class TestBoundaryMaturedThenGone(unittest.TestCase):
     for the UNREADABLE code.
 
     The second - GRAPH_NODE_DISAPPEARED also joining once the node is gone, still naming it -
-    needs node_death to have TRACKED the node at all, which only ever happens for a node armed
-    at least once: reliability_allows() requires "active" for a MANAGED node
-    (LifecycleWatcher::node_ok()). A managed_lifecycle instance that stays "unconfigured" its
-    whole life is never armed and so is structurally invisible to node_death whatever happens
-    to it afterwards - the second claim would be unreachable by ANY correct implementation
-    against that fixture, not merely an unimplemented one. This is why the launch drives
+    needs node_death to have TRACKED the node at all, which only ever happens for a node the gate
+    has admitted for presence ownership at least once: presence_ownership() needs a
+    MANAGED node's lifecycle state positively known to read "active". A managed_lifecycle
+    instance that stays "unconfigured" its whole life is never admitted and so is structurally
+    invisible to node_death whatever happens to it afterwards - the second claim would be
+    unreachable by ANY correct implementation against that fixture, not merely an unimplemented
+    one. This is why the launch drives
     TARGET_NODE through "active" FIRST (arming it - the same mechanism B4's target uses), THEN
     a real DEACTIVATE transition (maturing GRAPH_NODE_INACTIVE the same way the original
     "stays unconfigured" fixture did), THEN kills it: the node this row's second claim needs
@@ -1031,10 +1047,11 @@ class TestBoundaryRestartLoopStillCaught(unittest.TestCase):
 
     The target launches with auto_activate (the same mechanism B4's target uses) and keeps that
     parameter across every respawn, not merely the first start: node_death only ever tracks a
-    node it has seen ARMED at least once (reliability_allows() requires "active" for a managed
-    node - LifecycleWatcher::node_ok()), so a fixture that never activates would make
-    GRAPH_NODE_DISAPPEARED structurally unreachable for every cycle here, not merely slow to
-    catch - this row carries the evidence that forbidding absence from maturing an unmatured
+    node whose departure the gate has said it OWNS at least once (presence_ownership()
+    needs a managed node's lifecycle state positively known to read "active"), so a fixture that
+    never activates would make GRAPH_NODE_DISAPPEARED structurally unreachable for every cycle
+    here, not merely slow to catch - this row carries the evidence that forbidding absence from
+    maturing an unmatured
     streak is safe, so it has to run against a node that can actually be reported. Each cycle's
     respawned instance is re-armed (app_id-scoped wait_until_watchdog_armed, not merely
     presence) before the NEXT kill for the identical reason a fresh process needs it the first

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -1,0 +1,1414 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""node_death boundary, config and instrument e2e: the seam with lifecycle_expectation.
+
+Sibling of test_node_death_e2e.test.py and test_node_death_suppression_e2e.test.py, same shape.
+What makes this file different is B1 and B3: their claims are about lifecycle_expectation ALONE,
+independent of node_death, so an absence assertion there still discriminates a correct detector
+from no detector at all - see their own class docstrings for what was actually observed.
+
+Runs as EIGHT separate CTest targets (see CMakeLists.txt). WATCHDOG_E2E_SCENARIO selects which
+launch and which assertions run:
+
+- "b1_inactive_present": a require_active node (managed_lifecycle, never activated) sits in the
+  graph past `grace`. GRAPH_NODE_INACTIVE raises and names it - GENUINELY GREEN, because
+  lifecycle_expectation already ships this. GRAPH_NODE_DISAPPEARED stays absent for the whole
+  window - absence alone cannot distinguish a detector that correctly stays silent here from
+  one that raises nothing at all, but staying silent is also the permanently correct behaviour,
+  since this node never leaves the graph.
+- "b2_inactive_below_grace_then_gone": the same node, now driven to "active" FIRST (arming it
+  for node_death - see TestBoundaryInactiveBelowGraceThenGone's own class docstring for why
+  that is not optional), then to "inactive" via a real DEACTIVATE transition, then killed after
+  being observed non-active for only a couple of ticks - comfortably below `grace`. Absence may
+  continue a violation that has already matured, but must never mature one that has not: this row
+  pins the defect where GRAPH_NODE_INACTIVE used to mature from evidence gathered entirely after
+  the node could no longer be observed, proven with assert_fault_absent_throughout rather than
+  presented as prose. The below-grace precondition is itself proven from an OBSERVABLE
+  (GRAPH_NODE_INACTIVE still absent from /faults) immediately before the kill, not merely
+  inferred from how little time has elapsed - status_json() exposes no per-node violation-streak
+  count (see lifecycle_expectation_detector.cpp), so the fault surface is the only external
+  evidence available, and with confirmation_threshold=-2 the detector's first FAILED report IS
+  the confirmation. Both halves of the row are now reachable together: no GRAPH_NODE_INACTIVE is
+  born from the departure, and GRAPH_NODE_DISAPPEARED raises because the node was armed before
+  it died.
+- "b3_matured_then_gone": a require_active node driven to "active" first (arming it for
+  node_death - see TestBoundaryMaturedThenGone's own class docstring for why that is not
+  optional), then to "inactive" via a real DEACTIVATE transition and left there long enough
+  for GRAPH_NODE_INACTIVE to CONFIRM, before it is killed. The confirmed fault survives the
+  departure AND keeps naming the node (content follows the clocks, not the snapshot - already
+  shipped, GENUINELY proven here with assert_fault_describes_only rather than a code-only
+  persistence check, which a detector that dropped this node while keeping the code raised for
+  another one would still pass), and GRAPH_NODE_DISAPPEARED now joins it too, since the node
+  was genuinely armed before it died.
+- "b4_healthy_then_gone": the self-activating variant (managed_lifecycle_active) reaches "active"
+  and is then killed outright. No GRAPH_NODE_INACTIVE is born from a healthy departure
+  (release_uncorroborated - already shipped, genuinely proven here), but GRAPH_NODE_DISAPPEARED
+  never raises. RED.
+- "b5_restart_loop_still_caught": the same require_active node, now reaching "active" on EVERY
+  respawn (not merely the first start - see TestBoundaryRestartLoopStillCaught's own class
+  docstring for why a node that never arms would make this row unsatisfiable by any correct
+  implementation), restart-looping under this test's own control, killed and confirmed back
+  three times over. Nothing here checks GRAPH_NODE_INACTIVE - that is B2's and B3's row. This
+  one is entirely about whether the presence code catches the departure EVERY cycle, which is
+  what makes it safe to forbid absence from maturing an unmatured streak: once
+  GRAPH_NODE_DISAPPEARED independently catches a restart loop, lifecycle_expectation no longer
+  has to evade it via an unmatured streak maturing on absence. Configures
+  detectors.node_death.miss_grace explicitly (B5_MISS_GRACE, comfortably past the documented 3000
+  ms floor) and drives the node's own respawn on a delay
+  (B5_RESPAWN_DELAY_SEC) safely longer than that nominal grace, so a correct detector CAN
+  report every cycle - left at the 1.5 s launch-respawn floor, the outage would be shorter than
+  the floor the detector enforces and this row could never turn green for a right
+  implementation, only a wrong one lucky enough to report anyway.
+- "c4_config_endpoint_e2e": ONE gateway, ONE armed node, killed once, with a LARGE
+  detectors.node_death.miss_grace configured (C4_MISS_GRACE_LARGE, comfortably under the
+  documented 3600-tick ceiling). Proves the knob governs an observable by checking the SAME
+  gateway at two points on ONE timeline rather than comparing two gateways: a window
+  (C4_EARLY_WINDOW_SEC) long enough that a near-floor config (this suite's own ~4s convention -
+  B5_MISS_GRACE, D2_MISS_GRACE) would already have raised, in which this large-grace gateway
+  must stay silent - needle-scoped (assert_fault_never_names), so a raise for some unrelated
+  entity cannot decide the row - then, once the configured grace has had time to elapse, the
+  fault must still arrive and name the node: the large value delays the report, it does not
+  swallow it. RED.
+- "b6_never_armed_below_grace_then_gone": TARGET_NODE launched WITHOUT auto_activate, so it
+  sits at "unconfigured" its entire life and never once reaches "active" - the gate's
+  per-entity `armed` precondition (LifecycleWatcher::node_ok()) is therefore false for the
+  whole test, and node_death can never track it (NodeLivenessTracker only ever tracks a key
+  the gate has armed at least once). Killed after being observed non-active for only a
+  couple of ticks - comfortably below `grace`, proven the same way B2 proves it (an
+  immediate, single-instant read of GET /faults right before the kill, not inferred from
+  elapsed time). With node_death structurally unable to report this departure,
+  GRAPH_NODE_INACTIVE is the only detector that ever could - so unlike B2, absence maturing
+  the below-grace streak is not a defect here, it is the whole point: this is the row that
+  proves the silence a node like this used to fall into is gone.
+- "d2_ungated_clear": a death is confirmed, then the GATEWAY is restarted with a generous
+  warmup_cycles so the pre-arm window is wide enough to sample. During that window - before the
+  restarted plugin's own gate has armed anything - the stored fault's `last_passed` must stay
+  unset the whole time: an ungated detector tick must never report PASSED for a node it has not
+  actually measured in this process's lifetime. The window is bracketed by two single-shot reads
+  of the watchdog's own global_state, one immediately before it opens and one immediately after
+  it closes, both asserted != "armed" - restart-plus-recovery eating the whole nominal warmup
+  would otherwise let the sampled window land AFTER arming, and a legitimate post-arm PASSED
+  would then be misread as the ungated-clear bug this row exists to catch.
+
+### Which arming gate, and why B1 alone uses the global form
+
+The default rule every scenario in this file follows: gate on `app_id=<the node a scenario
+perturbs>`, and reserve the global form for a scenario that perturbs the gateway itself. B1 and
+B6 are the documented exceptions, for a reason specific to a require_active node rather than a
+style choice: ONE of
+`ReliabilityGate`'s own preconditions for a per-entity `armed` state is
+`LifecycleWatcher::node_ok()`, which is false for exactly a tracked node that is not (yet)
+"active" - the very state both targets sit in for their whole life, on purpose, since neither
+drives its node past "unconfigured" at all - that IS each row's claim (B1: still present; B6:
+gone before its own grace). Gating on `app_id=managed_lifecycle` would therefore wait for
+something that never becomes true in either scenario. This is not a new call:
+test_lifecycle_expectation_e2e.test.py's own "main" scenario already gates the identical fixture
+globally, for the identical reason, and this file follows that precedent rather than inventing a
+new one.
+
+B2, B3, B4 and B5 all use the app_id form instead, because for each of them the per-entity
+precondition genuinely becomes true: B4's target (managed_lifecycle_active) has always
+self-activated on its own; B2, B3 and B5 now launch TARGET_NODE (managed_lifecycle) with
+auto_activate too, specifically so node_death can track it at all - see
+`_lifecycle_node_action`'s own docstring and B2/B3/B5's own class docstrings for why a target
+that never reaches "active" would make GRAPH_NODE_DISAPPEARED structurally unreachable for any
+of the three, not merely slower to catch. B6 is the one row where that same unreachability is
+not a precondition to avoid but the claim under test, so it deliberately launches TARGET_NODE
+the OTHER way - without auto_activate - and asserts GRAPH_NODE_DISAPPEARED stays silent rather
+than waiting for it.
+
+B2 is the row where getting this wrong is easiest to miss: gating globally and never activating
+the target would still be correct for the INACTIVE half (which needs the node observed below
+`grace`, so it must never mature past it) while being fatal for the DISAPPEARED half (which
+needs node_death to have tracked the node at all, and a node that never arms is structurally
+invisible to it regardless of what kills it) - a row built that way could pass while silently
+proving nothing about the half it got wrong. B2 therefore follows the same rule every other row
+in this file uses: reach "active" first, however briefly, before doing anything else to the node
+a DISAPPEARED claim depends on.
+"""
+
+import os
+import signal
+import sys
+import time
+import unittest
+
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState, GetState
+import rclpy
+from rclpy.node import Node
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# I100 as well as E402: `harness` is only importable because of the sys.path line above, so this
+# import cannot be moved up to where the alphabetical order would put it.
+from harness import (  # noqa: E402, I100
+    API_BASE_PATH,
+    assert_fault_absent_throughout,
+    assert_fault_describes_only,
+    assert_fault_never_names,
+    assert_fault_persists_throughout,
+    create_watchdog_test_launch,
+    poll_cleared,
+    poll_detector_status,
+    poll_faults,
+    wait_until_faults_endpoint_live,
+    wait_until_watchdog_armed,
+)
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
+from ros2_medkit_test_utils.launch_helpers import DEMO_NODE_REGISTRY  # noqa: E402
+
+# No default on purpose - see harness-consuming siblings' identical rationale: a default makes
+# this file FAIL OPEN. A KeyError is loud.
+SCENARIO = os.environ['WATCHDOG_E2E_SCENARIO']
+PORT = get_test_port()
+
+FAULT_CODE_INACTIVE = 'GRAPH_NODE_INACTIVE'
+FAULT_CODE_DISAPPEARED = 'GRAPH_NODE_DISAPPEARED'
+DETECTOR_ID_LIFECYCLE = 'lifecycle_expectation'
+_LIFECYCLE_PREFIX = f'plugins.graph_watchdog.detectors.{DETECTOR_ID_LIFECYCLE}'
+_NODE_DEATH_PREFIX = 'plugins.graph_watchdog.detectors.node_death'
+
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+
+# The require_active node B1/B2/B3/B5 share: DEMO_NODE_REGISTRY's own 'managed_lifecycle' key -
+# stays "unconfigured" (never active) unless driven otherwise, the trigger every one of those
+# rows needs. B4 uses the self-activating 'managed_lifecycle_active' sibling instead.
+TARGET_NODE = 'managed_lifecycle'
+ACTIVE_NODE = 'managed_lifecycle_active'
+
+# grace small enough that B1 and B3 mature quickly - same value
+# test_lifecycle_expectation_e2e.test.py's own GRACE constant uses, for the same reason.
+GRACE = 3
+# B2's own grace: large enough that "killed after a couple of observed ticks" is unambiguously
+# BELOW it, whatever small overshoot this scenario's own polling interval costs.
+B2_GRACE = 15
+# B6's own grace: same magnitude as B2_GRACE and for the identical reason - "killed after a
+# couple of observed ticks" must be unambiguously BELOW it.
+B6_GRACE = 15
+# B5's own grace: large relative to one restart cycle's uptime. Not load-bearing for what this
+# row actually asserts (see the module docstring - B5 checks GRAPH_NODE_DISAPPEARED only), kept
+# generous so lifecycle_expectation's own behaviour cannot accidentally become this row's story.
+B5_GRACE = 50
+# B5's own node_death.miss_grace, explicitly configured rather than left at whatever default a
+# future detector ships with. min_node_death_miss_grace(TICK_INTERVAL_MS) - the wall-clock floor
+# node_death's own configure() silently raises an under-sized value to - is 14 at a 200 ms tick
+# (detector_config_keys.hpp: ceil(3000 / 200) - 1). "config sweep C1"
+# (NodeDeathIntegrationTest.C1_* in test_node_death_integration.cpp) is the suite that pins the
+# floor's own boundary values, but it never exercises tick_interval_ms=200 at all (its own cases
+# run at 1, 1000 and 3000 ms), so there is no boundary value at THIS tick period to land on by
+# accident - 16 carries two ticks of headroom purely to keep this row visibly off the floor
+# itself, the same "comfortably past, not exactly on" convention every miss_grace in this
+# package follows. Nominal grace is [B5_MISS_GRACE + 1] * TICK_INTERVAL_MS = 3400 ms;
+# B5_RESPAWN_DELAY_SEC below is sized against this value.
+B5_MISS_GRACE = 16
+# How long B5's own node is held down every cycle, overriding the launch-wide RESPAWN_DELAY_SEC
+# floor (1.5 s - too short to ever satisfy the 3000 ms floor above, let alone B5_MISS_GRACE's own
+# 3400 ms). respawn_delay is an ENFORCED floor under how soon launch may even attempt to restart
+# a respawn=True process (see _lifecycle_node_action's own docstring), so every cycle's actual
+# outage is guaranteed to be at least this long - a correct detector can therefore always report
+# it, which is the property this row needs to be satisfiable by a right implementation rather
+# than only by a wrong one.
+#
+# The margin over B5_MISS_GRACE's own nominal grace (3400 ms) has to cover two things a tick
+# count alone does not see: the entity cache a tick reads is rebuilt on a debounced graph event
+# "always serviced within refresh_debounce_ms + one 100 ms tick" (gateway_node.cpp) - 1100 ms
+# worst case before either end of the outage is even visible to node_death's own snapshot - and
+# the plugin's tick loop wakes on a condition-variable timed wait, not a hardware clock
+# (GraphWatchdogPlugin::wait_for_next_tick), with no enforced upper bound on how far CI
+# contention can slow it below its configured 200 ms period. Margin under the 1100 ms debounce
+# ceiling alone can be erased by a single unlucky refresh regardless of tick-loop speed at all,
+# and NodeLivenessTracker::update() resets a key's miss count to zero the instant it is seen
+# present again, with no way to recover a miss already lost that way - a cycle that loses this
+# race does not report late, it never reports at all. 12.5 s clears 3 * 3400 + 1100 = 11300 ms
+# (a tick loop running at a third of its configured rate, plus the full debounce ceiling on top)
+# by 1200 ms - worst-case observed window 12500 - 1100 = 11400 ms, 3.35x the nominal grace.
+B5_RESPAWN_DELAY_SEC = 12.5
+
+ARM_TIMEOUT_SEC = 60.0
+FAULTS_LIVE_TIMEOUT_SEC = 30.0
+PRESENCE_TIMEOUT_SEC = 30.0
+DEPARTURE_TIMEOUT_SEC = 30.0
+RAISE_TIMEOUT_SEC = 60.0
+CLEAR_TIMEOUT_SEC = 60.0
+# How long an absent or a persisting fault is watched for - measured from the arming gate, not
+# process start, so bringup cannot eat it. Matches test_node_death_e2e.test.py's identical
+# constant.
+SUSTAINED_WINDOW_SEC = 20.0
+
+# launch will not even ATTEMPT to restart a respawn=True process before this elapses - an
+# enforced floor under every kill-then-return gap this file measures.
+RESPAWN_DELAY_SEC = 1.5
+
+# ---- "b5_restart_loop_still_caught" scenario's own target --------------------------------------
+# The claim under test is that the presence code catches EVERY cycle of a restart loop, not
+# merely the first: three consecutive kill/raise/clear cycles establish that - this is a loop,
+# and each turn of it is caught. A fourth or fifth cycle would repeat an already-proven claim at
+# the full cost of B5_RESPAWN_DELAY_SEC apiece, buying no additional discriminating power against
+# the failure this row exists to catch (a detector that only reports the first departure, or
+# stops reporting after one). If a future change ever needs more cycles to expose something this
+# one does not, raising this single constant is the whole edit.
+B5_CYCLES = 3
+
+# ---- "c4_config_endpoint_e2e" scenario's own fixtures -------------------------------------------
+C4_TARGET_NODE = 'calibration'
+C4_TARGET_EXECUTABLE = 'demo_calibration_service'
+C4_TARGET_NAMESPACE = '/powertrain/engine'
+# Comfortably under the documented ceiling (3600 ticks - node_death's own kMaxNodeDeathGraceTicks
+# applies to miss_grace and prune_grace alike), chosen only to sit unambiguously outside
+# C4_EARLY_WINDOW_SEC below - 500 ticks at TICK_INTERVAL_MS is 100s, four times that window.
+C4_MISS_GRACE_LARGE = 500
+# Long enough that a near-floor config would already have raised several times over by the time
+# this window ends - the near-floor graces in this package run 16 to 20 ticks, 3.4s to 4.2s
+# nominal at TICK_INTERVAL_MS, see B5_MISS_GRACE and D2_MISS_GRACE - so staying silent through it
+# is evidence the large value is actually GOVERNING behaviour, not merely accepted and ignored;
+# short enough to sit comfortably inside C4_MISS_GRACE_LARGE's own ~100s nominal grace.
+C4_EARLY_WINDOW_SEC = 25.0
+# Measured from the END of C4_EARLY_WINDOW_SEC, not from the kill: comfortably covers the
+# remaining ~75s to C4_MISS_GRACE_LARGE's own nominal grace-crossing point plus reporting
+# latency.
+C4_LATE_RAISE_TIMEOUT_SEC = 100.0
+
+# ---- "d2_ungated_clear" scenario's own fixtures -------------------------------------------------
+D2_TARGET_NODE = 'calibration'
+D2_TARGET_EXECUTABLE = 'demo_calibration_service'
+D2_TARGET_NAMESPACE = '/powertrain/engine'
+D2_MISS_GRACE = 20
+# Deliberately large so the RESTARTED gateway's own pre-arm window is wide enough to sample
+# several times over - the whole point of this scenario is watching what happens DURING that
+# window, not merely before and after it. 150 ticks at TICK_INTERVAL_MS is 30s nominal warmup:
+# generous headroom over the restart itself, which is not instantaneous - create_gateway_node's
+# own respawn_delay (1.0s default) is an ENFORCED floor before launch even attempts to start
+# the replacement process, on top of that process's own ROS init and HTTP bind. Measured live at
+# 25 ticks (5s nominal): GET /faults was still completely unreachable (connection refused, not
+# even a 503) at the very first poll after the old port was confirmed down - the replacement
+# gateway had not bound its port yet. 150 leaves room for that plus real bringup variance.
+D2_WARMUP_CYCLES = 150
+# How long the post-restart, pre-arm window is watched for a premature PASSED, once the fault
+# surface is confirmed reachable (see test_02's own wait_until_faults_endpoint_live call before
+# this window opens). Comfortably inside D2_WARMUP_CYCLES * TICK_INTERVAL_MS (~30s nominal), so
+# a poll landing here is provably still INSIDE the ungated window rather than after it.
+D2_UNGATED_WATCH_SEC = 3.5
+
+
+def _lifecycle_node_action(
+        name, *, respawn=False, respawn_delay=RESPAWN_DELAY_SEC, auto_activate=None):
+    """One managed_lifecycle instance under `name`, with a PID handle the test can signal.
+
+    Uses DEMO_NODE_REGISTRY's own (executable, ros_name, namespace) triple for `name` so this
+    stays in lockstep with demo_nodes.launch.py, built by hand only because every scenario here
+    signals the process directly and create_demo_nodes() hands back no PID.
+
+    `auto_activate` is a ROS PARAMETER, not part of the registry triple, so it has to be set
+    here explicitly rather than inferred from it. Defaults to whether `name` is ACTIVE_NODE -
+    the historical convention every scenario but B3/B5 relies on - but a caller launching
+    TARGET_NODE (managed_lifecycle) for a scenario that needs it to actually ARM for
+    node_death passes `auto_activate=True` explicitly: node_death only ever tracks a node it
+    has seen armed at least once (reliability_allows() requires "active" for a managed node -
+    LifecycleWatcher::node_ok()), so a require_active node that never activates is invisible
+    to it no matter what happens to it afterwards. See TestBoundaryMaturedThenGone and
+    TestBoundaryRestartLoopStillCaught's own class docstrings.
+    """
+    executable, ros_name, namespace = DEMO_NODE_REGISTRY[name]
+    if auto_activate is None:
+        auto_activate = name == ACTIVE_NODE
+    node_kwargs = {
+        'package': 'ros2_medkit_integration_tests',
+        'executable': executable,
+        'name': ros_name,
+        'namespace': namespace,
+        'output': 'screen',
+        'additional_env': get_coverage_env('ros2_medkit_integration_tests'),
+        'sigterm_timeout': '30',
+        'sigkill_timeout': '15',
+        'respawn': respawn,
+        'respawn_delay': respawn_delay,
+    }
+    if auto_activate:
+        node_kwargs['parameters'] = [{'auto_activate': True}]
+    return launch_ros.actions.Node(**node_kwargs)
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+    }
+    demo_nodes = []
+    gateway_respawn = False
+
+    if SCENARIO == 'b1_inactive_present':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [TARGET_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = GRACE
+        demo_nodes = [TARGET_NODE]  # never killed - the whole point of this row
+    elif SCENARIO == 'b2_inactive_below_grace_then_gone':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [TARGET_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = B2_GRACE
+    elif SCENARIO == 'b3_matured_then_gone':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [TARGET_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = GRACE
+    elif SCENARIO == 'b4_healthy_then_gone':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [ACTIVE_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = GRACE
+    elif SCENARIO == 'b5_restart_loop_still_caught':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [TARGET_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = B5_GRACE
+        detector_params[f'{_NODE_DEATH_PREFIX}.miss_grace'] = B5_MISS_GRACE
+    elif SCENARIO == 'b6_never_armed_below_grace_then_gone':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [TARGET_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = B6_GRACE
+    elif SCENARIO == 'c4_config_endpoint_e2e':
+        detector_params[f'{_NODE_DEATH_PREFIX}.miss_grace'] = C4_MISS_GRACE_LARGE
+    elif SCENARIO == 'd2_ungated_clear':
+        detector_params[f'{_NODE_DEATH_PREFIX}.miss_grace'] = D2_MISS_GRACE
+        detector_params['plugins.graph_watchdog.warmup_cycles'] = D2_WARMUP_CYCLES
+        gateway_respawn = True
+    else:
+        raise RuntimeError(f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} has no launch configuration')
+
+    launch_description, context = create_watchdog_test_launch(
+        detector_params=detector_params,
+        demo_nodes=demo_nodes,
+        port=PORT,
+        gateway_respawn=gateway_respawn,
+    )
+
+    if SCENARIO == 'b2_inactive_below_grace_then_gone':
+        # auto_activate=True: this row's SECOND claim (GRAPH_NODE_DISAPPEARED) needs
+        # node_death to have tracked the node at all, which requires it to have been armed -
+        # see TestBoundaryInactiveBelowGraceThenGone's own class docstring and the module
+        # docstring's "Which arming gate" section.
+        target = _lifecycle_node_action(TARGET_NODE, respawn=False, auto_activate=True)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'b3_matured_then_gone':
+        # auto_activate=True: this row's SECOND claim (GRAPH_NODE_DISAPPEARED) needs
+        # node_death to have tracked the node at all, which requires it to have been armed -
+        # see TestBoundaryMaturedThenGone's own class docstring and
+        # _lifecycle_node_action's.
+        target = _lifecycle_node_action(TARGET_NODE, respawn=False, auto_activate=True)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'b4_healthy_then_gone':
+        target = _lifecycle_node_action(ACTIVE_NODE, respawn=False)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'b6_never_armed_below_grace_then_gone':
+        # auto_activate deliberately omitted (defaults False for TARGET_NODE): this row's
+        # whole claim is that the node NEVER arms - see the module docstring's "Which arming
+        # gate" section and TestBoundaryNeverArmedBelowGraceThenGone's own class docstring.
+        target = _lifecycle_node_action(TARGET_NODE, respawn=False)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'b5_restart_loop_still_caught':
+        # auto_activate=True: every respawned instance needs to reach "active" on its own
+        # for node_death to ever track it - see TestBoundaryRestartLoopStillCaught's own
+        # class docstring and _lifecycle_node_action's.
+        target = _lifecycle_node_action(
+            TARGET_NODE, respawn=True, respawn_delay=B5_RESPAWN_DELAY_SEC, auto_activate=True)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'd2_ungated_clear':
+        target = launch_ros.actions.Node(
+            package='ros2_medkit_integration_tests',
+            executable=D2_TARGET_EXECUTABLE,
+            name=D2_TARGET_NODE,
+            namespace=D2_TARGET_NAMESPACE,
+            output='screen',
+            additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+            sigterm_timeout='30',
+            sigkill_timeout='15',
+            # No respawn: the node must STAY gone across the gateway restart, or there would be
+            # nothing "stored" left for the warmup window to wrongly move toward healing.
+        )
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'c4_config_endpoint_e2e':
+        target = launch_ros.actions.Node(
+            package='ros2_medkit_integration_tests',
+            executable=C4_TARGET_EXECUTABLE,
+            name=C4_TARGET_NODE,
+            namespace=C4_TARGET_NAMESPACE,
+            output='screen',
+            additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+            sigterm_timeout='30',
+            sigkill_timeout='15',
+        )
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    return launch_description, context
+
+
+# ---------------------------------------------------------------------------------------
+# Local helpers - read the same endpoints harness.py's own helpers do, or a service this
+# file's own scenario needs that no shared helper covers.
+# ---------------------------------------------------------------------------------------
+
+def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` is no longer listed. ``True`` once it is gone."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id not in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_absent({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _poll_apps_present(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` IS listed. ``True`` once it appears."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_present({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _watchdog_global_state(port, timeout=5.0):
+    """One immediate read of GET /x-medkit-watchdog's own global_state field.
+
+    Not a polling helper: D2's pre-arm proof needs to know the state AT ONE INSTANT
+    (immediately before opening the ungated window, and again immediately after it closes),
+    not wait until some condition becomes true - a poll loop would blur exactly the boundary
+    this is meant to pin. Mirrors ReliabilityGate::status_json()'s own field (see
+    wait_until_watchdog_armed's docstring in harness.py: "armed" or "warming_up").
+
+    Returns the string, or ``None`` if the endpoint did not answer 200.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    try:
+        response = requests.get(f'{base}/x-medkit-watchdog', timeout=timeout)
+    except requests.exceptions.RequestException:
+        return None
+    if response.status_code != 200:
+        return None
+    return response.json().get('x-medkit-watchdog', {}).get('global_state')
+
+
+def _wait_until_port_is_down(port, timeout=60.0, interval=0.2):
+    """Wait until the gateway's HTTP port stops answering. ``True`` once it does."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            requests.get(f'{base}/health', timeout=2)
+        except requests.exceptions.RequestException:
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _fault_record(port, code, timeout=30.0, interval=0.5):
+    """Poll ``GET /faults?status=all`` until `code` appears, whatever its status.
+
+    ``poll_faults`` uses the default (pending+confirmed) filter, so a HEALED or CLEARED fault
+    disappears from it. D2 needs the record itself, including ``last_passed``, which survives
+    both. Returns the matching item dict, or ``None`` on timeout.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', params={'status': 'all'}, timeout=5)
+            if response.status_code == 200:
+                for item in response.json().get('items', []):
+                    if item.get('fault_code') == code:
+                        return item
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def _fault_present_now(port, code, timeout=5.0):
+    """One immediate GET /faults check for whether `code` is in the active-fault list.
+
+    Not a polling helper: B2's below-grace precondition has to be read from an OBSERVABLE AT
+    ONE INSTANT, immediately before the kill that follows it - a poll loop's own sampling
+    interval would widen exactly the race this exists to shrink. Uses the same default
+    (pending+confirmed) filter as poll_faults, so "False" here means the same thing a
+    poll_faults timeout does: not (yet) raised.
+
+    Returns ``True``/``False``, or ``None`` if the endpoint did not answer 200 - the caller must
+    tell that apart from ``False``, the same channel-alive discipline every window assertion in
+    this package's harness already applies.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    try:
+        response = requests.get(f'{base}/faults', timeout=timeout)
+    except requests.exceptions.RequestException:
+        return None
+    if response.status_code != 200:
+        return None
+    codes = {item.get('fault_code') for item in response.json().get('items', [])}
+    return code in codes
+
+
+def _assert_never_passed_throughout(test_case, port, code, duration, interval=0.2):
+    """Fail unless `code`'s stored record has ``last_passed is None`` on EVERY poll.
+
+    D2's own claim ("no clear reaches the fault manager before the detector has measured") is
+    about a FIELD staying unset across a window, not about the fault's presence/absence -
+    neither ``assert_fault_absent_throughout`` nor ``assert_fault_persists_throughout`` reads
+    ``last_passed``, so this file carries its own, narrow local helper rather than stretching
+    either one to fit. Same channel-alive discipline as harness.py's own window assertions: a
+    request error or a non-200 fails the assertion naming which poll and why, rather than being
+    swallowed the way a bare ``poll_cleared``/``assertFalse`` pair would be.
+
+    Parameters
+    ----------
+    test_case : unittest.TestCase
+    port : int
+        Gateway HTTP port.
+    code : str
+        The ``fault_code`` whose record must show no PASSED report.
+    duration : float
+        Total seconds to keep polling.
+    interval : float
+        Sleep between polls in seconds.
+
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + duration
+    polls = 0
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', params={'status': 'all'}, timeout=5)
+        except requests.exceptions.RequestException as exc:
+            test_case.fail(
+                f'/faults became unreachable {polls} poll(s) into a {duration}s ungated-window '
+                f'check (could not ask, which is not the same as "asked, and {code} was never '
+                f'reported PASSED"): {exc}')
+            return
+        if response.status_code != 200:
+            test_case.fail(
+                f'/faults answered HTTP {response.status_code} {polls} poll(s) into a '
+                f'{duration}s ungated-window check - the channel died mid-window, which this '
+                'assertion must not read as "never reported PASSED"')
+            return
+        record = next(
+            (item for item in response.json().get('items', []) if item.get('fault_code') == code),
+            None)
+        if record is None:
+            test_case.fail(
+                f'{code} was missing from the store {polls} poll(s) into a {duration}s '
+                'ungated-window check that was supposed to keep watching its record')
+            return
+        test_case.assertIsNone(
+            record.get('last_passed'),
+            f'{code} was reported PASSED (last_passed={record.get("last_passed")!r}) '
+            f'{polls} poll(s) into a {duration}s window that starts before the restarted '
+            "detector's own gate has armed anything - an ungated clear reached the fault "
+            'manager before anything was actually measured',
+        )
+        polls += 1
+        time.sleep(interval)
+    test_case.assertGreater(
+        polls, 0,
+        f'the {duration}s ungated-window check never actually polled /faults - duration must '
+        f'be >= interval ({interval}s)')
+
+
+def _get_lifecycle_label(client_node, service_name, timeout=10.0):
+    """One ``GetState`` call against `service_name`. Returns the state label, or ``None``.
+
+    Creates its own client rather than taking one, matching
+    test_node_death_e2e.test.py's identical helper.
+    """
+    client = client_node.create_client(GetState, service_name)
+    try:
+        if not client.wait_for_service(timeout_sec=timeout):
+            return None
+        future = client.call_async(GetState.Request())
+        rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+        result = future.result()
+        return None if result is None else result.current_state.label
+    finally:
+        client_node.destroy_client(client)
+
+
+def _poll_lifecycle_label(client_node, service_name, expected_label, timeout=30.0, interval=0.5):
+    """Poll ``GetState`` until `service_name` answers `expected_label`. ``True`` once it does.
+
+    One client for the whole poll, matching test_node_death_e2e.test.py's identical helper.
+    """
+    client = client_node.create_client(GetState, service_name)
+    try:
+        deadline = time.monotonic() + timeout
+        last_seen = f'{service_name} was never answered at all'
+        while time.monotonic() < deadline:
+            if client.wait_for_service(timeout_sec=interval):
+                future = client.call_async(GetState.Request())
+                rclpy.spin_until_future_complete(client_node, future, timeout_sec=interval)
+                result = future.result()
+                if result is not None:
+                    last_seen = result.current_state.label
+                    if last_seen == expected_label:
+                        return True
+            time.sleep(interval)
+        print(f'_poll_lifecycle_label({service_name!r}, expected={expected_label!r}) timed '
+              f'out after {timeout}s; last seen: {last_seen!r}')
+        return False
+    finally:
+        client_node.destroy_client(client)
+
+
+def _call_change_state_once(client_node, service_name, transition_id, timeout=30.0):
+    """One ``ChangeState`` call against `service_name`. ``True`` on ``result.success``."""
+    client = client_node.create_client(ChangeState, service_name)
+    if not client.wait_for_service(timeout_sec=timeout):
+        return False
+    request = ChangeState.Request()
+    request.transition.id = transition_id
+    future = client.call_async(request)
+    rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+    result = future.result()
+    return result is not None and result.success
+
+
+# ---------------------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------------------
+
+class TestBoundaryInactivePresent(unittest.TestCase):
+    """B1: a required node inactive past grace, still present: INACTIVE only.
+
+    GENUINELY GREEN, not a placeholder: lifecycle_expectation already ships, so the raise below
+    exercises real, already-merged code (LifecycleExpectationTracker's violation-streak clock
+    crossing `grace`). The GRAPH_NODE_DISAPPEARED absence half cannot, by itself, distinguish a
+    correct node_death from no detector at all - but staying silent is also the permanently
+    correct behaviour here, since this node never leaves the graph.
+    """
+
+    def test_inactive_past_grace_raises_no_disappeared(self):
+        # No target_node fixture: TARGET_NODE is launched via demo_nodes=[...] (create_demo_nodes
+        # gives no PID handle back, and this row never needs one - it kills nothing). Only the
+        # scenarios below that hand-build the node populate a 'target_node' context entry.
+        # Global gate: see the module docstring's "Which arming gate" section.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+        self.assertTrue(
+            _poll_apps_present(PORT, TARGET_NODE, timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never appeared on GET /apps - there is no present node here for '
+            'this row to measure',
+        )
+
+        fault = poll_faults(PORT, FAULT_CODE_INACTIVE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE_INACTIVE} never raised for {TARGET_NODE} past grace')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE_DISAPPEARED, SUSTAINED_WINDOW_SEC)
+
+        # The trigger was pinned before the window; confirm it survived to the end too, or most
+        # of the window measured a graph this row was not actually about.
+        self.assertTrue(
+            _poll_apps_present(PORT, TARGET_NODE, timeout=5.0),
+            f'{TARGET_NODE} is no longer present at the end of the window - the trigger did '
+            'not survive it',
+        )
+
+
+class TestBoundaryInactiveBelowGraceThenGone(unittest.TestCase):
+    """B2: a required node inactive for FEWER ticks than grace, then it vanishes.
+
+    Absence may continue a violation that has already matured, but must never mature one that
+    has not: the row it exists to pin is a defect where absence used to CONTINUE a violation
+    streak that had not yet matured when the node was last observed - necessary only because no
+    presence detector existed to catch a restart loop any other way. Once GRAPH_NODE_DISAPPEARED
+    has one, that continuation is no longer needed and absence must stop maturing an unmatured
+    streak.
+
+    Both of this row's claims are satisfiable together, which took getting the arming gate
+    wrong once to learn: the target must reach "active" FIRST, or GRAPH_NODE_DISAPPEARED can
+    never report its death, whatever kills it - reliability_allows() requires "active" for a
+    MANAGED node (LifecycleWatcher::node_ok()), so a managed_lifecycle instance that stays
+    "unconfigured" its whole life is structurally invisible to node_death, exactly as
+    TestBoundaryMaturedThenGone's own docstring explains for its target. The launch therefore
+    drives TARGET_NODE through "active" first, THEN a real DEACTIVATE transition - the same two
+    steps B3 takes - but where B3 leaves the node inactive long enough to CONFIRM (past
+    `grace`), B2 kills it almost immediately after: comfortably below `grace`, which is this
+    row's own claim and the reason it cannot simply reuse B3's fixture wholesale.
+
+    The below-grace precondition is proven from an OBSERVABLE immediately before the kill, not
+    inferred from how little time elapsed since the DEACTIVATE transition: status_json()
+    exposes no per-node violation-streak count (see lifecycle_expectation_detector.cpp's own
+    status_json, which reports only tracking_saturated/tracked_nodes/tracked_node_cap), so the
+    fault surface itself is the only external evidence of whether the streak has crossed
+    `grace`, and with confirmation_threshold=-2 the detector's first FAILED report IS the
+    confirmation - "absent from /faults" and "not yet matured" are the same fact, one HTTP
+    round trip apart. A failure at that check names a timing problem in this test's OWN setup
+    (B2_GRACE too tight against how long the DEACTIVATE round trip took this run), never the
+    absence-must-not-mature claim the kill exists to test - which is the point of reading an
+    observable immediately before acting instead of trusting a margin.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_boundary_b2_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_below_grace_departure_never_matures_inactive(self, target_node):
+        get_state_service = f'/{TARGET_NODE}/get_state'
+        change_state_service = f'/{TARGET_NODE}/change_state'
+
+        # app_id form: this node reaches "active" on its own now (auto_activate=True), so the
+        # per-entity armed precondition (LifecycleWatcher::node_ok()) genuinely becomes true -
+        # see the module docstring's "Which arming gate" section and this class's own
+        # docstring.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'active',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never reached "active" on its own - the trigger this row needs (a '
+            'node armed for node_death, then driven non-active BELOW grace) was never set up',
+        )
+        self.assertTrue(
+            _call_change_state_once(
+                type(self)._client_node, change_state_service,
+                Transition.TRANSITION_DEACTIVATE, timeout=PRESENCE_TIMEOUT_SEC),
+            'the real DEACTIVATE transition was rejected or never answered',
+        )
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'inactive',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never reached "inactive" after DEACTIVATE',
+        )
+
+        # tracked_nodes becoming 1 is the tracker's own proof that it matched TARGET_NODE at
+        # least once - the earliest moment a kill is guaranteed not to land before the detector
+        # was even permitted to look. B2_GRACE is generous enough that the handful of extra
+        # ticks the DEACTIVATE round trip and this poll's own interval can cost before the kill
+        # below still leaves the node comfortably below grace.
+        self.assertTrue(
+            poll_detector_status(
+                PORT, DETECTOR_ID_LIFECYCLE, 'tracked_nodes', 1, timeout=ARM_TIMEOUT_SEC),
+            f'lifecycle_expectation never reported tracking {TARGET_NODE} - it was never '
+            'matched at all, so killing it below would prove nothing about absence maturing '
+            'an unmatured streak',
+        )
+
+        # The row's own precondition, read from an observable immediately before the kill - see
+        # the class docstring for why this is the tightest proof available without new
+        # instrumentation. `is` rather than a plain falsy check: None (channel unreachable) must
+        # not be read as "confirmed absent".
+        below_grace = _fault_present_now(PORT, FAULT_CODE_INACTIVE)
+        self.assertIs(
+            below_grace, False,
+            f'{FAULT_CODE_INACTIVE} could not be proven absent immediately before the kill '
+            f'below (checked value: {below_grace!r}) - either the fault surface is unreachable, '
+            f'or B2_GRACE ({B2_GRACE} ticks) already matured before the DEACTIVATE round trip '
+            "finished this run, so the kill below would test B3's claim (already matured), not "
+            "this row's below-grace claim",
+        )
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        # The row's first claim: GRAPH_NODE_INACTIVE must never appear, however long the node
+        # stays gone - a below-grace streak is held by absence, never matured by it.
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE_INACTIVE, SUSTAINED_WINDOW_SEC)
+
+        # The row's second claim, reachable because TARGET_NODE was armed before it died - see
+        # the class docstring.
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE_DISAPPEARED} never raised for the departed {TARGET_NODE}')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+
+class TestBoundaryMaturedThenGone(unittest.TestCase):
+    """B3: a required node reaches active, is driven non-active past grace, then vanishes.
+
+    Two independent claims, BOTH satisfiable now. The first - "content follows the clocks, not
+    the snapshot" keeps a matured GRAPH_NODE_INACTIVE violation in place through the departure,
+    still naming the node - is already-shipped lifecycle_expectation behaviour, proven here
+    with assert_fault_describes_only against the real stack rather than a code-only persistence
+    check (a detector that dropped TARGET_NODE from the description while keeping some OTHER
+    node's violation raised under the same code would still pass a bare presence check), the
+    same claim test_lifecycle_expectation_e2e.test.py's own "departure_keeps" scenario proves
+    for the UNREADABLE code.
+
+    The second - GRAPH_NODE_DISAPPEARED also joining once the node is gone, still naming it -
+    needs node_death to have TRACKED the node at all, which only ever happens for a node armed
+    at least once: reliability_allows() requires "active" for a MANAGED node
+    (LifecycleWatcher::node_ok()). A managed_lifecycle instance that stays "unconfigured" its
+    whole life is never armed and so is structurally invisible to node_death whatever happens
+    to it afterwards - the second claim would be unreachable by ANY correct implementation
+    against that fixture, not merely an unimplemented one. This is why the launch drives
+    TARGET_NODE through "active" FIRST (arming it - the same mechanism B4's target uses), THEN
+    a real DEACTIVATE transition (maturing GRAPH_NODE_INACTIVE the same way the original
+    "stays unconfigured" fixture did), THEN kills it: the node this row's second claim needs
+    has to have been alive and armed at some point before it can ever be reported disappeared.
+    A future edit that reverts TARGET_NODE to launching without auto_activate would silently
+    make the second half of this row unreachable again.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_boundary_b3_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_matured_inactive_survives_departure_and_disappeared_joins(self, target_node):
+        get_state_service = f'/{TARGET_NODE}/get_state'
+        change_state_service = f'/{TARGET_NODE}/change_state'
+
+        # app_id form: this node reaches "active" on its own now (auto_activate=True), so the
+        # per-entity armed precondition (LifecycleWatcher::node_ok()) genuinely becomes true -
+        # see the module docstring's "Which arming gate" section.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'active',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never reached "active" on its own - the trigger this row needs (a '
+            'node armed for node_death, then driven non-active) was never set up',
+        )
+        self.assertTrue(
+            _call_change_state_once(
+                type(self)._client_node, change_state_service,
+                Transition.TRANSITION_DEACTIVATE, timeout=PRESENCE_TIMEOUT_SEC),
+            'the real DEACTIVATE transition was rejected or never answered',
+        )
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'inactive',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never reached "inactive" after DEACTIVATE',
+        )
+
+        fault = poll_faults(PORT, FAULT_CODE_INACTIVE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_INACTIVE} never raised for {TARGET_NODE} past grace - there is '
+                'nothing ALREADY CONFIRMED for the kill below to test the survival of')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        # Already-shipped lifecycle_expectation behaviour: proves the matured violation is not
+        # healed by the departure, and that the surviving content still names TARGET_NODE
+        # rather than merely keeping the code raised (see the class docstring for why a
+        # code-only check is not enough here).
+        assert_fault_describes_only(
+            self, PORT, FAULT_CODE_INACTIVE, required=[TARGET_NODE], forbidden=[],
+            duration=SUSTAINED_WINDOW_SEC)
+
+        # Reached only because the assertion above passed, unlike B2's sibling call. Reachable
+        # AT ALL because TARGET_NODE was armed before it died - see the class docstring.
+        second = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if second is None:
+            self.fail(f'{FAULT_CODE_DISAPPEARED} never raised for the departed {TARGET_NODE}')
+        self.assertIn(TARGET_NODE, second.get('description', ''))
+
+
+class TestBoundaryHealthyThenGone(unittest.TestCase):
+    """B4: a required node reaches active, then shuts down: DISAPPEARED only.
+
+    The INACTIVE-absence half is GENUINELY GREEN, already-shipped behaviour
+    (`release_uncorroborated`: a node last measured healthy that then departs starts no
+    violation) - proven here against the real stack, checked FIRST so its own result is never
+    masked by the DISAPPEARED half's own timeout budget. The DISAPPEARED half proves node_death
+    raises and names a node that was healthy right up to the moment it departed.
+    """
+
+    def test_healthy_departure_raises_only_disappeared(self, target_node):
+        # app_id form: unlike B1's target, this node reaches "active" on its own, so the
+        # per-entity armed precondition (LifecycleWatcher::node_ok()) genuinely becomes true
+        # here - see the module docstring's "Which arming gate" section.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=ACTIVE_NODE),
+            f'graph_watchdog never reported {ACTIVE_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, ACTIVE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{ACTIVE_NODE} never left GET /apps after SIGTERM')
+
+        # Already-shipped lifecycle_expectation behaviour: an active-then-departed node never
+        # becomes INACTIVE content.
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE_INACTIVE, SUSTAINED_WINDOW_SEC)
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE_DISAPPEARED} never raised for the departed {ACTIVE_NODE}')
+        self.assertIn(ACTIVE_NODE, fault.get('description', ''))
+
+
+class TestBoundaryRestartLoopStillCaught(unittest.TestCase):
+    """B5: a required node in a restart loop is still caught, every cycle, by the presence code.
+
+    The most important row in this file: it is what makes it safe for B2 to forbid absence from
+    maturing an unmatured streak. Once GRAPH_NODE_DISAPPEARED independently catches a departure
+    regardless of how briefly the node was up, lifecycle_expectation no longer has to lean on an
+    unmatured streak maturing on absence to keep a restart-looping node from evading every code.
+    This row does not touch GRAPH_NODE_INACTIVE at all - that claim belongs to B2 and B3.
+
+    The target launches with auto_activate (the same mechanism B4's target uses) and keeps that
+    parameter across every respawn, not merely the first start: node_death only ever tracks a
+    node it has seen ARMED at least once (reliability_allows() requires "active" for a managed
+    node - LifecycleWatcher::node_ok()), so a fixture that never activates would make
+    GRAPH_NODE_DISAPPEARED structurally unreachable for every cycle here, not merely slow to
+    catch - this row carries the evidence that forbidding absence from maturing an unmatured
+    streak is safe, so it has to run against a node that can actually be reported. Each cycle's
+    respawned instance is re-armed (app_id-scoped wait_until_watchdog_armed, not merely
+    presence) before the NEXT kill for the identical reason a fresh process needs it the first
+    time: a kill landing before a
+    just-restarted instance reaches "active" would leave that cycle's death untracked too, and
+    the following poll_faults would time out for a precondition reason having nothing to do
+    with the claim this row is about. A future edit that reverts TARGET_NODE to launching
+    without auto_activate would silently make every cycle of this row unreachable again.
+
+    Every cycle's outage is held down for B5_RESPAWN_DELAY_SEC, safely longer than the
+    explicitly-configured B5_MISS_GRACE this scenario launches with (see the module docstring):
+    left at launch's own 1.5 s respawn floor with no miss_grace configured, a correct detector's
+    own wall-clock floor could make the outage unreportable regardless of how many cycles this
+    test waits out, which is a row a right implementation cannot satisfy - not evidence of a
+    defect in one. Every raise is also checked by NAME, not merely by code, so a detector
+    reporting the same code for some other entity every cycle could not pass in TARGET_NODE's
+    place.
+    """
+
+    def test_every_restart_cycle_raises_and_clears(self, target_node):
+        # app_id form: this node reaches "active" on its own now (auto_activate=True), so the
+        # per-entity armed precondition genuinely becomes true - see the module docstring's
+        # "Which arming gate" section and this class's own docstring.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        pid = target_node.process_details['pid']
+        for cycle in range(1, B5_CYCLES + 1):
+            os.kill(pid, signal.SIGTERM)
+            self.assertTrue(
+                _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+                f'cycle {cycle}: {TARGET_NODE} never left GET /apps after SIGTERM',
+            )
+
+            fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+            if fault is None:
+                self.fail(f'cycle {cycle}: {FAULT_CODE_DISAPPEARED} never raised')
+            self.assertIn(
+                TARGET_NODE, fault.get('description', ''),
+                f'cycle {cycle}: {FAULT_CODE_DISAPPEARED} raised but did not name {TARGET_NODE}')
+
+            # app_id-scoped again, not just present: the respawned instance is a NEW process
+            # node_death has not armed yet, and the next iteration is about to kill it - the
+            # same precondition the FIRST kill above needed (see the class docstring).
+            self.assertTrue(
+                wait_until_watchdog_armed(
+                    PORT, timeout=DEPARTURE_TIMEOUT_SEC + B5_RESPAWN_DELAY_SEC,
+                    app_id=TARGET_NODE),
+                f'cycle {cycle}: {TARGET_NODE} never came back armed after the SIGTERM - '
+                'launch did not respawn it, or the respawned instance never reached "active"',
+            )
+            # A fresh pid every cycle: read it back rather than assume launch's respawn keeps
+            # the value this test already has.
+            pid = target_node.process_details['pid']
+
+            self.assertTrue(
+                poll_cleared(PORT, FAULT_CODE_DISAPPEARED, timeout=CLEAR_TIMEOUT_SEC),
+                f'cycle {cycle}: {FAULT_CODE_DISAPPEARED} never cleared once {TARGET_NODE} '
+                'came back - this row is about EVERY cycle being caught AND released, not a '
+                'single continuous outage',
+            )
+
+
+class TestBoundaryNeverArmedBelowGraceThenGone(unittest.TestCase):
+    """B6: a required node that never arms, killed below grace: INACTIVE only, and it must raise.
+
+    The row B2 cannot cover. B2's target reaches "active" first, so node_death can track it and
+    GRAPH_NODE_DISAPPEARED is the one to report a below-grace departure - which is exactly why
+    absence must NOT mature GRAPH_NODE_INACTIVE there. This target never reaches "active" at
+    all: LifecycleWatcher::node_ok() is false for its whole life, the gate never arms it
+    (per-entity `armed` requires "active" for a managed node), and node_death only ever tracks a
+    key the gate has armed at least once - so GRAPH_NODE_DISAPPEARED is structurally unable to
+    report this departure, whatever kills it. lifecycle_expectation is the only detector that
+    ever could, and closing that silence means absence has to be allowed to mature a below-grace
+    streak here, the opposite of B2's claim for the opposite reason.
+
+    Both halves are checked: GRAPH_NODE_INACTIVE must raise and name the node (the silence
+    closing), and GRAPH_NODE_DISAPPEARED must stay absent throughout (the structural reason the
+    silence existed at all - if this half ever raised, node_death would have tracked a node the
+    gate never armed, which would be its own defect, not evidence this row's fix works).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_boundary_b6_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_never_armed_departure_matures_inactive_disappeared_silent(self, target_node):
+        get_state_service = f'/{TARGET_NODE}/get_state'
+
+        # Global gate: see the module docstring's "Which arming gate" section - this target
+        # never reaches "active", so the app_id-scoped form would wait for something that
+        # never becomes true.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+        self.assertTrue(
+            _poll_apps_present(PORT, TARGET_NODE, timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never appeared on GET /apps - there is no present node here for '
+            'this row to measure',
+        )
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'unconfigured',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            f'{TARGET_NODE} did not sit at "unconfigured" - the trigger this row needs (a '
+            'required node that never arms) was never set up',
+        )
+
+        # tracked_nodes becoming 1 is the tracker's own proof that it matched TARGET_NODE at
+        # least once - the earliest moment a kill is guaranteed not to land before the
+        # detector was even permitted to look. B6_GRACE is generous enough that the handful
+        # of extra ticks this poll's own interval can cost before the kill below still leaves
+        # the node comfortably below grace.
+        self.assertTrue(
+            poll_detector_status(
+                PORT, DETECTOR_ID_LIFECYCLE, 'tracked_nodes', 1, timeout=ARM_TIMEOUT_SEC),
+            f'lifecycle_expectation never reported tracking {TARGET_NODE} - it was never '
+            'matched at all, so killing it below would prove nothing about absence maturing '
+            'a violation the presence detector could never have reported',
+        )
+
+        # The row's own precondition, read from an observable immediately before the kill -
+        # same instrument as B2's identical check, for the identical reason: `is` rather than
+        # a plain falsy check, since None (channel unreachable) must not be read as
+        # "confirmed absent".
+        below_grace = _fault_present_now(PORT, FAULT_CODE_INACTIVE)
+        self.assertIs(
+            below_grace, False,
+            f'{FAULT_CODE_INACTIVE} could not be proven absent immediately before the kill '
+            f'below (checked value: {below_grace!r}) - either the fault surface is '
+            f'unreachable, or B6_GRACE ({B6_GRACE} ticks) already matured while the node was '
+            'still present, so the kill below would prove nothing about absence maturing the '
+            'violation',
+        )
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        # The row this file exists to add: with node_death structurally unable to track a
+        # node that was never armed, lifecycle_expectation's own absence handling has to be
+        # the one that matures the below-grace streak, or the departure is reported by
+        # nothing at all.
+        fault = poll_faults(PORT, FAULT_CODE_INACTIVE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_INACTIVE} never raised for the departed {TARGET_NODE} - a node '
+                'the presence detector could never have reported went unreported by every '
+                'detector')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+        # The structural half: GRAPH_NODE_DISAPPEARED must never raise for this node. It was
+        # never armed, so node_death could never have tracked it in the first place - a raise
+        # here would mean node_death tracked a node the gate never armed, not that this row's
+        # fix works.
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE_DISAPPEARED, SUSTAINED_WINDOW_SEC)
+
+
+class TestBoundaryConfigEndpointE2E(unittest.TestCase):
+    """C4: `detectors.node_death.miss_grace` visibly changes when a death is reported.
+
+    One gateway, one armed node, killed once, with a LARGE miss_grace configured
+    (C4_MISS_GRACE_LARGE, comfortably under the documented 3600-tick ceiling). Proves the
+    knob governs an OBSERVABLE, not merely that the plugin accepts it at startup, by checking the
+    SAME gateway at two points on ONE timeline rather than comparing two gateways: first, a
+    window (C4_EARLY_WINDOW_SEC) long enough that a near-floor config (this suite's own ~4s
+    convention - B5_MISS_GRACE, D2_MISS_GRACE) would already have raised, in which this
+    large-grace gateway must stay silent - needle-scoped (assert_fault_never_names), so a
+    detector raising for some unrelated entity cannot decide the row; second, once the
+    configured grace has had time to elapse, the fault must still arrive and name the node - the
+    large value delays the report, it does not swallow it.
+    """
+
+    def test_large_miss_grace_delays_then_still_reports(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=C4_TARGET_NODE),
+            f'graph_watchdog never reported {C4_TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, C4_TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{C4_TARGET_NODE} never left GET /apps after SIGTERM')
+
+        # Needle-scoped: a raise for some OTHER entity must not decide this row (see
+        # assert_fault_never_names's own docstring). Long enough that a near-floor config would
+        # already have raised; short enough to sit well inside C4_MISS_GRACE_LARGE's own grace.
+        assert_fault_never_names(
+            self, PORT, FAULT_CODE_DISAPPEARED, forbidden=[C4_TARGET_NODE],
+            duration=C4_EARLY_WINDOW_SEC)
+
+        # Past the configured grace, the same knob that delayed the raise must not have
+        # suppressed it outright.
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=C4_LATE_RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for {C4_TARGET_NODE} even past the '
+                'configured C4_MISS_GRACE_LARGE grace')
+        self.assertIn(C4_TARGET_NODE, fault.get('description', ''))
+
+
+class TestBoundaryUngatedClear(unittest.TestCase):
+    """D2: an ungated clear must not push a stored fault toward healing before anything measured.
+
+    test_01 confirms the death and its stored record. test_02 then restarts the GATEWAY with a
+    wide warmup_cycles, and watches the pre-arm window that follows for a premature PASSED on
+    the stored record - the restarted detector must not report anything about a node it has
+    never actually measured in this process's lifetime.
+    """
+
+    def test_01_the_fault_raises_before_the_restart(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=D2_TARGET_NODE),
+            f'graph_watchdog never reported {D2_TARGET_NODE} armed')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, D2_TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{D2_TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for the departed {D2_TARGET_NODE} - '
+                'there is nothing STORED for the restart below to wrongly move toward healing')
+        self.assertIn(D2_TARGET_NODE, fault.get('description', ''))
+
+        record = _fault_record(PORT, FAULT_CODE_DISAPPEARED, timeout=DEPARTURE_TIMEOUT_SEC)
+        if record is None:
+            self.fail(f'{FAULT_CODE_DISAPPEARED} vanished from the store entirely')
+        self.assertIsNone(
+            record.get('last_passed'),
+            f'{FAULT_CODE_DISAPPEARED} was already reported PASSED before the restart '
+            f'(last_passed={record.get("last_passed")!r}) - there is nothing left here for '
+            'the restart below to wrongly preserve or wrongly heal',
+        )
+
+    def test_02_the_pre_arm_window_never_reports_passed(self, gateway_node, target_node):
+        del target_node  # stays gone by design; not signalled again in this method
+        old_pid = gateway_node.process_details['pid']
+        os.kill(old_pid, signal.SIGTERM)
+        self.assertTrue(
+            _wait_until_port_is_down(PORT, timeout=60.0),
+            f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing restarted')
+
+        # Gate on the fault surface being reachable AT ALL before opening the ungated-window
+        # clock. A restarted gateway's HTTP server - let alone its round trip to the
+        # fault_manager, a separate process this restart never touched - is not up the instant
+        # the OLD port stops answering: create_gateway_node's own respawn_delay is an ENFORCED
+        # floor before launch even starts the replacement, before that process's own ROS init
+        # and HTTP bind. A poll issued before either is up cannot ask this row's own question
+        # ("was PASSED reported") at all - it can only observe a channel that does not exist
+        # yet, which _assert_never_passed_throughout correctly reports as unreachable rather
+        # than silently reading as "never reported PASSED". Confirmed live: without this gate,
+        # the very first poll after the old port went down found GET /faults refusing the
+        # connection outright.
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 after the restart - the ungated-window check below '
+            'would have no live channel to ask anything on',
+        )
+
+        # The window has to be PROVEN pre-arm, not merely assumed from D2_WARMUP_CYCLES's own
+        # nominal budget: if restart-plus-HTTP-recovery above ate most or all of that nominal
+        # warmup, the watchdog could already be armed by the time the window below opens, and
+        # any PASSED it then observes would be legitimate post-arm behaviour, not the
+        # ungated-clear bug this row exists to catch. One immediate read, not a poll - the point
+        # is the state AT THIS INSTANT, immediately before the window starts.
+        pre_state = _watchdog_global_state(PORT)
+        self.assertNotEqual(
+            pre_state, 'armed',
+            f'the gateway was already armed (global_state={pre_state!r}) before the ungated '
+            'window below could even open - restart-plus-recovery consumed the whole nominal '
+            f'warmup (D2_WARMUP_CYCLES={D2_WARMUP_CYCLES}), so any PASSED observed below would '
+            'be legitimate post-arm behaviour, not the ungated-clear bug this row exists to '
+            'catch; widen D2_WARMUP_CYCLES rather than trusting this window without proof',
+        )
+
+        # The claim under test: for D2_UNGATED_WATCH_SEC once the surface is reachable, the
+        # stored fault's last_passed must stay None - comfortably before D2_WARMUP_CYCLES *
+        # TICK_INTERVAL_MS (~30s nominal) elapses, so the window is provably still INSIDE the
+        # period during which the restarted plugin's own gate has not armed anything.
+        _assert_never_passed_throughout(
+            self, PORT, FAULT_CODE_DISAPPEARED, D2_UNGATED_WATCH_SEC)
+
+        # The other bracket: prove the window closed still inside pre-arm too, or the samples
+        # above are not provably pre-arm from end to end - only from their own start.
+        post_state = _watchdog_global_state(PORT)
+        self.assertNotEqual(
+            post_state, 'armed',
+            f'the gateway armed (global_state={post_state!r}) DURING the {D2_UNGATED_WATCH_SEC}s '
+            'ungated window above - the samples it collected are no longer provably pre-arm '
+            'from end to end, so they cannot be read as evidence about the ungated-clear bug '
+            'this row exists to catch',
+        )
+
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=90.0),
+            'the gateway never came back armed after the restart - the warmup window this row '
+            'is about never actually ended, so the check above proved nothing about a window '
+            'that closes')
+        self.assertNotEqual(
+            gateway_node.process_details['pid'], old_pid,
+            'the gateway process id did not change, so this test never restarted anything')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 after the restart - the persistence check below '
+            'would prove nothing',
+        )
+        self.assertFalse(
+            _poll_apps_present(PORT, D2_TARGET_NODE, timeout=5.0),
+            f'{D2_TARGET_NODE} is back in GET /apps - this row is about a restart with the '
+            'node STILL gone, and it came back instead',
+        )
+
+        assert_fault_persists_throughout(self, PORT, FAULT_CODE_DISAPPEARED, SUSTAINED_WINDOW_SEC)
+
+        record = _fault_record(PORT, FAULT_CODE_DISAPPEARED, timeout=DEPARTURE_TIMEOUT_SEC)
+        if record is None:
+            self.fail(f'{FAULT_CODE_DISAPPEARED} vanished from the store after the restart')
+        self.assertIsNone(
+            record.get('last_passed'),
+            f'the restarted gateway reported {FAULT_CODE_DISAPPEARED} PASSED for a node it can '
+            f'never have observed in this process (last_passed={record.get("last_passed")!r})',
+        )
+
+
+# Each CTest target launches this file with one scenario, so only that scenario's case may
+# run. Removing the others from the module (rather than skipping them) means each run reports
+# exactly one case, and a missing result is a real failure rather than an expected line of
+# output - see test_node_death_e2e.test.py's identical rationale.
+_SCENARIO_CASES = {
+    'b1_inactive_present': 'TestBoundaryInactivePresent',
+    'b2_inactive_below_grace_then_gone': 'TestBoundaryInactiveBelowGraceThenGone',
+    'b3_matured_then_gone': 'TestBoundaryMaturedThenGone',
+    'b4_healthy_then_gone': 'TestBoundaryHealthyThenGone',
+    'b5_restart_loop_still_caught': 'TestBoundaryRestartLoopStillCaught',
+    'b6_never_armed_below_grace_then_gone': 'TestBoundaryNeverArmedBelowGraceThenGone',
+    'c4_config_endpoint_e2e': 'TestBoundaryConfigEndpointE2E',
+    'd2_ungated_clear': 'TestBoundaryUngatedClear',
+}
+if SCENARIO not in _SCENARIO_CASES:
+    raise RuntimeError(
+        f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} is not one of {sorted(_SCENARIO_CASES)}; the '
+        'CTest target and this file disagree about which scenarios exist')
+for _scenario, _case_name in _SCENARIO_CASES.items():
+    if _scenario != SCENARIO:
+        del globals()[_case_name]
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager/demo stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -270,11 +270,11 @@ FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Unchanged, and now it only has to cover what it can actually be held to. Every call site
 # proves the process EXITED first (assert_process_exited), so the two terms left are the ones
-# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
-# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
-# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
-# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
-# is gone' costs" note for who promises which term.
+# somebody owns: the DDS participant lease an unclean death costs before the graph drops the
+# participant, plus the gateway's own graph-to-/apps latency - 20 + 1.1 = 21.1 s. 30 s clears
+# that with room for the sanitizer jobs, so nothing here needed widening. Both figures, and
+# who promises which term, are in the gateway's docs/config/server.rst under "How long a
+# departed node keeps being listed".
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -203,10 +203,16 @@ ACTIVE_NODE = 'managed_lifecycle_active'
 # test_lifecycle_expectation_e2e.test.py's own GRACE constant uses, for the same reason.
 GRACE = 3
 # B2's own grace: large enough that "killed after a couple of observed ticks" is unambiguously
-# BELOW it, whatever small overshoot this scenario's own polling interval costs.
+# BELOW it, whatever small overshoot this scenario's own polling interval costs. The clock it
+# has to cover is NOT the whole setup: the violation streak starts at the tracker's first
+# observation of a non-active label, which for B2 is after the DEACTIVATE round trip, so only
+# the two polls between that and the kill are charged against this value.
 B2_GRACE = 15
 # B6's own grace: same magnitude as B2_GRACE and for the identical reason - "killed after a
-# couple of observed ticks" must be unambiguously BELOW it.
+# couple of observed ticks" must be unambiguously BELOW it. Charged the same way: the streak
+# advances from the tracker's first SETTLED reading of "unconfigured" (LifecycleWatcher seeds
+# get_state at a bounded rate and the tracker corroborates over several ticks before trusting a
+# label), not from the moment the gateway arms or the moment this row starts polling.
 B6_GRACE = 15
 # B5's own grace: large relative to one restart cycle's uptime. Not load-bearing for what this
 # row actually asserts (see the module docstring - B5 checks GRAPH_NODE_DISAPPEARED only), kept
@@ -1310,7 +1316,7 @@ class TestBoundaryUngatedClear(unittest.TestCase):
         old_pid = gateway_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _wait_until_port_is_down(PORT, timeout=60.0),
+            _wait_until_port_is_down(PORT, timeout=60.0 * TIME_SCALE),
             f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing restarted')
 
         # Gate on the fault surface being reachable AT ALL before opening the ungated-window

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
@@ -645,7 +645,11 @@ def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, 
     deadline = time.monotonic() + timeout
     status = None
     last_count = None
-    streak_start = None
+    # Seeded, not left None: the first sample can legitimately BE None (the route not up yet, or
+    # answering without a block for this detector), and None == last_count then takes the elif
+    # on the very first pass - which used to subtract from None and raise TypeError, turning an
+    # unrelated slow start into an error rather than a wait.
+    streak_start = time.monotonic()
     while time.monotonic() < deadline:
         now = time.monotonic()
         status = watchdog_detector_status(port, detector_id)
@@ -653,7 +657,10 @@ def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, 
         if count != last_count:
             last_count = count
             streak_start = now
-        elif now - streak_start >= stable_seconds:
+        elif count is not None and now - streak_start >= stable_seconds:
+            # A route that never answers holds None steady forever; that is not a settled
+            # count, it is an absent one, and calling it stable would hand the caller a
+            # baseline it never read.
             return status, True
         time.sleep(interval)
     return status, False
@@ -1414,10 +1421,10 @@ class TestNodeDeathRestartRebaseline(unittest.TestCase):
         old_pid = gateway_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
         self.assertTrue(
-            _wait_until_port_is_down(PORT, timeout=60.0),
+            _wait_until_port_is_down(PORT, timeout=60.0 * TIME_SCALE),
             f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing restarted')
         self.assertTrue(
-            wait_until_watchdog_armed(PORT, timeout=90.0),
+            wait_until_watchdog_armed(PORT, timeout=90.0 * TIME_SCALE),
             'the gateway never came back armed after the restart')
         self.assertNotEqual(
             gateway_node.process_details['pid'], old_pid,

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
@@ -213,11 +213,11 @@ FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Unchanged, and now it only has to cover what it can actually be held to. Every call site
 # proves the process EXITED first (assert_process_exited), so the two terms left are the ones
-# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
-# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
-# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
-# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
-# is gone' costs" note for who promises which term.
+# somebody owns: the DDS participant lease an unclean death costs before the graph drops the
+# participant, plus the gateway's own graph-to-/apps latency - 20 + 1.1 = 21.1 s. 30 s clears
+# that with room for the sanitizer jobs, so nothing here needed widening. Both figures, and
+# who promises which term, are in the gateway's docs/config/server.rst under "How long a
+# departed node keeps being listed".
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
@@ -117,6 +117,7 @@ from harness import (  # noqa: E402, I100
     assert_fault_absent_throughout,
     assert_fault_describes_only,
     assert_fault_persists_throughout,
+    assert_process_exited,
     create_watchdog_test_launch,
     poll_cleared,
     poll_entity_faults,
@@ -210,6 +211,13 @@ TIME_SCALE = get_time_scale()
 ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
 FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+# Unchanged, and now it only has to cover what it can actually be held to. Every call site
+# proves the process EXITED first (assert_process_exited), so the two terms left are the ones
+# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
+# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
+# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
+# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
+# is gone' costs" note for who promises which term.
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE
@@ -688,6 +696,7 @@ class TestNodeDeathRaise(unittest.TestCase):
         )
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM - this scenario never '
@@ -734,6 +743,7 @@ class TestNodeDeathClearOnReturn(unittest.TestCase):
 
         old_pid = target_node.process_details['pid']
         os.kill(old_pid, signal.SIGTERM)
+        assert_process_exited(self, old_pid, TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -780,6 +790,7 @@ class TestNodeDeathNoHealStandalone(unittest.TestCase):
         )
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -1054,6 +1065,7 @@ class TestNodeDeathRos2cliIgnored(unittest.TestCase):
                 )
 
                 os.kill(proc.pid, signal.SIGTERM)
+                assert_process_exited(self, proc.pid, name)
                 self.assertTrue(
                     _poll_apps_absent(PORT, name, timeout=DEPARTURE_TIMEOUT_SEC),
                     f'cycle {cycle}: {name} never left GET /apps after SIGTERM - this '
@@ -1192,6 +1204,7 @@ class TestNodeDeathBareNameCollision(unittest.TestCase):
 
         node_b_pid = node_b.process_details['pid']
         os.kill(node_a.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, node_a.process_details['pid'], COLLISION_APP_ID_A)
         self.assertTrue(
             _poll_apps_absent(PORT, COLLISION_APP_ID_A, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{COLLISION_APP_ID_A} never left GET /apps after SIGTERM')
@@ -1322,6 +1335,7 @@ class TestNodeDeathRestartLoopOccurrences(unittest.TestCase):
         pid = target_node.process_details['pid']
         for cycle in range(1, RESTART_LOOP_OCCURRENCES_TARGET + 1):
             os.kill(pid, signal.SIGTERM)
+            assert_process_exited(self, pid, TARGET_NODE)
             self.assertTrue(
                 _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
                 f'cycle {cycle}: {TARGET_NODE} never left GET /apps after SIGTERM',
@@ -1400,6 +1414,7 @@ class TestNodeDeathRestartRebaseline(unittest.TestCase):
             f'graph_watchdog never reported {TARGET_NODE} armed')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
@@ -1,0 +1,1477 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""node_death e2e: GRAPH_NODE_DISAPPEARED against the REAL gateway + fault_manager + graph.
+
+A scenario that asserts a RAISE proves the fault actually appears, naming the missing-fault
+case as the failure mode when it does not. A scenario that asserts an ABSENCE (a node that must
+never be called dead) cannot, by itself, discriminate a correct detector from no detector at
+all, because both produce the same silence; those scenarios are marked as such in each class's
+own docstring below.
+
+Runs as TEN separate CTest targets (see CMakeLists.txt), each launching its OWN
+gateway+fault_manager+demo-node stack, exactly as test_lifecycle_expectation_e2e.test.py
+does and for the same reason: the plugin reads its config once at set_context() time, so
+different configs need different gateway launches. WATCHDOG_E2E_SCENARIO selects which
+launch and which assertions run:
+
+- "raise": a plain node comes up, is armed, then its process exits. GRAPH_NODE_DISAPPEARED
+  appears and names it. Also runs both new harness self-tests
+  (prove_persistence_proof_catches_a_dead_fault_surface,
+  prove_describes_only_proof_catches_a_dead_fault_surface) - self-contained, so they run
+  alongside the real assertions without depending on them, the way the lifecycle e2e's
+  "default_config" scenario runs the silence one.
+- "clear_on_return": the same, then the node is started again. The fault clears once the
+  node is back - the occurrence model's own "outage genuinely ended" case: no forced
+  transition, the detector closes a cycle when the graph actually recovers.
+- "no_heal_standalone": the same drive as clear_on_return, but the fault_manager runs with
+  healing OFF. The fault does NOT clear - not a defect, the documented shape of a debounce
+  hysteresis latch that only a HEALED-enabled config can cross - proven as a SUSTAINED
+  claim over a window via assert_fault_persists_throughout, not a single sample.
+- "deactivated_not_dead": a managed lifecycle node reaches active on its own
+  (managed_lifecycle_active's auto_activate) and is then driven to DEACTIVATE by this test
+  through a real ChangeState call, while its process keeps running throughout. No
+  GRAPH_NODE_DISAPPEARED for the whole window - node_death is a presence detector; a
+  lifecycle transition is not a departure, and telling the two apart is
+  lifecycle_expectation's job, not this one's (see B1-B5 in
+  test_node_death_boundary_e2e.test.py, none of them written here). See
+  TestNodeDeathDeactivatedNotDead's own docstring for what this absence does and does not
+  prove.
+- "manifest_never_online": a hybrid-mode manifest declares an App whose ROS binding never
+  starts. No GRAPH_NODE_DISAPPEARED for it, ever - the promise the public issue leads with:
+  a manifest node keeps its App in the snapshot with the online flag cleared, so a detector
+  that counted snapshot membership alone would call it immortal - see
+  TestNodeDeathManifestNeverOnline's own docstring for what this absence does and does not
+  prove.
+- "ros2cli_ignored": a node renamed to carry the ros2cli hidden-node prefix is armed then
+  killed, three times over with distinct names. No fault, and the detector's own
+  tracked-count status field does not grow across the three cycles - a node matching the
+  naming convention must not accumulate as permanent tracked state, regardless of what
+  process gave it that name. A second check pins that fixture's prefix against the
+  installed ros2cli package's own naming constants, so the fixture cannot silently drift
+  from what ros2cli itself actually uses - see TestNodeDeathRos2cliIgnored's own docstring
+  for what this absence does and does not prove.
+- "bare_name_collision": two nodes named 'calibration' in different namespaces; one exits.
+  The fault names the one that exited and does not name the one still running - proven with
+  assert_fault_describes_only so the claim holds over the WHOLE window, not one lucky read.
+- "fast_tick_floor": a short tick_interval_ms, with a node continuously present. No fault.
+  Narrower than the row this is named for: it does not force a stale graph-cache
+  generation (config sweep C1 owns the miss_grace floor's own boundary values), only that
+  fast ticking alone, with nothing perturbing the graph, is safe - see
+  TestNodeDeathFastTickFloor's own docstring for what was investigated and why forcing the
+  stronger condition was not implemented - see TestNodeDeathDeactivatedNotDead's own note
+  for what this absence does and does not prove either way.
+- "restart_loop_occurrences": a node killed and restarted three times, each cycle closed
+  with an explicit acknowledge before the next kill. The fault's occurrence_count reaches
+  3 - the fault manager's own occurrence model (a FAILED event reactivating a CLEARED
+  record bumps the count; a re-report on a still-active fault does not) rather than any
+  trick the detector plays. See TestNodeDeathRestartLoopOccurrences's own docstring for why
+  this class stops at occurrence_count and does not attempt the per-occurrence RECORDING
+  half of this row.
+- "restart_rebaseline": a node dies, the fault confirms, then the gateway is killed by PID
+  and comes back with the node still gone. RECORDS the boundary, the way
+  TestLifecycleExpectationRestartDeparted does for the sibling detector: the fault stays
+  CONFIRMED, proven as a sustained claim across the restart via
+  assert_fault_persists_throughout, not discovered by a single sample.
+
+Every scenario gates on wait_until_watchdog_armed(PORT) BEFORE asserting anything, and
+every scenario that asserts an ABSENCE additionally gates on
+wait_until_faults_endpoint_live(PORT) - see harness.py's own docstrings for why a stack
+that never came up otherwise produces exactly the silence an absence claim is looking for.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix, get_package_share_directory
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState, GetState
+import rclpy
+from rclpy.node import HIDDEN_NODE_PREFIX, Node
+import requests
+from ros2cli.node import NODE_NAME_PREFIX
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# I100 as well as E402: `harness` is only importable because of the sys.path line above,
+# so this import cannot be moved up to where the alphabetical order would put it.
+from harness import (  # noqa: E402, I100
+    API_BASE_PATH,
+    assert_fault_absent_throughout,
+    assert_fault_describes_only,
+    assert_fault_persists_throughout,
+    create_watchdog_test_launch,
+    poll_cleared,
+    poll_entity_faults,
+    poll_faults,
+    prove_describes_only_proof_catches_a_dead_fault_surface,
+    prove_persistence_proof_catches_a_dead_fault_surface,
+    wait_until_faults_endpoint_live,
+    wait_until_watchdog_armed,
+    watchdog_detector_status,
+)
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
+
+# No default on purpose - a default makes this file FAIL OPEN (see harness-consuming
+# siblings' identical rationale): if the CTest ENVIRONMENT property never reaches the
+# process, the launch and the assertions would degrade together into one scenario and
+# still report 1/1 passed. A KeyError is loud.
+SCENARIO = os.environ['WATCHDOG_E2E_SCENARIO']
+PORT = get_test_port()
+
+FAULT_CODE = 'GRAPH_NODE_DISAPPEARED'
+# The detector's own id, matched against GET /x-medkit-watchdog's `detectors` block by
+# watchdog_detector_status(). node_death has no config to isolate a fault ON (it is
+# zero-config: every App the graph carries is in scope, not an explicit require_active-style
+# list), so unlike lifecycle_expectation's _DETECTOR_PREFIX-scoped keys, only `miss_grace`
+# and `prune_grace` below are ever set under it.
+DETECTOR_ID = 'node_death'
+_DETECTOR_PREFIX = f'plugins.graph_watchdog.detectors.{DETECTOR_ID}'
+
+# Fast tick cadence + a miss_grace comfortably PAST the documented 3000 ms floor
+# (min_node_death_miss_grace(200) == 14, detector_config_keys.hpp) without sitting exactly on
+# it. "config sweep C1" (NodeDeathIntegrationTest.C1_* in test_node_death_integration.cpp) owns
+# the floor's own boundary values, but never exercises tick_interval_ms=200 at all (its own
+# cases run at 1, 1000 and 3000 ms), so there is no boundary value at this tick period to land
+# on by accident - 16 carries two ticks of headroom purely to keep this row visibly off the
+# floor itself. 16 ticks * 200 ms = 3400 ms nominal grace; RESPAWN_DELAY_SEC below is sized
+# against this value.
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+MISS_GRACE = 16
+
+# The plain node most scenarios kill: DEMO_NODE_REGISTRY's own executable/name/namespace
+# for the 'calibration' key, constructed by hand (not via demo_nodes=[...]) wherever a
+# scenario needs a PID to signal - create_demo_nodes() gives no handle back. Single
+# occurrence of the bare name 'calibration' in this launch, so the discovery layer's
+# collision-avoidance never engages and the App id IS the bare name (verified against
+# ros2_runtime_introspection.cpp's own collision rule: only namespace-prefixed when the
+# SAME bare name appears in more than one namespace at once).
+TARGET_NODE = 'calibration'
+TARGET_EXECUTABLE = 'demo_calibration_service'
+TARGET_NAMESPACE = '/powertrain/engine'
+
+# launch will not even ATTEMPT to restart a respawn=True process before this elapses, so
+# it is a real, enforced floor under every kill-then-return gap this file measures. Must
+# clear the detector's OWN raise threshold, not just be "over one tick interval": a death is
+# reported once misses EXCEED miss_grace, i.e. after (MISS_GRACE + 1) * TICK_INTERVAL_MS =
+# 17 * 200ms = 3400ms of real absence. A respawn_delay short of that heals the outage before
+# a correct detector could ever confirm it, so clear_on_return/no_heal_standalone/
+# restart_loop_occurrences (the three scenarios that actually respawn TARGET_NODE) would
+# time out waiting for a raise that is never supposed to happen - not a detector defect.
+# Mirrors B5_RESPAWN_DELAY_SEC in the boundary e2e file (same detector, same tick interval,
+# same derivation - see that constant's own comment for the full arithmetic). 3400ms nominal
+# grace is not the whole budget a tick-counted miss_grace needs: the entity cache is refreshed
+# on a debounced graph event, up to 1100ms of latency on either end of the outage
+# (gateway_node.cpp), and the plugin's own tick loop can run slower than its configured period
+# under CI contention with no enforced upper bound. Margin under the 1100ms debounce ceiling
+# alone can be erased by a single unlucky refresh regardless of tick-loop speed, and
+# NodeLivenessTracker::update() resets a key's miss count to zero the instant it is seen
+# present again, so a cycle that loses this race does not raise late, it never raises at all.
+# 12.5s clears 3*3400+1100=11300ms (a tick loop running at a third of its configured rate,
+# plus the full debounce ceiling on top) by 1200ms - worst-case observed window
+# 12500-1100=11400ms, 3.35x the nominal grace.
+RESPAWN_DELAY_SEC = 12.5
+
+ARM_TIMEOUT_SEC = 60.0
+FAULTS_LIVE_TIMEOUT_SEC = 30.0
+PRESENCE_TIMEOUT_SEC = 30.0
+DEPARTURE_TIMEOUT_SEC = 30.0
+RAISE_TIMEOUT_SEC = 60.0
+CLEAR_TIMEOUT_SEC = 60.0
+# How long a fault must stay ABSENT, or CONFIRMED, for the scenarios whose claim is
+# sustained rather than momentary. Short (well under a minute) because every window here
+# is measured from the arming gate, not process start, so bringup cannot eat it - matching
+# SILENT_WINDOW_SEC's own rationale in the lifecycle e2e file.
+SUSTAINED_WINDOW_SEC = 20.0
+
+# The entity that owns the aggregated fault this plugin raises - proven already by
+# test_lifecycle_expectation_e2e.test.py's own poll_entity_faults(PORT,
+# 'apps/graph_watchdog', ...) calls, reused here for the REST-scoped clear_fault call
+# restart_loop_occurrences needs.
+SOURCE_ENTITY_PATH = 'apps/graph_watchdog'
+
+# ---- the "fast_tick_floor" scenario's own cadence ---------------------------------------
+#
+# Deliberately tiny: at 50 ms/tick, a miss_grace of 1 tick is 50 ms of NOMINAL grace - far
+# under the documented 3000 ms floor (config sweep C1). If the floor did not exist, a
+# single stale graph-cache generation between two ticks would be enough to call a healthy,
+# present node dead. The claim under test is that it is not enough, because the floor
+# raises the EFFECTIVE grace regardless of how small tick_interval_ms is configured.
+FAST_TICK_INTERVAL_MS = 50
+FAST_MISS_GRACE = 1
+
+# ---- the "bare_name_collision" scenario's own namespaces ---------------------------------
+#
+# Short and distinctive so they cannot be confused with any area/namespace used elsewhere
+# in this file or in the shared demo fixtures.
+COLLISION_NAMESPACE_A = '/coll_a'
+COLLISION_NAMESPACE_B = '/coll_b'
+# ros2_runtime_introspection.cpp's own collision-avoidance rule, applied by hand: two nodes
+# named 'calibration' in different namespaces get namespace-prefixed ids
+# ('<ns-without-leading-slash-slashes-as-underscores>_<name>'), so the bare 'calibration'
+# alone is no longer sufficient to tell them apart - which is exactly what this scenario
+# means by "the fault names the one that exited and does not name the one still running".
+COLLISION_APP_ID_A = 'coll_a_calibration'
+COLLISION_APP_ID_B = 'coll_b_calibration'
+# How long the "names the dead one, not the alive one" claim is watched for. Short (a few
+# ticks at TICK_INTERVAL_MS) because the claim is "never confuses the two", not "forever" -
+# but a WINDOW checked on every poll, never a single sample.
+MUTUAL_NAMING_WINDOW_SEC = 5.0
+
+# ---- the "ros2cli_ignored" scenario's own fixtures -----------------------------------------
+# The naming convention node_death filters on: a leaf node name
+# starting with this prefix, regardless of what process created it. The load-bearing half
+# of this scenario proves the convention itself, not any particular producer of it - see
+# TestNodeDeathRos2cliIgnored's own docstring for why that distinction is the whole point.
+# Pinned against the installed `ros2cli` package's own NODE_NAME_PREFIX, not just assumed
+# to stay correct - see this class's test_02.
+ROS2CLI_FAKE_NODE_PREFIX = '_ros2cli_fake_'
+# How many renamed-node arm/kill cycles the scenario runs, and how many distinct
+# ROS2CLI_FAKE_NODE_PREFIX-named nodes it exercises.
+ROS2CLI_CYCLES = 3
+# How long the before/after tracked_count samples may take to settle (see
+# _poll_stable_tracked_count) - generous against gateway-internal infrastructure (confirmed
+# live: a hidden `_param_client_node`, visible only because this scenario turns off
+# filter_internal_nodes) arming on its own schedule, not against anything this scenario's
+# own cycles do. Must comfortably exceed _poll_stable_tracked_count's own stable_seconds
+# default (10.0), or the poll could time out before stability was ever even reachable.
+STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0
+
+# ---- the "restart_loop_occurrences" scenario's own target -------------------------------
+# The claim under test is that occurrence_count tracks the number of genuine deaths. Three
+# distinct occurrences demonstrate that exactly as well as five: what would falsify the claim
+# is a count that stops incrementing (a detector that goes silent after the first cycle) or
+# double-counts (an ungated clear or a duplicate FAILED inflating the number), and either
+# failure mode shows up by the third cycle - a fourth or fifth would only repeat the same
+# proof at the full cost of RESPAWN_DELAY_SEC apiece. If a future change ever needs more
+# cycles to expose something this one does not, raising this single constant is the whole
+# edit.
+RESTART_LOOP_OCCURRENCES_TARGET = 3
+
+
+def _target_node_action(*, respawn=False, respawn_delay=RESPAWN_DELAY_SEC):
+    """One manually-constructed TARGET_NODE action, with a PID handle the test can signal.
+
+    Mirrors DEMO_NODE_REGISTRY's own 'calibration' entry exactly (same package, executable,
+    name, namespace) so this is the identical fixture every other scenario in this package
+    gets via demo_nodes=['calibration'] - just launched by hand because a scenario that
+    kills it needs the launch action's own process_details, which create_demo_nodes() does
+    not hand back.
+    """
+    return launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable=TARGET_EXECUTABLE,
+        name=TARGET_NODE,
+        namespace=TARGET_NAMESPACE,
+        output='screen',
+        additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+        respawn=respawn,
+        respawn_delay=respawn_delay,
+    )
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+        f'{_DETECTOR_PREFIX}.miss_grace': MISS_GRACE,
+    }
+    extra_gateway_params = None
+    demo_nodes = []
+    healing_enabled = True
+    gateway_respawn = False
+
+    if SCENARIO == 'raise':
+        pass  # target node launched by hand below, killed once, never restarted
+    elif SCENARIO == 'clear_on_return':
+        pass  # target node launched by hand below, killed then respawned
+    elif SCENARIO == 'no_heal_standalone':
+        healing_enabled = False  # the whole point of this scenario
+    elif SCENARIO == 'deactivated_not_dead':
+        demo_nodes = ['managed_lifecycle_active']  # self-activates; this test deactivates it
+    elif SCENARIO == 'manifest_never_online':
+        pkg_share = get_package_share_directory('ros2_medkit_gateway')
+        manifest_path = os.path.join(pkg_share, 'config', 'examples', 'demo_nodes_manifest.yaml')
+        extra_gateway_params = {
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': manifest_path,
+            # The manifest's own validator can turn an informational notice into a load
+            # failure under strict validation, which in hybrid mode silently degrades the
+            # gateway to runtime_only - see this package's CLAUDE.md gotcha and
+            # test_discovery_gap_fill.test.py's identical setting for the same manifest.
+            'discovery.manifest_strict_validation': False,
+        }
+        # Only 'calibration' comes online - it satisfies 'engine-calibration-service's
+        # ros_binding, giving the arming gate something to report on. Every OTHER app the
+        # manifest declares (e.g. 'lidar-sensor', bound to a 'lidar_sensor' node this
+        # launch never starts) stays in the snapshot with its online flag cleared and
+        # nothing ever links it - the exact fixture this scenario needs, already sitting in
+        # the manifest that ships as this repo's own integration-test fixture.
+        demo_nodes = ['calibration']
+    elif SCENARIO == 'ros2cli_ignored':
+        # No demo_nodes: test_01 spawns and kills its own renamed nodes by hand, and
+        # test_02 is a pure constant comparison against the installed ros2cli package -
+        # neither needs anything else running.
+        extra_gateway_params = {
+            # OFF for this scenario only. Left at its true default (on), a node named
+            # like the ros2cli convention would be invisible upstream of EVERYTHING -
+            # GET /apps, the entity cache, any IntrospectionProvider plugin gets fed
+            # from it - which would make this scenario pass for the wrong reason: never
+            # tracked at all, rather than tracked and then correctly excluded by name.
+            # This scenario is about node_death's OWN name-based exclusion, which needs a
+            # node the detector's input can actually see. See the class docstring.
+            'discovery.runtime.filter_internal_nodes': False,
+        }
+    elif SCENARIO == 'bare_name_collision':
+        pass  # two hand-built nodes below, same bare name, different namespaces
+    elif SCENARIO == 'fast_tick_floor':
+        detector_params['plugins.graph_watchdog.tick_interval_ms'] = FAST_TICK_INTERVAL_MS
+        detector_params[f'{_DETECTOR_PREFIX}.miss_grace'] = FAST_MISS_GRACE
+        demo_nodes = ['calibration']
+    elif SCENARIO == 'restart_loop_occurrences':
+        pass  # target node launched by hand below, respawning under this test's control
+    elif SCENARIO == 'restart_rebaseline':
+        gateway_respawn = True  # this scenario's own subject, like lifecycle's "main"
+    else:
+        raise RuntimeError(f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} has no launch configuration')
+
+    launch_description, context = create_watchdog_test_launch(
+        detector_params=detector_params,
+        extra_gateway_params=extra_gateway_params,
+        demo_nodes=demo_nodes,
+        port=PORT,
+        healing_enabled=healing_enabled,
+        gateway_respawn=gateway_respawn,
+    )
+
+    if SCENARIO in ('raise', 'restart_rebaseline'):
+        # No respawn: both scenarios kill the node PERMANENTLY and measure what happens to
+        # the fault it left behind - a bounce back would defeat the departure each is
+        # actually about.
+        target = _target_node_action(respawn=False)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO in ('clear_on_return', 'no_heal_standalone', 'restart_loop_occurrences'):
+        # respawn=True: every one of these scenarios kills the node and then needs it back
+        # - once for clear_on_return/no_heal_standalone, three times in a loop for
+        # restart_loop_occurrences - and create_demo_nodes() gives no PID handle to SIGTERM
+        # by hand in the first place, so this fixture is built here regardless.
+        target = _target_node_action(respawn=True, respawn_delay=RESPAWN_DELAY_SEC)
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'bare_name_collision':
+        node_a = launch_ros.actions.Node(
+            package='ros2_medkit_integration_tests',
+            executable=TARGET_EXECUTABLE,
+            name=TARGET_NODE,
+            namespace=COLLISION_NAMESPACE_A,
+            output='screen',
+            additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+            sigterm_timeout='30',
+            sigkill_timeout='15',
+        )
+        node_b = launch_ros.actions.Node(
+            package='ros2_medkit_integration_tests',
+            executable=TARGET_EXECUTABLE,
+            name=TARGET_NODE,
+            namespace=COLLISION_NAMESPACE_B,
+            output='screen',
+            additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+            sigterm_timeout='30',
+            sigkill_timeout='15',
+        )
+        launch_description.add_action(TimerAction(period=2.0, actions=[node_a, node_b]))
+        context['node_a'] = node_a
+        context['node_b'] = node_b
+
+    return launch_description, context
+
+
+# ---------------------------------------------------------------------------------------
+# Local helpers. These read the SAME endpoints harness.py's own helpers do, but with
+# either a different status filter (occurrence_count and last_passed survive a HEAL or a
+# CLEAR, both of which drop out of the default active-only listing) or a service this
+# file's scenarios need that no existing harness helper covers.
+# ---------------------------------------------------------------------------------------
+
+def _fault_record(port, code, timeout=30.0, interval=0.5):
+    """Poll ``GET /faults?status=all`` until `code` appears, whatever its status.
+
+    ``poll_faults`` uses the default (pending+confirmed) filter, so a HEALED or CLEARED
+    fault disappears from it - indistinguishable from one that was never raised. The
+    restart and occurrence scenarios need the record itself, including fields
+    (``last_passed``, ``occurrence_count``) that survive both. Returns the matching item
+    dict, or ``None`` on timeout.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', params={'status': 'all'}, timeout=5)
+            if response.status_code == 200:
+                for item in response.json().get('items', []):
+                    if item.get('fault_code') == code:
+                        return item
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def _poll_occurrence_count(port, code, expected, timeout=60.0, interval=0.5):
+    """Poll until `code`'s stored ``occurrence_count`` equals `expected`. ``True`` once it does.
+
+    Not "at least" - a detector that fires an extra spurious reactivation would satisfy
+    "at least 5" just as well as one that fires exactly 5, so an exact match is what
+    actually discriminates. Prints the last-seen record on timeout, which is gone once the
+    launch tears down.
+    """
+    deadline = time.monotonic() + timeout
+    last_seen = f'{code} was never in the store at all'
+    while time.monotonic() < deadline:
+        record = _fault_record(port, code, timeout=interval)
+        if record is not None:
+            last_seen = str(record)
+            if record.get('occurrence_count') == expected:
+                return True
+        time.sleep(interval)
+    print(f'_poll_occurrence_count({code!r}, expected={expected!r}) timed out after '
+          f'{timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _wait_until_port_is_down(port, timeout=60.0, interval=0.2):
+    """Wait until the gateway's HTTP port stops answering. True once it does."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            requests.get(f'{base}/health', timeout=2)
+        except requests.exceptions.RequestException:
+            return True
+        time.sleep(interval)
+    return False
+
+
+def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` is no longer listed. ``True`` once it is gone."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id not in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_absent({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _poll_apps_present(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` IS listed. ``True`` once it appears."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_present({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _clear_fault(port, entity_path, code, timeout=10.0):
+    """``DELETE {entity_path}/faults/{code}`` - the REST acknowledge, ``~/clear_fault``.
+
+    Unconditional: it writes CLEARED whatever the fault's current status is
+    (``fault_storage.cpp``'s own ``clear_fault`` takes no status guard), which is exactly
+    why it - and not a heal race - is what restart_loop_occurrences uses to close one
+    outage cycle before the next kill reactivates it as a fresh occurrence. Returns
+    ``True`` on any 2xx response.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    try:
+        response = requests.delete(f'{base}/{entity_path}/faults/{code}', timeout=timeout)
+    except requests.exceptions.RequestException:
+        return False
+    return 200 <= response.status_code < 300
+
+
+def _get_lifecycle_label(client_node, service_name, timeout=10.0):
+    """One ``GetState`` call against `service_name`. Returns the state label, or ``None``.
+
+    Creates its own client rather than taking one, since this is also called standalone
+    (the end-of-window check in "deactivated_not_dead") where polling's own reused client
+    would be the wrong lifetime to share.
+    """
+    client = client_node.create_client(GetState, service_name)
+    try:
+        if not client.wait_for_service(timeout_sec=timeout):
+            return None
+        future = client.call_async(GetState.Request())
+        rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+        result = future.result()
+        return None if result is None else result.current_state.label
+    finally:
+        client_node.destroy_client(client)
+
+
+def _poll_lifecycle_label(client_node, service_name, expected_label, timeout=30.0, interval=0.5):
+    """Poll ``GetState`` until `service_name` answers `expected_label`. ``True`` once it does.
+
+    One client for the whole poll (not one per iteration, unlike a single
+    `_get_lifecycle_label` call) - a 30 s poll at the default 0.5 s interval is up to 60
+    iterations, and creating and destroying a client every single one of them is needless
+    churn for what is otherwise an identical repeated call.
+    """
+    client = client_node.create_client(GetState, service_name)
+    try:
+        deadline = time.monotonic() + timeout
+        last_seen = f'{service_name} was never answered at all'
+        while time.monotonic() < deadline:
+            if client.wait_for_service(timeout_sec=interval):
+                future = client.call_async(GetState.Request())
+                rclpy.spin_until_future_complete(client_node, future, timeout_sec=interval)
+                result = future.result()
+                if result is not None:
+                    last_seen = result.current_state.label
+                    if last_seen == expected_label:
+                        return True
+            time.sleep(interval)
+        print(f'_poll_lifecycle_label({service_name!r}, expected={expected_label!r}) timed '
+              f'out after {timeout}s; last seen: {last_seen!r}')
+        return False
+    finally:
+        client_node.destroy_client(client)
+
+
+def _call_change_state_once(client_node, service_name, transition_id, timeout=30.0):
+    """One ``ChangeState`` call against `service_name`. ``True`` on ``result.success``."""
+    client = client_node.create_client(ChangeState, service_name)
+    if not client.wait_for_service(timeout_sec=timeout):
+        return False
+    request = ChangeState.Request()
+    request.transition.id = transition_id
+    future = client.call_async(request)
+    rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+    result = future.result()
+    return result is not None and result.success
+
+
+def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, interval=1.0):
+    """Poll the detector's status block until ``tracked_count`` holds steady.
+
+    "Holds steady" means the SAME value for a continuous `stable_seconds` before `timeout`
+    elapses. A single sample says nothing about whether the graph has settled: node_death is
+    zero-config and tracks every armed App, not just this scenario's own three renamed
+    fixtures. With `discovery.runtime.filter_internal_nodes` off (this scenario's own
+    requirement - see the class docstring), that includes normally-hidden gateway-internal
+    nodes too: confirmed live, the gateway keeps its own hidden `_param_client_node` for
+    querying newly-discovered nodes' parameters (the same path that logs "Parameter service
+    not available for node: ..." for each renamed fixture below), and that node is present
+    from early on but can still be inside its OWN per-entity warmup - and so absent from
+    tracked_count - at the moment a single sample happens to land, only to arm and join the
+    tracked set a few seconds later. A single `before` sample can therefore catch it
+    mid-warmup while a single `after` sample catches it already armed, reading as
+    tracked_count GROWTH that has nothing to do with the ros2cli exclusion this row is
+    actually about. `stable_seconds` has to be long enough to let that settle BEFORE either
+    sample is trusted, not merely long enough to smooth over network jitter - a handful of
+    consecutive reads close together would still land inside the SAME few-second warmup
+    window and call it "stable" too early.
+
+    Returns ``(status, stable)`` - `status` is the LAST status block read (possibly still
+    unsettled, so a caller can still report what it saw), `stable` is False if the value
+    never held for a continuous `stable_seconds` inside `timeout`. A status that reads None
+    on every poll (no `detectors.node_death` block at all - meaning no such detector is
+    registered) counts as stable at None: the caller's existing ``if before is not None``
+    gate still skips the comparison the same way a single-sample None always did.
+    """
+    deadline = time.monotonic() + timeout
+    status = None
+    last_count = None
+    streak_start = None
+    while time.monotonic() < deadline:
+        now = time.monotonic()
+        status = watchdog_detector_status(port, detector_id)
+        count = status.get('tracked_count') if status is not None else None
+        if count != last_count:
+            last_count = count
+            streak_start = now
+        elif now - streak_start >= stable_seconds:
+            return status, True
+        time.sleep(interval)
+    return status, False
+
+
+# ---------------------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------------------
+
+class TestNodeDeathRaise(unittest.TestCase):
+    """A plain node's process exits: GRAPH_NODE_DISAPPEARED names it."""
+
+    def test_process_exit_raises_naming_the_node(self, target_node):
+        # app_id=TARGET_NODE, not the global gate: the global gate is satisfied by ANY
+        # entity being armed, so it can go true from something else in the graph while
+        # TARGET_NODE itself has not been read even once. Killing it before that read
+        # happens is a kill a correct detector was never permitted to see - the raise
+        # below would then time out for a precondition reason and read exactly like the
+        # detector-missing red this suite is supposed to produce.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed - the plugin did not load, '
+            f'{TARGET_NODE} was never discovered, or the bringup grace never elapsed, so '
+            'no raise below could mean anything',
+        )
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM - this scenario never '
+            'produced the departure it is named for',
+        )
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE} never raised after {TARGET_NODE} exited')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+        # The flat /faults list carries a fault whatever its source is; only the
+        # entity-scoped surface proves an operator can OPEN it somewhere.
+        self.assertIsNotNone(
+            poll_entity_faults(
+                PORT, SOURCE_ENTITY_PATH, FAULT_CODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{FAULT_CODE} is not reachable at /{SOURCE_ENTITY_PATH}/faults - the entity '
+            'the plugin publishes does not own the fault it raises',
+        )
+
+    def test_self_tests_catch_a_dead_fault_surface(self):
+        """The tests of the tests for both new harness helpers, run once per this file.
+
+        Self-contained (a local HTTP server stands in for the gateway) - runs alongside
+        the real assertions above without depending on them, the way the lifecycle e2e's
+        "default_config" scenario runs the silence one.
+        """
+        prove_persistence_proof_catches_a_dead_fault_surface(self)
+        prove_describes_only_proof_catches_a_dead_fault_surface(self)
+
+
+class TestNodeDeathClearOnReturn(unittest.TestCase):
+    """A dead node coming back clears the fault.
+
+    The occurrence model's own "outage genuinely ended" case.
+    """
+
+    def test_node_returning_clears_the_fault(self, target_node):
+        # app_id=TARGET_NODE: see TestNodeDeathRaise's identical gate for why the global
+        # gate alone is not enough before a kill.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+
+        old_pid = target_node.process_details['pid']
+        os.kill(old_pid, signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} never raised after {TARGET_NODE} exited')
+
+        # launch's own respawn (this scenario's target node is launched with respawn=True)
+        # brings the same node back under the same name.
+        self.assertTrue(
+            _poll_apps_present(
+                PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC + RESPAWN_DELAY_SEC),
+            f'{TARGET_NODE} never came back after the SIGTERM - launch did not respawn it, '
+            'so there is nothing here that could clear the fault by returning',
+        )
+
+        self.assertTrue(
+            poll_cleared(PORT, FAULT_CODE, timeout=CLEAR_TIMEOUT_SEC),
+            f'{FAULT_CODE} did not clear after {TARGET_NODE} came back - the outage ended '
+            'but the fault manager still reports it active',
+        )
+
+
+class TestNodeDeathNoHealStandalone(unittest.TestCase):
+    """The same drive as clear_on_return, with the fault_manager's healing turned OFF.
+
+    The fault must NOT clear - the documented shape of the debounce hysteresis latch
+    (compute_debounce_status: a CONFIRMED fault stays put unless healing is enabled and the
+    counter reaches the healing threshold), not a defect. Proven as a SUSTAINED claim over
+    a window via assert_fault_persists_throughout, not a single sample that could just be
+    "not healed yet".
+    """
+
+    def test_node_returning_does_not_clear_the_fault(self, target_node):
+        # app_id=TARGET_NODE: see TestNodeDeathRaise's identical gate for why the global
+        # gate alone is not enough before a kill.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - a persistence claim below would prove '
+            'nothing about the detector if the channel itself never came up',
+        )
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} never raised after {TARGET_NODE} exited')
+
+        self.assertTrue(
+            _poll_apps_present(
+                PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC + RESPAWN_DELAY_SEC),
+            f'{TARGET_NODE} never came back after the SIGTERM',
+        )
+
+        assert_fault_persists_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+
+class TestNodeDeathDeactivatedNotDead(unittest.TestCase):
+    """A managed node that DEACTIVATES but keeps running is never called dead.
+
+    Absence alone cannot distinguish a detector that correctly ignores lifecycle state
+    from one that raises nothing at all - both leave GRAPH_NODE_DISAPPEARED silent here.
+    What this row catches is a detector that conflates "not active" with "gone":
+    node_death tracks graph PRESENCE only, so a node that deactivates without leaving the
+    graph must never be named.
+
+    Uses managed_lifecycle_active (self-activates via launch's own auto_activate
+    parameter) rather than extending droppable_lifecycle_node.cpp: that fixture's own
+    ChangeState handler is a documented stub ("Never driven: only
+    find_lifecycle_get_state_path()'s type check needs it to exist") that always returns
+    success without changing state, so it cannot be driven through a REAL
+    active-then-deactivate transition at all - it can only ever answer a label FIXED at
+    launch. managed_lifecycle is a real rclcpp_lifecycle::LifecycleNode and already
+    supports genuine ChangeState transitions (see test_lifecycle_expectation_e2e.test.py's
+    "main" scenario), so it needs no fixture changes for this scenario.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_e2e_deactivate_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_deactivate_while_alive_never_raises(self):
+        get_state_service = '/managed_lifecycle_active/get_state'
+        change_state_service = '/managed_lifecycle_active/change_state'
+
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the absence below would prove nothing')
+
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'active',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            'managed_lifecycle_active never reached "active" on its own - the trigger '
+            'this scenario needs (an active node that then deactivates) was never set up',
+        )
+
+        self.assertTrue(
+            _call_change_state_once(
+                type(self)._client_node, change_state_service,
+                Transition.TRANSITION_DEACTIVATE, timeout=PRESENCE_TIMEOUT_SEC),
+            'the real DEACTIVATE transition was rejected or never answered',
+        )
+        self.assertTrue(
+            _poll_lifecycle_label(
+                type(self)._client_node, get_state_service, 'inactive',
+                timeout=PRESENCE_TIMEOUT_SEC),
+            'managed_lifecycle_active never reached "inactive" after DEACTIVATE',
+        )
+
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+        # The trigger was pinned at the START of the window; confirm it survived to the
+        # end too, or most of the window measured an empty graph instead.
+        self.assertEqual(
+            _get_lifecycle_label(type(self)._client_node, get_state_service, timeout=15.0),
+            'inactive',
+            'managed_lifecycle_active is no longer reading "inactive" at the END of the '
+            'silence window - the trigger did not survive it',
+        )
+
+
+class TestNodeDeathManifestNeverOnline(unittest.TestCase):
+    """A manifest-declared App that never comes online is never called dead.
+
+    Absence alone cannot distinguish a detector that correctly reads the online flag from
+    one that raises nothing at all - see TestNodeDeathDeactivatedNotDead's own note. What
+    it catches: a manifest node keeps its App in the snapshot with the online flag
+    cleared, so a detector that counted snapshot membership alone would call it immortal;
+    node_death instead arms only apps it has read online at least once.
+    """
+
+    NEVER_ONLINE_APP_ID = 'lidar-sensor'  # declared in demo_nodes_manifest.yaml; its
+    # ros_binding (node 'lidar_sensor') is never launched by this scenario.
+    # The manifest's own id for the app bound to the 'calibration' node. In hybrid mode a
+    # linked App is exposed under the manifest's declared id, not the runtime-derived bare
+    # node name - unlike the other scenarios in this file, which run runtime_only.
+    ONLINE_APP_ID = 'engine-calibration-service'
+
+    def test_never_online_manifest_app_never_raises(self):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state - if the manifest failed '
+            'to load (see discovery.manifest_strict_validation) this could be silently '
+            'measuring runtime_only instead of the hybrid launch this scenario needs',
+        )
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the absence below would prove nothing')
+        self.assertTrue(
+            _poll_apps_present(PORT, self.ONLINE_APP_ID, timeout=PRESENCE_TIMEOUT_SEC),
+            f'{self.ONLINE_APP_ID} never appeared on GET /apps - without at least one '
+            'online app this launch gives the arming gate nothing to report on',
+        )
+        self.assertTrue(
+            _poll_apps_present(PORT, self.NEVER_ONLINE_APP_ID, timeout=PRESENCE_TIMEOUT_SEC),
+            f'{self.NEVER_ONLINE_APP_ID} is not even in the manifest-derived snapshot - '
+            'this scenario needs it present-but-offline, not absent from discovery '
+            'entirely, or the trigger it is named for was never set up',
+        )
+
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+
+class TestNodeDeathRos2cliIgnored(unittest.TestCase):
+    """A node named like ros2cli's own hidden-node convention is never tracked or raised.
+
+    What node_death actually implements for this case is a NAME test: it takes the leaf
+    after the last ``/`` and checks whether it starts with
+    ``_ros2cli_``. Nothing in that check knows or cares that a real `ros2` CLI process
+    produced the node - so the fixture that measures it should not depend on one either.
+
+    An earlier version of this scenario drove a real ``ros2 topic echo`` process for
+    every cycle and polled for its ephemeral ``_ros2cli_<pid>`` node. That instrument was
+    wrong for what it was measuring: it put the ros2cli daemon (`NodeStrategy`'s
+    daemon-vs-direct-node dispatch), ros2cli's own entry-point process layout, and
+    ephemeral-process DDS discovery timing all between the test and the one branch this
+    scenario is actually about - three sources of failure that have nothing to do with
+    the claim. Verified live, repeatedly: cycles failed in different, unrelated-looking
+    ways across separate runs (a wrong default spin-time, a bare-vs-FQN mismatch, then -
+    even after both of those were fixed and the mechanism rebuilt around a persistent
+    rclpy client node - a specific cycle timing out waiting for presence, and which cycle
+    failed was not even consistent between runs). That instability was in the instrument,
+    not in anything this suite is trying to prove.
+
+    test_01 (load-bearing) replaces it: an ordinary, long-lived `demo_engine_temp_sensor`
+    process, renamed via ``-r __node:={ROS2CLI_FAKE_NODE_PREFIX}<cycle>`` so the ONLY
+    thing distinguishing it from any other target node in this package is its name. Being
+    long-lived and entirely under this test's own control (started and killed on
+    purpose, not exiting on its own schedule), it can be armed and gated exactly like
+    every other scenario's target - something an ephemeral CLI subprocess's short, racy
+    lifetime never allowed. Three cycles, three distinct names, each proven present and
+    armed BEFORE being killed, so a kill never lands on a node the gate never saw.
+
+    This scenario's gateway launches with `discovery.runtime.filter_internal_nodes`
+    explicitly OFF (see `generate_test_description`). Left at its true default (on), a
+    ``_ros2cli_``-named node would be invisible upstream of everything - GET /apps, the
+    entity cache, any `IntrospectionProvider` plugin's own input - which would make this
+    scenario pass for the exact wrong reason: never tracked at all, rather than tracked
+    and then correctly excluded by name. This scenario is about the detector's OWN
+    name-based exclusion (belt-and-braces on top of,
+    not a substitute for, the gateway's separate and already-covered generic filter), and
+    that requires a node the detector's input can actually see.
+
+    test_02 does not drive a process at all. Two earlier attempts to keep a live realism
+    check both failed to hold up on this stack: a per-cycle ``ros2 topic echo`` (one real
+    CLI process per cycle) failed in different, unrelated-looking ways across separate
+    runs (see above), and a single, demoted invocation with a 60 s budget - this method's
+    own prior version - still did not observe its ephemeral node appear in the ROS graph
+    within that budget. What test_01's fixture actually needs to stay honest is not proof
+    that a live CLI process exists, but proof that ROS2CLI_FAKE_NODE_PREFIX is still built
+    from the same prefix the installed `ros2cli` package would use - a plain constant
+    comparison against `ros2cli.node.NODE_NAME_PREFIX`, deterministic and immediate, that
+    fails loudly the day the convention changes instead of quietly testing a prefix
+    nothing real uses anymore.
+
+    The tracked-count half of test_01's claim compares two STABLE reads
+    (_poll_stable_tracked_count), not two single samples: node_death is zero-config and
+    tracks every armed App in the graph, not just this scenario's own three renamed
+    fixtures, and with `discovery.runtime.filter_internal_nodes` off (this scenario's own
+    requirement, see above) that includes gateway-internal hidden nodes too. Confirmed live:
+    the gateway keeps a hidden `_param_client_node` for querying newly-discovered nodes'
+    parameters - present from early on, but still inside its OWN per-entity warmup, and so
+    briefly absent from tracked_count, at the moment a bare single sample happens to land. A
+    `before`/`after` pair of single samples straddling that node's own warmup completion
+    would read as tracked_count growth that has nothing to do with the ros2cli exclusion
+    this row is actually about - `_poll_stable_tracked_count` requires the value to hold for
+    a continuous stable_seconds specifically so that kind of late arrival is waited out
+    before either sample is trusted, not merely smoothed over. If
+    `watchdog_detector_status(PORT, DETECTOR_ID)` returns None on every read - no
+    `detectors.node_death` block at all, meaning no such detector is registered - that
+    counts as "stable at None" and is the one condition allowed to skip the comparison
+    entirely; once a detector exists the block stops being None and a subsequent
+    disappearance, a malformed shape, or a tracked_count that never actually settles fails
+    loudly instead of being silently discarded (see test_01's own comments).
+    """
+
+    def _spawn_renamed_node(self, name):
+        """Start an ordinary demo node renamed to carry the ros2cli hidden-node prefix.
+
+        `demo_engine_temp_sensor` (`DEMO_NODE_REGISTRY`'s 'temp_sensor' executable) needs
+        no parameters to start; ``-r __node:={name}`` is a plain ROS 2 remap, not a
+        ros2cli mechanism.
+
+        Invokes the installed binary directly - NOT ``ros2 run`` - so the returned
+        `Popen`'s own pid IS the node's pid. `ros2run.api.run_executable`
+        (confirmed directly against the installed `ros2run` package, not assumed) spawns
+        the target executable as ITS OWN child via a second `subprocess.Popen`, and only
+        ever forwards `KeyboardInterrupt` (SIGINT) to it; nothing in that function
+        forwards SIGTERM. A SIGTERM sent to a `ros2 run` wrapper's own pid therefore
+        kills only the wrapper - by Python's default disposition, not any handler ros2run
+        installs - and orphans the real node underneath it, which is then never signaled
+        at all and never leaves the graph. Reproduced live: an earlier version of this
+        method went through `ros2 run` and left an actual `demo_engine_temp_sensor`
+        process running with ppid 1 (reparented to init) for over an hour after its
+        scenario's own SIGTERM. The process this spawns instead knows nothing about
+        ros2cli or ros2run - it lives exactly as long as the caller lets it, and a
+        SIGTERM reaches it directly, the same way every other scenario in this file kills
+        ITS target node.
+        """
+        exe = os.path.join(
+            get_package_prefix('ros2_medkit_integration_tests'), 'lib',
+            'ros2_medkit_integration_tests', 'demo_engine_temp_sensor')
+        return subprocess.Popen(
+            [exe, '--ros-args', '-r', f'__node:={name}'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    def test_01_renamed_node_matching_the_convention_is_never_tracked(self):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the absence below would prove nothing')
+
+        before, before_stable = _poll_stable_tracked_count(
+            PORT, DETECTOR_ID, timeout=STABLE_TRACKED_COUNT_TIMEOUT_SEC)
+        self.assertTrue(
+            before_stable or before is None,
+            f'tracked_count never settled before the renamed-node cycles even started (last '
+            f'read: {before!r}) - the before/after comparison below would measure a moving '
+            "target, not this row's own claim",
+        )
+        for cycle in range(1, ROS2CLI_CYCLES + 1):
+            name = f'{ROS2CLI_FAKE_NODE_PREFIX}{cycle}'
+            proc = self._spawn_renamed_node(name)
+            try:
+                self.assertTrue(
+                    _poll_apps_present(PORT, name, timeout=PRESENCE_TIMEOUT_SEC),
+                    f'cycle {cycle}: {name} never appeared on GET /apps even with '
+                    'discovery.runtime.filter_internal_nodes off for this scenario - '
+                    'the arm/kill sequence below would prove nothing about the '
+                    'detector, only that this node failed to start or be discovered',
+                )
+                # app_id=name, not the global gate: see TestNodeDeathRaise's identical
+                # gate for why the global gate is not enough - it can go true from
+                # something else in the graph while this cycle's own node has not been
+                # read even once.
+                self.assertTrue(
+                    wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=name),
+                    f'cycle {cycle}: graph_watchdog never reported {name} armed - '
+                    'killing it before that would be a kill a correct detector was '
+                    'never permitted to see',
+                )
+
+                os.kill(proc.pid, signal.SIGTERM)
+                self.assertTrue(
+                    _poll_apps_absent(PORT, name, timeout=DEPARTURE_TIMEOUT_SEC),
+                    f'cycle {cycle}: {name} never left GET /apps after SIGTERM - this '
+                    'cycle never produced the departure it is about',
+                )
+                proc.wait(timeout=15)
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.wait(timeout=15)
+        after, after_stable = _poll_stable_tracked_count(
+            PORT, DETECTOR_ID, timeout=STABLE_TRACKED_COUNT_TIMEOUT_SEC)
+        # `before` reads None only if GET /x-medkit-watchdog carries no `detectors.node_death`
+        # block at all - the ONLY condition allowed to skip the comparison, kept for
+        # structural symmetry with `_poll_stable_tracked_count`'s own "stable at None"
+        # contract, not because it is expected here. With the detector registered, `before`
+        # is populated and the comparison below always runs: checking `before is not None`
+        # alone (not also `after is not None`) is what makes a status block that vanishes or
+        # loses its shape MID-scenario fail loudly instead of being discarded along with the
+        # genuinely-inapplicable case.
+        if before is not None:
+            self.assertTrue(
+                after_stable,
+                f'tracked_count never settled after the renamed-node cycles (last read: '
+                f'{after!r}) - cannot tell whether the ros2cli exclusion held or something '
+                'else in the graph is simply still arming, so reporting this rather than '
+                'comparing against a moving target',
+            )
+            self.assertIsNotNone(
+                after,
+                f'the node_death detector status block was present before the '
+                f'renamed-node cycles ({before!r}) and is gone after them - it '
+                'disappeared mid-scenario',
+            )
+            self.assertIn(
+                'tracked_count', after,
+                f"the node_death detector status block lost its 'tracked_count' field "
+                f'after the renamed-node cycles ({before!r} -> {after!r})',
+            )
+            if before.get('tracked_count') != after.get('tracked_count'):
+                try:
+                    apps_url = f'http://127.0.0.1:{PORT}{API_BASE_PATH}/apps'
+                    apps_now = requests.get(apps_url, timeout=5).json().get('items', [])
+                    ids_now = [item.get('id') for item in apps_now]
+                except requests.exceptions.RequestException as exc:
+                    ids_now = f'GET /apps failed: {exc}'
+                self.fail(
+                    f'the node_death detector status block reports a different tracked_count '
+                    f'after {ROS2CLI_CYCLES} renamed-node arm/kill cycles ({before!r} -> '
+                    f'{after!r}) - GET /apps right now: {ids_now!r}',
+                )
+
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+    def test_02_the_fake_prefix_still_matches_ros2clis_own_convention(self):
+        """Pins test_01's fixture to ros2cli's OWN naming convention, not a copy of it.
+
+        What this protects against: test_01 kills nodes it names itself
+        (``ROS2CLI_FAKE_NODE_PREFIX`` + a cycle number). If the installed `ros2cli`
+        package ever changed what prefix it hands its own hidden nodes, test_01 would
+        keep passing - proving a detector ignores a prefix WE made up - while the actual
+        convention moved out from under it, and `node_death`'s exclusion would silently
+        stop matching reality. Nothing else in this scenario would notice that drift.
+
+        Reads the installed package rather than driving a process because a live check
+        was tried first, twice, and neither held up on this stack: a per-cycle ``ros2
+        topic echo`` (one real CLI process per cycle, three cycles) failed in different,
+        unrelated-looking ways across separate runs (a wrong default spin-time, a
+        bare-vs-FQN mismatch, then - even after both were fixed - a specific cycle timing
+        out waiting for presence, inconsistently between runs); a single, demoted
+        invocation with a 60 s budget (this method's own prior version) still did not
+        observe its ephemeral node appear in the ROS graph within that budget. Both tries
+        were proving a live process exists, which this scenario does not actually need -
+        it needs to know what NAME ros2cli would give that process, and that is a plain
+        constant lookup, not a fact about a live graph. Deterministic, no subprocess, no
+        discovery, and it fails loudly the day the convention changes - exactly what the
+        two process-driving attempts before it were for, and could not reliably do here.
+
+        `rclpy.node.HIDDEN_NODE_PREFIX` is the general ROS 2 hidden-node convention
+        (``'_'``); `ros2cli.node.NODE_NAME_PREFIX` is ros2cli's own
+        ``HIDDEN_NODE_PREFIX + 'ros2cli'`` - both imported from the installed packages,
+        not hardcoded here, so this check tracks them automatically. See also
+        `ros2cli.node.direct.DirectNode`, which builds an actual CLI invocation's node
+        name as ``NODE_NAME_PREFIX + '_%d' % os.getpid()`` - the shape both live attempts
+        above were trying, and failing, to observe.
+        """
+        self.assertEqual(
+            NODE_NAME_PREFIX, HIDDEN_NODE_PREFIX + 'ros2cli',
+            f'ros2cli.node.NODE_NAME_PREFIX ({NODE_NAME_PREFIX!r}) is no longer built '
+            f"from rclpy's own hidden-node prefix ({HIDDEN_NODE_PREFIX!r}) the way this "
+            'test assumed - the composition itself changed, not just the value',
+        )
+        self.assertTrue(
+            ROS2CLI_FAKE_NODE_PREFIX.startswith(NODE_NAME_PREFIX),
+            f'test_01 kills nodes named {ROS2CLI_FAKE_NODE_PREFIX!r}<cycle>, but the '
+            f'installed ros2cli package now builds its own hidden node names from '
+            f'{NODE_NAME_PREFIX!r} - these no longer match, so test_01 passing would no '
+            'longer mean what this scenario claims it means',
+        )
+
+
+class TestNodeDeathBareNameCollision(unittest.TestCase):
+    """Two nodes sharing a bare name in different namespaces; one exits.
+
+    The fault names the one that exited and does not name the one still running - proven
+    with assert_fault_describes_only so the claim holds for the WHOLE window a scenario
+    watches it, not one lucky read taken before a second tick could have widened (or
+    corrupted) the description.
+
+    Required/forbidden are the two nodes' FULLY QUALIFIED names, not their discovery-layer
+    App ids. The collision-avoidance rule that gives the two colliding nodes their
+    namespace-prefixed ids (`ros2_runtime_introspection.cpp`) is re-evaluated on every
+    discovery sweep from whichever bare names are CURRENTLY duplicated - it is not a
+    property assigned once and kept. Once node_a departs, only one 'calibration' remains,
+    the collision that justified prefixing it resolves, and node_b's own id reverts to the
+    bare 'calibration' - confirmed live: GET /apps read `coll_a_calibration` and
+    `coll_b_calibration` while both were up, then just `calibration` once node_a was gone.
+    A forbidden needle keyed to an id that stops existing the moment the departure this
+    scenario is about actually happens would not discriminate anything. The FQN carries no
+    such collision-avoidance and stays valid for both nodes throughout.
+    """
+
+    def test_dead_one_named_alive_one_not(self, node_a, node_b):
+        # Both ids, not the global gate: this scenario perturbs (kills) node_a and its
+        # claim is about node_b too ("does not name the one still running"), so both must
+        # have been read by the detector before node_a dies - see TestNodeDeathRaise's
+        # identical gate for why the global gate alone would not prove that.
+        for app_id in (COLLISION_APP_ID_A, COLLISION_APP_ID_B):
+            self.assertTrue(
+                wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=app_id),
+                f'graph_watchdog never reported {app_id} armed - the discovery layer did '
+                'not namespace-disambiguate the bare-name collision the way this scenario '
+                'assumes, or one of the two fixtures never came up, or it did but was '
+                'never read',
+            )
+
+        node_b_pid = node_b.process_details['pid']
+        os.kill(node_a.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, COLLISION_APP_ID_A, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{COLLISION_APP_ID_A} never left GET /apps after SIGTERM')
+        # node_b's OWN discovery-layer id is not stable across node_a's departure (see the
+        # class docstring), so its continued survival is checked at the OS level instead -
+        # the one identity that does not shift when the collision this scenario sets up
+        # resolves.
+        try:
+            os.kill(node_b_pid, 0)
+        except ProcessLookupError:
+            self.fail(
+                f'node_b (pid {node_b_pid}) is gone too - only node_a was meant to die, '
+                'so the pair no longer discriminates')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} never raised after {COLLISION_APP_ID_A} exited')
+
+        assert_fault_describes_only(
+            self, PORT, FAULT_CODE,
+            required=[f'{COLLISION_NAMESPACE_A}/{TARGET_NODE}'],
+            forbidden=[f'{COLLISION_NAMESPACE_B}/{TARGET_NODE}'],
+            duration=MUTUAL_NAMING_WINDOW_SEC)
+
+
+class TestNodeDeathFastTickFloor(unittest.TestCase):
+    """A very short tick_interval_ms, with the node continuously present, raises nothing.
+
+    Narrower than this row's own name suggests, and deliberately so - see below. Absence
+    alone cannot distinguish a detector that is correctly silent here from one that raises
+    nothing at all - see TestNodeDeathDeactivatedNotDead's own note.
+
+    What this scenario does NOT prove: that the documented miss_grace floor (config sweep
+    C1's own concern) is what stands between a fast tick and a false raise. The row exists
+    because a fast-ticking detector could read the SAME stale entity-cache generation many
+    times before the cache refreshes, and - absent the floor - a naive per-tick counter
+    would count each of those reads as an independent miss rather than one. This scenario
+    never forces that condition: the node is present throughout and the cache is never
+    caught between a real departure and a real return, so there is no stale generation to
+    misread in the first place. A detector built WITHOUT the floor would pass this
+    scenario just as easily as one built with it, as long as no such staleness happened to
+    occur in the window - which, with nothing perturbing the graph, it never does.
+
+    Investigated, not assumed, whether the precondition can be forced deterministically.
+    Traced the real mechanism in `gateway_node.cpp`: the entity cache refreshes on a ROS
+    graph event, coalesced to at most one refresh per `discovery.refresh_debounce_ms`
+    (default 1000 ms) via `graph_check_timer_`/`decide_graph_refresh` - PLUS an
+    independent, unconditional `backstop_timer_` on its own `refresh_interval_ms` cadence,
+    which the shared `create_gateway_node()` factory pins to 1000 ms for every launch in
+    this test suite. Both are overridable via `extra_gateway_params`, which in principle
+    opens a multi-second window: kill the node, poll GET /apps until the departure is
+    reflected (proving a refresh already consumed the debounce budget), then respawn it
+    by hand (not launch's own `respawn=True`, whose `RESPAWN_DELAY_SEC` floor is
+    calibrated to be slow elsewhere in this file and is the wrong direction here) fast
+    enough to land inside the same now-widened window, and confirm the new process is
+    genuinely alive via a DIRECT service call that bypasses the gateway entirely while
+    GET /apps still reports it absent.
+
+    Not implemented. Two reasons: (1) it is a real race, not a guaranteed sequence -
+    "deterministic" has to mean reliable across CI hardware, and nothing pins how long DDS
+    discovery takes to converge on the manually-respawned process relative to the widened
+    window, only that it is likely to fit; (2) winning the race would require new
+    subprocess-lifecycle code (resolving the demo executable's install path, building its
+    `--ros-args` remapping by hand, coverage-env parity with every other fixture in this
+    file, guaranteed cleanup on a failed assertion) whose own bugs could leak an orphaned
+    process - exactly what this package's own test discipline warns leaks into the NEXT run
+    as a false regression. Forcing the precondition would exercise a real detector rather
+    than prove something trivially true either way, which is what makes the remaining cost
+    purely about race reliability and fixture risk, not about whether the result would mean
+    anything.
+    """
+
+    def test_fast_tick_alone_never_raises(self):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the absence below would prove nothing')
+        self.assertTrue(
+            _poll_apps_present(PORT, 'calibration', timeout=PRESENCE_TIMEOUT_SEC),
+            "'calibration' never appeared on GET /apps - there is no present node here "
+            'whose non-death this scenario is about',
+        )
+
+        assert_fault_absent_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+        self.assertTrue(
+            _poll_apps_present(PORT, 'calibration', timeout=5.0),
+            "'calibration' is no longer present at the END of the silence window - the "
+            'trigger (a present node, ticked over rapidly) did not survive it',
+        )
+
+
+class TestNodeDeathRestartLoopOccurrences(unittest.TestCase):
+    """A node killed and restarted three times: occurrence_count reaches 3.
+
+    Each cycle: kill, wait for the fault to CONFIRM (a fresh occurrence), wait for the node
+    to come back, THEN explicitly acknowledge it via DELETE
+    {SOURCE_ENTITY_PATH}/faults/{code} - the fault manager's own boundary between
+    occurrences: `~/clear_fault` IS the acknowledge, not a deletion, and a FAILED event
+    reactivating a CLEARED record is what the fault manager counts as a new occurrence
+    (`fault_storage.cpp`'s own comment: "a new outage cycle, not a continuation of the one
+    that just cleared"). A level-triggered heal on return would NOT do this - reconfirming
+    from HEALED (rather than from CLEARED) does not bump occurrence_count at all
+    (`fault_storage.cpp`: "a re-report on a still-active fault... the same continuous
+    occurrence"), which is why this scenario acknowledges explicitly between cycles instead
+    of waiting for an organic heal.
+
+    Deliberately does NOT assert the "more than one recording" half of this row. The
+    per-fault rosbag store enforces `fault_code` as UNIQUE (`sqlite_fault_storage.cpp`'s
+    `store_rosbag_file_locked`: "INSERT OR REPLACE INTO rosbag_files ... (fault_code is
+    UNIQUE)" - the SAME fault_code can hold at most one recording ROW, structurally, and a
+    re-confirm deletes the previous bag file from disk). No config key in the fault manager
+    lifts this cap today: recording more than one rosbag per fault_code needs the storage
+    schema itself to change. Asserting a recording count here would either assert something
+    trivially true for the wrong reason (no captures happen at all without a detector) or
+    something structurally impossible to ever pass - neither is written.
+    """
+
+    def test_repeated_kills_reach_matching_occurrence_count(self, target_node):
+        # app_id=TARGET_NODE: see TestNodeDeathRaise's identical gate for why the global
+        # gate alone is not enough before a kill. Re-checked before every LATER kill too
+        # (below), since a respawned instance needs its own read just as much as the first.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+
+        pid = target_node.process_details['pid']
+        for cycle in range(1, RESTART_LOOP_OCCURRENCES_TARGET + 1):
+            os.kill(pid, signal.SIGTERM)
+            self.assertTrue(
+                _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+                f'cycle {cycle}: {TARGET_NODE} never left GET /apps after SIGTERM',
+            )
+            self.assertTrue(
+                _poll_occurrence_count(PORT, FAULT_CODE, cycle, timeout=RAISE_TIMEOUT_SEC),
+                f'cycle {cycle}: {FAULT_CODE} never reached occurrence_count={cycle}',
+            )
+
+            if cycle < RESTART_LOOP_OCCURRENCES_TARGET:
+                # Wait for the RETURN before acknowledging - not merely a style choice:
+                # clearing while the node is still absent leaves a window in which a live
+                # detector's own continued FAILED reports (the SAME departure, still being
+                # measured) would reactivate the just-cleared record too, one cycle early.
+                # Waiting for the return first means every reactivation this loop measures
+                # is attributable to the NEXT kill, not a race against this one's tail end.
+                # app_id-scoped again, not just present: the respawned instance is a NEW
+                # process the detector has not read yet, and the next iteration is about
+                # to kill it - the same precondition the FIRST kill above needed.
+                self.assertTrue(
+                    wait_until_watchdog_armed(
+                        PORT, timeout=DEPARTURE_TIMEOUT_SEC + RESPAWN_DELAY_SEC,
+                        app_id=TARGET_NODE),
+                    f'cycle {cycle}: {TARGET_NODE} never came back armed after the SIGTERM - '
+                    'launch did not respawn it, or the respawned instance was never read, '
+                    'so this is a single departure, not a loop',
+                )
+                self.assertTrue(
+                    _clear_fault(PORT, SOURCE_ENTITY_PATH, FAULT_CODE),
+                    f'cycle {cycle}: DELETE /{SOURCE_ENTITY_PATH}/faults/{FAULT_CODE} '
+                    'did not acknowledge the fault - the next kill could not reactivate '
+                    'it as a fresh occurrence',
+                )
+                # A fresh pid every cycle: read it back rather than assume launch's
+                # respawn keeps the value this test already has.
+                pid = target_node.process_details['pid']
+
+        record = _fault_record(PORT, FAULT_CODE, timeout=DEPARTURE_TIMEOUT_SEC)
+        if record is None:
+            self.fail(f'{FAULT_CODE} vanished from the store entirely')
+        self.assertEqual(
+            record.get('occurrence_count'), RESTART_LOOP_OCCURRENCES_TARGET,
+            f'{FAULT_CODE} ended the loop with occurrence_count='
+            f'{record.get("occurrence_count")!r}, not {RESTART_LOOP_OCCURRENCES_TARGET}',
+        )
+
+
+class TestNodeDeathRestartRebaseline(unittest.TestCase):
+    """A gateway restart with a death outstanding: the re-baseline boundary is pinned.
+
+    RECORDS a boundary, the way TestLifecycleExpectationRestartDeparted does for the
+    sibling detector - this test does not fix anything. Pin: the fault stays CONFIRMED
+    across the restart, proven as a SUSTAINED claim (assert_fault_persists_throughout),
+    not a single sample that could just mean "not yet re-evaluated".
+
+    Reasoning, on file rather than assumed: node_death has no forced state transition - a
+    violation's evidence closes only when the graph genuinely recovers, or an operator
+    explicitly acknowledges it. A gateway restart is neither: the node is
+    STILL gone, and the freshly-started detector process, having never observed it
+    present in this lifetime, has nothing to report either way. Unlike
+    lifecycle_expectation's require_active (an explicit, possibly-mistyped list that has
+    to eventually give up on an entry that never matches anything, or a typo would block
+    healing forever), node_death is zero-config: it has no static entries to protect
+    against typos in the first place, so it has no equivalent reason to ever manufacture a
+    clear for a node it has simply never seen.
+    """
+
+    def test_01_the_fault_raises_and_survives_the_node_leaving(self, target_node):
+        # app_id=TARGET_NODE: see TestNodeDeathRaise's identical gate for why the global
+        # gate alone is not enough before a kill. test_02 below gates globally instead -
+        # by then TARGET_NODE is gone BY DESIGN, so an app_id gate on it could never
+        # succeed; what test_02 checks is that the PLUGIN itself is back up post-restart,
+        # not that this specific (permanently absent) node is.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        self.assertIsNotNone(fault, f'{FAULT_CODE} never raised for the departed {TARGET_NODE}')
+
+        record = _fault_record(PORT, FAULT_CODE, timeout=DEPARTURE_TIMEOUT_SEC)
+        if record is None:
+            self.fail(f'{FAULT_CODE} vanished from the store')
+        self.assertIsNone(
+            record.get('last_passed'),
+            f'{FAULT_CODE} was reported PASSED before the restart '
+            f'(last_passed={record.get("last_passed")!r}) - there is nothing left here for '
+            'the restart below to wrongly preserve or wrongly heal',
+        )
+
+    def test_02_a_gateway_restart_does_not_manufacture_a_clear(self, gateway_node, target_node):
+        old_pid = gateway_node.process_details['pid']
+        os.kill(old_pid, signal.SIGTERM)
+        self.assertTrue(
+            _wait_until_port_is_down(PORT, timeout=60.0),
+            f'the gateway (pid {old_pid}) kept answering after SIGTERM - nothing restarted')
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=90.0),
+            'the gateway never came back armed after the restart')
+        self.assertNotEqual(
+            gateway_node.process_details['pid'], old_pid,
+            'the gateway process id did not change, so this test never restarted anything')
+        # The armed gate is served by the plugin INSIDE the restarted gateway process and
+        # proves nothing about its connection to the fault_manager - a SEPARATE process
+        # that survived the restart, but whose services the freshly restarted gateway has
+        # to rediscover from scratch. Without this, the persistence window below could
+        # start against a /faults that has not reconnected yet and fail for that reason
+        # instead of the boundary this test is actually pinning.
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 after the restart - the restarted gateway '
+            'never reconnected to the fault_manager, so the persistence window below '
+            'would prove nothing',
+        )
+        self.assertFalse(
+            _poll_apps_present(PORT, TARGET_NODE, timeout=5.0),
+            f'{TARGET_NODE} is back in GET /apps - the boundary this test pins is about '
+            'a restart with the node STILL gone, and it came back instead',
+        )
+
+        # The pin: sustained across a real window post-restart, not a single sample.
+        assert_fault_persists_throughout(self, PORT, FAULT_CODE, SUSTAINED_WINDOW_SEC)
+
+        record = _fault_record(PORT, FAULT_CODE, timeout=DEPARTURE_TIMEOUT_SEC)
+        if record is None:
+            self.fail(f'{FAULT_CODE} vanished from the store after the restart')
+        self.assertIsNone(
+            record.get('last_passed'),
+            f'the restarted gateway reported {FAULT_CODE} PASSED for a node it can never '
+            f'have observed in this process (last_passed={record.get("last_passed")!r}) - '
+            'the boundary this test pins no longer holds',
+        )
+
+
+# Each CTest target launches this file with one scenario, so only that scenario's case may
+# run. Removing the others from the module (rather than skipping them) means each run
+# reports exactly one case, and a missing result is a real failure rather than an expected
+# line of output - see test_lifecycle_expectation_e2e.test.py's identical rationale.
+_SCENARIO_CASES = {
+    'raise': 'TestNodeDeathRaise',
+    'clear_on_return': 'TestNodeDeathClearOnReturn',
+    'no_heal_standalone': 'TestNodeDeathNoHealStandalone',
+    'deactivated_not_dead': 'TestNodeDeathDeactivatedNotDead',
+    'manifest_never_online': 'TestNodeDeathManifestNeverOnline',
+    'ros2cli_ignored': 'TestNodeDeathRos2cliIgnored',
+    'bare_name_collision': 'TestNodeDeathBareNameCollision',
+    'fast_tick_floor': 'TestNodeDeathFastTickFloor',
+    'restart_loop_occurrences': 'TestNodeDeathRestartLoopOccurrences',
+    'restart_rebaseline': 'TestNodeDeathRestartRebaseline',
+}
+if SCENARIO not in _SCENARIO_CASES:
+    raise RuntimeError(
+        f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} is not one of {sorted(_SCENARIO_CASES)}; '
+        'the CTest target and this file disagree about which scenarios exist')
+for _scenario, _case_name in _SCENARIO_CASES.items():
+    if _scenario != SCENARIO:
+        del globals()[_case_name]
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager/demo stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_e2e.test.py
@@ -128,7 +128,11 @@ from harness import (  # noqa: E402, I100
     watchdog_detector_status,
 )
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.constants import (  # noqa: E402
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
 from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
 
 # No default on purpose - a default makes this file FAIL OPEN (see harness-consuming
@@ -192,12 +196,23 @@ TARGET_NAMESPACE = '/powertrain/engine'
 # 12500-1100=11400ms, 3.35x the nominal grace.
 RESPAWN_DELAY_SEC = 12.5
 
-ARM_TIMEOUT_SEC = 60.0
-FAULTS_LIVE_TIMEOUT_SEC = 30.0
-PRESENCE_TIMEOUT_SEC = 30.0
-DEPARTURE_TIMEOUT_SEC = 30.0
-RAISE_TIMEOUT_SEC = 60.0
-CLEAR_TIMEOUT_SEC = 60.0
+# The budgets below are scaled by MEDKIT_TEST_TIME_SCALE, which the sanitizer jobs set to the
+# same factor they apply to every declared CTest timeout. A deadline asserted INSIDE a test is
+# invisible to that rewrite, so an instrumented graph that takes longer to forget a departed
+# node blows a budget here and the failure reads as a detector that never reported - the exact
+# red this suite exists to produce for a real defect. Unset elsewhere, so the normal jobs keep
+# the tight budgets that give these assertions their falsifying edge.
+#
+# Poll intervals, enforced respawn delays and the sustained-observation windows are NOT scaled.
+# Those are not give-up bounds: stretching a window a scenario watches for silence buys no
+# confidence and spends the whole package's test budget to do it.
+TIME_SCALE = get_time_scale()
+ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
+FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+PRESENCE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
+CLEAR_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long a fault must stay ABSENT, or CONFIRMED, for the scenarios whose claim is
 # sustained rather than momentary. Short (well under a minute) because every window here
 # is measured from the arming gate, not process start, so bringup cannot eat it - matching
@@ -255,7 +270,7 @@ ROS2CLI_CYCLES = 3
 # filter_internal_nodes) arming on its own schedule, not against anything this scenario's
 # own cycles do. Must comfortably exceed _poll_stable_tracked_count's own stable_seconds
 # default (10.0), or the poll could time out before stability was ever even reachable.
-STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0
+STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0 * TIME_SCALE
 
 # ---- the "restart_loop_occurrences" scenario's own target -------------------------------
 # The claim under test is that occurrence_count tracks the number of genuine deaths. Three

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -1,0 +1,773 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""node_death suppression e2e: allowlist, self-suppression and pruning against the REAL stack.
+
+Sibling of test_node_death_e2e.test.py, same shape: each RAISE row proves the fault actually
+appears, naming the missing-fault case as the failure mode when it does not. An ABSENCE row
+cannot, by itself, discriminate a correct suppressor from no detector at all, because both
+produce the same silence; each such row's own class docstring says so and states what the row
+catches instead.
+
+Runs as FIVE separate CTest targets (see CMakeLists.txt), each launching its OWN
+gateway+fault_manager+demo-node stack - the plugin reads its config once at set_context() time, so
+different configs need different gateway launches. WATCHDOG_E2E_SCENARIO selects which launch and
+which assertions run:
+
+- "allowlist_suppresses": ``detectors.node_death.allowlist: [TARGET_NODE]`` with
+  ``suppress: ["allowlist"]`` - the node is armed, then killed. No GRAPH_NODE_DISAPPEARED names
+  it, for a sustained window - narrower than "the code never appears at all": a correct
+  detector raising the code for some OTHER entity must leave this row green, so the assertion
+  is needle-scoped (assert_fault_never_names) rather than a bare absence check. CANNOT
+  DISCRIMINATE BY ITSELF: silence here is consistent with a suppressor correctly
+  honouring the allowlist, and equally consistent with one that never consults it, since both
+  leave the code unraised.
+- "allowlist_not_named_is_inert": the SAME allowlist, but ``suppress`` does not name
+  "allowlist" - naming an entry on the allowlist is not, by itself, a request to suppress it;
+  only listing the mechanism in ``suppress`` opts it in, unlike the ported source, which
+  activated a configured allowlist unconditionally. The fault raises and names the node - a
+  genuine RAISE row - and a startup warning says the list is inert. The warning half is read
+  straight off the
+  gateway process's own stderr via launch_testing's ``proc_output`` fixture, the same instrument
+  test_startup_param_clamp_warnings.test.py already uses for an identical "did we say so" claim -
+  no new harness helper, just a capability already available at this tier and never exercised in
+  this package's own e2e suite before. The match itself is a compiled regex, not the bare
+  substring "allowlist": a line mentioning the word for an unrelated reason (reporting its size,
+  say) must not satisfy a warning this specific, so the pattern requires "allowlist" and
+  "suppress" on the SAME line at WARN severity - see _INERT_ALLOWLIST_WARNING_RE.
+- "lifecycle_clean_shutdown": self-suppression - a node this package already watches through
+  lifecycle_expectation is suppressed only when it departed while not active, not a
+  lifecycle-agnostic notion of "clean". Two identical managed_lifecycle instances, both listed in
+  ``detectors.lifecycle_expectation.require_active`` (self-suppression needs BOTH "this node is
+  require_active-owned" and "it departed while not active" - the lifecycle label alone would
+  over-suppress a node nobody is watching), AND ``detectors.node_death.suppress: ["lifecycle"]``
+  naming the self-suppression mechanism this row is about - suppression is opt-in by ruling, so
+  without that entry a correct detector reports BOTH departed nodes and this row's own "the clean
+  one is never named" half would be false against a correct implementation. One is driven through
+  a REAL ``lifecycle_msgs/srv/ChangeState`` UNCONFIGURED_SHUTDOWN transition (reaching
+  "finalized") before its process is killed; the other reaches "active" (auto_activate) and is
+  killed outright, still active. The finalized one is never named; the active one is - proven
+  with assert_fault_describes_only so the claim holds over the whole window, not one lucky read.
+- "suppression_is_opt_in": the allowlist key is set, but ``suppress`` is not configured AT ALL -
+  merely naming a node on the allowlist must not suppress it by itself. The fault raises and
+  names the node.
+- "prune_no_false_heal": TWO independent nodes. TARGET_NODE carries
+  ``allowlist: [TARGET_NODE]`` with ``suppress: ["allowlist"]`` - the ONLY shape pruning ever
+  applies to (``NodeLivenessTracker::prune()`` reclaims a key only once it has been DURABLY
+  suppressed; an unsuppressed death has no reclaim path at all - see node_liveness_tracker.hpp's
+  own doc). SECOND_NODE carries no suppression at all, so its death is an ordinary, permanently
+  outstanding fault - the control this row needs, since a single-node shape cannot tell "prune()
+  reclaimed the right key" from "prune() reclaimed (or healed) something it should not have".
+  Both are killed; TARGET_NODE's bookkeeping is then observed reclaimed past
+  ``detectors.node_death.prune_grace`` as a `tracked_count` DELTA of exactly one off a baseline
+  (never against zero - the aggregate also carries every other armed App in the graph, so it can
+  never read exactly zero), while SECOND_NODE's fault must stay CONFIRMED and keep naming it,
+  never TARGET_NODE, for a window spanning straight through the tick TARGET_NODE's own reclaim
+  happens on.
+
+Every scenario gates on wait_until_watchdog_armed(PORT, app_id=...) BEFORE asserting anything -
+see harness.py's own docstring for why a stack that never came up otherwise produces exactly the
+silence an absence claim is looking for. "lifecycle_clean_shutdown" is the one exception: both its
+nodes are non-active managed_lifecycle instances, and ReliabilityGate reports a tracked node with
+a known non-active label as "warming_up" by design (LifecycleWatcher::node_ok() is false for
+exactly the node this whole detector class exists to catch) - so a per-entity armed gate on either
+one would wait for something that can never become true. It gates on the GLOBAL armed state
+instead, exactly as test_lifecycle_expectation_e2e.test.py's own "main" scenario does for the
+identical reason.
+
+"allowlist_not_named_is_inert" and "lifecycle_clean_shutdown" both configure
+``suppress: ["lifecycle"]`` for the second suppression mechanism this port carries (see
+lifecycle_shutdown_suppressor.hpp). In "allowlist_not_named_is_inert" it is chosen so the row
+is a well-formed "suppress names something, but not allowlist" rather than a malformed-entry
+row (C2's own territory); in "lifecycle_clean_shutdown" it is the entry that actually has to be
+present for the row's own claim to be testable at all - self-suppression is opt-in like every
+other mechanism here, so without naming it a correct detector reports both departed nodes.
+"""
+
+import os
+import re
+import signal
+import sys
+import time
+import unittest
+
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing
+from lifecycle_msgs.msg import Transition
+from lifecycle_msgs.srv import ChangeState
+import rclpy
+from rclpy.node import Node
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# I100 as well as E402: `harness` is only importable because of the sys.path line above, so this
+# import cannot be moved up to where the alphabetical order would put it.
+from harness import (  # noqa: E402, I100
+    API_BASE_PATH,
+    assert_fault_describes_only,
+    assert_fault_never_names,
+    create_watchdog_test_launch,
+    poll_detector_status,
+    poll_faults,
+    prove_never_names_proof_catches_a_wrongly_scoped_absence,
+    wait_until_faults_endpoint_live,
+    wait_until_watchdog_armed,
+    watchdog_detector_status,
+)
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
+
+# No default on purpose - see harness-consuming siblings' identical rationale: a default makes
+# this file FAIL OPEN. A KeyError is loud.
+SCENARIO = os.environ['WATCHDOG_E2E_SCENARIO']
+PORT = get_test_port()
+
+FAULT_CODE = 'GRAPH_NODE_DISAPPEARED'
+_NODE_DEATH_PREFIX = 'plugins.graph_watchdog.detectors.node_death'
+_LIFECYCLE_PREFIX = 'plugins.graph_watchdog.detectors.lifecycle_expectation'
+
+# Same fast cadence and miss_grace convention test_node_death_e2e.test.py uses: comfortably past
+# the documented 3000 ms floor (config sweep C1 owns the floor's own boundary values) without
+# accidentally landing on it.
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+MISS_GRACE = 20
+
+# The plain node every scenario but "lifecycle_clean_shutdown" kills - same DEMO_NODE_REGISTRY
+# fixture test_node_death_e2e.test.py uses, built by hand for the same reason: a scenario that
+# signals it needs a PID, and create_demo_nodes() gives none back.
+TARGET_NODE = 'calibration'
+TARGET_EXECUTABLE = 'demo_calibration_service'
+TARGET_NAMESPACE = '/powertrain/engine'
+
+ARM_TIMEOUT_SEC = 60.0
+FAULTS_LIVE_TIMEOUT_SEC = 30.0
+DEPARTURE_TIMEOUT_SEC = 30.0
+RAISE_TIMEOUT_SEC = 60.0
+# How long an absent or a persisting fault is watched for. Short (well under a minute) because
+# every window here is measured from the arming gate, not process start, so bringup cannot eat
+# it - matching test_node_death_e2e.test.py's SUSTAINED_WINDOW_SEC.
+SUSTAINED_WINDOW_SEC = 20.0
+# How long the "allowlist is inert" startup warning is waited for on the gateway's own stderr.
+# Config parsing happens at plugin set_context() time, at process start - well before the demo
+# node and fault_manager even come up (create_watchdog_test_launch's own demo_delay) - so this
+# only needs to be generous against process-startup jitter, not against anything downstream.
+WARNING_TIMEOUT_SEC = 30.0
+
+# Matches a single stderr line that names BOTH "allowlist" and "suppress" - the two config
+# keys an inert allowlist is about - at WARN severity, not the bare substring "allowlist",
+# which a detector could satisfy with an unrelated line ("allowlist contains 1 entry") while
+# never claiming anything is inert. Neither token pins node_death's own exact wording, but the
+# codebase's own convention (test_startup_param_clamp_warnings.test.py) is to echo a config key
+# verbatim in its warning, and an allowlist that suppress does not name must say so - i.e. be
+# logged via RCLCPP_WARN, whose default format always stamps the literal "[WARN]" tag. Requiring
+# all three on one line, in any order, rules out a routine config-echo (no [WARN]), a bare size
+# report (no "suppress"), and an unrelated warning that happens to mention "suppress" for a
+# different reason (no "allowlist") - none of which is the inert-allowlist warning this row is
+# about.
+_INERT_ALLOWLIST_WARNING_RE = re.compile(
+    r'^(?=.*\[WARN\])(?=.*\ballowlist\b)(?=.*\bsuppress\b).*$', re.IGNORECASE | re.MULTILINE)
+
+# ---- "lifecycle_clean_shutdown" scenario's own fixtures ---------------------------------------
+# Distinct, self-describing names so this scenario's own two nodes are never confused with the
+# plain TARGET_NODE above or with anything a shared demo fixture might also be named.
+CLEAN_NODE = 'suppress_lifecycle_clean'
+KILLED_NODE = 'suppress_lifecycle_active'
+LIFECYCLE_EXECUTABLE = 'managed_lifecycle'  # DEMO_NODE_REGISTRY's own executable for both variants
+LIFECYCLE_GRACE = 5
+
+# ---- "prune_no_false_heal" scenario's own prune_grace ------------------------------------------
+# Must be >= miss_grace + 1 (config sweep C1's own clamp) or it is silently raised to that floor.
+# Set to exactly the floor so pruning becomes eligible as soon as this scenario's own window can
+# show it.
+PRUNE_GRACE = MISS_GRACE + 1
+
+# ---- "prune_no_false_heal" scenario's own second, UNSUPPRESSED node ----------------------------
+# A second, independent identity carrying no suppression at all, so its death is an ordinary,
+# permanently-outstanding fault - the control this row needs to prove that reclaiming
+# TARGET_NODE's (suppressed, prune-eligible) bookkeeping never touches it.
+SECOND_NODE = 'prune_second_unsuppressed'
+SECOND_NAMESPACE = '/powertrain/unsuppressed'
+# How long the reclaim-delta baseline is allowed to take to SETTLE (see
+# _poll_stable_tracked_count) before either node departs. wait_until_watchdog_armed(app_id=...)
+# only proves the gate considers TARGET_NODE/SECOND_NODE armed, not that node_death's own tick
+# has already added their keys to tracker_ (see that helper's own docstring) - this is generous
+# against that residual lag, not against anything this scenario's own cycle does. Mirrors
+# test_node_death_e2e.test.py's identical STABLE_TRACKED_COUNT_TIMEOUT_SEC, same detector, same
+# hazard.
+STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0
+
+
+def _target_node_action():
+    """One manually-constructed TARGET_NODE action, with a PID handle the test can signal.
+
+    Mirrors DEMO_NODE_REGISTRY's own 'calibration' entry exactly, the same way
+    test_node_death_e2e.test.py's identical helper does - built by hand only because every
+    scenario in this file needs to SIGTERM it, and create_demo_nodes() hands back no PID.
+    Every scenario here kills it exactly once and never respawns it, so respawn is not a
+    parameter.
+    """
+    return launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable=TARGET_EXECUTABLE,
+        name=TARGET_NODE,
+        namespace=TARGET_NAMESPACE,
+        output='screen',
+        additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
+
+def _second_node_action():
+    """SECOND_NODE: a second, independent, never-allowlisted identity for "prune_no_false_heal".
+
+    Same executable as TARGET_NODE, under its own name/namespace so it is a genuinely distinct
+    node - built by hand for the same PID-handle reason _target_node_action() is.
+    """
+    return launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable=TARGET_EXECUTABLE,
+        name=SECOND_NODE,
+        namespace=SECOND_NAMESPACE,
+        output='screen',
+        additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
+
+def _lifecycle_node_action(name, *, auto_activate):
+    """One managed_lifecycle instance under `name`, optionally self-activating.
+
+    Same executable DEMO_NODE_REGISTRY's 'managed_lifecycle'/'managed_lifecycle_active' entries
+    use, launched by hand under this scenario's own names (not create_demo_nodes(), which hands
+    back no PID) so both instances can run side by side without colliding on the bare node name.
+    """
+    node_kwargs = {
+        'package': 'ros2_medkit_integration_tests',
+        'executable': LIFECYCLE_EXECUTABLE,
+        'name': name,
+        'namespace': '',
+        'output': 'screen',
+        'additional_env': get_coverage_env('ros2_medkit_integration_tests'),
+        'sigterm_timeout': '30',
+        'sigkill_timeout': '15',
+    }
+    if auto_activate:
+        node_kwargs['parameters'] = [{'auto_activate': True}]
+    return launch_ros.actions.Node(**node_kwargs)
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+    }
+    demo_nodes = []
+
+    if SCENARIO == 'allowlist_suppresses':
+        detector_params[f'{_NODE_DEATH_PREFIX}.allowlist'] = [TARGET_NODE]
+        detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['allowlist']
+    elif SCENARIO == 'allowlist_not_named_is_inert':
+        detector_params[f'{_NODE_DEATH_PREFIX}.allowlist'] = [TARGET_NODE]
+        # Non-empty and NOT "allowlist" - see the module docstring's own note on why this
+        # cannot be an empty list (ROS 2 launch crashes on an empty list parameter) and why
+        # this specific string is a placeholder for the framework's second mechanism rather
+        # than a malformed entry.
+        detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['lifecycle']
+    elif SCENARIO == 'lifecycle_clean_shutdown':
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [CLEAN_NODE, KILLED_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = LIFECYCLE_GRACE
+        # Suppression is opt-in by ruling: without naming the self-suppression mechanism here,
+        # a correct detector reports BOTH departed nodes, and this scenario's own "the clean one
+        # is never named" half would be false against a correct implementation.
+        detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['lifecycle']
+    elif SCENARIO == 'suppression_is_opt_in':
+        detector_params[f'{_NODE_DEATH_PREFIX}.allowlist'] = [TARGET_NODE]
+        # No 'suppress' key at all - the whole point of this scenario.
+    elif SCENARIO == 'prune_no_false_heal':
+        detector_params[f'{_NODE_DEATH_PREFIX}.miss_grace'] = MISS_GRACE
+        detector_params[f'{_NODE_DEATH_PREFIX}.prune_grace'] = PRUNE_GRACE
+        # Durable suppression is the only path prune() ever reclaims through - see the
+        # module docstring's own note on why an unsuppressed death cannot exercise it.
+        detector_params[f'{_NODE_DEATH_PREFIX}.allowlist'] = [TARGET_NODE]
+        detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['allowlist']
+    else:
+        raise RuntimeError(f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} has no launch configuration')
+
+    launch_description, context = create_watchdog_test_launch(
+        detector_params=detector_params,
+        demo_nodes=demo_nodes,
+        port=PORT,
+    )
+
+    if SCENARIO in ('allowlist_suppresses', 'allowlist_not_named_is_inert',
+                    'suppression_is_opt_in', 'prune_no_false_heal'):
+        target = _target_node_action()
+        launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+        context['target_node'] = target
+
+    if SCENARIO == 'prune_no_false_heal':
+        second = _second_node_action()
+        launch_description.add_action(TimerAction(period=2.0, actions=[second]))
+        context['second_node'] = second
+
+    if SCENARIO == 'lifecycle_clean_shutdown':
+        clean = _lifecycle_node_action(CLEAN_NODE, auto_activate=False)
+        killed = _lifecycle_node_action(KILLED_NODE, auto_activate=True)
+        launch_description.add_action(TimerAction(period=2.0, actions=[clean, killed]))
+        context['clean_node'] = clean
+        context['killed_node'] = killed
+
+    return launch_description, context
+
+
+# ---------------------------------------------------------------------------------------
+# Local helpers - read the same endpoints harness.py's own helpers do, or a service this
+# file's own scenario needs that no shared helper covers.
+# ---------------------------------------------------------------------------------------
+
+def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` is no longer listed. ``True`` once it is gone."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id not in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_absent({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _poll_watchdog_entity(port, app_id, lifecycle, timeout=30.0, interval=0.5):
+    """Poll GET /x-medkit-watchdog until `app_id` appears with this lifecycle label.
+
+    Same instrument, same rationale, as test_lifecycle_expectation_e2e.test.py's identical
+    local helper: proves the target's label was actually READ by the live stack, which
+    wait_until_watchdog_armed cannot (an unread label is treated as benign, so a run in which
+    the label never arrived would look identical to one where it did). '' (empty string) is
+    "asked, and still waiting", never "no data yet" - LifecycleWatcher seeds a tracked entry's
+    label to "" and only overwrites it once a real read succeeds.
+
+    Returns the matching entity dict, or ``None`` on timeout (after printing the last-seen
+    payload, which is gone once the launch tears down).
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /x-medkit-watchdog was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/x-medkit-watchdog', timeout=5)
+            if response.status_code != 200:
+                last_seen = f'HTTP {response.status_code} from GET /x-medkit-watchdog'
+            else:
+                status = response.json().get('x-medkit-watchdog', {})
+                last_seen = str(status)
+                for entity in status.get('entities') or []:
+                    if entity.get('id') == app_id and entity.get('lifecycle') == lifecycle:
+                        return entity
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /x-medkit-watchdog failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_watchdog_entity(app_id={app_id!r}, lifecycle={lifecycle!r}) timed out after '
+          f'{timeout}s; last watchdog status: {last_seen}')
+    return None
+
+
+def _call_change_state_once(client_node, service_name, transition_id, timeout=30.0):
+    """One ``ChangeState`` call against `service_name`. ``True`` on ``result.success``.
+
+    Same shape as test_node_death_e2e.test.py's identical local helper.
+    """
+    client = client_node.create_client(ChangeState, service_name)
+    try:
+        if not client.wait_for_service(timeout_sec=timeout):
+            return False
+        request = ChangeState.Request()
+        request.transition.id = transition_id
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+        result = future.result()
+        return result is not None and result.success
+    finally:
+        client_node.destroy_client(client)
+
+
+def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, interval=0.5):
+    """Poll the detector's status block until ``tracked_count`` holds steady.
+
+    "Holds steady" means the SAME value for a continuous `stable_seconds` before `timeout`
+    elapses. A single sample proves nothing about whether node_death has actually caught up:
+    wait_until_watchdog_armed(app_id=...) only proves the RELIABILITY GATE considers an entity
+    armed, not that node_death's own tick has already added its key to tracker_ - see that
+    helper's own docstring ("What this does NOT prove is that a detector has already READ the
+    app... Callers that need a captured baseline must still allow the sweep a window after this
+    returns"). A baseline read immediately after both TARGET_NODE and SECOND_NODE gate-arm can
+    therefore land before either one (or both) has actually joined tracked_count, understating
+    the baseline - and since this row's own claim is a tracked_count DELTA off that baseline, an
+    understated baseline makes the later reclaim assertion fail for a reason that has nothing to
+    do with prune(). Same helper, same detector, same hazard as
+    test_node_death_e2e.test.py's identical ``_poll_stable_tracked_count``.
+
+    Returns ``(status, stable)`` - `status` is the LAST status block read (possibly still
+    unsettled, so a caller can still report what it saw), `stable` is False if the value never
+    held for a continuous `stable_seconds` inside `timeout`.
+    """
+    deadline = time.monotonic() + timeout
+    status = None
+    last_count = None
+    streak_start = None
+    while time.monotonic() < deadline:
+        now = time.monotonic()
+        status = watchdog_detector_status(port, detector_id)
+        count = status.get('tracked_count') if status is not None else None
+        if count != last_count:
+            last_count = count
+            streak_start = now
+        elif now - streak_start >= stable_seconds:
+            return status, True
+        time.sleep(interval)
+    return status, False
+
+
+# ---------------------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------------------
+
+class TestSuppressionAllowlistSuppresses(unittest.TestCase):
+    """A node named in the allowlist, with suppress opting the allowlist in, is never named.
+
+    The claim is needle-scoped ("no GRAPH_NODE_DISAPPEARED names it"), not "the code never
+    appears at all": a correct detector raising the code for some OTHER entity in this launch
+    (the fault_manager's own node, say) must leave this row green, since that has nothing to do
+    with whether allowlist-suppression works. A bare code-absence check cannot tell the two
+    apart, so this uses assert_fault_never_names.
+
+    CANNOT DISCRIMINATE BY ITSELF: silence here is consistent with a suppressor correctly
+    honouring the allowlist, and equally consistent with one that never consults it, since both
+    leave the code unraised. Recorded as such rather than presented as proof of correct
+    suppression - ``test_allowlist_suppressor.cpp`` pins the matcher's own discrimination
+    directly, and ``prune_no_false_heal`` below runs the SAME allowlist against a second,
+    unlisted node under the identical config to show the two are told apart.
+    """
+
+    def test_allowlisted_death_never_raises(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed - the plugin did not load, '
+            f'{TARGET_NODE} was never discovered, or the bringup grace never elapsed, so no '
+            'absence below could mean anything',
+        )
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the absence below would prove nothing')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM - this scenario never produced '
+            'the departure it is named for',
+        )
+
+        assert_fault_never_names(
+            self, PORT, FAULT_CODE, forbidden=[TARGET_NODE], duration=SUSTAINED_WINDOW_SEC)
+
+    def test_self_test_catches_a_wrongly_scoped_absence(self):
+        """The test of the test for assert_fault_never_names, run once per this file.
+
+        Self-contained (a local HTTP server stands in for the gateway) - runs alongside the
+        real assertion above without depending on it, the same convention
+        test_node_death_e2e.test.py's own "raise" scenario and
+        test_lifecycle_expectation_e2e.test.py's "main" scenario already use for their own new
+        harness helpers.
+        """
+        prove_never_names_proof_catches_a_wrongly_scoped_absence(self)
+
+
+class TestSuppressionAllowlistNotNamedIsInert(unittest.TestCase):
+    """An allowlist that `suppress` does not name has no effect, and says so."""
+
+    def test_inert_allowlist_still_raises_and_warns(self, target_node, proc_output, gateway_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE} never raised after {TARGET_NODE} exited - an allowlist entry '
+                "that 'suppress' does not name must not suppress it")
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+        # The warning is read straight off the gateway's own stderr - the same instrument
+        # test_startup_param_clamp_warnings.test.py already uses for an identical "did we say
+        # so" claim. No exact wording is pinned (node_death's own log text is free to change);
+        # this asks that a WARN-severity line names BOTH "allowlist" and "suppress" together -
+        # see _INERT_ALLOWLIST_WARNING_RE for why the bare substring "allowlist" is not enough.
+        self.assertTrue(
+            proc_output.waitFor(
+                _INERT_ALLOWLIST_WARNING_RE, process=gateway_node, stream='stderr',
+                timeout=WARNING_TIMEOUT_SEC),
+            "no startup WARNING naming both 'allowlist' and 'suppress' on the same line "
+            f"appeared on the gateway's stderr within {WARNING_TIMEOUT_SEC}s - a configured "
+            'allowlist that suppress does not name must say so at WARN severity',
+        )
+
+
+class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
+    """Self-suppression: a require_active node that departed while not active is not named.
+
+    Two managed_lifecycle instances, both require_active-owned - self-suppression needs "this
+    node is owned by lifecycle_expectation", "it departed while not active", AND
+    ``detectors.node_death.suppress`` naming the mechanism (suppression is opt-in like every
+    other mechanism this package carries); the lifecycle label alone would over-suppress a node
+    nobody is watching, and leaving suppress unset would make a correct detector report both
+    departed nodes. CLEAN_NODE is driven through a real UNCONFIGURED_SHUTDOWN transition
+    (reaching "finalized", a non-active label) before its process dies; KILLED_NODE reaches
+    "active" on its own and is killed outright, still active. Only the second is a departure
+    lifecycle_expectation has nothing else to say about.
+
+    GRAPH_NODE_DISAPPEARED raises and names KILLED_NODE. The "CLEAN_NODE is never named" half
+    cannot, by itself, discriminate a working self-suppressor from no detector at all - both
+    leave CLEAN_NODE unnamed - so it is proven alongside the positive KILLED_NODE claim rather
+    than on its own.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_suppression_e2e_shutdown_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_clean_shutdown_not_named_active_kill_is(self, clean_node, killed_node):
+        # Global gate, not app_id: both nodes are require_active-tracked and neither starts
+        # active, so ReliabilityGate reports each of them "warming_up" (LifecycleWatcher's
+        # node_ok() is false for exactly this case) until KILLED_NODE activates - a per-entity
+        # gate on CLEAN_NODE specifically would wait for something that can never become true.
+        # Same reasoning test_lifecycle_expectation_e2e.test.py's "main" scenario gives for its
+        # identical choice.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, CLEAN_NODE, 'unconfigured', timeout=ARM_TIMEOUT_SEC),
+            f'{CLEAN_NODE} never read as "unconfigured" - the fixture was not discovered as a '
+            'managed node, or this scenario never set up the trigger it is named for',
+        )
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, KILLED_NODE, 'active', timeout=ARM_TIMEOUT_SEC),
+            f'{KILLED_NODE} never reached "active" on its own - the contrast this scenario '
+            'needs (an active node killed outright) was never set up',
+        )
+
+        change_state_service = f'/{CLEAN_NODE}/change_state'
+        self.assertTrue(
+            _call_change_state_once(
+                type(self)._client_node, change_state_service,
+                Transition.TRANSITION_UNCONFIGURED_SHUTDOWN, timeout=30.0),
+            f'the real UNCONFIGURED_SHUTDOWN transition on {CLEAN_NODE} was rejected or never '
+            'answered',
+        )
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, CLEAN_NODE, 'finalized', timeout=30.0),
+            f'{CLEAN_NODE} never read as "finalized" after its own UNCONFIGURED_SHUTDOWN - the '
+            'clean-shutdown trigger this scenario is about was never actually reached',
+        )
+
+        os.kill(clean_node.process_details['pid'], signal.SIGTERM)
+        os.kill(killed_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, CLEAN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{CLEAN_NODE} never left GET /apps after SIGTERM')
+        self.assertTrue(
+            _poll_apps_absent(PORT, KILLED_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{KILLED_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE} never raised after {KILLED_NODE} (active, killed outright) '
+                'exited - a departure lifecycle_expectation has nothing to say about must still '
+                'be named')
+
+        assert_fault_describes_only(
+            self, PORT, FAULT_CODE,
+            required=[KILLED_NODE], forbidden=[CLEAN_NODE],
+            duration=SUSTAINED_WINDOW_SEC)
+
+
+class TestSuppressionOptIn(unittest.TestCase):
+    """An allowlist entry with no `suppress` key at all does not suppress by itself."""
+
+    def test_no_suppress_key_still_raises(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE} never raised after {TARGET_NODE} exited - an allowlist entry '
+                'with no suppress key at all must not suppress by itself (suppression is '
+                'opt-in)')
+        self.assertIn(TARGET_NODE, fault.get('description', ''))
+
+
+class TestSuppressionPruneNoFalseHeal(unittest.TestCase):
+    """Reclaiming an allowlisted key's bookkeeping never heals an unrelated, still-true fault.
+
+    Two independent nodes. TARGET_NODE is on the allowlist (suppress: ["allowlist"]) - the
+    ONLY shape prune() ever reclaims through: node_liveness_tracker.hpp's own doc states the
+    consequence directly - an unsuppressed death has no reclaim path at all and so must stay
+    reported "permanent until acknowledged" for as long as it is actually dead. That is
+    exactly why this row cannot point its reclaim proof at an unsuppressed node: prune() would
+    never reclaim it, so a reclaim assertion against it could only ever fail. SECOND_NODE,
+    carrying no suppression, is instead the permanently-outstanding control, not a second
+    reclaim candidate.
+
+    Reclaim itself is proven as a tracked_count DELTA off a baseline, not against zero: the
+    aggregate also carries every other armed App in the graph (the gateway's own entity among
+    them), so it can never read exactly zero regardless of whether pruning works.
+    """
+
+    def test_pruning_the_suppressed_key_never_heals_the_unsuppressed_one(
+            self, target_node, second_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=TARGET_NODE),
+            f'graph_watchdog never reported {TARGET_NODE} armed')
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=SECOND_NODE),
+            f'graph_watchdog never reported {SECOND_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - the claims below would prove nothing about the '
+            'detector if the channel itself never came up',
+        )
+
+        # Baseline for the reclaim delta: both nodes are present and tracked NOW, before
+        # either departs. wait_until_watchdog_armed above proves the GATE considers both
+        # armed, not that node_death's own tick has already added their keys to tracker_ (see
+        # _poll_stable_tracked_count's own docstring) - so the baseline is read only once
+        # tracked_count has genuinely settled, not off the first sample after both gate-arm.
+        baseline, stable = _poll_stable_tracked_count(
+            PORT, 'node_death', timeout=STABLE_TRACKED_COUNT_TIMEOUT_SEC)
+        self.assertTrue(
+            stable,
+            f'node_death tracked_count never held steady before either node departed (last '
+            f'read: {baseline!r}) - the baseline below could not be trusted to already '
+            f'include {TARGET_NODE} and {SECOND_NODE}, which would make the reclaim delta '
+            'below meaningless',
+        )
+        self.assertIsNotNone(baseline, 'no node_death status block on GET /x-medkit-watchdog')
+        baseline_count = baseline['tracked_count']
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        os.kill(second_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{TARGET_NODE} never left GET /apps after SIGTERM')
+        self.assertTrue(
+            _poll_apps_absent(PORT, SECOND_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{SECOND_NODE} never left GET /apps after SIGTERM')
+
+        # SECOND_NODE carries no suppression: it must raise, ordinarily, like any other death.
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE} never raised after {SECOND_NODE} exited')
+
+        # PRUNE_GRACE consecutive suppressed ticks reclaims TARGET_NODE's own bookkeeping -
+        # tracked_count dropping by exactly one from the baseline, proving prune() genuinely
+        # ran (not merely that TARGET_NODE was never raised, which a deleted prune() would
+        # also produce). SECOND_NODE's own departed-but-unsuppressed entry stays tracked
+        # throughout - only TARGET_NODE's disappears - so the delta is exactly one.
+        self.assertTrue(
+            poll_detector_status(
+                PORT, 'node_death', 'tracked_count', baseline_count - 1,
+                timeout=RAISE_TIMEOUT_SEC),
+            f'{TARGET_NODE} was never reclaimed - detectors.node_death.tracked_count never '
+            f'dropped by exactly one from its baseline ({baseline_count}) even after '
+            'PRUNE_GRACE, so this row cannot tell a working prune() from one that never runs')
+
+        # The reclaim above must never have touched SECOND_NODE's own, unrelated, genuinely
+        # outstanding fault: it must stay CONFIRMED and keep naming SECOND_NODE - never
+        # TARGET_NODE - for a window spanning straight through the reclaim tick just observed.
+        # describes_only, not a bare presence check: a detector that let pruning heal the
+        # wrong entry, or empty the description, must turn this row red.
+        assert_fault_describes_only(
+            self, PORT, FAULT_CODE, required=[SECOND_NODE], forbidden=[TARGET_NODE],
+            duration=SUSTAINED_WINDOW_SEC)
+
+
+# Each CTest target launches this file with one scenario, so only that scenario's case may
+# run. Removing the others from the module (rather than skipping them) means each run reports
+# exactly one case, and a missing result is a real failure rather than an expected line of
+# output - see test_node_death_e2e.test.py's identical rationale.
+_SCENARIO_CASES = {
+    'allowlist_suppresses': 'TestSuppressionAllowlistSuppresses',
+    'allowlist_not_named_is_inert': 'TestSuppressionAllowlistNotNamedIsInert',
+    'lifecycle_clean_shutdown': 'TestSuppressionLifecycleCleanShutdown',
+    'suppression_is_opt_in': 'TestSuppressionOptIn',
+    'prune_no_false_heal': 'TestSuppressionPruneNoFalseHeal',
+}
+if SCENARIO not in _SCENARIO_CASES:
+    raise RuntimeError(
+        f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} is not one of {sorted(_SCENARIO_CASES)}; the '
+        'CTest target and this file disagree about which scenarios exist')
+for _scenario, _case_name in _SCENARIO_CASES.items():
+    if _scenario != SCENARIO:
+        del globals()[_case_name]
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager/demo stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -656,12 +656,13 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
         # consulted, and the row green for a mechanism that never ran - which is exactly how it
         # was vacuous before. A settled tracked_count is the detector's own signal that its
         # sweep has caught up.
-        _, admitted = _poll_stable_tracked_count(
+        before_walk, admitted = _poll_stable_tracked_count(
             PORT, DETECTOR_ID_NODE_DEATH, timeout=ARM_TIMEOUT_SEC, stable_seconds=3.0)
         self.assertTrue(
             admitted,
             "node_death's tracked_count never settled while both fixtures were active, so this "
             'row cannot tell whether the key it is about was ever admitted')
+        tracked_while_active = before_walk.get('tracked_count')
 
         # The whole way down, one real transition at a time, each one confirmed on the status
         # route before the next: the suppressor classifies the LAST label the watcher saw, and
@@ -684,6 +685,30 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
                 'watcher did not see the step, so the departure it records cannot be classified '
                 'as a clean shutdown',
             )
+
+        # The key is STILL tracked now that it reads "finalized", and that is what makes this row
+        # about self-suppression rather than about a key nobody ever admitted. The count alone is
+        # an aggregate, but the DIFFERENCE across the walk is not: nothing appeared or left the
+        # graph between the two samples - both fixtures are still running - so the only thing that
+        # changed is CLEAN_NODE's lifecycle label. A detector that refuses or drops a finalized
+        # key at admission whenever the lifecycle suppressor is configured shows up here as a
+        # count one lower, while passing every other assertion in this row and in its
+        # unsuppressed sibling. A correct one keeps the key: an EARNED admission is not withdrawn
+        # by a later non-active label, and suppression happens at report time, not at admission.
+        after_walk, settled = _poll_stable_tracked_count(
+            PORT, DETECTOR_ID_NODE_DEATH, timeout=ARM_TIMEOUT_SEC, stable_seconds=3.0)
+        self.assertTrue(
+            settled,
+            "node_death's tracked_count never settled after the shutdown walk")
+        self.assertEqual(
+            after_walk.get('tracked_count'), tracked_while_active,
+            f'node_death stopped tracking a key when {CLEAN_NODE} reached "finalized" '
+            f'({tracked_while_active} -> {after_walk.get("tracked_count")}, with both fixtures '
+            'still running and nothing else changed). The suppressor is only ever consulted for '
+            'a key that is still tracked when the node departs, so with the key dropped here the '
+            'silence below is a key that was never admitted, not self-suppression working',
+        )
+
         os.kill(clean_node.process_details['pid'], signal.SIGTERM)
         os.kill(killed_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -47,18 +47,22 @@ which assertions run:
   say) must not satisfy a warning this specific, so the pattern requires "allowlist" and
   "suppress" on the SAME line at WARN severity - see _INERT_ALLOWLIST_WARNING_RE.
 - "lifecycle_clean_shutdown": self-suppression - a node this package already watches through
-  lifecycle_expectation is suppressed only when it departed while not active, not a
-  lifecycle-agnostic notion of "clean". Two identical managed_lifecycle instances, both listed in
+  lifecycle_expectation is suppressed only when it departed through a real clean shutdown, not a
+  lifecycle-agnostic notion of "clean". The node is driven ACTIVE first and only then walked
+  down to finalized: node_death admits a managed key only on a measurement of "active", so a
+  fixture that never activates never reaches the suppressor at all and the row would pass with
+  the mechanism deleted. Two identical managed_lifecycle instances, both listed in
   ``detectors.lifecycle_expectation.require_active`` (self-suppression needs BOTH "this node is
-  require_active-owned" and "it departed while not active" - the lifecycle label alone would
-  over-suppress a node nobody is watching), AND ``detectors.node_death.suppress: ["lifecycle"]``
-  naming the self-suppression mechanism this row is about - suppression is opt-in by ruling, so
-  without that entry a correct detector reports BOTH departed nodes and this row's own "the clean
-  one is never named" half would be false against a correct implementation. One is driven through
-  a REAL ``lifecycle_msgs/srv/ChangeState`` UNCONFIGURED_SHUTDOWN transition (reaching
-  "finalized") before its process is killed; the other reaches "active" (auto_activate) and is
-  killed outright, still active. The finalized one is never named; the active one is - proven
-  with assert_fault_describes_only so the claim holds over the whole window, not one lucky read.
+  require_active-owned" and "it departed cleanly" - the lifecycle label alone would over-suppress
+  a node nobody is watching), AND ``detectors.node_death.suppress: ["lifecycle"]`` naming the
+  self-suppression mechanism this row is about - suppression is opt-in by ruling, so without that
+  entry a correct detector reports BOTH departed nodes and this row's own "the clean one is never
+  named" half would be false against a correct implementation. Both reach "active"
+  (auto_activate); one is then walked down through REAL
+  ``lifecycle_msgs/srv/ChangeState`` DEACTIVATE, CLEANUP and UNCONFIGURED_SHUTDOWN transitions
+  (reaching "finalized") before its process is killed, the other is killed outright while still
+  active. The finalized one is never named; the active one is - proven with
+  assert_fault_describes_only so the claim holds over the whole window, not one lucky read.
 - "suppression_is_opt_in": the allowlist key is set, but ``suppress`` is not configured AT ALL -
   merely naming a node on the allowlist must not suppress it by itself. The fault raises and
   names the node.
@@ -78,13 +82,14 @@ which assertions run:
 
 Every scenario gates on wait_until_watchdog_armed(PORT, app_id=...) BEFORE asserting anything -
 see harness.py's own docstring for why a stack that never came up otherwise produces exactly the
-silence an absence claim is looking for. "lifecycle_clean_shutdown" is the one exception: both its
-nodes are non-active managed_lifecycle instances, and ReliabilityGate reports a tracked node with
-a known non-active label as "warming_up" by design (LifecycleWatcher::node_ok() is false for
-exactly the node this whole detector class exists to catch) - so a per-entity armed gate on either
-one would wait for something that can never become true. It gates on the GLOBAL armed state
-instead, exactly as test_lifecycle_expectation_e2e.test.py's own "main" scenario does for the
-identical reason.
+silence an absence claim is looking for. "lifecycle_clean_shutdown" is the one exception: it
+walks one of its nodes down to "finalized", and ReliabilityGate reports a tracked node with a
+known non-active label as "warming_up" by design (LifecycleWatcher::node_ok() is false for
+exactly the node this whole detector class exists to catch) - so a per-entity armed gate on that
+one would stop being true partway through the row. It gates on the GLOBAL armed state instead,
+exactly as test_lifecycle_expectation_e2e.test.py's own "main" scenario does, and then waits for
+node_death's own tracked count to settle before driving anything, which is the fact the row
+actually depends on.
 
 "allowlist_not_named_is_inert" and "lifecycle_clean_shutdown" both configure
 ``suppress: ["lifecycle"]`` for the second suppression mechanism this port carries (see
@@ -141,11 +146,17 @@ PORT = get_test_port()
 
 FAULT_CODE = 'GRAPH_NODE_DISAPPEARED'
 _NODE_DEATH_PREFIX = 'plugins.graph_watchdog.detectors.node_death'
+DETECTOR_ID_NODE_DEATH = 'node_death'
 _LIFECYCLE_PREFIX = 'plugins.graph_watchdog.detectors.lifecycle_expectation'
 
 # Same fast cadence and miss_grace convention test_node_death_e2e.test.py uses: comfortably past
 # the documented 3000 ms floor (config sweep C1 owns the floor's own boundary values) without
-# accidentally landing on it.
+# accidentally landing on it. Applied to EVERY scenario in this file, not only the one that
+# reasons about the window: left unset, node_death takes kDefaultMissGrace (2), which spans
+# 600 ms at this tick and is silently raised to the floor (14) with a startup warning - so the
+# gateway would run on a grace no constant here names. Every silence window in this file is
+# SUSTAINED_WINDOW_SEC, several times the (MISS_GRACE + 1) * TICK_INTERVAL_MS a death needs, so
+# an unsuppressed report still lands well inside the window an absence claim watches.
 TICK_INTERVAL_MS = 200
 WARMUP_CYCLES = 3
 MISS_GRACE = 20
@@ -291,6 +302,7 @@ def generate_test_description():
     detector_params = {
         'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
         'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+        f'{_NODE_DEATH_PREFIX}.miss_grace': MISS_GRACE,
     }
     demo_nodes = []
 
@@ -304,18 +316,20 @@ def generate_test_description():
         # this specific string is a placeholder for the framework's second mechanism rather
         # than a malformed entry.
         detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['lifecycle']
-    elif SCENARIO == 'lifecycle_clean_shutdown':
+    elif SCENARIO in ('lifecycle_clean_shutdown', 'lifecycle_clean_shutdown_unsuppressed'):
         detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [CLEAN_NODE, KILLED_NODE]
         detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = LIFECYCLE_GRACE
-        # Suppression is opt-in by ruling: without naming the self-suppression mechanism here,
-        # a correct detector reports BOTH departed nodes, and this scenario's own "the clean one
-        # is never named" half would be false against a correct implementation.
-        detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['lifecycle']
+        if SCENARIO == 'lifecycle_clean_shutdown':
+            # Suppression is opt-in by ruling: without naming the self-suppression mechanism
+            # here, a correct detector reports BOTH departed nodes, and this scenario's own "the
+            # clean one is never named" half would be false against a correct implementation.
+            # The paired _unsuppressed scenario differs in this key and NOTHING else, which is
+            # what lets it stand in for the admission this row cannot observe directly.
+            detector_params[f'{_NODE_DEATH_PREFIX}.suppress'] = ['lifecycle']
     elif SCENARIO == 'suppression_is_opt_in':
         detector_params[f'{_NODE_DEATH_PREFIX}.allowlist'] = [TARGET_NODE]
         # No 'suppress' key at all - the whole point of this scenario.
     elif SCENARIO == 'prune_no_false_heal':
-        detector_params[f'{_NODE_DEATH_PREFIX}.miss_grace'] = MISS_GRACE
         detector_params[f'{_NODE_DEATH_PREFIX}.prune_grace'] = PRUNE_GRACE
         # Durable suppression is the only path prune() ever reclaims through - see the
         # module docstring's own note on why an unsuppressed death cannot exercise it.
@@ -341,8 +355,13 @@ def generate_test_description():
         launch_description.add_action(TimerAction(period=2.0, actions=[second]))
         context['second_node'] = second
 
-    if SCENARIO == 'lifecycle_clean_shutdown':
-        clean = _lifecycle_node_action(CLEAN_NODE, auto_activate=False)
+    if SCENARIO in ('lifecycle_clean_shutdown', 'lifecycle_clean_shutdown_unsuppressed'):
+        # auto_activate: the suppressor is only ever consulted for a key node_death ADMITTED,
+        # and it admits a managed node only once the graph has measured it active. A fixture
+        # that never activates is refused before the suppressor exists, so the row that names
+        # this mechanism has to start from a node that genuinely became the presence
+        # detector's, then walk the whole way down to finalized.
+        clean = _lifecycle_node_action(CLEAN_NODE, auto_activate=True)
         killed = _lifecycle_node_action(KILLED_NODE, auto_activate=True)
         launch_description.add_action(TimerAction(period=2.0, actions=[clean, killed]))
         context['clean_node'] = clean
@@ -455,7 +474,11 @@ def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, 
     deadline = time.monotonic() + timeout
     status = None
     last_count = None
-    streak_start = None
+    # Seeded, not left None: the first sample can legitimately BE None (the route not up yet, or
+    # answering without a block for this detector), and None == last_count then takes the elif
+    # on the very first pass - which used to subtract from None and raise TypeError, turning an
+    # unrelated slow start into an error rather than a wait.
+    streak_start = time.monotonic()
     while time.monotonic() < deadline:
         now = time.monotonic()
         status = watchdog_detector_status(port, detector_id)
@@ -463,7 +486,10 @@ def _poll_stable_tracked_count(port, detector_id, timeout, stable_seconds=10.0, 
         if count != last_count:
             last_count = count
             streak_start = now
-        elif now - streak_start >= stable_seconds:
+        elif count is not None and now - streak_start >= stable_seconds:
+            # A route that never answers holds None steady forever; that is not a settled
+            # count, it is an absent one, and calling it stable would hand the caller a
+            # baseline it never read.
             return status, True
         time.sleep(interval)
     return status, False
@@ -559,7 +585,17 @@ class TestSuppressionAllowlistNotNamedIsInert(unittest.TestCase):
 
 
 class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
-    """Self-suppression: a require_active node that departed while not active is not named.
+    """Self-suppression: a node that reached a clean shutdown before departing is not named.
+
+    The route to the mechanism matters as much as the outcome, because for a long time this row
+    did not take it. The suppressor is consulted only for a key node_death ADMITTED, and it
+    admits a managed node only once the graph has measured it ACTIVE - so a fixture that sat at
+    unconfigured and was shut down from there never entered the dead set, never reached the
+    suppressor, and left this row green with the suppressor deleted entirely. It now starts the
+    node active, waits for node_death's own tracked count to settle so the admission is real
+    rather than assumed, and walks it down deactivate, cleanup, shutdown with each step
+    confirmed on the status route before the next - which is what leaves the watcher holding
+    "finalized" WITH the transitions that classify it as clean.
 
     Two managed_lifecycle instances, both require_active-owned - self-suppression needs "this
     node is owned by lifecycle_expectation", "it departed while not active", AND
@@ -602,9 +638,10 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
             'GET /faults never answered 200 - nothing below would prove anything')
 
         self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, CLEAN_NODE, 'unconfigured', timeout=ARM_TIMEOUT_SEC),
-            f'{CLEAN_NODE} never read as "unconfigured" - the fixture was not discovered as a '
-            'managed node, or this scenario never set up the trigger it is named for',
+            _poll_watchdog_entity(PORT, CLEAN_NODE, 'active', timeout=ARM_TIMEOUT_SEC),
+            f'{CLEAN_NODE} never reached "active" - node_death only admits a managed node the '
+            'graph has measured active, and a key it never admitted never reaches the '
+            'suppressor at all, so the whole row would pass without the mechanism existing',
         )
         self.assertIsNotNone(
             _poll_watchdog_entity(PORT, KILLED_NODE, 'active', timeout=ARM_TIMEOUT_SEC),
@@ -612,20 +649,41 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
             'needs (an active node killed outright) was never set up',
         )
 
-        change_state_service = f'/{CLEAN_NODE}/change_state'
+        # And the presence detector has to have ADMITTED it before anything is driven, which
+        # the route's label does not say: the label is LifecycleWatcher's, republished the
+        # moment a transition_event lands, while the admission happens on node_death's own next
+        # tick. Deactivating in that gap leaves the key never admitted, the suppressor never
+        # consulted, and the row green for a mechanism that never ran - which is exactly how it
+        # was vacuous before. A settled tracked_count is the detector's own signal that its
+        # sweep has caught up.
+        _, admitted = _poll_stable_tracked_count(
+            PORT, DETECTOR_ID_NODE_DEATH, timeout=ARM_TIMEOUT_SEC, stable_seconds=3.0)
         self.assertTrue(
-            _call_change_state_once(
-                type(self)._client_node, change_state_service,
-                Transition.TRANSITION_UNCONFIGURED_SHUTDOWN, timeout=30.0),
-            f'the real UNCONFIGURED_SHUTDOWN transition on {CLEAN_NODE} was rejected or never '
-            'answered',
-        )
-        self.assertIsNotNone(
-            _poll_watchdog_entity(PORT, CLEAN_NODE, 'finalized', timeout=30.0),
-            f'{CLEAN_NODE} never read as "finalized" after its own UNCONFIGURED_SHUTDOWN - the '
-            'clean-shutdown trigger this scenario is about was never actually reached',
-        )
+            admitted,
+            "node_death's tracked_count never settled while both fixtures were active, so this "
+            'row cannot tell whether the key it is about was ever admitted')
 
+        # The whole way down, one real transition at a time, each one confirmed on the status
+        # route before the next: the suppressor classifies the LAST label the watcher saw, and
+        # it only counts "finalized" when it also saw the transitions leading there. Jumping
+        # straight to shutdown from a node that never activated is what made this row vacuous.
+        change_state_service = f'/{CLEAN_NODE}/change_state'
+        for transition_id, reached in (
+                (Transition.TRANSITION_DEACTIVATE, 'inactive'),
+                (Transition.TRANSITION_CLEANUP, 'unconfigured'),
+                (Transition.TRANSITION_UNCONFIGURED_SHUTDOWN, 'finalized')):
+            self.assertTrue(
+                _call_change_state_once(
+                    type(self)._client_node, change_state_service, transition_id, timeout=30.0),
+                f'the real transition {transition_id} on {CLEAN_NODE} was rejected or never '
+                'answered, so the clean shutdown this row is about was never performed',
+            )
+            self.assertIsNotNone(
+                _poll_watchdog_entity(PORT, CLEAN_NODE, reached, timeout=30.0),
+                f'{CLEAN_NODE} never read as "{reached}" after transition {transition_id} - the '
+                'watcher did not see the step, so the departure it records cannot be classified '
+                'as a clean shutdown',
+            )
         os.kill(clean_node.process_details['pid'], signal.SIGTERM)
         os.kill(killed_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
@@ -645,6 +703,102 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
         assert_fault_describes_only(
             self, PORT, FAULT_CODE,
             required=[KILLED_NODE], forbidden=[CLEAN_NODE],
+            duration=SUSTAINED_WINDOW_SEC)
+
+
+class TestSuppressionLifecycleCleanShutdownUnsuppressed(unittest.TestCase):
+    """The control for the row above: without `suppress`, the cleanly shut-down node IS named.
+
+    The suppressed row cannot prove what it most needs to. Its positive claim is about
+    KILLED_NODE and its negative claim is that CLEAN_NODE is never named - and "never named" is
+    equally true of a node the presence detector never ADMITTED, so an implementation that
+    admits only the node it is going to report would pass it. The settled tracked_count that row
+    waits on is an aggregate: it says some number of keys is being tracked, never which.
+
+    This scenario is the same launch with `detectors.node_death.suppress` removed and nothing
+    else changed. It drives CLEAN_NODE down the identical deactivate/cleanup/shutdown walk and
+    kills both processes the same way, and requires BOTH names in the description. A key that
+    was never admitted cannot be named whatever the suppression configuration, so the pair
+    together says what neither says alone: CLEAN_NODE entered node_death's tracked set, and the
+    suppressor - not an absent admission - is what keeps it out of the fault.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('node_death_suppression_e2e_unsuppressed_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_without_the_suppressor_the_clean_node_is_named_too(self, clean_node, killed_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC),
+            'graph_watchdog never reported an armed global state')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        for node_id in (CLEAN_NODE, KILLED_NODE):
+            self.assertIsNotNone(
+                _poll_watchdog_entity(PORT, node_id, 'active', timeout=ARM_TIMEOUT_SEC),
+                f'{node_id} never reached "active" - node_death only admits a managed node the '
+                'graph has measured active, so this control would be measuring the same '
+                'never-admitted key the suppressed row cannot rule out',
+            )
+
+        # Same gate as the suppressed row, for the same reason: the route's label is the
+        # watcher's and moves the instant a transition_event lands, while admission happens on
+        # node_death's own next tick.
+        _, admitted = _poll_stable_tracked_count(
+            PORT, DETECTOR_ID_NODE_DEATH, timeout=ARM_TIMEOUT_SEC, stable_seconds=3.0)
+        self.assertTrue(
+            admitted,
+            "node_death's tracked_count never settled while both fixtures were active")
+
+        change_state_service = f'/{CLEAN_NODE}/change_state'
+        for transition_id, reached in (
+                (Transition.TRANSITION_DEACTIVATE, 'inactive'),
+                (Transition.TRANSITION_CLEANUP, 'unconfigured'),
+                (Transition.TRANSITION_UNCONFIGURED_SHUTDOWN, 'finalized')):
+            self.assertTrue(
+                _call_change_state_once(
+                    type(self)._client_node, change_state_service, transition_id, timeout=30.0),
+                f'the real transition {transition_id} on {CLEAN_NODE} was rejected or never '
+                'answered, so this control is not driving the same shutdown the suppressed row '
+                'does',
+            )
+            self.assertIsNotNone(
+                _poll_watchdog_entity(PORT, CLEAN_NODE, reached, timeout=30.0),
+                f'{CLEAN_NODE} never read as "{reached}" after transition {transition_id}',
+            )
+
+        os.kill(clean_node.process_details['pid'], signal.SIGTERM)
+        os.kill(killed_node.process_details['pid'], signal.SIGTERM)
+        for node_id in (CLEAN_NODE, KILLED_NODE):
+            self.assertTrue(
+                _poll_apps_absent(PORT, node_id, timeout=DEPARTURE_TIMEOUT_SEC),
+                f'{node_id} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(f'{FAULT_CODE} never raised after both fixtures exited')
+
+        # BOTH, sustained. The clean one being named here is the whole point: it proves the key
+        # was in the tracked set all along, which is what the suppressed row's silence cannot
+        # distinguish from a key that was never there.
+        description = fault.get('description', '')
+        self.assertIn(
+            CLEAN_NODE, description,
+            f'{CLEAN_NODE} shut down cleanly and departed, and with no suppressor configured it '
+            f'was still not named (description: {description!r}) - node_death never admitted '
+            'that key, so the suppressed row proves nothing about self-suppression',
+        )
+        assert_fault_describes_only(
+            self, PORT, FAULT_CODE,
+            required=[CLEAN_NODE, KILLED_NODE], forbidden=[],
             duration=SUSTAINED_WINDOW_SEC)
 
 
@@ -763,6 +917,7 @@ _SCENARIO_CASES = {
     'allowlist_suppresses': 'TestSuppressionAllowlistSuppresses',
     'allowlist_not_named_is_inert': 'TestSuppressionAllowlistNotNamedIsInert',
     'lifecycle_clean_shutdown': 'TestSuppressionLifecycleCleanShutdown',
+    'lifecycle_clean_shutdown_unsuppressed': 'TestSuppressionLifecycleCleanShutdownUnsuppressed',
     'suppression_is_opt_in': 'TestSuppressionOptIn',
     'prune_no_false_heal': 'TestSuppressionPruneNoFalseHeal',
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -127,7 +127,11 @@ from harness import (  # noqa: E402, I100
     watchdog_detector_status,
 )
 
-from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, get_test_port  # noqa: E402
+from ros2_medkit_test_utils.constants import (  # noqa: E402
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
 from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
 
 # No default on purpose - see harness-consuming siblings' identical rationale: a default makes
@@ -153,10 +157,21 @@ TARGET_NODE = 'calibration'
 TARGET_EXECUTABLE = 'demo_calibration_service'
 TARGET_NAMESPACE = '/powertrain/engine'
 
-ARM_TIMEOUT_SEC = 60.0
-FAULTS_LIVE_TIMEOUT_SEC = 30.0
-DEPARTURE_TIMEOUT_SEC = 30.0
-RAISE_TIMEOUT_SEC = 60.0
+# The budgets below are scaled by MEDKIT_TEST_TIME_SCALE, which the sanitizer jobs set to the
+# same factor they apply to every declared CTest timeout. A deadline asserted INSIDE a test is
+# invisible to that rewrite, so an instrumented graph that takes longer to forget a departed
+# node blows a budget here and the failure reads as a detector that never reported - the exact
+# red this suite exists to produce for a real defect. Unset elsewhere, so the normal jobs keep
+# the tight budgets that give these assertions their falsifying edge.
+#
+# Poll intervals, enforced respawn delays and the sustained-observation windows are NOT scaled.
+# Those are not give-up bounds: stretching a window a scenario watches for silence buys no
+# confidence and spends the whole package's test budget to do it.
+TIME_SCALE = get_time_scale()
+ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
+FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long an absent or a persisting fault is watched for. Short (well under a minute) because
 # every window here is measured from the arming gate, not process start, so bringup cannot eat
 # it - matching test_node_death_e2e.test.py's SUSTAINED_WINDOW_SEC.
@@ -165,7 +180,7 @@ SUSTAINED_WINDOW_SEC = 20.0
 # Config parsing happens at plugin set_context() time, at process start - well before the demo
 # node and fault_manager even come up (create_watchdog_test_launch's own demo_delay) - so this
 # only needs to be generous against process-startup jitter, not against anything downstream.
-WARNING_TIMEOUT_SEC = 30.0
+WARNING_TIMEOUT_SEC = 30.0 * TIME_SCALE
 
 # Matches a single stderr line that names BOTH "allowlist" and "suppress" - the two config
 # keys an inert allowlist is about - at WARN severity, not the bare substring "allowlist",
@@ -208,7 +223,7 @@ SECOND_NAMESPACE = '/powertrain/unsuppressed'
 # against that residual lag, not against anything this scenario's own cycle does. Mirrors
 # test_node_death_e2e.test.py's identical STABLE_TRACKED_COUNT_TIMEOUT_SEC, same detector, same
 # hazard.
-STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0
+STABLE_TRACKED_COUNT_TIMEOUT_SEC = 40.0 * TIME_SCALE
 
 
 def _target_node_action():

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -184,11 +184,11 @@ ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
 FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Unchanged, and now it only has to cover what it can actually be held to. Every call site
 # proves the process EXITED first (assert_process_exited), so the two terms left are the ones
-# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
-# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
-# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
-# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
-# is gone' costs" note for who promises which term.
+# somebody owns: the DDS participant lease an unclean death costs before the graph drops the
+# participant, plus the gateway's own graph-to-/apps latency - 20 + 1.1 = 21.1 s. 30 s clears
+# that with room for the sanitizer jobs, so nothing here needed widening. Both figures, and
+# who promises which term, are in the gateway's docs/config/server.rst under "How long a
+# departed node keeps being listed".
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long an absent or a persisting fault is watched for. Short (well under a minute) because

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_suppression_e2e.test.py
@@ -123,6 +123,7 @@ from harness import (  # noqa: E402, I100
     API_BASE_PATH,
     assert_fault_describes_only,
     assert_fault_never_names,
+    assert_process_exited,
     create_watchdog_test_launch,
     poll_detector_status,
     poll_faults,
@@ -181,6 +182,13 @@ TARGET_NAMESPACE = '/powertrain/engine'
 TIME_SCALE = get_time_scale()
 ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
 FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+# Unchanged, and now it only has to cover what it can actually be held to. Every call site
+# proves the process EXITED first (assert_process_exited), so the two terms left are the ones
+# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
+# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
+# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
+# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
+# is gone' costs" note for who promises which term.
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
 # How long an absent or a persisting fault is watched for. Short (well under a minute) because
@@ -528,6 +536,7 @@ class TestSuppressionAllowlistSuppresses(unittest.TestCase):
             'GET /faults never answered 200 - the absence below would prove nothing')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM - this scenario never produced '
@@ -558,6 +567,7 @@ class TestSuppressionAllowlistNotNamedIsInert(unittest.TestCase):
             f'graph_watchdog never reported {TARGET_NODE} armed')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -711,6 +721,8 @@ class TestSuppressionLifecycleCleanShutdown(unittest.TestCase):
 
         os.kill(clean_node.process_details['pid'], signal.SIGTERM)
         os.kill(killed_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, clean_node.process_details['pid'], CLEAN_NODE)
+        assert_process_exited(self, killed_node.process_details['pid'], KILLED_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, CLEAN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{CLEAN_NODE} never left GET /apps after SIGTERM')
@@ -802,6 +814,8 @@ class TestSuppressionLifecycleCleanShutdownUnsuppressed(unittest.TestCase):
 
         os.kill(clean_node.process_details['pid'], signal.SIGTERM)
         os.kill(killed_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, clean_node.process_details['pid'], CLEAN_NODE)
+        assert_process_exited(self, killed_node.process_details['pid'], KILLED_NODE)
         for node_id in (CLEAN_NODE, KILLED_NODE):
             self.assertTrue(
                 _poll_apps_absent(PORT, node_id, timeout=DEPARTURE_TIMEOUT_SEC),
@@ -836,6 +850,7 @@ class TestSuppressionOptIn(unittest.TestCase):
             f'graph_watchdog never reported {TARGET_NODE} armed')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')
@@ -899,6 +914,8 @@ class TestSuppressionPruneNoFalseHeal(unittest.TestCase):
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
         os.kill(second_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], TARGET_NODE)
+        assert_process_exited(self, second_node.process_details['pid'], SECOND_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, TARGET_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{TARGET_NODE} never left GET /apps after SIGTERM')

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
@@ -123,6 +123,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from harness import (  # noqa: E402, I100
     API_BASE_PATH,
     assert_fault_absent_throughout,
+    assert_fault_never_names,
     create_watchdog_test_launch,
     poll_fault_describing,
     poll_faults,
@@ -659,21 +660,24 @@ class TestBudgetSpentThenOwned(unittest.TestCase):
             wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
             'GET /faults never answered 200 - nothing below would prove anything')
 
-        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        # SETTLED ignorance, read off the route rather than argued from how many ticks the
+        # steps above must have cost: measurement_pending=False is the watcher saying it has
+        # stopped asking. Without it this polls only for an unread label, which is equally true
+        # while the reads are still in flight - the PENDING half of the bound, where the
+        # opposite answer is correct and this row would be testing the other case.
+        entity = _poll_watchdog_entity(
+            PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC, measurement_pending=False)
         self.assertIsNotNone(
             entity,
-            f'{UNREADABLE_NODE} never appeared with an EMPTY lifecycle label - the fixture was '
-            'either not tracked as managed at all or its GetState was answered, and this row '
-            'needs a node that is tracked and unmeasured')
+            f'{UNREADABLE_NODE} never reached an EMPTY lifecycle label with the asking finished '
+            '- the fixture was either not tracked as managed at all, or its GetState was '
+            'answered, or the watcher is still retrying; this row needs a node that is tracked '
+            'and settled-unmeasured')
         self.assertTrue(
             entity.get('armed'),
             f'{UNREADABLE_NODE} is unmeasured but NOT armed, so node_death would decline it for '
             'the warmup reason instead of the ownership reason this row is about')
 
-        # The budget is spent within a handful of ticks of discovery (kReseedAttempts issued
-        # reads, each cut off by the reader's own timeout), and everything above has already
-        # cost far more than that. Killing here therefore lands in the SETTLED half of the
-        # bound, which is what this row is about.
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
@@ -730,11 +734,14 @@ class TestNoRequireActiveStillOwned(unittest.TestCase):
             wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
             'GET /faults never answered 200 - nothing below would prove anything')
 
-        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        # Settled, not merely unread - same instrument and same reason as the sibling row: an
+        # unread label alone is also what a node in the middle of its reseed attempts shows.
+        entity = _poll_watchdog_entity(
+            PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC, measurement_pending=False)
         self.assertIsNotNone(
             entity,
-            f'{UNREADABLE_NODE} never appeared with an EMPTY lifecycle label, so this row is not '
-            'about an unmeasured managed node at all')
+            f'{UNREADABLE_NODE} never reached an EMPTY lifecycle label with the asking finished, '
+            'so this row is not about a settled-unmeasured managed node at all')
         self.assertTrue(entity.get('armed'))
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
@@ -1112,8 +1119,14 @@ class TestProvisionalOwnershipYieldsToARealLabel(unittest.TestCase):
             'detector handed back was then reported by nobody at all '
             f'(last description: {description!r})')
 
-        assert_fault_absent_throughout(
-            self, PORT, FAULT_CODE_DISAPPEARED, SILENCE_WINDOW_SEC)
+        # Needle-scoped, and the distinction is not cosmetic: the code-only form fails for a
+        # GRAPH_NODE_DISAPPEARED about ANY node, so its red cannot say whether the handover
+        # broke or some unrelated entity died, and a reader has to go and find out. This row's
+        # claim is about one node, so the assertion names it and the next failure carries the
+        # answer. Anything else disappearing here is not this row's business.
+        assert_fault_never_names(
+            self, PORT, FAULT_CODE_DISAPPEARED, forbidden=[UNREADABLE_NODE],
+            duration=SILENCE_WINDOW_SEC)
 
 
 class TestGateStaysPermissiveForTheOtherDetectors(unittest.TestCase):

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
@@ -1,0 +1,1237 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Presence ownership e2e: which detector owns the departure of an UNMEASURED managed node.
+
+The division of labour between the two detectors rests on one question - will node_death be
+able to report this node's departure - and that question has to be answered from knowledge, not
+from the reliability gate's silence about a lifecycle state nobody has read. The gate answers
+"fine" for a managed node whose label is still empty exactly as it does for one reading
+"active", and those are not the same fact.
+
+test_node_death_boundary_e2e.test.py's B6 row already covers the shape with a REAL managed node
+that answers "unconfigured": a required node that never activates, killed below `grace`, must be
+reported by GRAPH_NODE_INACTIVE and never by GRAPH_NODE_DISAPPEARED. What it cannot do is hold
+the label EMPTY on purpose - a real rclcpp_lifecycle node answers GetState immediately, so the
+unmeasured window there is a race between the seed and the warmup, wide open on a loaded runner
+and shut on an idle one. This file makes that window permanent by using the fixture whose
+GetState never answers at all, and adds the discriminating other half: the same fixture, told to
+start answering, must end up owned by the presence detector after all.
+
+Ignorance is BOUNDED, and that bound is what these scenarios are about. Presence ownership is
+withheld only while the ignorance can still resolve: LifecycleWatcher charges its GetState
+re-seed budget per node and only for a read that actually ran, so an empty label with attempts
+left is "we have not finished asking" and an empty label with the budget spent is "we asked and
+failed". Refusing ownership past that point is not a handover, it is a silence - nothing else
+will ever measure the node, and `lifecycle_expectation` returns early unless an operator named
+it in `require_active`, which defaults to empty.
+
+Runs as FIVE separate CTest targets (see CMakeLists.txt). WATCHDOG_E2E_SCENARIO selects which
+launch and which assertions run:
+
+- "budget_spent_then_owned": the fixture is never told to answer, so its label stays "" for its
+  whole life; it is killed once the watcher has spent every GetState attempt it will ever make.
+  GRAPH_NODE_DISAPPEARED must raise and name it, and GRAPH_NODE_UNREADABLE must raise too - both
+  are true at once, and neither excuses the other. `require_active` names the node here.
+- "no_require_active_still_owned": the same fixture and the same kill, with NO `require_active`
+  entry anywhere in the configuration - the SHIPPED default. Nothing but node_death can report
+  this death, so GRAPH_NODE_DISAPPEARED must raise and name it. Paired with the row above, it
+  also rules out an implementation that decides ownership from `require_active` membership
+  rather than from lifecycle knowledge: the two rows differ in exactly that configuration and
+  expect the same answer.
+- "answered_then_owned": the same fixture under the SAME configuration as
+  "budget_spent_then_owned" (`require_active` names it), unmeasured across the whole warmup
+  (proven from the status route, not assumed), then told to answer via its `start_answering`
+  parameter. Once the label reads "active" the node is killed, and GRAPH_NODE_DISAPPEARED must
+  raise naming it. The only variable against its sibling is what the node's lifecycle state
+  turned out to be.
+- "measured_then_unmeasured": the reverse transition, on a live node, followed by its departure.
+  `droppable_lifecycle_node` answers "active" (measured, and owned), then stops advertising its
+  lifecycle services on command - the watcher drops the record and the status route reports
+  `lifecycle: null` - and only then is it killed. GRAPH_NODE_DISAPPEARED must still raise: a
+  node whose measurement goes away does not stop being the presence detector's.
+- "provisional_yields_to_a_real_label": the row that separates the two GROUNDS for ownership.
+  The same never-answering fixture is left until its budget is spent, so the presence detector
+  owns it PROVISIONALLY, and only then is it told to announce "inactive" - the
+  ~/transition_event subscription outlives the seed budget, so a real label genuinely can still
+  arrive. Once the status route reports that label the node is killed. GRAPH_NODE_INACTIVE must
+  raise and name it, and GRAPH_NODE_DISAPPEARED must never appear: the only reason the presence
+  detector held this node was that nobody else could report it, and the label ends that. It is
+  also the one row that rejects a detector wired to the permissive `reliability_allows()`, which
+  admits the node during the unread window and, tracking being sticky, never lets go.
+- "restart_inside_warmup": a crash loop whose uptime is shorter than the warmup. The node is
+  killed, reported, and comes back - and while it is merely RE-WARMING the gate has no claim to
+  state either way, which is not the same fact as the graph having measured the node as another
+  detector's. A key already admitted must survive that, or its next death is reported by nobody
+  and the detector spends the whole outage saying PASSED. The row kills the returned node
+  without waiting for it to arm, and asserts both halves: the second death advances the stored
+  record's `last_occurred`, and `last_passed` stays frozen for as long as the node is dead.
+- "gate_unaffected": nothing is killed. With the same unmeasured managed node in the graph, the
+  three other detectors must still report. GRAPH_PARAM_DRIFT is the discriminating leg - it is
+  the only one of the three whose raise passes through the app-keyed gate at all
+  (param_drift_detector.cpp calls reliability_allows(ctx.gate, app_id)), so it can only name
+  this node if the gate still permits an unread label. GRAPH_QOS_MISMATCH and GRAPH_ORPHAN are
+  keyed by topic rather than by App::id (orphan_detector.cpp says so in its own class doc, and
+  qos_mismatch_detector.cpp never consults the gate), so the app-keyed predicate can never
+  suppress them; their legs guard against a regression that stopped either detector reporting
+  at all in a graph carrying such a node, and the QoS leg's mismatched pair includes the
+  fixture's OWN publisher.
+
+### Which arming gate
+
+Every scenario here gates on the `app_id` of the node it perturbs. That works
+precisely because of the behaviour under test: LifecycleWatcher::node_ok() treats an unread
+label as ok, so the gate does reach the per-entity "armed" state for this fixture even while
+nothing has ever been measured. A scenario whose target never becomes per-entity armed (a node
+sitting at "unconfigured", say) has to use the global form instead - see
+test_node_death_boundary_e2e.test.py's own "Which arming gate" section.
+"""
+
+import os
+import signal
+import sys
+import time
+import unittest
+
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing
+from lifecycle_msgs.msg import TransitionEvent
+from rcl_interfaces.msg import Parameter, ParameterType, ParameterValue
+from rcl_interfaces.srv import SetParameters
+import rclpy
+from rclpy.duration import Duration
+from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
+import requests
+from sensor_msgs.msg import LaserScan
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+# I100 as well as E402: `harness` is only importable because of the sys.path line above, so this
+# import cannot be moved up to where the alphabetical order would put it.
+from harness import (  # noqa: E402, I100
+    API_BASE_PATH,
+    assert_fault_absent_throughout,
+    create_watchdog_test_launch,
+    poll_fault_describing,
+    poll_faults,
+    wait_until_faults_endpoint_live,
+    wait_until_watchdog_armed,
+    watchdog_detector_status,
+)
+
+from ros2_medkit_test_utils.constants import (  # noqa: E402
+    ALLOWED_EXIT_CODES,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.coverage import get_coverage_env  # noqa: E402
+from ros2_medkit_test_utils.launch_helpers import DEMO_NODE_REGISTRY  # noqa: E402
+
+# No default on purpose - see the harness-consuming siblings' identical rationale: a default
+# makes this file FAIL OPEN, because generate_test_description() would then silently build some
+# other scenario's launch while the assertions still ran. A KeyError is loud and immediate.
+SCENARIO = os.environ['WATCHDOG_E2E_SCENARIO']
+PORT = get_test_port()
+
+FAULT_CODE_DISAPPEARED = 'GRAPH_NODE_DISAPPEARED'
+FAULT_CODE_INACTIVE = 'GRAPH_NODE_INACTIVE'
+FAULT_CODE_UNREADABLE = 'GRAPH_NODE_UNREADABLE'
+FAULT_CODE_PARAM_DRIFT = 'GRAPH_PARAM_DRIFT'
+FAULT_CODE_QOS = 'GRAPH_QOS_MISMATCH'
+FAULT_CODE_ORPHAN = 'GRAPH_ORPHAN'
+
+DETECTOR_ID_NODE_DEATH = 'node_death'
+
+_LIFECYCLE_PREFIX = 'plugins.graph_watchdog.detectors.lifecycle_expectation'
+_NODE_DEATH_PREFIX = 'plugins.graph_watchdog.detectors.node_death'
+_PARAM_DRIFT_PREFIX = 'plugins.graph_watchdog.detectors.param_drift'
+
+# The fixture: a plain rclcpp::Node that advertises get_state/change_state of the right SERVICE
+# TYPES (all find_lifecycle_get_state_path() checks) and never answers GetState until its
+# `start_answering` parameter is set - see unreadable_lifecycle_node.cpp's file doc.
+UNREADABLE_NODE = 'unreadable_lifecycle'
+ANSWER_PARAM = 'start_answering'
+
+# Fast tick cadence + short warmup so the whole story (gateway/fault_manager startup, fixture
+# discovery, per-app arm, global bringup grace) fits inside the poll timeouts below without a
+# hand-tuned pre-sleep - the same rationale every e2e file in this package states.
+TICK_INTERVAL_MS = 200
+WARMUP_CYCLES = 3
+
+# "restart_inside_warmup" needs the RE-WARM window to be wide enough for the test to observe
+# the returned node un-armed and kill it again inside that window, which the shipped-size
+# warmup above cannot give it: 3 ticks is 600 ms, shorter than one entity-cache refresh. 30
+# ticks is 6 s at this cadence, and the row asserts the un-armed state from the status route
+# rather than trusting the arithmetic.
+RESTART_WARMUP_CYCLES = 30
+
+# The plain demo node that row restarts. No lifecycle interface at all, so the gate's ownership
+# answer for it is EARNED throughout and the row turns on nothing but arming.
+PLAIN_NODE = 'calibration'
+
+# How long the plain node stays down after each kill - an enforced floor under the outage, not
+# a sleep. It has to clear two windows, not one: the detector's own miss window
+# ([MISS_GRACE + 1] * TICK_INTERVAL_MS = 3400 ms) plus the entity cache's refresh debounce,
+# before the death can be reported at all; and then the whole no-PASSED window this row watches
+# afterwards, because the node coming back is a legitimate reason to report PASSED and would
+# land inside that window otherwise. 30 s covers ~5 s of detection plus SILENCE_WINDOW_SEC with
+# margin to spare.
+RESTART_RESPAWN_DELAY_SEC = 30.0
+
+# node_death's grace, in TICKS. Nominal window is [MISS_GRACE + 1] * TICK_INTERVAL_MS = 3400 ms,
+# comfortably past the 3000 ms wall-clock floor configure() would otherwise raise it to and two
+# ticks clear of that floor's own boundary value (14 at this tick period) - the "comfortably
+# past, not exactly on" convention this package's other miss_grace values follow. Small on
+# purpose: every scenario here either waits for a departure to be reported or watches for one
+# that must never be, and both want the detector's own decision to have been made long before
+# the assertion is read.
+MISS_GRACE = 16
+
+# The budgets below are scaled by MEDKIT_TEST_TIME_SCALE, which the sanitizer jobs set to the
+# same factor they apply to every declared CTest timeout; a deadline asserted INSIDE a test is
+# invisible to that rewrite. The sustained-observation window is deliberately NOT scaled: it is
+# not a give-up bound, and stretching a window that watches for silence buys no confidence.
+TIME_SCALE = get_time_scale()
+ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
+FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+LABEL_TIMEOUT_SEC = 30.0 * TIME_SCALE
+DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
+PARAM_SET_TIMEOUT_SEC = 30.0 * TIME_SCALE
+RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
+
+# GRAPH_NODE_UNREADABLE needs kUnmeasuredHoldTicks (60, fixed - not configurable) consecutive
+# unmeasured ticks, ~12 s at this cadence, plus the absence grace once the node is killed. 90 s
+# is the same shape of budget the "unreadable" scenario in test_lifecycle_expectation_e2e.test.py
+# sizes for the identical hold at a comparable cadence.
+UNREADABLE_RAISE_TIMEOUT_SEC = 90.0 * TIME_SCALE
+
+# How long the restart row waits for the respawned node to reappear: the enforced respawn delay
+# plus the entity cache's own refresh, with margin.
+RESTART_RETURN_TIMEOUT_SEC = (RESTART_RESPAWN_DELAY_SEC + 30.0) * TIME_SCALE
+
+# How long a code that must NOT appear is watched for, once the code that must appear already
+# has. Not a give-up bound and deliberately not scaled: it is a window in which every poll has
+# to answer 200 and carry no such fault.
+SILENCE_WINDOW_SEC = 10.0
+
+# The QoS leg's mismatched pair. The fixture publishes ~/transition_event with no deadline (the
+# most permissive offer); a subscriber that REQUESTS a finite deadline is RxO-incompatible with
+# it - see qos_policy.hpp's qos_incompatibility() deadline branch, and test_qos_e2e.test.py's
+# test_04, which pins the same dimension against a purpose-built pair.
+QOS_TOPIC = f'/{UNREADABLE_NODE}/transition_event'
+QOS_SUB_DEADLINE_SEC = 0.1
+
+# The "measured_then_unmeasured" fixture: a plain rclcpp::Node that looks managed, answers
+# get_state with a chosen label, and destroys both lifecycle services when `drop_services` is
+# set - see test/e2e/droppable_lifecycle_node.cpp. It is the only fixture in this package that
+# can take a node from MEASURED to UNMEASURED without killing it.
+DROPPABLE_NODE = 'presence_ownership_droppable'
+DROP_PARAM = 'drop_services'
+
+# The label the never-answering fixture announces once it is told to answer. "inactive" is a
+# measured, NON-active state: it says the node was never the presence detector's, which is
+# exactly what a provisional grant has to yield to.
+# The rclpy node this row's own test process spins to drive the fixture's parameter. It is an
+# App like any other, so node_death admits it too - and an admission landing between the
+# release and the sample that looks for it hides the release completely, because tracked_count
+# is a graph-wide total rather than a per-key flag. The row therefore waits for this one to arm
+# before it takes its baseline, which leaves the fixture's release the only admission event
+# still to come.
+LATE_LABEL_CLIENT_NODE = 'presence_ownership_late_label_client'
+
+TRANSITION_LABEL_PARAM = 'transition_label'
+LATE_LABEL = 'inactive'
+
+# lifecycle_expectation's own grace, in ticks, for the row where GRAPH_NODE_INACTIVE is the
+# positive control. Small so the violation confirms while the node is still present, which
+# keeps the row about ownership rather than about absence maturing a streak.
+LATE_LABEL_GRACE = 2
+
+# The orphan leg's near-miss pair: one publisher-only topic and one subscriber-only topic, same
+# type, same namespace, leaf edit distance 1. Both endpoints belong to this test process; the
+# detector keys its finding on the TOPIC, so there is no way to make either of them the
+# fixture's own (its only non-system topic already carries endpoints on both sides).
+ORPHAN_TYPO_TOPIC = f'/{UNREADABLE_NODE}/scam'
+ORPHAN_TARGET_TOPIC = f'/{UNREADABLE_NODE}/scan'
+
+
+def _droppable_node_action():
+    """Build the droppable fixture as a launch action with a PID handle the test can signal.
+
+    Answers "active" from the start, so the node is MEASURED - and therefore owned by the
+    presence detector - before anything is done to it.
+    """
+    return launch_ros.actions.Node(
+        package='ros2_medkit_graph_watchdog',
+        executable='droppable_lifecycle_node',
+        name=DROPPABLE_NODE,
+        output='screen',
+        parameters=[{'state_label': 'active'}],
+        additional_env=get_coverage_env('ros2_medkit_graph_watchdog'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
+
+def _plain_node_action():
+    """Build the plain demo node as a respawning launch action with a PID handle.
+
+    No lifecycle services at all, so the gate answers kEarned for it whenever it is armed and
+    nothing about this row depends on a lifecycle label. `respawn` is what brings the SAME node
+    name back after the test kills it, under a new pid the action reports.
+    """
+    executable, ros_name, namespace = DEMO_NODE_REGISTRY[PLAIN_NODE]
+    return launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable=executable,
+        name=ros_name,
+        namespace=namespace,
+        output='screen',
+        additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+        respawn=True,
+        respawn_delay=RESTART_RESPAWN_DELAY_SEC,
+    )
+
+
+def _unreadable_node_action(transition_label=None):
+    """Build the fixture as a launch action with a PID handle the test can signal.
+
+    Uses DEMO_NODE_REGISTRY's own (executable, ros_name, namespace) triple so this stays in
+    lockstep with demo_nodes.launch.py, built by hand only because the scenarios here signal the
+    process directly and create_demo_nodes() hands back no PID.
+    """
+    executable, ros_name, namespace = DEMO_NODE_REGISTRY[UNREADABLE_NODE]
+    # Only passed when a scenario needs the fixture to announce something other than its
+    # default: every other row here depends on the default being what it always was.
+    parameters = ([{TRANSITION_LABEL_PARAM: transition_label}] if transition_label is not None
+                  else [])
+    return launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable=executable,
+        name=ros_name,
+        namespace=namespace,
+        parameters=parameters,
+        output='screen',
+        additional_env=get_coverage_env('ros2_medkit_integration_tests'),
+        sigterm_timeout='30',
+        sigkill_timeout='15',
+    )
+
+
+def generate_test_description():
+    detector_params = {
+        'plugins.graph_watchdog.tick_interval_ms': TICK_INTERVAL_MS,
+        'plugins.graph_watchdog.warmup_cycles': WARMUP_CYCLES,
+        f'{_NODE_DEATH_PREFIX}.miss_grace': MISS_GRACE,
+    }
+
+    if SCENARIO == 'provisional_yields_to_a_real_label':
+        # require_active is what makes GRAPH_NODE_INACTIVE available as the positive control:
+        # the node has to be reported by SOMEBODY once the presence detector hands it back, or
+        # the row cannot tell a correct handover from a plain silence.
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [UNREADABLE_NODE]
+        detector_params[f'{_LIFECYCLE_PREFIX}.grace'] = LATE_LABEL_GRACE
+    elif SCENARIO in ('budget_spent_then_owned', 'answered_then_owned'):
+        # The SAME configuration for both, deliberately: require_active names the fixture in
+        # each, so the only thing that differs between the two rows is what the node's
+        # lifecycle state turned out to be. It also makes GRAPH_NODE_UNREADABLE available as
+        # this row's corroboration that lifecycle_expectation is watching the same node.
+        detector_params[f'{_LIFECYCLE_PREFIX}.require_active'] = [UNREADABLE_NODE]
+    elif SCENARIO == 'no_require_active_still_owned':
+        # Deliberately nothing: require_active defaults to empty, which is the shipped
+        # configuration, and in it lifecycle_expectation returns before it looks at anything.
+        pass
+    elif SCENARIO == 'measured_then_unmeasured':
+        # node_death is zero-config, and this row is entirely about it.
+        pass
+    elif SCENARIO == 'restart_inside_warmup':
+        # A wide warmup is the whole instrument here: it makes the re-warm window observable
+        # and long enough to act inside, instead of something the test would have to race.
+        detector_params['plugins.graph_watchdog.warmup_cycles'] = RESTART_WARMUP_CYCLES
+    elif SCENARIO == 'gate_unaffected':
+        # `baseline: false` plus one absolute `expect` pin: the pin fires on a STATIC graph, with
+        # no runtime perturbation to race, and it only fires for a node that HAS the parameter
+        # (ParamDriftPolicy::evaluate skips a pin the observed set does not carry). start_answering
+        # exists on the fixture and nowhere else, so GRAPH_PARAM_DRIFT can only be about this
+        # node - an aggregate that named half the graph could be truncated past it.
+        detector_params[f'{_PARAM_DRIFT_PREFIX}.baseline'] = False
+        detector_params[f'{_PARAM_DRIFT_PREFIX}.expect.{ANSWER_PARAM}'] = True
+    else:
+        raise RuntimeError(f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} has no launch configuration')
+
+    launch_description, context = create_watchdog_test_launch(
+        detector_params=detector_params,
+        demo_nodes=None,
+        port=PORT,
+    )
+
+    if SCENARIO == 'measured_then_unmeasured':
+        target = _droppable_node_action()
+    elif SCENARIO == 'restart_inside_warmup':
+        target = _plain_node_action()
+    elif SCENARIO == 'provisional_yields_to_a_real_label':
+        target = _unreadable_node_action(transition_label=LATE_LABEL)
+    else:
+        target = _unreadable_node_action()
+    launch_description.add_action(TimerAction(period=2.0, actions=[target]))
+    context['target_node'] = target
+    return launch_description, context
+
+
+def _poll_watchdog_entity(port, app_id, lifecycle, timeout=30.0, interval=0.5,
+                          measurement_pending=None):
+    """Poll GET /x-medkit-watchdog until `app_id` appears with this lifecycle label.
+
+    The PAIR is the instrument these scenarios need, not `armed` on its own: `armed` reads the
+    same for a plain node and for a managed one whose state nobody has ever read, and the whole
+    claim is about telling those two apart. ``''`` is not "no data yet" - LifecycleWatcher seeds
+    a TRACKED entry's label to ``''`` and only overwrites it once a real read succeeds, so it
+    means "asked, and still waiting", while a node with no managed record at all reports null.
+
+    `measurement_pending`, when given, additionally requires the route's field of the same
+    name. An unread label alone does not say whether the watcher still intends to ask, and the
+    two answers put the node in opposite hands: still asking means the presence detector must
+    keep off it, finished asking means the presence detector is all it has. A row that turns on
+    that difference has to READ it rather than wait out an amount of time that looks about
+    right.
+
+    Returns the matching entity dict, or ``None`` on timeout (after printing the last-seen
+    payload, which is gone once the launch tears down).
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /x-medkit-watchdog was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/x-medkit-watchdog', timeout=5)
+            if response.status_code != 200:
+                last_seen = f'HTTP {response.status_code} from GET /x-medkit-watchdog'
+            else:
+                status = response.json().get('x-medkit-watchdog', {})
+                last_seen = str(status)
+                for entity in status.get('entities') or []:
+                    if entity.get('id') != app_id or entity.get('lifecycle') != lifecycle:
+                        continue
+                    if (measurement_pending is not None
+                            and entity.get('measurement_pending') is not measurement_pending):
+                        continue
+                    return entity
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /x-medkit-watchdog failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_watchdog_entity(app_id={app_id!r}, lifecycle={lifecycle!r}, '
+          f'measurement_pending={measurement_pending!r}) timed out after {timeout}s; '
+          f'last watchdog status: {last_seen}')
+    return None
+
+
+def _poll_apps_absent(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` is no longer listed. ``True`` once it is gone.
+
+    Confirms the SIGTERM'd fixture is really out of the operator-visible entity graph before
+    anything is asserted about a fault: ``GET /apps`` and the detector's own per-tick snapshot
+    read the same ThreadSafeEntityCache, so this polls the precise input the detector sees.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id not in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_absent({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _fault_record(port, code, timeout=30.0, interval=0.5):
+    """Poll ``GET /faults?status=all`` until `code` appears, whatever its status.
+
+    ``poll_faults`` uses the default (pending + confirmed) filter, so a record that HEALED
+    while the node was briefly back drops out of it. The restart row needs the record itself -
+    ``last_occurred``, which advances on every FAILED, and ``last_passed``, which advances on
+    every PASSED - and both survive healing. Returns the matching item dict, or ``None``.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/faults', params={'status': 'all'}, timeout=5)
+            if response.status_code == 200:
+                for item in response.json().get('items', []):
+                    if item.get('fault_code') == code:
+                        return item
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def _poll_watchdog_entity_state(port, app_id, timeout=30.0, interval=0.5):
+    """Return the entity's own ``state`` from GET /x-medkit-watchdog, or ``None``.
+
+    The restart row needs the OPPOSITE of what wait_until_watchdog_armed waits for: proof that
+    a node which has just come back is NOT yet armed, so the kill that follows lands inside the
+    re-warm window rather than after it.
+    """
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/x-medkit-watchdog', timeout=5)
+            if response.status_code == 200:
+                status = response.json().get('x-medkit-watchdog', {})
+                for entity in status.get('entities') or []:
+                    if entity.get('id') == app_id:
+                        return entity.get('state')
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(interval)
+    return None
+
+
+def _poll_apps_present(port, app_id, timeout=30.0, interval=0.5):
+    """Poll ``GET /apps`` until `app_id` IS listed. ``True`` once it appears."""
+    base = f'http://127.0.0.1:{port}{API_BASE_PATH}'
+    deadline = time.monotonic() + timeout
+    last_seen = 'GET /apps was never answered at all'
+    while time.monotonic() < deadline:
+        try:
+            response = requests.get(f'{base}/apps', timeout=5)
+            if response.status_code == 200:
+                ids = [item.get('id') for item in response.json().get('items', [])]
+                last_seen = str(ids)
+                if app_id in ids:
+                    return True
+            else:
+                last_seen = f'HTTP {response.status_code} from GET /apps'
+        except requests.exceptions.RequestException as exc:
+            last_seen = f'GET /apps failed: {exc}'
+        time.sleep(interval)
+    print(f'_poll_apps_present({app_id!r}) timed out after {timeout}s; last seen: {last_seen}')
+    return False
+
+
+def _poll_tracked_count_below(port, detector_id, threshold, timeout=30.0, interval=0.2):
+    """Poll until `detector_id` reports a `tracked_count` strictly below `threshold`.
+
+    The one observable on this route that reflects what the DETECTOR did rather than what the
+    watcher knows. Everything else an ownership row could gate on is published straight from
+    LifecycleWatcher: `lifecycle` is its cached label, and the per-entity `armed`/`state` pair
+    is warmup plus node_ok(), so all three flip the moment a transition_event lands, whole
+    detector ticks before node_death has looked at the graph again. Its own `tracked_count`
+    comes off the tracker, republished once per tick, so it only moves when a key is actually
+    admitted or released.
+
+    It is a graph-WIDE total, though, and that costs the caller two obligations. The count must
+    have stopped moving before it is used as a threshold, or the admission this release will
+    later undo is not inside it. And every other App that will ever be admitted must already
+    be admitted, or one landing after the release refills the total and hides it: measured on a
+    live stack, a release dipped the count for 200 ms before the test's own client node was
+    admitted, which a 200 ms poll reads as no release at all. `_poll_stable_tracked_count`
+    covers the first; gating on every other node being armed covers the second.
+
+    Returns ``True`` once the count drops, ``False`` on timeout (after printing the last value,
+    which is gone once the launch tears down).
+    """
+    deadline = time.monotonic() + timeout
+    last_seen = 'the node_death status block was never answered at all'
+    while time.monotonic() < deadline:
+        block = watchdog_detector_status(port, detector_id, timeout=5.0)
+        if block is not None:
+            last_seen = str(block)
+            count = block.get('tracked_count')
+            if isinstance(count, int) and count < threshold:
+                return True
+        time.sleep(interval)
+    print(f'_poll_tracked_count_below({detector_id!r}, {threshold}) timed out after {timeout}s; '
+          f'last status: {last_seen}')
+    return False
+
+
+def _poll_stable_tracked_count(port, detector_id, samples=5, interval=0.25, timeout=30.0):
+    """Return `detector_id`'s `tracked_count` once it has held the same value `samples` times.
+
+    A baseline read the instant the gate answers PROVISIONAL is taken too early: the gate is
+    answering out of LifecycleWatcher, and the admission it licenses happens on the detector's
+    next tick. Sampling until the value stops moving is what puts the admission inside the
+    baseline instead of after it - without that, the release later returns the count to exactly
+    the number this captured and "fell below" is never true.
+
+    Returns the stable value, or ``None`` on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    history = []
+    while time.monotonic() < deadline:
+        block = watchdog_detector_status(port, detector_id, timeout=5.0)
+        count = block.get('tracked_count') if block else None
+        history = (history + [count]) if count is not None else []
+        if len(history) >= samples and len(set(history[-samples:])) == 1:
+            return history[-1]
+        time.sleep(interval)
+    print(f'_poll_stable_tracked_count({detector_id!r}) never settled in {timeout}s; '
+          f'last samples: {history[-samples:]}')
+    return None
+
+
+def _set_bool_parameter(client_node, service_name, param_name, value, timeout=30.0):
+    """Set one bool parameter on a REMOTE node via its own ``set_parameters`` service.
+
+    Every ``rclcpp::Node`` starts that service automatically, and the fixture registers an
+    on-set callback that answers its held GetState requests and publishes the one
+    ~/transition_event the watcher needs - see unreadable_lifecycle_node.cpp's file doc for why
+    the event, not the answer, is what moves the cached label at this point.
+
+    Returns ``True`` once the remote node accepts the change.
+    """
+    client = client_node.create_client(SetParameters, service_name)
+    if not client.wait_for_service(timeout_sec=timeout):
+        return False
+    request = SetParameters.Request()
+    request.parameters = [Parameter(
+        name=param_name,
+        value=ParameterValue(type=ParameterType.PARAMETER_BOOL, bool_value=value),
+    )]
+    future = client.call_async(request)
+    rclpy.spin_until_future_complete(client_node, future, timeout_sec=timeout)
+    result = future.result()
+    if result is None or not result.results:
+        return False
+    return bool(result.results[0].successful)
+
+
+class TestBudgetSpentThenOwned(unittest.TestCase):
+    """A managed node the watcher asked and could not read is the presence detector's.
+
+    The gate's raise permission is deliberately permissive for an unread label - every other
+    detector depends on that, or a node whose lifecycle service is broken would have every
+    fault suppressed - so ownership cannot be admitted on that answer alone. But refusing it
+    forever is not a handover either: once LifecycleWatcher has spent the GetState attempts it
+    charges per node, nothing will ever ASK this node again, and the only detector that could
+    report its departure instead is `lifecycle_expectation`, which looks at nothing unless an
+    operator named it in `require_active`. (Asking is not the only channel: ~/transition_event
+    stays subscribed, so a label can still arrive unasked - which is what the sibling row
+    "provisional_yields_to_a_real_label" is about.)
+
+    So the answer is bounded: withheld while the ignorance can still resolve, taken once it
+    cannot. Here `require_active` DOES name the node, so both codes are available and both must
+    appear - GRAPH_NODE_DISAPPEARED because the node died and nobody else can say so, and
+    GRAPH_NODE_UNREADABLE because its lifecycle promise was never verified. Neither excuses the
+    other.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def test_settled_ignorance_is_reported_by_presence_and_by_lifecycle(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=UNREADABLE_NODE),
+            f'graph_watchdog never reported {UNREADABLE_NODE} armed - the permissive gate answer '
+            'this row is about was never reached, so nothing below would prove anything')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            entity,
+            f'{UNREADABLE_NODE} never appeared with an EMPTY lifecycle label - the fixture was '
+            'either not tracked as managed at all or its GetState was answered, and this row '
+            'needs a node that is tracked and unmeasured')
+        self.assertTrue(
+            entity.get('armed'),
+            f'{UNREADABLE_NODE} is unmeasured but NOT armed, so node_death would decline it for '
+            'the warmup reason instead of the ownership reason this row is about')
+
+        # The budget is spent within a handful of ticks of discovery (kReseedAttempts issued
+        # reads, each cut off by the reader's own timeout), and everything above has already
+        # cost far more than that. Killing here therefore lands in the SETTLED half of the
+        # bound, which is what this row is about.
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for {UNREADABLE_NODE} - the watcher had '
+                'already asked for its state as often as it ever will, so withholding ownership '
+                'here leaves the death to a detector that only ever looks at require_active '
+                'entries')
+        self.assertIn(UNREADABLE_NODE, fault.get('description', ''))
+
+        # The other code, and it is not an alternative to the one above: the node also never
+        # kept the lifecycle promise an operator wrote down for it.
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE_UNREADABLE, [UNREADABLE_NODE],
+            timeout=UNREADABLE_RAISE_TIMEOUT_SEC)
+        self.assertTrue(
+            found,
+            f'{FAULT_CODE_UNREADABLE} never raised naming {UNREADABLE_NODE} - the presence code '
+            'raising must not have cost the lifecycle code its own report '
+            f'(last description: {description!r})')
+
+
+class TestNoRequireActiveStillOwned(unittest.TestCase):
+    """The same death in the SHIPPED configuration, where nothing else is watching at all.
+
+    `require_active` defaults to empty and `lifecycle_expectation` returns before it looks at
+    anything, so in this launch node_death is the only detector that can report this node's
+    departure. A predicate that refuses a managed node whose state it could never read produces
+    a deterministic silence here - strictly worse than the racy one the bound exists to close,
+    because no configuration and no timing makes it come back.
+
+    Its pairing with the sibling row is what rules out an implementation deciding ownership
+    from `require_active` membership: the two rows differ in exactly that key and expect the
+    same answer.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def test_a_node_nobody_watches_is_still_reported_when_it_dies(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=UNREADABLE_NODE),
+            f'graph_watchdog never reported {UNREADABLE_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            entity,
+            f'{UNREADABLE_NODE} never appeared with an EMPTY lifecycle label, so this row is not '
+            'about an unmeasured managed node at all')
+        self.assertTrue(entity.get('armed'))
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for {UNREADABLE_NODE} - with no '
+                'require_active entry anywhere, this death was reported by nobody at all')
+        self.assertIn(UNREADABLE_NODE, fault.get('description', ''))
+
+        # And nothing else picked it up, which is the point of the row: in this configuration
+        # the lifecycle codes are structurally unreachable, so the presence code standing alone
+        # is the whole of the operator's warning.
+        assert_fault_absent_throughout(
+            self, PORT, FAULT_CODE_UNREADABLE, SILENCE_WINDOW_SEC)
+
+
+class TestMeasuredNodeIsOwnedByPresence(unittest.TestCase):
+    """The same fixture, told to answer: once its state IS known, node_death owns its departure.
+
+    Runs under the SAME configuration as "budget_spent_then_owned" - `require_active` names the
+    fixture in both - so the only variable between the two rows is what the node's lifecycle
+    state turned out to be. Refusing ownership for every managed node, or granting it to
+    everything, is ruled out by the pair rather than by either row alone: this one is measured
+    "active" and must be reported by the presence code, its sibling is never measured at all and
+    must be too, and B6 in test_node_death_boundary_e2e.test.py is measured NOT-active and must
+    not be.
+
+    The node is unmeasured across the whole warmup first (proven from the status route before
+    anything else happens), then answers, then dies, so what this row exercises is a CHANGE in
+    knowledge rather than a node that started out measurable.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('presence_ownership_answer_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_a_node_that_starts_answering_is_owned_by_presence(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=UNREADABLE_NODE),
+            f'graph_watchdog never reported {UNREADABLE_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        # The precondition that makes this a CHANGE rather than a steady state: armed, and
+        # unmeasured, before the flip.
+        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            entity,
+            f'{UNREADABLE_NODE} was never observed armed-and-unmeasured, so the flip below would '
+            'not be a transition from ignorance to knowledge')
+        self.assertTrue(entity.get('armed'))
+
+        self.assertTrue(
+            _set_bool_parameter(
+                type(self)._client_node, f'/{UNREADABLE_NODE}/set_parameters',
+                ANSWER_PARAM, True, timeout=PARAM_SET_TIMEOUT_SEC),
+            f'setting {ANSWER_PARAM}:=true on /{UNREADABLE_NODE}/set_parameters never succeeded - '
+            'the fixture never started answering, so this row would test the sibling scenario')
+
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, 'active', timeout=LABEL_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never reported an "active" lifecycle label after the flip - its '
+            'state is still unmeasured, so a silent GRAPH_NODE_DISAPPEARED below would be '
+            'correct rather than a defect')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for {UNREADABLE_NODE} - a node whose '
+                "lifecycle state WAS measured active before it died is the presence detector's "
+                'to report, and refusing every managed node would look exactly like this')
+        self.assertIn(UNREADABLE_NODE, fault.get('description', ''))
+
+
+class TestMeasuredThenUnmeasured(unittest.TestCase):
+    """A node whose MEASUREMENT goes away, on a live node, and then it dies.
+
+    The reverse of the sibling rows, and the direction an injected label cannot reach: this
+    fixture is measured "active" first - so the presence detector owns it outright - and then
+    stops advertising its lifecycle services, which makes the watcher drop the record
+    altogether. The status route reports `lifecycle: null` afterwards, the same value a node
+    that never had a lifecycle reports, and that is the state the node is in when it is killed.
+
+    GRAPH_NODE_DISAPPEARED must still raise. Ownership is latched from the fact the gate gave
+    while the node was measurable, and a node with no managed record is owned outright anyway,
+    so both routes to the answer agree here. What the row rules out is an implementation that
+    re-derives ownership from whatever the watcher happens to say at the moment of death and
+    finds nothing to go on.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node('presence_ownership_drop_client')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_a_node_that_stops_being_measurable_is_still_owned(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=DROPPABLE_NODE),
+            f'graph_watchdog never reported {DROPPABLE_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, DROPPABLE_NODE, 'active', timeout=LABEL_TIMEOUT_SEC),
+            f'{DROPPABLE_NODE} never reported an "active" lifecycle label, so the measurement '
+            'this row is about losing was never made in the first place')
+
+        self.assertTrue(
+            _set_bool_parameter(
+                type(self)._client_node, f'/{DROPPABLE_NODE}/set_parameters',
+                DROP_PARAM, True, timeout=PARAM_SET_TIMEOUT_SEC),
+            f'setting {DROP_PARAM}:=true on /{DROPPABLE_NODE}/set_parameters never succeeded - '
+            'the node never stopped looking like a managed lifecycle node')
+
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, DROPPABLE_NODE, None, timeout=LABEL_TIMEOUT_SEC),
+            f'{DROPPABLE_NODE} still carries a lifecycle label after its services were dropped - '
+            'the watcher never let go of the record, so the transition this row needs did not '
+            'happen')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, DROPPABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{DROPPABLE_NODE} never left GET /apps after SIGTERM')
+
+        fault = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if fault is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for {DROPPABLE_NODE} - a node that was '
+                'measured active and then lost its lifecycle interface is still the presence '
+                "detector's to report")
+        self.assertIn(DROPPABLE_NODE, fault.get('description', ''))
+
+
+class TestRestartInsideWarmup(unittest.TestCase):
+    """A crash loop whose uptime is shorter than the warmup: the second death must be reported.
+
+    Handing a key back is for one situation only - the graph has MEASURED the node as something
+    the presence detector must not own. A node that is merely re-warming has been measured as
+    nothing at all: the gate withholds a claim because warmup is incomplete, which is the
+    absence of knowledge, not knowledge of another owner. Releasing a key on that answer costs
+    two things at once, and this row asserts both. The node's next death goes unreported,
+    because the key is no longer tracked; and the detector reports PASSED every tick while the
+    node is dead, because an empty dead set reads as health.
+
+    The other restart rows in this package all wait for the returned node to arm before killing
+    it again, so none of them can see this: they only ever kill an armed node. This one kills
+    inside the re-warm window on purpose, and proves it was inside by reading the entity's own
+    state off the watchdog route rather than by timing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def test_a_second_death_inside_the_rewarm_window_is_still_reported(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=PLAIN_NODE),
+            f'graph_watchdog never reported {PLAIN_NODE} armed, so the first death below could '
+            'never have been tracked at all')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, PLAIN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{PLAIN_NODE} never left GET /apps after the first SIGTERM')
+        first = poll_faults(PORT, FAULT_CODE_DISAPPEARED, timeout=RAISE_TIMEOUT_SEC)
+        if first is None:
+            self.fail(
+                f'{FAULT_CODE_DISAPPEARED} never raised for the first death of {PLAIN_NODE} - '
+                'there is no first death here for a second one to follow')
+        self.assertIn(PLAIN_NODE, first.get('description', ''))
+
+        # The node comes back under the same name and a new pid. Everything after this point
+        # happens inside its re-warm window, which is why nothing here waits for arming.
+        self.assertTrue(
+            _poll_apps_present(PORT, PLAIN_NODE, timeout=RESTART_RETURN_TIMEOUT_SEC),
+            f'{PLAIN_NODE} never came back into GET /apps after its respawn')
+        state = _poll_watchdog_entity_state(PORT, PLAIN_NODE, timeout=LABEL_TIMEOUT_SEC)
+        self.assertEqual(
+            state, 'warming_up',
+            f'{PLAIN_NODE} was already {state!r} when it came back, so the kill below would land '
+            'AFTER the re-warm window and this row would be a second copy of the restart-loop '
+            'scenarios that already pass')
+
+        before = _fault_record(PORT, FAULT_CODE_DISAPPEARED, timeout=DEPARTURE_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            before, f'{FAULT_CODE_DISAPPEARED} left the store entirely once {PLAIN_NODE} came '
+                    'back, so there is no record for the second death to move')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, PLAIN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{PLAIN_NODE} never left GET /apps after the second SIGTERM')
+
+        deadline = time.monotonic() + RAISE_TIMEOUT_SEC
+        after = before
+        while time.monotonic() < deadline:
+            after = _fault_record(PORT, FAULT_CODE_DISAPPEARED, timeout=5.0) or after
+            if after.get('last_occurred') != before.get('last_occurred'):
+                break
+            time.sleep(0.5)
+        self.assertNotEqual(
+            after.get('last_occurred'), before.get('last_occurred'),
+            f'{FAULT_CODE_DISAPPEARED} was never reported again for the second death of '
+            f'{PLAIN_NODE} (last_occurred stayed {before.get("last_occurred")!r}) - the key was '
+            'handed back while the node was merely re-warming, so nothing was tracking it when '
+            'it died')
+
+        # The other half of the same defect: with nothing tracked, an empty dead set reads as
+        # health and the detector reports PASSED for a node that is lying dead in front of it.
+        passed_at_confirmation = after.get('last_passed')
+        deadline = time.monotonic() + SILENCE_WINDOW_SEC
+        polls = 0
+        while time.monotonic() < deadline:
+            record = _fault_record(PORT, FAULT_CODE_DISAPPEARED, timeout=5.0)
+            self.assertIsNotNone(
+                record, f'{FAULT_CODE_DISAPPEARED} left the store {polls} poll(s) into the '
+                        'window that was supposed to show no PASSED at all')
+            self.assertEqual(
+                record.get('last_passed'), passed_at_confirmation,
+                f'{FAULT_CODE_DISAPPEARED} was reported PASSED {polls} poll(s) after it was '
+                f'confirmed dead again (last_passed moved to {record.get("last_passed")!r}) - '
+                f'{PLAIN_NODE} is still gone, so that is a heal for a node nobody is watching')
+            polls += 1
+            time.sleep(0.5)
+        self.assertGreater(polls, 0, 'the no-PASSED window never actually polled the store')
+
+
+class TestProvisionalOwnershipYieldsToARealLabel(unittest.TestCase):
+    """A provisional owner hands the node back the moment the graph says whose it is.
+
+    Ownership granted because the asking stopped is granted for one reason only: nobody else
+    can report this node. That reason is not permanent. LifecycleWatcher stops issuing GetState
+    when the re-seed budget runs out, but it never drops the ~/transition_event subscription, so
+    a real label can still arrive afterwards - and a label saying the node is inactive says the
+    node was lifecycle_expectation's all along.
+
+    Waiting for the budget alone would only DELAY the defect this slice exists to close: the
+    presence detector would latch the node during the unread window and still be holding it when
+    it died inactive. So the row drives the whole sequence - unread, budget spent, label arrives
+    non-active, node killed - and asserts the handover happened: GRAPH_NODE_INACTIVE names the
+    node, GRAPH_NODE_DISAPPEARED never appears.
+
+    This is also the row that rejects a detector wired to the permissive `reliability_allows()`
+    where `presence_ownership()` belongs: that predicate is TRUE for an unread label, tracking is
+    sticky, and the node would be reported dead here.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls._client_node = Node(LATE_LABEL_CLIENT_NODE)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._client_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_a_late_non_active_label_takes_the_node_back(self, target_node):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=UNREADABLE_NODE),
+            f'graph_watchdog never reported {UNREADABLE_NODE} armed')
+        self.assertTrue(
+            wait_until_faults_endpoint_live(PORT, timeout=FAULTS_LIVE_TIMEOUT_SEC),
+            'GET /faults never answered 200 - nothing below would prove anything')
+
+        # The provisional grant, OBSERVED rather than waited out: an unread label whose
+        # measurement is no longer pending is exactly the state in which the presence detector
+        # takes the node for want of anyone else.
+        entity = _poll_watchdog_entity(
+            PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC, measurement_pending=False)
+        self.assertIsNotNone(
+            entity,
+            f'{UNREADABLE_NODE} never reached an unread label with the asking finished - without '
+            'that state there is no provisional grant for the label below to revoke')
+        self.assertTrue(entity.get('armed'))
+
+        # Everything else that will ever be admitted must be admitted FIRST, or the baseline
+        # below is measured against a moving total. This process's own client node is the one
+        # that moves it: it is an ordinary App, node_death admits it like any other, and an
+        # admission landing between the release and the sample looking for it puts the count
+        # straight back where it started. Measured on a live stack: the release dipped the
+        # count for 200 ms and the client node's admission refilled it, which a 200 ms poll
+        # sees as no release at all.
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC,
+                                      app_id=LATE_LABEL_CLIENT_NODE),
+            f'{LATE_LABEL_CLIENT_NODE} never armed, so an admission of it could still land on '
+            'top of the release this row has to see')
+
+        # And the baseline has to include the fixture's OWN admission, which the gate licenses
+        # a tick before the detector acts on it. Sampling until the total stops moving is what
+        # puts it inside; capturing on the gate's answer alone captures the number the release
+        # will later return to, and "fell below" is then never true however long it waits.
+        tracked_before = _poll_stable_tracked_count(PORT, DETECTOR_ID_NODE_DEATH,
+                                                    timeout=LABEL_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            tracked_before,
+            "node_death's tracked_count never settled, so there is no baseline here that the "
+            'release below could be measured against')
+        self.assertGreater(
+            tracked_before, 0,
+            'node_death is tracking nothing at all, so there is no admitted key here for the '
+            'label to take back')
+
+        self.assertTrue(
+            _set_bool_parameter(
+                type(self)._client_node, f'/{UNREADABLE_NODE}/set_parameters',
+                ANSWER_PARAM, True, timeout=PARAM_SET_TIMEOUT_SEC),
+            f'setting {ANSWER_PARAM}:=true on /{UNREADABLE_NODE}/set_parameters never succeeded - '
+            'the late label this row turns on never arrived')
+
+        self.assertIsNotNone(
+            _poll_watchdog_entity(PORT, UNREADABLE_NODE, LATE_LABEL, timeout=LABEL_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never reported the "{LATE_LABEL}" label - the graph never said '
+            'whose node this is, so a presence report below would not be a defect')
+
+        # The label being READABLE is the watcher's fact, and it is not the one this row needs.
+        # node_death hands a provisionally owned key back inside its own tick, and only on a
+        # tick that still sees the app present - a kill landing between the label appearing on
+        # this route and that tick finds the key admitted, and the death is then reported by a
+        # detector the label had already disqualified. Measured on a live stack: the label
+        # became visible 210 ms before tracked_count dropped. So wait for the DETECTOR's own
+        # view to move before killing anything; gating on the label alone tests the watcher and
+        # calls it the detector.
+        self.assertTrue(
+            _poll_tracked_count_below(PORT, DETECTOR_ID_NODE_DEATH, tracked_before,
+                                      timeout=LABEL_TIMEOUT_SEC),
+            f'node_death never released {UNREADABLE_NODE} after the "{LATE_LABEL}" label - its '
+            f'tracked_count never fell below {tracked_before}, so the key was still admitted '
+            'and the kill below would be measuring the window rather than the handover')
+
+        os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        self.assertTrue(
+            _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
+            f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
+
+        # The positive control, and it runs first: the node IS reported, by the detector the
+        # label handed it to. An absence assertion after a silent stack would prove nothing.
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE_INACTIVE, [UNREADABLE_NODE], timeout=RAISE_TIMEOUT_SEC)
+        self.assertTrue(
+            found,
+            f'{FAULT_CODE_INACTIVE} never raised naming {UNREADABLE_NODE} - the node the presence '
+            'detector handed back was then reported by nobody at all '
+            f'(last description: {description!r})')
+
+        assert_fault_absent_throughout(
+            self, PORT, FAULT_CODE_DISAPPEARED, SILENCE_WINDOW_SEC)
+
+
+class TestGateStaysPermissiveForTheOtherDetectors(unittest.TestCase):
+    """The three other detectors still report in a graph carrying an unmeasured managed node.
+
+    The guard on having left ReliabilityGate::allows_raise() and LifecycleWatcher::node_ok()
+    alone. Tightening either one would have been the shorter fix and would have silenced every
+    fault about a node whose GetState never answers.
+
+    The three legs are not equal, and saying so is the point:
+
+    - GRAPH_PARAM_DRIFT is app-keyed. param_drift builds its read set from
+      reliability_allows(ctx.gate, app_id), so this fixture is read at all only while the gate
+      stays permissive about an unread label. This leg discriminates.
+    - GRAPH_QOS_MISMATCH and GRAPH_ORPHAN are keyed by topic, not by App::id, and neither
+      detector consults the per-entity gate - orphan_detector.cpp states it outright. They
+      cannot be suppressed by an app-keyed predicate however it is written, so these two legs
+      are regression guards on the detectors still running at all in this graph, not evidence
+      about the gate. The QoS pair does include the fixture's own publisher.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        # A finite REQUESTED deadline against the fixture's own no-deadline OFFER on
+        # ~/transition_event: RxO-incompatible, so the mismatched pair has the unmeasured
+        # managed node on one end of it. Never spun - DDS endpoint discovery is what the
+        # detector reads, and it is populated by DDS's own background discovery.
+        cls._qos_node = Node('presence_ownership_qos_sub')
+        cls._qos_sub = cls._qos_node.create_subscription(
+            TransitionEvent, QOS_TOPIC, lambda _msg: None,
+            QoSProfile(depth=10, reliability=ReliabilityPolicy.RELIABLE,
+                       deadline=Duration(seconds=QOS_SUB_DEADLINE_SEC)))
+
+        # One publisher-only topic and one subscriber-only topic, same type, same namespace,
+        # leaf edit distance 1 - the remap-typo signature the orphan detector looks for.
+        cls._orphan_node = Node('presence_ownership_orphan')
+        cls._orphan_pub = cls._orphan_node.create_publisher(
+            LaserScan, ORPHAN_TYPO_TOPIC, QoSProfile(depth=10))
+        cls._orphan_sub = cls._orphan_node.create_subscription(
+            LaserScan, ORPHAN_TARGET_TOPIC, lambda _msg: None, QoSProfile(depth=10))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._orphan_node.destroy_node()
+        cls._qos_node.destroy_node()
+        rclpy.shutdown()
+
+    def test_01_param_drift_still_reads_the_unmeasured_managed_node(self):
+        self.assertTrue(
+            wait_until_watchdog_armed(PORT, timeout=ARM_TIMEOUT_SEC, app_id=UNREADABLE_NODE),
+            f'graph_watchdog never reported {UNREADABLE_NODE} armed')
+        entity = _poll_watchdog_entity(PORT, UNREADABLE_NODE, '', timeout=LABEL_TIMEOUT_SEC)
+        self.assertIsNotNone(
+            entity,
+            f'{UNREADABLE_NODE} never appeared with an EMPTY lifecycle label - without an '
+            'unmeasured managed node in the graph none of the three legs below is about anything')
+
+        # The needle is the descriptor param_drift actually writes: "<app_id>:<name> expected=..",
+        # with the NAME json-dumped (ParamDriftPolicy::safe_name), so it carries its own quotes.
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE_PARAM_DRIFT, [f'{UNREADABLE_NODE}:"{ANSWER_PARAM}"'],
+            timeout=RAISE_TIMEOUT_SEC)
+        self.assertTrue(
+            found,
+            f"{FAULT_CODE_PARAM_DRIFT} never named {UNREADABLE_NODE}'s {ANSWER_PARAM} - the "
+            'app-keyed gate stopped permitting a node whose lifecycle label was never read, so '
+            f'param_drift never read it (last description: {description!r})')
+
+    def test_02_qos_mismatch_still_reports_a_pair_including_that_node(self):
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE_QOS, [QOS_TOPIC], timeout=RAISE_TIMEOUT_SEC)
+        self.assertTrue(
+            found,
+            f'{FAULT_CODE_QOS} never named {QOS_TOPIC} - a deadline-incompatible subscriber '
+            "against the fixture's own publisher went unreported "
+            f'(last description: {description!r})')
+
+    def test_03_orphan_still_reports_a_near_miss_pair(self):
+        found, description = poll_fault_describing(
+            PORT, FAULT_CODE_ORPHAN, [ORPHAN_TYPO_TOPIC, ORPHAN_TARGET_TOPIC],
+            timeout=RAISE_TIMEOUT_SEC)
+        self.assertTrue(
+            found,
+            f'{FAULT_CODE_ORPHAN} never named the {ORPHAN_TYPO_TOPIC} / {ORPHAN_TARGET_TOPIC} '
+            f'pair (last description: {description!r})')
+
+
+# Each CTest target launches this file with one scenario, so only that scenario's case may run.
+# Removing the others from the module (rather than skipping them) means each run reports exactly
+# one case, and a missing result is a real failure rather than an expected line of output - see
+# the sibling e2e files' identical rationale.
+_SCENARIO_CASES = {
+    'restart_inside_warmup': 'TestRestartInsideWarmup',
+    'provisional_yields_to_a_real_label': 'TestProvisionalOwnershipYieldsToARealLabel',
+    'budget_spent_then_owned': 'TestBudgetSpentThenOwned',
+    'no_require_active_still_owned': 'TestNoRequireActiveStillOwned',
+    'answered_then_owned': 'TestMeasuredNodeIsOwnedByPresence',
+    'measured_then_unmeasured': 'TestMeasuredThenUnmeasured',
+    'gate_unaffected': 'TestGateStaysPermissiveForTheOtherDetectors',
+}
+if SCENARIO not in _SCENARIO_CASES:
+    raise RuntimeError(
+        f'WATCHDOG_E2E_SCENARIO={SCENARIO!r} is not one of {sorted(_SCENARIO_CASES)}; the CTest '
+        'target and this file disagree about which scenarios exist')
+for _scenario, _case_name in _SCENARIO_CASES.items():
+    if _scenario != SCENARIO:
+        del globals()[_case_name]
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Verify the gateway/fault_manager/fixture stack exits cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            self.assertIn(
+                info.returncode,
+                ALLOWED_EXIT_CODES,
+                f'Process {info.process_name} exited with {info.returncode}',
+            )

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
@@ -124,6 +124,7 @@ from harness import (  # noqa: E402, I100
     API_BASE_PATH,
     assert_fault_absent_throughout,
     assert_fault_never_names,
+    assert_process_exited,
     create_watchdog_test_launch,
     poll_fault_describing,
     poll_faults,
@@ -208,6 +209,13 @@ TIME_SCALE = get_time_scale()
 ARM_TIMEOUT_SEC = 60.0 * TIME_SCALE
 FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 LABEL_TIMEOUT_SEC = 30.0 * TIME_SCALE
+# Unchanged, and now it only has to cover what it can actually be held to. Every call site
+# proves the process EXITED first (assert_process_exited), so the two terms left are the ones
+# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
+# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
+# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
+# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
+# is gone' costs" note for who promises which term.
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PARAM_SET_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE
@@ -679,6 +687,7 @@ class TestBudgetSpentThenOwned(unittest.TestCase):
             'the warmup reason instead of the ownership reason this row is about')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], UNREADABLE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
@@ -745,6 +754,7 @@ class TestNoRequireActiveStillOwned(unittest.TestCase):
         self.assertTrue(entity.get('armed'))
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], UNREADABLE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
@@ -820,6 +830,7 @@ class TestMeasuredNodeIsOwnedByPresence(unittest.TestCase):
             'correct rather than a defect')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], UNREADABLE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')
@@ -886,6 +897,7 @@ class TestMeasuredThenUnmeasured(unittest.TestCase):
             'happen')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], DROPPABLE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, DROPPABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{DROPPABLE_NODE} never left GET /apps after SIGTERM')
@@ -934,6 +946,7 @@ class TestRestartInsideWarmup(unittest.TestCase):
             'GET /faults never answered 200 - nothing below would prove anything')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], PLAIN_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, PLAIN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{PLAIN_NODE} never left GET /apps after the first SIGTERM')
@@ -962,6 +975,7 @@ class TestRestartInsideWarmup(unittest.TestCase):
                     'back, so there is no record for the second death to move')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], PLAIN_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, PLAIN_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{PLAIN_NODE} never left GET /apps after the second SIGTERM')
@@ -1105,6 +1119,7 @@ class TestProvisionalOwnershipYieldsToARealLabel(unittest.TestCase):
             'and the kill below would be measuring the window rather than the handover')
 
         os.kill(target_node.process_details['pid'], signal.SIGTERM)
+        assert_process_exited(self, target_node.process_details['pid'], UNREADABLE_NODE)
         self.assertTrue(
             _poll_apps_absent(PORT, UNREADABLE_NODE, timeout=DEPARTURE_TIMEOUT_SEC),
             f'{UNREADABLE_NODE} never left GET /apps after SIGTERM')

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_presence_ownership_e2e.test.py
@@ -211,11 +211,11 @@ FAULTS_LIVE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 LABEL_TIMEOUT_SEC = 30.0 * TIME_SCALE
 # Unchanged, and now it only has to cover what it can actually be held to. Every call site
 # proves the process EXITED first (assert_process_exited), so the two terms left are the ones
-# somebody owns: the Fast DDS participant lease an unclean death costs before the graph drops
-# the participant (measured 19.8-20.1 s on this stack) plus the gateway's own graph-to-/apps
-# latency (refresh_debounce_ms 1000 + one 100 ms tick) = 21.1 s. 30 s clears that with room
-# for the sanitizer jobs, so nothing here needed widening - see harness.py's "What 'the node
-# is gone' costs" note for who promises which term.
+# somebody owns: the DDS participant lease an unclean death costs before the graph drops the
+# participant, plus the gateway's own graph-to-/apps latency - 20 + 1.1 = 21.1 s. 30 s clears
+# that with room for the sanitizer jobs, so nothing here needed widening. Both figures, and
+# who promises which term, are in the gateway's docs/config/server.rst under "How long a
+# departed node keeps being listed".
 DEPARTURE_TIMEOUT_SEC = 30.0 * TIME_SCALE
 PARAM_SET_TIMEOUT_SEC = 30.0 * TIME_SCALE
 RAISE_TIMEOUT_SEC = 60.0 * TIME_SCALE

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_allowlist_suppressor.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_allowlist_suppressor.cpp
@@ -1,0 +1,125 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Pure logic: no rclcpp::init() needed - AllowlistSuppressor::suppresses() ignores ctx
+// entirely, so a default-constructed DetectorContext (every pointer null) is enough.
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+
+#include "ros2_medkit_graph_watchdog/allowlist_suppressor.hpp"
+
+using ros2_medkit_graph_watchdog::AllowlistSuppressor;
+using ros2_medkit_graph_watchdog::DetectorContext;
+
+TEST(AllowlistSuppressor, ExactMatchSuppresses) {
+  AllowlistSuppressor s({"/a", "/b"});
+  DetectorContext ctx;
+  EXPECT_TRUE(s.suppresses("/a", ctx));
+  EXPECT_TRUE(s.suppresses("/b", ctx));
+}
+
+TEST(AllowlistSuppressor, NonMemberAbstains) {
+  AllowlistSuppressor s({"/a"});
+  DetectorContext ctx;
+  EXPECT_FALSE(s.suppresses("/c", ctx));
+}
+
+TEST(AllowlistSuppressor, PrefixOfAnAllowedEntryIsNotAMatch) {
+  AllowlistSuppressor s({"/r1/x"});
+  DetectorContext ctx;
+  EXPECT_FALSE(s.suppresses("/r1/x/child", ctx));
+  EXPECT_FALSE(s.suppresses("/r1", ctx));
+}
+
+TEST(AllowlistSuppressor, ASharedSuffixAcrossDifferentNamespacesIsNotAMatch) {
+  // /r1/x on the list must never reach /r2/x - the whole reason this is an exact-match
+  // set rather than a leaf/substring comparison.
+  AllowlistSuppressor s({"/r1/x"});
+  DetectorContext ctx;
+  EXPECT_FALSE(s.suppresses("/r2/x", ctx));
+}
+
+TEST(AllowlistSuppressor, EmptyAllowSetSuppressesNothing) {
+  AllowlistSuppressor s({});
+  DetectorContext ctx;
+  EXPECT_FALSE(s.suppresses("", ctx));
+  EXPECT_FALSE(s.suppresses("/a", ctx));
+}
+
+TEST(AllowlistSuppressor, IsDurable) {
+  AllowlistSuppressor s({"/a"});
+  EXPECT_TRUE(s.durable());
+}
+
+// The three matching forms this class deliberately mirrors from
+// lifecycle_expectation_detector.cpp's own require_active matching (id / effective_fqn() /
+// bare leaf) - see the class doc. suppresses() itself only ever sees one string (the entity
+// key) and so only ever proves the two forms derivable from that string alone; the id form
+// is proven separately below through allows(), the method a caller holding a captured
+// App::id uses instead - see node_death_detector.cpp's tick().
+
+TEST(AllowlistSuppressor, FullFqnFormSuppressesViaExactMatch) {
+  // The form the ORIGINAL exact-match tests above already exercise, named here so all three
+  // forms appear together as one group.
+  AllowlistSuppressor s({"/powertrain/engine/calibration"});
+  DetectorContext ctx;
+  EXPECT_TRUE(s.suppresses("/powertrain/engine/calibration", ctx));
+}
+
+TEST(AllowlistSuppressor, BareLeafFormSuppressesANamespacedKey) {
+  // The bug this fix closes: an operator writes the bare node name they see in the graph,
+  // not its full namespaced fqn.
+  AllowlistSuppressor s({"calibration"});
+  DetectorContext ctx;
+  EXPECT_TRUE(s.suppresses("/powertrain/engine/calibration", ctx));
+}
+
+TEST(AllowlistSuppressor, BareLeafFormMatchesEveryNamespaceOfThatName) {
+  // Deliberately fleet-wide, mirroring lifecycle_expectation's own require_active: a bare
+  // name matches every namespace's node of that name. An operator who wants to pin one
+  // namespace uses a full fqn entry instead (see FullFqnFormSuppressesViaExactMatch).
+  AllowlistSuppressor s({"calibration"});
+  DetectorContext ctx;
+  EXPECT_TRUE(s.suppresses("/coll_a/calibration", ctx));
+  EXPECT_TRUE(s.suppresses("/coll_b/calibration", ctx));
+}
+
+TEST(AllowlistSuppressor, KeyWithNoSlashIsAbstainedWhenNotListed) {
+  // Exercises the slash == npos branch: entity_key is already its own bare leaf, so there is
+  // no second form left to try once the exact-match check above has already missed.
+  AllowlistSuppressor s({"other"});
+  DetectorContext ctx;
+  EXPECT_FALSE(s.suppresses("calibration", ctx));
+}
+
+TEST(AllowlistSuppressor, IdFormMatchesThroughAllowsDirectly) {
+  // The id form: a caller (node_death_detector.cpp) that has captured App::id while an
+  // entity was still present checks it against allows() directly, bypassing suppresses()
+  // entirely - see the class doc for why suppresses() alone cannot answer this for a dead
+  // key. The id used here is what a bare-name collision produces
+  // ('<namespace-without-slashes>_<name>'), proven end to end (including the sibling that
+  // must NOT match) in test_node_death_integration.cpp's own collision test.
+  AllowlistSuppressor s({"coll_a_calibration"});
+  EXPECT_TRUE(s.allows("coll_a_calibration"));
+}
+
+TEST(AllowlistSuppressor, AllowsIsAnExactCheckWithNoLeafDerivation) {
+  // allows() is the raw building block suppresses() itself is built from - it does not also
+  // derive a bare leaf the way suppresses() does, so a candidate that would only match via
+  // leaf-derivation must not match here.
+  AllowlistSuppressor s({"calibration"});
+  EXPECT_FALSE(s.allows("/powertrain/engine/calibration"));
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
@@ -280,6 +280,36 @@ class FakeContextChurningApps : public FakeContext {
   mutable std::atomic<int> counter_{0};
 };
 
+// Reports a permanently-present "/anchor" app (so the snapshot is never empty - an empty
+// snapshot re-arms ReliabilityGate's global bringup grace, which would delay arming for a
+// reason unrelated to what this context exists to drive) plus one "/victim" app on the VERY
+// FIRST call only - departed on every call after that. Built for
+// MalformedNodeDeathPruneGraceUsesThePluginScopeFallbackNotTheDetectorsOwnDefault, which
+// needs a real death to drive real reclaim timing, not merely a config-read seam.
+class FakeContextVictimDepartsAfterFirstTick : public FakeContext {
+ public:
+  using FakeContext::FakeContext;
+  ros2_medkit_gateway::IntrospectionInput get_entity_snapshot() const override {
+    ros2_medkit_gateway::IntrospectionInput input;
+    ros2_medkit_gateway::App anchor;
+    anchor.id = "/anchor";
+    anchor.bound_fqn = "/anchor";
+    anchor.is_online = true;
+    input.apps.push_back(anchor);
+    if (calls_.fetch_add(1) == 0) {
+      ros2_medkit_gateway::App victim;
+      victim.id = "/victim";
+      victim.bound_fqn = "/victim";
+      victim.is_online = true;
+      input.apps.push_back(victim);
+    }
+    return input;
+  }
+
+ private:
+  mutable std::atomic<int> calls_{0};
+};
+
 class GraphWatchdogPluginTest : public ::testing::Test {
  protected:
   void SetUp() override {
@@ -330,6 +360,34 @@ TEST_F(GraphWatchdogPluginTest, PluginScopePruneGraceStillAppliesWhenTheDetector
   std::lock_guard<std::mutex> lk(g_captured_mutex);
   ASSERT_TRUE(g_captured_config.contains("prune_grace"));
   EXPECT_EQ(g_captured_config["prune_grace"].get<int>(), 42) << "the plugin-scope value is still the default";
+}
+
+// compute_departed_retention_ticks() needs no ROS node at all - it reads only its own
+// config_snapshot parameter plus tick_interval_ms_/prune_grace_, both left at their
+// constructor defaults (1000, 60) when configure()/set_context() are never called.
+TEST(ComputeDepartedRetentionTicks, OversizedNodeDeathPruneGraceIsRejectedNotTruncated) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  const int ticks = plugin.compute_departed_retention_ticks_for_test(
+      nlohmann::json{{"detectors", {{"node_death", {{"prune_grace", 4294967296LL}}}}}});
+  // 4294967296 (2^32) narrowed to int BEFORE a range check wraps to exactly 0, which passes
+  // a bare ">= 0" check silently - node_death_detector.cpp's own configure() rejects this
+  // same value and keeps its default (60), so the correct retention here is computed from
+  // that same default: prune_ticks=max(60, miss_grace+1), miss_grace floored to 2 at the
+  // 1000ms default tick (unaffected, since the floor only bites below ~1500ms), so
+  // 60+2+1=63. A narrow-then-validate bug would instead compute from the wrapped 0:
+  // max(0,3)+2+1=6.
+  EXPECT_EQ(ticks, 63);
+}
+
+TEST(ComputeDepartedRetentionTicks, OversizedNodeDeathMissGraceIsRejectedNotTruncated) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  const int ticks = plugin.compute_departed_retention_ticks_for_test(
+      nlohmann::json{{"detectors", {{"node_death", {{"miss_grace", 4294967296LL}}}}}});
+  // Same shape as the prune_grace case above, for the other field this function reads the
+  // same way. miss_grace stays at its default (2, unaffected by the floor at the 1000ms
+  // default tick), prune_grace stays at the plugin's own default (60):
+  // prune_ticks=max(60,3)=60, retention=60+2+1=63.
+  EXPECT_EQ(ticks, 63);
 }
 
 TEST_F(GraphWatchdogPluginTest, ExportsAdvertiseCorrectApiVersion) {
@@ -501,6 +559,107 @@ TEST_F(GraphWatchdogPluginTest, WatchdogStatusRouteReportsEntityLifecycleAndArme
   EXPECT_EQ(entity["state"], "armed");
   EXPECT_TRUE(entity["armed"].get<bool>());
   EXPECT_TRUE(entity.contains("lifecycle"));  // untracked (non-lifecycle) node -> null, but key present
+
+  EXPECT_NO_THROW(plugin.shutdown());
+  exec.cancel();
+  spin.join();
+}
+
+// The plugin injects its own prune_grace default only when the
+// per-detector key is ABSENT (see set_context()'s configure loop), so a PRESENT but
+// malformed detectors.node_death.prune_grace used to reach node_death's own configure()
+// unfiltered, which falls back to ITS OWN hardcoded default (60) rather than the plugin's.
+// compute_departed_retention_ticks() independently falls back to the plugin's own
+// prune_grace_ for the exact same malformed value, so the two disagreed whenever an
+// operator's plugin-scope prune_grace was anything other than the coincidentally-matching
+// 60 - sizing the lifecycle-departed retention window for a reclaim tick node_death would
+// not actually reach for roughly another 57 ticks. Proven here through REAL reclaim timing
+// (an allowlisted, durably-suppressed death) rather than by inspecting either side's
+// computation in isolation - either side alone can look right while still disagreeing with
+// the other, which is exactly why OversizedNodeDeathPruneGraceIsRejectedNotTruncated below
+// (plugin-scope prune_grace left at the coincidentally-matching default 60) could not catch
+// this.
+TEST_F(GraphWatchdogPluginTest, MalformedNodeDeathPruneGraceUsesThePluginScopeFallbackNotTheDetectorsOwnDefault) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContextVictimDepartsAfterFirstTick ctx(gateway_node_.get());
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node_);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  // tick_interval_ms MUST be 3000: node_death's own wall-clock floor
+  // (min_node_death_miss_grace) bumps a fast-tick miss_grace up regardless of what is
+  // configured, and prune_ticks = max(prune_grace, miss_grace + 1) - a bumped-up miss_grace
+  // would dominate that max() identically whether prune_grace fell back to 1 or to 60,
+  // masking the exact divergence this test exists to catch. At 3000ms the floor is exactly
+  // 0, so the configured miss_grace(0) is used as written.
+  plugin.configure(
+      nlohmann::json{{"tick_interval_ms", 3000},
+                     {"warmup_cycles", 0},
+                     {"prune_grace", 0},  // plugin-scope, deliberately far from node_death's own hardcoded 60
+                     {"detectors",
+                      {{"node_death",
+                        {{"miss_grace", 0},
+                         {"prune_grace", "invalid"},  // malformed: must fall back, not pass through unfiltered
+                         {"allowlist", nlohmann::json::array({"/victim"})},
+                         {"suppress", nlohmann::json::array({"allowlist"})}}}}}});
+  plugin.set_context(ctx);
+
+  const auto routes = plugin.get_routes();
+  const auto route_it = find_watchdog_route(routes);
+  ASSERT_NE(route_it, routes.end());
+
+  // node_death's tracked_count_ atomic default-initializes to 0 - the SAME value a reclaimed
+  // /victim would leave it at - so reading it before the first tick has actually run would
+  // make the deadline below pass vacuously, having proven nothing. Wait for the first tick to
+  // publish "both anchor and victim are tracked" (2) before timing anything past it.
+  const auto armed_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  std::size_t tracked_count = 0;
+  while (std::chrono::steady_clock::now() < armed_deadline) {
+    TestResponseSink armed_sink;
+    ros2_medkit_gateway::PluginRequest armed_req(nullptr);
+    ros2_medkit_gateway::PluginResponse armed_res(&armed_sink);
+    route_it->handler(armed_req, armed_res);
+    const auto & armed_detectors = armed_sink.body["x-medkit-watchdog"]["detectors"];
+    if (armed_detectors.contains("node_death")) {
+      tracked_count = armed_detectors["node_death"]["tracked_count"].get<std::size_t>();
+      if (tracked_count >= 2) {
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  ASSERT_EQ(tracked_count, 2u) << "precondition: anchor and victim must both have been observed "
+                                  "tracked at least once, or the reclaim timing below proves "
+                                  "nothing";
+
+  // prune_ticks = max(0, miss_grace(0)+1=1) = 1 if the plugin-scope fallback is used: victim
+  // departs and mis-suppresses on tick 2 (streak 1), reclaimed on tick 3 (streak 2 > 1) - two
+  // more 3000ms ticks past the precondition above, ~6-7s including scheduling slack. If
+  // node_death instead fell back to its own hardcoded 60, reclaim needs streak 61 - roughly
+  // 180s at this tick rate. The deadline sits well inside that gap: generous for the fixed
+  // case, a small fraction of the hardcoded-fallback case, so this discriminates rather than
+  // merely giving both enough time to pass.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(12);
+  while (std::chrono::steady_clock::now() < deadline) {
+    TestResponseSink sink;
+    ros2_medkit_gateway::PluginRequest req(nullptr);
+    ros2_medkit_gateway::PluginResponse res(&sink);
+    route_it->handler(req, res);
+    const auto & detectors = sink.body["x-medkit-watchdog"]["detectors"];
+    if (detectors.contains("node_death")) {
+      tracked_count = detectors["node_death"]["tracked_count"].get<std::size_t>();
+      if (tracked_count == 1) {
+        break;
+      }
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_EQ(tracked_count, 1u) << "the allowlisted, durably-suppressed /victim must be reclaimed within a few prune "
+                                  "ticks sized off the plugin's OWN prune_grace default, not node_death's unrelated "
+                                  "hardcoded fallback - only the anchor (never departed) should remain tracked";
 
   EXPECT_NO_THROW(plugin.shutdown());
   exec.cancel();

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_graph_watchdog_plugin.cpp
@@ -116,11 +116,97 @@ class RaisingDetector : public ros2_medkit_graph_watchdog::Detector {
   }
 };
 
+// ---- The presence-view handoff: publisher, and one observer on each side of it ----------
+//
+// DetectorContext::presence_tracked is produced by the PLUGIN, from whichever emitting
+// detector exposes tracked_departure_keys(). Every other test of that seam stages the view by
+// hand, which cannot tell a working publication from a deleted one, so these three stand in for
+// the two real detectors and let the plugin do the work.
+
+/// Stands in for the presence class. Its key set GROWS inside its own tick(), which is what
+/// makes "pointer into live state" and "copy taken at one point" distinguishable from the
+/// outside: with a pointer, an observer that ticks before it and one that ticks after it read
+/// different contents on the same sweep.
+std::atomic<int> g_owner_ticks{0};
+
+class FakePresenceOwner : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "fake_owner";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & /*ctx*/) override {
+    keys_.insert("/grown_" + std::to_string(g_owner_ticks.fetch_add(1)));
+  }
+  const std::set<std::string> * tracked_departure_keys() const override {
+    return &keys_;
+  }
+
+ private:
+  std::set<std::string> keys_{"/seeded"};
+};
+
+/// What one observer saw, in sweep order: the Nth entry of two observers' logs belong to the
+/// same sweep, because the plugin ticks every detector once per sweep in registry order.
+struct ViewLog {
+  std::mutex mutex;
+  std::vector<std::optional<std::set<std::string>>> seen;
+};
+ViewLog g_view_before;
+ViewLog g_view_after;
+
+void record_view(ViewLog & log, const ros2_medkit_graph_watchdog::DetectorContext & ctx) {
+  std::lock_guard<std::mutex> lk(log.mutex);
+  if (ctx.presence_tracked == nullptr) {
+    log.seen.emplace_back(std::nullopt);
+  } else {
+    log.seen.emplace_back(*ctx.presence_tracked);
+  }
+}
+
+std::vector<std::optional<std::set<std::string>>> view_snapshot(ViewLog & log) {
+  std::lock_guard<std::mutex> lk(log.mutex);
+  return log.seen;
+}
+
+void reset_view_logs() {
+  {
+    std::lock_guard<std::mutex> lk(g_view_before.mutex);
+    g_view_before.seen.clear();
+  }
+  std::lock_guard<std::mutex> lk(g_view_after.mutex);
+  g_view_after.seen.clear();
+}
+
+class ViewObserverBefore : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "view_obs_before";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & ctx) override {
+    record_view(g_view_before, ctx);
+  }
+};
+
+class ViewObserverAfter : public ros2_medkit_graph_watchdog::Detector {
+ public:
+  std::string id() const override {
+    return "view_obs_after";
+  }
+  void tick(ros2_medkit_graph_watchdog::DetectorContext & ctx) override {
+    record_view(g_view_after, ctx);
+  }
+};
+
 REGISTER_DETECTOR(CountingDetector, "counting")
 REGISTER_DETECTOR(RaisingDetector, "raising")
 REGISTER_DETECTOR(ThrowingDetector, "throwing")
 REGISTER_DETECTOR(OffDetector, "offd")
 REGISTER_DETECTOR(ConfigCapturingDetector, "capturing")
+// Order matters here and nowhere else in this file: DetectorRegistry keeps its factories in a
+// vector, so these three tick in exactly this order and the owner sits BETWEEN its observers.
+REGISTER_DETECTOR(ViewObserverBefore, "view_obs_before")
+REGISTER_DETECTOR(FakePresenceOwner, "fake_owner")
+REGISTER_DETECTOR(ViewObserverAfter, "view_obs_after")
 
 }  // namespace
 
@@ -426,6 +512,183 @@ TEST_F(GraphWatchdogPluginTest, LifecycleRunsTickAndShutsDownCleanly) {
 
   exec.cancel();
   spin.join();
+}
+
+// ---- DetectorContext::presence_tracked, as the PLUGIN actually produces it ----------------
+
+namespace {
+/// Runs a real plugin until both observers have logged at least `sweeps` ticks. Returns their
+/// logs. node_death is turned OFF in every caller: it is linked into this binary, exposes a
+/// view of its own, and the publication loop takes the FIRST emitting detector that has one -
+/// which would make these tests depend on static-init order ACROSS translation units.
+std::pair<std::vector<std::optional<std::set<std::string>>>, std::vector<std::optional<std::set<std::string>>>>
+run_until_observed(rclcpp::Node::SharedPtr gateway_node, const nlohmann::json & detectors_config, std::size_t sweeps) {
+  reset_view_logs();
+  g_owner_ticks.store(0);
+
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node.get());
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(gateway_node);
+  std::thread spin([&exec] {
+    exec.spin();
+  });
+
+  nlohmann::json config{{"tick_interval_ms", 50}, {"detectors", detectors_config}};
+  config["detectors"]["node_death"] = {{"mode", "off"}};
+  plugin.configure(config);
+  plugin.set_context(ctx);
+
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (view_snapshot(g_view_before).size() >= sweeps && view_snapshot(g_view_after).size() >= sweeps) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  plugin.shutdown();
+  exec.cancel();
+  spin.join();
+  return {view_snapshot(g_view_before), view_snapshot(g_view_after)};
+}
+}  // namespace
+
+// The publication itself. Nothing in this test stages a view by hand, so deleting the plugin's
+// publication loop - or having it hand out a view the owning detector never produced - leaves
+// every observation null and fails here.
+TEST_F(GraphWatchdogPluginTest, ThePluginPublishesTheOwningDetectorsKeysToEveryDetector) {
+  const auto [before, after] = run_until_observed(gateway_node_, nlohmann::json::object(), 3);
+  ASSERT_GE(before.size(), 3u) << "the plugin never completed enough sweeps to observe a handoff";
+  ASSERT_GE(after.size(), 3u);
+
+  EXPECT_FALSE(before.front().has_value())
+      << "the very first sweep has no previous sweep to publish, so the view must be null there "
+         "rather than an empty set a reader would take for 'tracked nothing'";
+  ASSERT_TRUE(before[1].has_value()) << "the owner's key set never reached a detector at all - the plugin is not "
+                                        "publishing what tracked_departure_keys() returns";
+  EXPECT_EQ(before[1]->count("/seeded"), 1u) << "the published view is not the owner's own set";
+  ASSERT_TRUE(after[1].has_value());
+  EXPECT_EQ(after[1]->count("/seeded"), 1u);
+}
+
+// A SNAPSHOT, not a pointer into the owner's live set. The owner grows its set inside its own
+// tick(), and these two observers sit on either side of it in the registry: with a pointer they
+// read different contents on the same sweep, and which one a real detector gets would depend on
+// where it happens to be registered.
+TEST_F(GraphWatchdogPluginTest, EveryDetectorInASweepSeesTheSameViewWhateverItsRegistryPosition) {
+  const auto [before, after] = run_until_observed(gateway_node_, nlohmann::json::object(), 5);
+  ASSERT_GE(before.size(), 5u);
+  ASSERT_GE(after.size(), 5u);
+
+  const std::size_t sweeps = std::min(before.size(), after.size());
+  for (std::size_t i = 0; i < sweeps; ++i) {
+    ASSERT_EQ(before[i].has_value(), after[i].has_value()) << "sweep " << i
+                                                           << ": one side saw a view and the other "
+                                                              "did not";
+    if (before[i].has_value()) {
+      EXPECT_EQ(*before[i], *after[i])
+          << "sweep " << i
+          << ": the detector that ticks BEFORE the owner and the one that ticks AFTER it read "
+             "different contents, so what a detector sees depends on where it sits in the "
+             "registry - the view is a pointer into live state, not a snapshot";
+    }
+  }
+
+  // And the snapshot is genuinely refreshed, not frozen: the owner adds a key per tick, so a
+  // later sweep must see more than an earlier one. Without this, publishing a copy ONCE would
+  // satisfy the equality above.
+  ASSERT_TRUE(before[1].has_value() && before[sweeps - 1].has_value());
+  EXPECT_GT(before[sweeps - 1]->size(), before[1]->size())
+      << "the published view stopped tracking the owner's set after the first sweep";
+}
+
+// An Advisory owner speaks for nobody: it tracks keys it will never file a fault for, and a
+// reader treating that as "somebody has this covered" would hold back its own report.
+TEST_F(GraphWatchdogPluginTest, AnAdvisoryOwnersKeysAreNeverPublished) {
+  const auto [before, after] = run_until_observed(gateway_node_, {{"fake_owner", {{"mode", "advisory"}}}}, 3);
+  ASSERT_GE(before.size(), 3u);
+  ASSERT_GE(after.size(), 3u);
+  for (std::size_t i = 0; i < before.size(); ++i) {
+    EXPECT_FALSE(before[i].has_value()) << "sweep " << i
+                                        << ": an Advisory detector's tracked keys were published as "
+                                           "though somebody would report those departures";
+  }
+  for (std::size_t i = 0; i < after.size(); ++i) {
+    EXPECT_FALSE(after[i].has_value()) << "sweep " << i;
+  }
+  EXPECT_GT(g_owner_ticks.load(), 0) << "the Advisory detector never ticked, so this test never had a view to "
+                                        "exclude in the first place";
+}
+
+// And with no owner at all the view is null rather than an empty set: "nobody is tracking
+// anything" and "somebody is tracking nothing" select opposite behaviour in the reader.
+TEST_F(GraphWatchdogPluginTest, WithNoPresenceDetectorAtAllTheViewIsNull) {
+  const auto [before, after] = run_until_observed(gateway_node_, {{"fake_owner", {{"mode", "off"}}}}, 3);
+  ASSERT_GE(before.size(), 3u);
+  ASSERT_GE(after.size(), 3u);
+  for (std::size_t i = 0; i < before.size(); ++i) {
+    EXPECT_FALSE(before[i].has_value()) << "sweep " << i;
+  }
+  for (std::size_t i = 0; i < after.size(); ++i) {
+    EXPECT_FALSE(after[i].has_value()) << "sweep " << i;
+  }
+  EXPECT_EQ(g_owner_ticks.load(), 0) << "an Off detector must not be built into the active set at all";
+}
+
+// Plugin-scope integer keys are checked WIDE. JSON and ROS parameters both carry 64-bit
+// integers, so narrowing first lets a huge value wrap back into the accepted band and pass as
+// though the operator had asked for something legal. 4294967346 is 2^32 + 50: narrowed first it
+// becomes a perfectly plausible 50 ms cadence, which is why the retention window - the one
+// observable that reads tick_interval_ms_ without running the tick loop - is what this asserts
+// on rather than the absence of a log line.
+TEST_F(GraphWatchdogPluginTest, AnOutOfRangeTickIntervalIsRejectedRatherThanWrappedIntoTheBand) {
+  ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+  FakeContext ctx(gateway_node_.get());
+  plugin.configure(nlohmann::json{{"tick_interval_ms", 4294967346LL}});
+  plugin.set_context(ctx);  // load_parameters() runs here, not in configure()
+  plugin.shutdown();
+
+  // The default 1000 ms cadence: miss_grace defaults to 2 (its floor at this tick is 2), so
+  // prune_ticks = max(60, 3) = 60 and retention = 60 + 2 + 1.
+  EXPECT_EQ(plugin.compute_departed_retention_ticks_for_test(nlohmann::json::object()), 63)
+      << "tick_interval_ms=4294967346 was narrowed to 50 and accepted, so every window sized "
+         "from the cadence is sized for a configuration nobody asked for";
+}
+
+// Both ends of the band, against the same observable. The upper endpoint (INT_MAX) is
+// deliberately NOT asserted here: at any tick past 1500 ms the 3000 ms floor needs no ticks at
+// all, so its retention is arithmetically identical to the default's and the check could not
+// tell an applied value from an ignored one.
+TEST_F(GraphWatchdogPluginTest, TheTickIntervalBandIsEnforcedAtBothEnds) {
+  {  // the smallest accepted cadence, and it must genuinely take effect
+    ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+    FakeContext ctx(gateway_node_.get());
+    plugin.configure(nlohmann::json{{"tick_interval_ms", 1}});
+    plugin.set_context(ctx);
+    plugin.shutdown();
+    // A 1 ms tick needs 2999 ticks to span the 3000 ms floor, so miss_grace is raised from 2 to
+    // 2999: prune_ticks = max(60, 3000) = 3000, retention = 3000 + 2999 + 1.
+    EXPECT_EQ(plugin.compute_departed_retention_ticks_for_test(nlohmann::json::object()), 6000)
+        << "the low endpoint of the documented band was not applied";
+  }
+  {  // one below it, which must be refused and leave the default standing
+    ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+    FakeContext ctx(gateway_node_.get());
+    plugin.configure(nlohmann::json{{"tick_interval_ms", 0}});
+    plugin.set_context(ctx);
+    plugin.shutdown();
+    EXPECT_EQ(plugin.compute_departed_retention_ticks_for_test(nlohmann::json::object()), 63)
+        << "a zero cadence was accepted";
+  }
+  {  // and the negative that a narrowing read turns 2147483648 into
+    ros2_medkit_graph_watchdog::GraphWatchdogPlugin plugin;
+    FakeContext ctx(gateway_node_.get());
+    plugin.configure(nlohmann::json{{"tick_interval_ms", 2147483648LL}});
+    plugin.set_context(ctx);
+    plugin.shutdown();
+    EXPECT_EQ(plugin.compute_departed_retention_ticks_for_test(nlohmann::json::object()), 63)
+        << "a value one past INT_MAX was not rejected on the wide integer";
+  }
 }
 
 TEST_F(GraphWatchdogPluginTest, FansOutTicksSkipsOffModeAndIsolatesThrowingDetector) {

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
@@ -196,6 +196,7 @@ IntrospectionInput snapshot_of(const std::vector<std::string> & ids) {
     App a;
     a.id = id;
     a.bound_fqn = "/" + id;
+    a.is_online = true;  // App defaults it to FALSE; every app here models a node that is running
     snapshot.apps.push_back(a);
   }
   return snapshot;
@@ -209,6 +210,7 @@ IntrospectionInput namespaced_snapshot_of(const std::string & ns, const std::str
   App a;
   a.id = ns + "_" + leaf;
   a.bound_fqn = "/" + ns + "/" + leaf;
+  a.is_online = true;  // see snapshot_of() - the default is FALSE, which models a different node
   snapshot.apps.push_back(a);
   return snapshot;
 }
@@ -307,8 +309,25 @@ class LifecycleExpectationIntegrationTest : public ::testing::Test {
       App a;
       a.id = id;
       a.bound_fqn = "/" + id;
+      // App::is_online defaults to FALSE, which is the manifest-declared-but-not-running
+      // shape - a node node_death skips entirely. Every app built here models a node that
+      // IS running, and the detector's own `armed` fact depends on the difference, so it is
+      // set explicitly rather than inherited. set_offline_app() stages the other one.
+      a.is_online = true;
       snapshot_.apps.push_back(a);
     }
+  }
+
+  // The manifest shape the builders above deliberately do not produce: an app the gateway
+  // carries with no running node behind it. node_death skips such an app outright, so
+  // nothing about it can ever be reported by the presence class.
+  void set_offline_app(const std::string & id) {
+    snapshot_.apps.clear();
+    App a;
+    a.id = id;
+    a.bound_fqn = "/" + id;
+    a.is_online = false;
+    snapshot_.apps.push_back(a);
   }
 
   // Seed apps with EXPLICIT (id, fqn) pairs - to reproduce App::id instability, where the
@@ -319,6 +338,7 @@ class LifecycleExpectationIntegrationTest : public ::testing::Test {
       App a;
       a.id = id;
       a.bound_fqn = fqn;
+      a.is_online = true;  // see set_apps() for why this is explicit
       snapshot_.apps.push_back(a);
     }
   }
@@ -340,6 +360,7 @@ class LifecycleExpectationIntegrationTest : public ::testing::Test {
     a.id = id;
     a.bound_fqn = fqn;
     a.services = {get_state, change_state};
+    a.is_online = true;  // see set_apps() for why this is explicit
     snapshot_.apps.push_back(a);
   }
 
@@ -4002,6 +4023,50 @@ TEST_F(LifecycleExpectationIntegrationTest, BelowGraceStreakSurvivesTheTightestP
 // BelowGraceStreakSurvivesTheTightestPruneGraceWithoutConfirmingWhileAbsent immediately
 // above, with arming the only difference - together the two rows prove the split is keyed on
 // arming and nothing else.
+// The gate has no notion of `is_online`, but node_death does: it skips an app that is not
+// online before it ever consults the gate. So an OFFLINE app can be armed, can be owned by the
+// gate's own answer (it carries no lifecycle record, and a node with no record is the presence
+// detector's outright), and can still be one node_death will never track. Latching that answer
+// makes this detector hand a departure to a detector that structurally cannot report it - the
+// same silence a permanently unmeasured node used to fall into.
+//
+// Staged in the order that reaches it: the app is offline and unmeasured while the gate arms
+// it (the window where a naive `armed` latches), then reads inactive, then vanishes below
+// grace. Nothing else can report that departure, so absence has to mature the violation.
+TEST_F(LifecycleExpectationIntegrationTest, OfflineAppIsNeverTreatedAsOwnedByThePresenceDetector) {
+  set_offline_app("a");
+  ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
+  arm_global_grace(gate);
+
+  auto det = make_lifecycle_expectation();
+  ASSERT_TRUE(det);
+  det->configure(nlohmann::json{{"require_active", nlohmann::json::array({"a"})}, {"grace", 4}});
+  auto ctx = make_ctx(DetectorMode::Raise, &gate);
+
+  // The window a naive `armed` latches in: armed by the gate, no lifecycle record at all, so
+  // the gate's ownership answer is TRUE for an app node_death has already skipped.
+  ASSERT_TRUE(gate.allows_raise("a")) << "the app was never armed, so the latch window this test "
+                                         "is about was never open";
+  ASSERT_EQ(gate.presence_ownership("a"), ros2_medkit_graph_watchdog::PresenceOwnership::kEarned)
+      << "the gate must still say it OWNS an app with no lifecycle record, and own it OUTRIGHT - "
+         "if it did not, this test would pass for a reason that has nothing to do with is_online";
+  det->tick(ctx);
+
+  gate.set_lifecycle_state_for_test("a", "inactive");
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  det->tick(ctx);  // streak 1, well below grace(4)
+  ASSERT_EQ(det->tracked_count_for_test(), 1u);
+  std::this_thread::sleep_for(200ms);
+  ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "the node was confirmed already, so grace(4) was never in force and the absence run "
+         "below proves nothing about a below-grace streak";
+
+  snapshot_.apps.clear();
+  ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before, *det, ctx))
+      << "a below-grace violation on an OFFLINE app did not mature from absence - node_death "
+         "skips an app that is not online, so this departure is reported by nothing at all";
+}
+
 TEST_F(LifecycleExpectationIntegrationTest, NeverArmedBelowGraceStreakMaturesFromAbsenceInsteadOfHoldingIndefinitely) {
   set_apps({"a"});
   ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
@@ -76,6 +76,7 @@ using ros2_medkit_graph_watchdog::DetectorContext;
 using ros2_medkit_graph_watchdog::DetectorMode;
 using ros2_medkit_graph_watchdog::kDefaultAbsenceGrace;
 using ros2_medkit_graph_watchdog::ReliabilityGate;
+using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeDisappeared;
 using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeInactive;
 using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeNotManaged;
 using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeUnreadable;
@@ -87,6 +88,17 @@ namespace {
 // The detector class is file-local in lifecycle_expectation_detector.cpp but
 // self-registers via REGISTER_DETECTOR, which runs when that .cpp is linked into this
 // test. Pull an instance from the registry (no production factory needed).
+/// The presence detector, from the same global registry. Both detectors are linked into this
+/// binary because the handover between them is what several cases here are about.
+std::unique_ptr<ros2_medkit_graph_watchdog::Detector> make_node_death() {
+  for (auto & d : ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all()) {
+    if (d->id() == "node_death") {
+      return std::move(d);
+    }
+  }
+  return nullptr;
+}
+
 std::unique_ptr<ros2_medkit_graph_watchdog::Detector> make_lifecycle_expectation() {
   for (auto & d : ros2_medkit_graph_watchdog::DetectorRegistry::instance().create_all()) {
     if (d->id() == "lifecycle_expectation") {
@@ -1644,6 +1656,58 @@ TEST_F(LifecycleExpectationIntegrationTest, NeverMatchedEntryPastTheHoldBoundSto
 // and finding nothing. The two reasons release on different conditions, so the log has to
 // say which one is in effect - here the measured-but-below-grace one, whose hold ends when
 // the node reads active or its streak passes grace, NOT after a fixed number of ticks.
+// The same log line for a node that has LEFT. Both exits the present-node sentence offers -
+// reading active, or the streak crossing grace - are unreachable for a departed node the
+// presence detector still holds: absence holds that streak rather than advancing it, and there
+// is no node left to read active. An operator told to wait for either is being pointed at
+// something that cannot happen, so the two cases get different sentences.
+TEST_F(LifecycleExpectationIntegrationTest, WithholdingForADepartedNodeSaysWhatCannotHappenInstead) {
+  const LogCapture log;
+  set_apps({"a"});
+  ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
+  arm_global_grace(gate);
+
+  auto life = make_lifecycle_expectation();
+  auto death = make_node_death();
+  ASSERT_TRUE(life);
+  ASSERT_TRUE(death);
+  life->configure(nlohmann::json{{"require_active", nlohmann::json::array({"a"})}, {"grace", 200}});
+  death->configure(nlohmann::json{{"tick_interval_ms", 3000}, {"miss_grace", 3600}});  // never reports here
+
+  std::set<std::string> published;
+  auto ctx = make_ctx(DetectorMode::Raise, &gate);
+  ctx.presence_tracked = &published;
+  const auto sweep = [&] {
+    life->tick(ctx);
+    death->tick(ctx);
+    if (const auto * keys = death->tracked_departure_keys()) {
+      published = *keys;
+    }
+  };
+
+  // Owned by the presence detector (measured active), then measured non-active, so the streak
+  // starts while node_death keeps the key - which is what makes absence HOLD it below.
+  gate.set_lifecycle_state_for_test("a", "active");
+  sweep();
+  ASSERT_EQ(published.count("/a"), 1u) << "the presence detector never admitted the node, so the "
+                                          "hold this test is about would have a different cause";
+  gate.set_lifecycle_state_for_test("a", "inactive");
+  sweep();
+
+  set_apps({});
+  for (int i = 0; i < 30; ++i) {  // well past the reporting horizon and the absence grace
+    sweep();
+  }
+
+  EXPECT_EQ(log.count("withheld from clearing"), 1)
+      << "a hold that outlives the reporting horizon must be explained exactly once per episode";
+  EXPECT_EQ(log.count("have since LEFT the graph"), 1)
+      << "the operator was told to wait for a reading the departed node cannot produce";
+  EXPECT_EQ(log.count("measured not-active but still within grace"), 0)
+      << "the present-node sentence was used for a node that is gone - its two exits (reads "
+         "active, or the streak passes grace) are both unreachable while the node is absent";
+}
+
 TEST_F(LifecycleExpectationIntegrationTest, WithholdingForAYoungStreakSaysSoInTheLog) {
   const LogCapture log;
   set_apps({"a"});
@@ -3966,7 +4030,20 @@ TEST_F(LifecycleExpectationIntegrationTest, BelowGraceStreakSurvivesTheTightestP
   det->configure(nlohmann::json{{"require_active", nlohmann::json::array({"a"})}, {"grace", 4}, {"prune_grace", 0}});
   auto ctx = make_ctx(DetectorMode::Raise, &gate);
 
+  // The hold this case is about applies only where the presence detector will report the
+  // departure instead, and that is now asked of node_death rather than inferred from a label -
+  // so the owner has to be here and has to have admitted the key. Ticked alongside below for
+  // the same reason: its set is what this detector reads.
+  auto death = make_node_death();
+  ASSERT_TRUE(death);
+  death->configure(nlohmann::json{{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  ctx.presence_tracked = death->tracked_departure_keys();
+
   gate.set_lifecycle_state_for_test("a", "active");
+  death->tick(ctx);  // measured active: the presence detector admits the key
+  ASSERT_EQ(death->tracked_count_for_test(), 1u)
+      << "the presence detector never admitted the node, so there is nothing here that could "
+         "report its departure and the hold below would be wrong rather than right";
   ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_PASSED, 0, *det, ctx))
       << "the healthy baseline never cleared, so the node below cannot be shown to have armed";
   gate.set_lifecycle_state_for_test("a", "inactive");
@@ -4033,6 +4110,137 @@ TEST_F(LifecycleExpectationIntegrationTest, BelowGraceStreakSurvivesTheTightestP
 // Staged in the order that reaches it: the app is offline and unmeasured while the gate arms
 // it (the window where a naive `armed` latches), then reads inactive, then vanishes below
 // grace. Nothing else can report that departure, so absence has to mature the violation.
+// The handover has to agree from BOTH sides, and this is the sweep where it did not. A dying
+// managed node loses its get_state service one sweep before its App leaves the snapshot, so for
+// that one tick the gate has no record for it and answers kEarned - the same shape node_death
+// already refuses, because a lost measurement is not a measurement. This detector mirrored the
+// gate's answer instead of asking who actually owns the node, latched ever_armed on it, and
+// then HELD the below-grace streak through the departure waiting for a presence report that
+// was never coming: node_death had never admitted the key at all.
+//
+// The cost is the worst shape this work can produce - a require_active node that sat
+// unconfigured and then died is reported by NOBODY, permanently, and GRAPH_NODE_INACTIVE's
+// clear stays withheld behind it for every other node. Absence maturing the streak is what
+// this package shipped before the boundary existed, and it is what must still happen here.
+TEST_F(LifecycleExpectationIntegrationTest, ADroppedRecordOnADisownedNodeIsNotAPresenceHandover) {
+  set_apps({"victim"});
+  ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
+  arm_global_grace(gate);
+
+  auto life = make_lifecycle_expectation();
+  auto death = make_node_death();
+  ASSERT_TRUE(life);
+  ASSERT_TRUE(death);
+  life->configure(nlohmann::json{{"require_active", nlohmann::json::array({"victim"})}, {"grace", 30}});
+  death->configure(nlohmann::json{{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  auto ctx = make_ctx(DetectorMode::Raise, &gate);
+  // The plugin republishes this view after each sweep; a test pointing straight at the owner's
+  // set sees it a tick sooner, which is strictly the harder case for a claim about a latch.
+  ctx.presence_tracked = death->tracked_departure_keys();
+  ASSERT_NE(ctx.presence_tracked, nullptr) << "the presence detector must expose what it tracks, "
+                                              "or this test is asserting against a null view";
+
+  // Measured non-active for ten present ticks: this node is the lifecycle detector's, and
+  // node_death must never admit it.
+  gate.set_lifecycle_state_for_test("victim", "unconfigured");
+  for (int i = 0; i < 10; ++i) {
+    life->tick(ctx);
+    death->tick(ctx);
+  }
+  ASSERT_EQ(death->tracked_count_for_test(), 0u)
+      << "the presence detector must not have admitted a node it measured as unconfigured, or "
+         "the handover below is not the one under test";
+
+  // The drop sweep. The App is still present; only its lifecycle record goes, which is what a
+  // node dying looks like to the snapshot one sweep before it disappears.
+  gate.update(snapshot_, 99);
+  ASSERT_FALSE(gate.lifecycle_state_of("victim").has_value())
+      << "the record must be gone here, or this test is not driving the sweep that used to "
+         "latch ever_armed";
+  life->tick(ctx);
+  death->tick(ctx);
+  ASSERT_EQ(death->tracked_count_for_test(), 0u)
+      << "losing a record is not a measurement, so the presence detector must still be out";
+
+  // And now it dies, below grace. Nothing else can report this, so absence has to mature it.
+  set_apps({});
+  const auto inactive_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED, kNodeInactive);
+  ASSERT_TRUE(
+      poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, inactive_before, *life, ctx, kNodeInactive))
+      << "a below-grace violation on a node the presence detector never owned did not mature "
+         "from absence - it is now reported by nobody at all, and every other required node's "
+         "clear is withheld behind it";
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED, kNodeDisappeared), 0u)
+      << "the presence detector must not report a node it never admitted";
+}
+
+TEST_F(LifecycleExpectationIntegrationTest, AProvisionalAdmissionLaterDisownedDoesNotSilenceTheDeparture) {
+  set_apps({"victim"});
+  ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
+  arm_global_grace(gate);
+
+  auto life = make_lifecycle_expectation();
+  auto death = make_node_death();
+  ASSERT_TRUE(life);
+  ASSERT_TRUE(death);
+  life->configure(nlohmann::json{{"require_active", nlohmann::json::array({"victim"})}, {"grace", 30}});
+  death->configure(nlohmann::json{{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+
+  // The production handoff reproduced exactly, rather than pointed at the owner's live set: the
+  // plugin COPIES the key set after the whole sweep, so a reader sees it as it stood at the end
+  // of the previous tick. Staging it any fresher would hide a latch that only shows up when the
+  // membership a reader saw is later withdrawn.
+  std::set<std::string> published;
+  auto ctx = make_ctx(DetectorMode::Raise, &gate);
+  ctx.presence_tracked = &published;
+  const auto sweep = [&] {
+    life->tick(ctx);
+    death->tick(ctx);
+    if (const auto * keys = death->tracked_departure_keys()) {
+      published = *keys;
+    }
+  };
+
+  // A PROVISIONAL admission: the label has never been read and the watcher's re-seed budget is
+  // spent, so node_death takes the node for want of anyone else - ignorance, not knowledge.
+  gate.set_lifecycle_state_for_test("victim", "", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), ros2_medkit_graph_watchdog::PresenceOwnership::kProvisional)
+      << "the admission under test has to rest on a spent budget and an unread label, or this "
+         "sequence is about some other ground entirely";
+  for (int i = 0; i < 3; ++i) {
+    sweep();
+  }
+  ASSERT_EQ(published.count("/victim"), 1u)
+      << "the provisionally admitted key never reached the published view, so nothing here could "
+         "have latched and the rest of this test proves nothing";
+
+  // The label finally arrives - the ~/transition_event subscription outlives the seed budget -
+  // and it disowns the node. node_death hands the key back while the node is still present.
+  gate.set_lifecycle_state_for_test("victim", "inactive", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), ros2_medkit_graph_watchdog::PresenceOwnership::kDisowned);
+  for (int i = 0; i < 8; ++i) {
+    sweep();
+  }
+  ASSERT_EQ(published.count("/victim"), 0u)
+      << "node_death still holds a key the graph measured as another detector's, so the silence "
+         "below would have a different cause than the one under test";
+  ASSERT_EQ(death->tracked_count_for_test(), 0u);
+
+  // And it dies with its violation streak still far below grace(30). node_death gave the key
+  // back, so nothing over there will report this. Holding the streak because the node was ONCE
+  // in the published set means the departure is reported by nobody, and the pending entry keeps
+  // every other required node's clear withheld behind it.
+  set_apps({});
+  const auto inactive_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED, kNodeInactive);
+  ASSERT_TRUE(
+      poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, inactive_before, *life, ctx, kNodeInactive))
+      << "a below-grace violation on a node whose ONLY claim to being owned was a provisional "
+         "admission that has since been withdrawn did not mature from absence - stickiness was "
+         "earned by ignorance, and this departure is now reported by nobody at all";
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED, kNodeDisappeared), 0u)
+      << "node_death reported a node it had handed back";
+}
+
 TEST_F(LifecycleExpectationIntegrationTest, OfflineAppIsNeverTreatedAsOwnedByThePresenceDetector) {
   set_offline_app("a");
   ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_integration.cpp
@@ -1752,14 +1752,18 @@ TEST_F(LifecycleExpectationIntegrationTest, ANodeCrossingAfterTheCapIsFullIsName
 // broke - and the operator is then told about the one that is gone instead of the one that
 // needs attention.
 //
-// Paced so both crossings land on one tick: the departed batch is measured not-active once
-// and then vanishes, its streaks resuming past the 3-tick absence grace, while the present
-// node starts its own streak exactly late enough that the two reach `grace + 1` together. The
-// batch is sized by fill_count_past_cap from the REAL detail builder, so its details alone
-// exceed the 480-char cap - which is what makes "which one is named" a real choice rather
-// than a cosmetic ordering, and the present node's id sorts LAST among them all.
+// A departed node can no longer cross INTO GRAPH_NODE_INACTIVE from a below-grace
+// streak (see the tracker's own class doc), so "both cross on the same tick" is no longer a
+// reachable shape for this fault - a departed entry only ever carries content it EARNED
+// before it left. What is still reachable, and still the real question, is whether a node
+// that just broke is named ahead of a pile of nodes that broke earlier and left: the departed
+// batch matures FIRST while present, THEN leaves for good, THEN present_id joins and crosses
+// grace fresh, on its own tick, while the batch is still absent-and-content. The batch is
+// sized by fill_count_past_cap from the REAL detail builder, so its details alone exceed the
+// 480-char cap - which is what makes "which one is named" a real choice rather than a
+// cosmetic ordering - and the present node's id sorts LAST among them all.
 TEST_F(LifecycleExpectationIntegrationTest, PresentNodeCrossingWithDepartedOnesIsNamedAheadOfThem) {
-  constexpr int kGrace = 5;
+  constexpr int kGrace = 1;
   std::vector<std::string> departed_ids;
   const std::size_t departed_count = fill_count_past_cap("g", departed_ids);
   ASSERT_GT(departed_count, 1u);
@@ -1783,19 +1787,27 @@ TEST_F(LifecycleExpectationIntegrationTest, PresentNodeCrossingWithDepartedOnesI
     gate.set_lifecycle_state_for_test(id, "inactive");
   }
 
-  // Tick 1: the soon-to-depart batch is measured not-active (streak 1). The present node is
-  // not in the graph yet, so it is not tracked at all.
+  // The departed batch matures FIRST, on its own: present_id is not in the snapshot yet.
   set_apps(departed_ids);
-  det->tick(ctx);
-  // Ticks 2-3: everything absent. Inside the 3-tick absence grace, so the batch's streaks are
-  // simply held.
-  set_apps({});
-  det->tick(ctx);
-  det->tick(ctx);
+  for (int i = 0; i < kGrace + 1; ++i) {
+    det->tick(ctx);
+    std::this_thread::sleep_for(5ms);
+  }
+  std::this_thread::sleep_for(200ms);
+  ASSERT_TRUE(any_failed_desc_contains(kGraphSource, departed_ids.front()))
+      << "the departed batch never matured, so nothing below tests what an ALREADY-CONTENT entry "
+         "does once it leaves - only what a fresh crossing does";
 
-  // Ticks 4-9: only the present node is in the graph, reading not-active. Its streak runs
-  // 1..6 across these six ticks; the batch's absence passes the grace on tick 5 and its
-  // streaks resume 2..6 across ticks 5-9. Both reach grace + 1 on tick 9 - the same tick.
+  // The batch leaves for good, past the absence grace. It is already matured, so absence
+  // continues it unconditionally - "has since left the graph" and all.
+  set_apps({});
+  for (int i = 0; i < kDefaultAbsenceGrace + 2; ++i) {
+    det->tick(ctx);
+    std::this_thread::sleep_for(5ms);
+  }
+
+  // present_id joins and crosses grace fresh, on its own tick, while the departed batch is
+  // still absent-and-content.
   const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
   set_apps({present_id});
   for (int i = 0; i < kGrace + 1; ++i) {
@@ -1803,7 +1815,7 @@ TEST_F(LifecycleExpectationIntegrationTest, PresentNodeCrossingWithDepartedOnesI
     std::this_thread::sleep_for(5ms);
   }
   ASSERT_TRUE(wait_for_count(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before + 1))
-      << "nothing crossed at all, so this test never reached the tick it is about";
+      << "present_id never crossed grace, so this test never reached the tick it is about";
   std::this_thread::sleep_for(300ms);
 
   const std::string desc = last_failed_description(kGraphSource);
@@ -1812,6 +1824,10 @@ TEST_F(LifecycleExpectationIntegrationTest, PresentNodeCrossingWithDepartedOnesI
       << "the PRESENT node that crossed on this very tick was truncated out of the description by "
          "nodes that had already left the graph - the operator is told about the departures and not "
          "about the node that just broke. Full description: "
+      << desc;
+  ASSERT_NE(desc.find(departed_ids.front()), std::string::npos)
+      << "the departed batch left no trace at all, so the ordering claim below would be vacuous - its "
+         "evidence must survive the departure, just behind present_id. Full description: "
       << desc;
   EXPECT_LT(desc.find(present_id), desc.find(departed_ids.front()))
       << "the present node is named, but behind a departed one - a departure is never more urgent "
@@ -3168,11 +3184,15 @@ TEST_F(LifecycleExpectationIntegrationTest, NotManagedNodeInARestartLoopIsStillR
          "never raised GRAPH_NODE_NOT_MANAGED";
 }
 
-// The pair no test at any tier covered: a MEASURED not-active read alternating with a
-// NOT-MANAGED one, the two separated by absence runs longer than the absence grace. Driven
-// through the REAL gate rather than the injection seam, which can only ever SET a label and
-// never remove tracking: toggling whether "a" carries GetState/ChangeState services is what
-// produces a genuine nullopt for a previously-tracked fqn.
+// A MEASURED not-active read alternating with a NOT-MANAGED one, the two separated by
+// absence runs longer than the absence grace. Driven through the REAL gate rather than the
+// injection seam, which can only ever SET a label and never remove tracking: toggling
+// whether "a" carries GetState/ChangeState services is what produces a genuine nullopt for a
+// previously-tracked fqn. Neither the not-managed legs (which never touch the
+// violation streak) nor the absence gaps (which hold a below-grace streak rather than
+// advancing it) contribute anything on their own - only the repeated MEASURED not-active
+// legs do, one real tick at a time - so this still raises, from real evidence accumulated
+// across several cycles of presence rather than from any of the gaps in between.
 TEST_F(LifecycleExpectationIntegrationTest, InactiveAlternatingWithNotManagedAcrossAbsenceGapsRaisesInactive) {
   set_apps({});
   ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
@@ -3263,6 +3283,15 @@ TEST_F(LifecycleExpectationIntegrationTest, HealthyNodeThatVanishesRaisesNothing
   EXPECT_EQ(det->tracked_count_for_test(), 0u) << "an idle entry for a departed healthy node was never reclaimed";
 }
 
+// Unlike its UNREADABLE and NOT-MANAGED siblings above, GRAPH_NODE_INACTIVE no longer treats
+// this shape as an evasion to close on its own: absence contributes nothing to a
+// below-grace violation streak (see the tracker's own class doc), so a node that is inactive
+// for one tick and then gone for a run, forever, only accumulates evidence from its PRESENT
+// ticks - one per cycle here. It is still eventually reported, because it really was measured
+// not-active repeatedly; it just now takes grace + 1 cycles of presence rather than grace + 1
+// ticks of any kind. Closing the evasion in the ABSENCE itself is GRAPH_NODE_DISAPPEARED's job
+// now (this package's own node_death detector), not this streak leaning on a departure it
+// cannot corroborate.
 TEST_F(LifecycleExpectationIntegrationTest, InactiveNodeInARestartLoopIsStillReported) {
   set_apps({"a"});
   ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
@@ -3892,16 +3921,21 @@ TEST(LifecycleExpectationConfig, LiveClockIsNotErasedAtTheTightestGraceAndPruneG
 }
 
 // The combination the old clamp existed for - a wide `grace` next to the tightest
-// `prune_grace` - is now simply safe: a node still climbing toward that wide grace is
-// carrying evidence, so the hair-trigger prune horizon never reaches it, and it goes on to
-// be confirmed at exactly the tick it would have been confirmed at anyway.
+// `prune_grace` - is where a below-grace streak's two guarantees have to meet: it must not be
+// reclaimed as IDLE (it is not - violation_streak != 0 - even though it is small), and it must
+// not be silently matured by the absence run either (only a present tick may still advance it
+// - see the tracker's own class doc). So the entry survives, HELD, exactly where it was: never
+// confirmed while the node stays gone, never pruned either, and ready to resume - not restart
+// - the moment the node returns. It is a fixture test rather than a bare configure()-level one
+// because only the fake ReportFault sink can see the (absence of a) raise.
 //
-// The instrument is the CONFIRMATION, not the map size. A map size of 1 is satisfied by an
-// implementation that keeps the entry but freezes its clock through absence - which is the
-// bug that makes a node vanishing while not-active permanently invisible, i.e. exactly the
-// thing this test is named for. It is a fixture test rather than a bare configure()-level one
-// for that reason: only the fake ReportFault sink can see the raise.
-TEST_F(LifecycleExpectationIntegrationTest, WideGraceWithTheTightestPruneGraceStillConfirmsAVanishedNode) {
+// The node is armed (read "active") once before anything else: this claim holds only for a
+// node the presence detector could itself have reported (node_death tracks any node the gate
+// has armed at least once), so the fixture has to BE one, or the absence run below would be
+// proving something about a different node than the one this test names. A node that never
+// arms gets absence-driven maturation instead - see
+// NeverArmedBelowGraceStreakMaturesFromAbsenceInsteadOfHoldingIndefinitely below for that one.
+TEST_F(LifecycleExpectationIntegrationTest, BelowGraceStreakSurvivesTheTightestPruneGraceWithoutConfirmingWhileAbsent) {
   set_apps({"a"});
   ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
   arm_global_grace(gate);
@@ -3910,6 +3944,10 @@ TEST_F(LifecycleExpectationIntegrationTest, WideGraceWithTheTightestPruneGraceSt
   ASSERT_TRUE(det);
   det->configure(nlohmann::json{{"require_active", nlohmann::json::array({"a"})}, {"grace", 4}, {"prune_grace", 0}});
   auto ctx = make_ctx(DetectorMode::Raise, &gate);
+
+  gate.set_lifecycle_state_for_test("a", "active");
+  ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_PASSED, 0, *det, ctx))
+      << "the healthy baseline never cleared, so the node below cannot be shown to have armed";
   gate.set_lifecycle_state_for_test("a", "inactive");
 
   const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
@@ -3918,18 +3956,82 @@ TEST_F(LifecycleExpectationIntegrationTest, WideGraceWithTheTightestPruneGraceSt
   std::this_thread::sleep_for(200ms);
   ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
       << "the node was confirmed on its first not-active tick, so grace(4) was never in force and "
-         "the absence run below proves nothing about a clock that has to keep climbing";
+         "the absence run below proves nothing about a below-grace streak";
 
-  // "a" vanishes with a streak of 1 out of 4. Absence must go on advancing it, so it is
-  // confirmed while GONE - and the tightest prune horizon must not reach it on the way.
+  // "a" vanishes with a streak of 1 out of 4, at the tightest prune_grace (0) - an IDLE entry
+  // would be reclaimed on the very next absent tick.
+  set_apps({});
+  for (int i = 0; i < 20; ++i) {
+    det->tick(ctx);
+    std::this_thread::sleep_for(5ms);
+  }
+  std::this_thread::sleep_for(200ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "GRAPH_NODE_INACTIVE was confirmed from a below-grace streak while the node was absent the "
+         "whole time - a fault born from evidence gathered while nobody could observe the node";
+  ASSERT_EQ(det->tracked_count_for_test(), 1u)
+      << "the entry was reclaimed by the tightest prune_grace despite carrying a live (if below-grace) "
+         "streak - is_idle() must not treat a non-zero streak as nothing to lose";
+
+  // It resumes rather than restarts: held at 1, three more present ticks reach grace(4), the
+  // fourth crosses it - due on that exact tick and no later, so a streak that had restarted
+  // from zero (needing a fifth) would still read grace here, not past it.
+  set_apps({"a"});
+  for (int i = 0; i < 3; ++i) {
+    det->tick(ctx);  // resumed streak 2, 3, 4 (== grace, not past it)
+    std::this_thread::sleep_for(5ms);
+  }
+  std::this_thread::sleep_for(200ms);
+  ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "resumed streak reached grace(4) but was already confirmed one tick early";
+  det->tick(ctx);  // resumed streak 5 > grace: due on this exact tick
+  EXPECT_TRUE(wait_for_count(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before + 1))
+      << "resumed streak 5 > grace(4) was not confirmed on this exact tick - the streak restarted "
+         "from zero on return instead of resuming where the absence had held it";
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, "a"))
+      << "the confirmation did not name the node once it finally raised";
+}
+
+// The row the test immediately above cannot cover: a node that is NEVER armed, because it
+// never once reads "active" - exactly a require_active node that comes up unconfigured and
+// stays there. node_death only ever tracks a key the reliability gate has armed at least
+// once, so nothing else in the plugin can ever report this node's departure; through the
+// real gate and the real (fake-service-backed) fault client, a below-grace streak on such a
+// node must still mature from absence alone, or the departure is reported by nothing at all.
+// Same grace, same streak-at-departure, same fixture shape as
+// BelowGraceStreakSurvivesTheTightestPruneGraceWithoutConfirmingWhileAbsent immediately
+// above, with arming the only difference - together the two rows prove the split is keyed on
+// arming and nothing else.
+TEST_F(LifecycleExpectationIntegrationTest, NeverArmedBelowGraceStreakMaturesFromAbsenceInsteadOfHoldingIndefinitely) {
+  set_apps({"a"});
+  ReliabilityGate gate(kWarmupCycles, gateway_.get(), &node_mutex_);
+  arm_global_grace(gate);
+
+  auto det = make_lifecycle_expectation();
+  ASSERT_TRUE(det);
+  det->configure(nlohmann::json{{"require_active", nlohmann::json::array({"a"})}, {"grace", 4}});
+  auto ctx = make_ctx(DetectorMode::Raise, &gate);
+
+  // Never armed: "a" reads non-active from the very first tick and never once reads "active",
+  // so LifecycleWatcher::node_ok() is false for its whole life here and the gate never arms
+  // it.
+  gate.set_lifecycle_state_for_test("a", "inactive");
+
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  det->tick(ctx);  // streak 1, well below grace(4)
+  ASSERT_EQ(det->tracked_count_for_test(), 1u);
+  std::this_thread::sleep_for(200ms);
+  ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "the node was confirmed on its first not-active tick, so grace(4) was never in force and "
+         "the absence run below proves nothing about a below-grace streak";
+
+  // "a" vanishes with a streak of 1 out of 4. Nothing else will ever report this departure,
+  // so absence itself has to mature the streak.
   set_apps({});
   ASSERT_TRUE(poll_for_new(kGraphSource, ReportFault::Request::EVENT_FAILED, failed_before, *det, ctx))
-      << "a node that left the graph with a streak below a wide grace was never confirmed at all - "
-         "its clock was frozen or its entry pruned while absent, so a node that vanishes while "
-         "not-active is permanently invisible";
-  EXPECT_EQ(det->tracked_count_for_test(), 1u)
-      << "the entry was pruned by the tightest prune_grace despite carrying evidence";
+      << "a below-grace violation on a node the presence detector could never have tracked did "
+         "not mature from absence alone - its departure is reported by nothing at all";
   EXPECT_TRUE(any_failed_desc_contains(kGraphSource, "has since left the graph"))
-      << "the confirmation did not say the node had left the graph, so an operator is sent looking "
-         "for a node that is no longer there";
+      << "the fault matured from absence must say the node has since left the graph, or the "
+         "operator is sent looking for a node that is not there";
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
@@ -39,9 +39,12 @@ using ros2_medkit_graph_watchdog::LifecycleMatch;
 using M = std::vector<LifecycleMatch>;
 
 // Violations are keyed by the NODE, so a match carries both the config entry that
-// matched and the node's stable fqn.
-LifecycleMatch match(const std::string & entry, const std::string & fqn, std::optional<std::string> state) {
-  return LifecycleMatch{entry, fqn, std::move(state)};
+// matched and the node's stable fqn. `armed` defaults true, matching LifecycleMatch's own
+// default: a call that does not pass it exercises a node the presence detector could
+// report, and only a test about the never-armed split passes `false` explicitly.
+LifecycleMatch match(const std::string & entry, const std::string & fqn, std::optional<std::string> state,
+                     bool armed = true) {
+  return LifecycleMatch{entry, fqn, std::move(state), armed};
 }
 
 // ---- Violation streak: unchanged behaviour from before this slice's redesign ----
@@ -259,37 +262,39 @@ TEST(LifecycleExpectation, AlternatingEveryTickStillMaturesTheClockEventually) {
 
 // The pair the two clocks have to divide between them: a node alternating between a REAL
 // not-active read and a not-managed one, with runs of ABSENCE longer than the absence grace
-// in between - so every tick belongs to one of the three cases and the alternation crosses
-// both ownership and presence. kNotManaged never touches the violation streak and kInactive
-// always resets the unmeasured clock, so the streak is the only clock that can accumulate
-// here, and it must: whichever way the node flaps, it was MEASURED not-active repeatedly.
-TEST(LifecycleExpectation, InactiveAlternatingWithNotManagedAcrossAbsenceGapsStillConfirmsTheViolation) {
+// in between - so every tick belongs to one of the three cases. kNotManaged never touches the
+// violation streak (only its own unmeasured clock), kInactive always resets the unmeasured
+// clock, and absence below grace contributes to neither (see the kInactive case in update()'s
+// absence loop) - so the ONLY thing that can ever advance the violation streak here is a
+// genuine matched "inactive" read, and it takes exactly grace + 1 of them, however many
+// not-managed legs and absence gaps sit in between.
+TEST(LifecycleExpectation, InactiveAlternatingWithNotManagedAcrossAbsenceGapsCountsOnlyMatchedReads) {
   constexpr int kGap = kDefaultAbsenceGrace + 1;
-  LifecycleExpectationTracker t({"a"}, /*grace=*/5, kDefaultAbsenceGrace);
-  bool reported = false;
-  for (int cycle = 0; cycle < 20 && !reported; ++cycle) {
+  constexpr int kGrace = 3;
+  LifecycleExpectationTracker t({"a"}, kGrace, kDefaultAbsenceGrace);
+  for (int matched_tick = 1; matched_tick <= kGrace; ++matched_tick) {
     auto measured = t.update(M{match("a", "/a", "inactive")});
-    reported = !measured.affected.empty();
-    for (int i = 0; i < kGap && !reported; ++i) {
-      reported = !t.update(M{}).affected.empty();
-    }
-    if (reported) {
-      break;
+    EXPECT_TRUE(measured.affected.empty())
+        << "matched tick " << matched_tick << " crossed grace(" << kGrace << ") early";
+    for (int i = 0; i < kGap; ++i) {
+      EXPECT_TRUE(t.update(M{}).affected.empty())
+          << "matched tick " << matched_tick << ", absence gap " << i << ": crossed on an ABSENT tick";
     }
     auto unmanaged = t.update(M{match("a", "/a", std::nullopt)});
-    EXPECT_TRUE(unmanaged.affected.empty()) << "cycle " << cycle
-                                            << ": a node inside an unmeasured spell is not confirmed content, "
-                                               "however far its held streak had already climbed";
+    EXPECT_TRUE(unmanaged.affected.empty())
+        << "matched tick " << matched_tick << ": a not-managed read crossed grace on its own";
     EXPECT_EQ(unmanaged.pending_violation.count("/a"), 1u)
-        << "cycle " << cycle << ": the streak was RESET by a not-managed tick instead of merely held";
-    for (int i = 0; i < kGap && !reported; ++i) {
-      reported = !t.update(M{}).affected.empty();
+        << "matched tick " << matched_tick << ": the streak was RESET by a not-managed tick instead of held";
+    for (int i = 0; i < kGap; ++i) {
+      EXPECT_TRUE(t.update(M{}).affected.empty())
+          << "matched tick " << matched_tick << ", trailing gap " << i << ": crossed on an ABSENT tick";
     }
   }
-  EXPECT_TRUE(reported) << "a node alternating between a measured not-active read and a not-managed one, "
-                           "separated by absence runs longer than the absence grace, was never confirmed - "
-                           "invisible to GRAPH_NODE_INACTIVE and, since the unmeasured clock keeps being reset "
-                           "by the real reads, to its siblings too";
+  auto crossed = t.update(M{match("a", "/a", "inactive")});  // the (grace + 1)-th matched inactive read
+  EXPECT_EQ(crossed.affected.count("/a"), 1u)
+      << "never crossed grace after exactly grace + 1 matched inactive reads - the not-managed legs and "
+         "absence gaps in between must have contributed nothing to either side of the count";
+  EXPECT_EQ(crossed.newly_affected, (std::vector<std::string>{"/a"}));
 }
 
 // The violation streak resets ONLY on kActive. A mutant that zeroed it on every unmeasured
@@ -584,24 +589,138 @@ TEST(LifecycleExpectation, NotManagedInterleavedWithAbsenceRunsStillMaturesAndRe
   }
 }
 
-TEST(LifecycleExpectation, InactiveInterleavedWithAbsenceRunsStillCrossesGraceAndReports) {
+// Companion to UnreadableInterleavedWithAbsenceRunsStillMaturesAndReports and its
+// not-managed sibling above, but for the VIOLATION streak the claim is the opposite: an
+// absence run - however many, however long, however far past kDefaultAbsenceGrace - must
+// contribute NOTHING to a streak that has not yet crossed `grace`. Crossing happens at
+// exactly grace + 1 MATCHED "inactive" reads, never earlier and never later, whatever the
+// interleaved absence pattern looks like - absence must never mature an unmatured streak,
+// pinned directly against the exact shape that used to defeat that rule.
+TEST(LifecycleExpectation, InactiveInterleavedWithAbsenceRunsNeverCrossesGraceFromAbsenceAlone) {
   for (const int run_length : kAbsenceRunLengths) {
-    LifecycleExpectationTracker t({"a"}, /*grace=*/5, kDefaultAbsenceGrace);
-    bool reported = false;
-    for (int cycle = 0; cycle < kDefaultUnmeasuredHoldTicks + 5 && !reported; ++cycle) {
+    constexpr int kGrace = 3;
+    LifecycleExpectationTracker t({"a"}, kGrace, kDefaultAbsenceGrace);
+    for (int matched_tick = 1; matched_tick <= kGrace; ++matched_tick) {
       auto present = t.update(M{match("a", "/a", "inactive")});
-      reported = !present.affected.empty();
+      EXPECT_TRUE(present.affected.empty()) << "run_length=" << run_length << ": matched tick " << matched_tick
+                                            << " crossed grace(" << kGrace << ") early";
       EXPECT_TRUE(present.unreadable_affected.empty() && present.not_managed_affected.empty())
           << "run_length=" << run_length << ": a MEASURED read must never feed an unmeasured code";
-      for (int i = 0; i < run_length && !reported; ++i) {
-        reported = !t.update(M{}).affected.empty();
+      for (int i = 0; i < run_length; ++i) {
+        auto absent = t.update(M{});
+        EXPECT_TRUE(absent.affected.empty()) << "run_length=" << run_length
+                                             << ": crossed grace on an ABSENT tick - a below-grace violation "
+                                                "must never mature while nobody can observe the node";
       }
     }
-    EXPECT_TRUE(reported) << "run_length=" << run_length
-                          << ": a node measured inactive whenever it is present and absent the rest "
-                             "of the time never crossed grace - the violation streak was discarded "
-                             "by every absence run";
+    // The (grace + 1)-th matched tick, after grace full interleaved cycles that must have
+    // contributed nothing: this crosses if and only if every absence run above truly added
+    // zero to the streak.
+    auto crossed = t.update(M{match("a", "/a", "inactive")});
+    EXPECT_EQ(crossed.affected.count("/a"), 1u)
+        << "run_length=" << run_length
+        << ": never crossed after exactly grace + 1 matched ticks - an "
+           "absence run either stole progress from a match or silently added some of its own";
+    EXPECT_EQ(crossed.newly_affected, (std::vector<std::string>{"/a"}));
   }
+}
+
+// ---- Never armed: nothing else can ever report the departure, so absence must mature it ----
+
+// The node the row above cannot cover: one the reliability gate never armed at all. Compare
+// directly against InactiveInterleavedWithAbsenceRunsNeverCrossesGraceFromAbsenceAlone above -
+// same shape, same grace, same absence budget - with the single difference being `armed`.
+// There the presence detector could report the departure instead, so absence merely holds a
+// below-grace streak; here nothing else in the plugin ever will, so absence has to be the one
+// that matures it, or the node's departure is reported by nothing at all.
+TEST(LifecycleExpectation, NeverArmedNodeMaturesFromAbsenceAloneAndStaysGone) {
+  constexpr int kGrace = 5;
+  constexpr int kAbsenceGrace = 2;
+  LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty())
+      << "sanity: one present tick, streak 1 <= grace";
+
+  // Node vanishes forever. Inside the blink tolerance nothing moves - a never-armed node
+  // gets the same blink tolerance as any other.
+  for (int i = 0; i < kAbsenceGrace; ++i) {
+    EXPECT_TRUE(t.update(M{}).affected.empty()) << "absence " << i << ": still inside the blink tolerance";
+  }
+  // Past the blink, absence itself keeps the streak climbing. It was 1 after the one present
+  // tick above, so exactly (kGrace - 1) further absent ticks reach kGrace (still not past it)
+  // and the next one crosses.
+  for (int i = 0; i < kGrace - 1; ++i) {
+    EXPECT_TRUE(t.update(M{}).affected.empty()) << "past the blink, iteration " << i;
+  }
+  auto matured = t.update(M{});
+  ASSERT_EQ(matured.affected.count("/a"), 1u)
+      << "a below-grace violation on a node the presence detector could never have reported "
+         "must still mature from absence alone, or its departure is reported by nothing";
+  EXPECT_NE(matured.affected.at("/a").find("has since left the graph"), std::string::npos);
+  EXPECT_EQ(matured.newly_affected, (std::vector<std::string>{"/a"}));
+
+  // And it stays matured while the node remains gone - absence never un-matures a violation,
+  // never-armed or not.
+  for (int i = 0; i < 5; ++i) {
+    auto still = t.update(M{});
+    EXPECT_EQ(still.affected.count("/a"), 1u) << "iteration " << i;
+    EXPECT_TRUE(still.newly_affected.empty()) << "iteration " << i << ": no re-raise churn while merely absent";
+  }
+}
+
+// The narrowing itself, restated for the case it must keep working for: a node armed once
+// (however briefly) before it went non-active. `ever_armed` is sticky, so the CURRENT tick
+// reading non-active - which, against a real gate, means NOT currently armed, since a managed
+// node's node_ok() is false whenever it reads anything but "active" - must not un-arm it. This
+// is the fact GRAPH_NODE_DISAPPEARED needs in order to be ABLE to report this exact node, so
+// GRAPH_NODE_INACTIVE must stay out of the way, exactly as
+// InactiveInterleavedWithAbsenceRunsNeverCrossesGraceFromAbsenceAlone already pins for the
+// unqualified (default-armed) case.
+TEST(LifecycleExpectation, ArmedNodeBelowGraceThenGoneStillDoesNotMatureFromAbsence) {
+  constexpr int kGrace = 5;
+  constexpr int kAbsenceGrace = 2;
+  LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
+  ASSERT_TRUE(t.update(M{match("a", "/a", "active", /*armed=*/true)}).affected.empty()) << "sanity: arms the node";
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty())
+      << "sanity: one inactive tick, streak 1 <= grace";
+
+  for (int i = 0; i < kAbsenceGrace + 20; ++i) {
+    auto report = t.update(M{});
+    EXPECT_TRUE(report.affected.empty()) << "iteration " << i
+                                         << ": a node the presence detector could report must never have "
+                                            "its below-grace streak matured by absence alone";
+    EXPECT_EQ(report.pending_violation.count("/a"), 1u)
+        << "iteration " << i << ": the streak must stay HELD, not erased either";
+  }
+}
+
+// A never-armed node that RESUMES rather than restarts: absence-driven progress survives the
+// return exactly like a present-tick streak already does (see
+// ViolationStreakSurvivesNonMaturingUnmeasuredTicksAndIsNotRestarted for the unmeasured-clock
+// analogue), counted exactly enough that a mutant which restarted the streak at zero - either
+// on absence or on return - would need more matched ticks than this test gives it.
+TEST(LifecycleExpectation, NeverArmedNodeResumesRatherThanRestartingAfterReturning) {
+  constexpr int kGrace = 5;
+  constexpr int kAbsenceGrace = 2;
+  LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
+  t.update(M{match("a", "/a", "inactive", /*armed=*/false)});                                // streak 1
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty());  // streak 2
+
+  // Vanishes long enough to pass the blink and advance on absence alone a few times, but
+  // stops short of grace: 2 held (absent_ticks 1..kAbsenceGrace) + 1 advancing tick
+  // (absent_ticks kAbsenceGrace+1, streak 2 -> 3).
+  for (int i = 0; i < kAbsenceGrace + 1; ++i) {
+    EXPECT_TRUE(t.update(M{}).affected.empty()) << "absence " << i;
+  }
+
+  // Node returns, still inactive. If absence above had genuinely advanced the streak to 3
+  // (not restarted it), exactly 2 more matched ticks reach grace(5) and the 3rd crosses.
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty()) << "streak 3 -> 4";
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty()) << "streak 4 -> 5 == grace";
+  auto crossed = t.update(M{match("a", "/a", "inactive", /*armed=*/false)});  // streak 5 -> 6 > grace
+  EXPECT_EQ(crossed.affected.count("/a"), 1u)
+      << "the streak restarted at zero across the absence run instead of resuming what absence "
+         "had already advanced - a node that departs and returns while never armed would then "
+         "need far longer than grace + 1 present ticks to ever be reported";
 }
 
 // The tightest prune horizon the documented config space can produce (grace: 0 with
@@ -946,35 +1065,74 @@ TEST(LifecycleExpectation, NodeCrossingGraceDoesNotDisturbAnothersAbsenceBookkee
   EXPECT_EQ(crossed.newly_affected[0], "/a");
 }
 
-// Sustained absence CONTINUES the streak instead of discarding it: the node was measured
-// not-active, nothing has said otherwise, and being gone is not an answer.
-TEST(LifecycleExpectation, SustainedAbsenceContinuesTheStreakAndEventuallyConfirmsIt) {
-  LifecycleExpectationTracker t({"a"}, /*grace=*/2, /*absence_grace=*/1);
-  t.update(M{match("a", "/a", "inactive")});  // streak 1 <= grace
-  EXPECT_TRUE(t.update(M{}).affected.empty()) << "absent 1 == absence_grace: held, not advanced";
-  EXPECT_TRUE(t.update(M{}).affected.empty()) << "absent 2 > absence_grace: streak 2 == grace, not past it";
-  auto crossed = t.update(M{});  // absent 3: streak 3 > grace
-  ASSERT_EQ(crossed.affected.count("/a"), 1u)
-      << "absence discarded the streak instead of continuing it, so a node that leaves while "
-         "violating is never confirmed";
-  EXPECT_EQ(crossed.newly_affected, (std::vector<std::string>{"/a"}));
-  EXPECT_NE(crossed.affected.at("/a").find("inactive"), std::string::npos)
+// Sustained absence CONTINUES an ALREADY-MATURED streak instead of discarding it: the node
+// was CONFIRMED not-active, nothing has said otherwise, and being gone is not an answer. It
+// does not create one that was not already there - see
+// BelowGraceStreakStaysPendingForeverWhileAbsentAndNeverBecomesContent for the below-grace
+// half of the same absence branch.
+TEST(LifecycleExpectation, MaturedStreakSurvivesAbsenceUnconditionally) {
+  LifecycleExpectationTracker t({"a"}, /*grace=*/1, /*absence_grace=*/1);
+  t.update(M{match("a", "/a", "inactive")});                   // streak 1 <= grace
+  auto confirmed = t.update(M{match("a", "/a", "inactive")});  // streak 2 > grace: confirmed
+  ASSERT_EQ(confirmed.affected.count("/a"), 1u) << "sanity: must be confirmed before it can survive a departure";
+
+  t.update(M{});  // absent 1 == absence_grace: held through the blink, unchanged
+  for (int i = 0; i < 10; ++i) {
+    auto still = t.update(M{});  // absent 2.. > absence_grace
+    ASSERT_EQ(still.affected.count("/a"), 1u)
+        << "iteration " << i
+        << ": absence discarded an already-confirmed streak instead of continuing "
+           "it, so a node that leaves while violating is not confirmed any more";
+    EXPECT_TRUE(still.newly_affected.empty()) << "iteration " << i << ": no re-raise churn while merely absent";
+  }
+  auto report = t.update(M{});
+  const std::string & detail = report.affected.at("/a");
+  EXPECT_NE(detail.find("inactive"), std::string::npos)
       << "the detail must still name the state the node was last measured in";
-  EXPECT_NE(crossed.affected.at("/a").find("has since left the graph"), std::string::npos);
+  EXPECT_NE(detail.find("has since left the graph"), std::string::npos);
 }
 
-// `pending` gives way to CONTENT, never to silence: the withheld-clear hold ends because
-// the tracker finally settled the node's status, not because it gave up on it.
-TEST(LifecycleExpectation, PendingBecomesContentWhenAbsenceOutlivesTheAbsenceGrace) {
+// The other half: a streak that had NOT yet crossed grace when the node left is held at
+// whatever it already reached, resuming rather than restarting. Counted exactly - a streak
+// that had restarted at zero would still read `grace` (not past it) after these same three
+// return ticks, one short of the four a fresh climb needs.
+TEST(LifecycleExpectation, BelowGraceStreakHeldByAbsenceResumesRatherThanRestartsOnReturn) {
+  constexpr int kGrace = 3;
+  LifecycleExpectationTracker t({"a"}, kGrace, /*absence_grace=*/1);
+  auto first = t.update(M{match("a", "/a", "inactive")});  // streak 1 <= grace
+  ASSERT_EQ(first.pending_violation.count("/a"), 1u);
+
+  for (int i = 0; i < 30; ++i) {
+    t.update(M{});  // absent, well past absence_grace: held at streak 1 the whole time
+  }
+
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "resumed streak 2 <= grace";
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "resumed streak 3 == grace";
+  auto confirmed = t.update(M{match("a", "/a", "inactive")});  // resumed streak 4 > grace
+  ASSERT_EQ(confirmed.affected.count("/a"), 1u)
+      << "the streak restarted from zero on return instead of resuming where the absence had held it";
+  EXPECT_EQ(confirmed.newly_affected, (std::vector<std::string>{"/a"}));
+}
+
+// `pending` NEVER becomes content merely by waiting: a below-grace streak that goes absent
+// stays exactly where it was for as long as the node is gone, so the withheld-clear hold has
+// no timeout of its own - it ends only when the tracker actually SETTLES the node's status (a
+// fresh present tick reading active or inactive), never because enough absent ticks went by.
+// Maturing a below-grace streak on absence alone would raise GRAPH_NODE_INACTIVE from ticks
+// gathered while nobody could observe the node at all.
+TEST(LifecycleExpectation, BelowGraceStreakStaysPendingForeverWhileAbsentAndNeverBecomesContent) {
   LifecycleExpectationTracker t({"a"}, /*grace=*/3, /*absence_grace=*/2);
-  EXPECT_EQ(t.update(M{match("a", "/a", "inactive")}).pending.count("/a"), 1u);  // streak 1
-  EXPECT_EQ(t.update(M{}).pending.count("/a"), 1u) << "absent 1: inside the blink tolerance, held";
-  EXPECT_EQ(t.update(M{}).pending.count("/a"), 1u) << "absent 2 == absence_grace: still held";
-  EXPECT_EQ(t.update(M{}).pending.count("/a"), 1u) << "absent 3: streak 2, still below grace";
-  EXPECT_EQ(t.update(M{}).pending.count("/a"), 1u) << "absent 4: streak 3 == grace, still below";
-  auto settled = t.update(M{});  // absent 5: streak 4 > grace
-  EXPECT_TRUE(settled.pending.empty()) << "the hold must end by SETTLING, not by discarding";
-  EXPECT_EQ(settled.affected.count("/a"), 1u);
+  EXPECT_EQ(t.update(M{match("a", "/a", "inactive")}).pending.count("/a"), 1u);  // streak 1 <= grace
+
+  for (int i = 0; i < 50; ++i) {
+    auto report = t.update(M{});  // absent, past absence_grace for every iteration but the first two
+    EXPECT_EQ(report.pending.count("/a"), 1u) << "iteration " << i
+                                              << ": the hold ended without the node ever being measured active or "
+                                                 "confirmed inactive";
+    EXPECT_EQ(report.pending_violation.count("/a"), 1u) << "iteration " << i;
+    EXPECT_TRUE(report.affected.empty()) << "iteration " << i
+                                         << ": a below-grace streak matured purely from waiting while absent";
+  }
 }
 
 // A node the detector already reported keeps its content through a blink AND past it - it
@@ -1204,18 +1362,29 @@ TEST(LifecycleExpectation, CorroboratedUnmeasuredRunBeforeADepartureIsStillRepor
 }
 
 // A real measurement needs no corroboration at all: one not-active read is a fact about the
-// node, so a node that departs immediately after it still confirms. Without this the
-// settling rule would swallow the very case the detector exists for at grace: 0.
+// node, so it is content the instant it is read (grace: 0 makes that one tick the crossing
+// tick), and a node that departs immediately after keeps that content unconditionally, the
+// same as any other already-matured entry. Without instant settling for a real measurement,
+// the corroboration rule built for the unmeasured clock would swallow the very case grace: 0
+// exists for. grace: 0 also keeps this test meaningful now that absence alone may not mature
+// a below-grace streak: at any grace > 0 a single read leaves the streak BELOW grace, and a
+// below-grace streak is now held rather than
+// confirmed by a departure - see BelowGraceStreakStaysPendingForeverWhileAbsentAndNever
+// BecomesContent for that (deliberately different) claim.
 TEST(LifecycleExpectation, OneMeasuredNotActiveReadBeforeADepartureStillConfirms) {
-  LifecycleExpectationTracker t({"a"}, /*grace=*/2);
-  t.update(M{match("a", "/a", "inactive")});  // exactly one real measurement, then gone
-  bool confirmed = false;
-  for (int i = 0; i < kDefaultAbsenceGrace + 10 && !confirmed; ++i) {
-    confirmed = !t.update(M{}).affected.empty();
+  LifecycleExpectationTracker t({"a"}, /*grace=*/0);
+  auto confirmed_before_leaving = t.update(M{match("a", "/a", "inactive")});  // grace 0: confirmed on this tick
+  ASSERT_EQ(confirmed_before_leaving.affected.count("/a"), 1u)
+      << "sanity: the node must already be confirmed before it departs, or nothing below is tested";
+
+  for (int i = 0; i < kDefaultAbsenceGrace + 10; ++i) {
+    auto report = t.update(M{});  // gone, immediately
+    ASSERT_EQ(report.affected.count("/a"), 1u)
+        << "iteration " << i
+        << ": a node measured not-active once, already confirmed, and then gone lost "
+           "its fault - a lifecycle label is a measurement, not something a sweep can invent, so it needs "
+           "no corroborating, and a departure must not un-confirm it either";
   }
-  EXPECT_TRUE(confirmed) << "a node measured not-active once and then gone was never confirmed - a "
-                            "lifecycle label is a measurement, not something a sweep can invent, so it "
-                            "needs no corroborating";
 }
 
 // ---- The cap: a present node always wins a slot ----
@@ -1296,6 +1465,36 @@ TEST(LifecycleExpectation, ANodeReturningAfterItsEntryWasCollapsedIsMeasuredAfre
       << "the collapsed count was dropped when the node came back, so a fault that a departure must "
          "never heal was healed by one: "
       << AggregatedFault::describe(returned.affected);
+}
+
+// The one cap/collapse shape no OTHER test in this file can tell apart: every sibling above
+// uses grace=0, where violation_streak > 0 and violation_streak > grace_ are the SAME
+// condition, so they cannot distinguish count_collapsed() counting "any non-zero streak" from
+// counting "only an already-matured one". Here grace is wide enough that the departed entry
+// is genuinely BELOW it when the cap forces its collapse: under the design this replaces,
+// absence kept advancing it regardless, so folding it into collapsed_inactive_ merely
+// anticipated a maturity it would have reached anyway. That is no longer true now that
+// absence alone never matures a below-grace streak - so collapsing it as content would
+// fabricate a violation the node never earned.
+TEST(LifecycleExpectation, BelowGraceDepartedEntryCollapsedAtTheCapContributesNothingToTheCount) {
+  constexpr int kCap = 1;
+  LifecycleExpectationTracker t({"/held", "/live"}, /*grace=*/5, /*absence_grace=*/1, kDefaultNoMatchWarnTicks,
+                                LifecycleExpectationTracker::kNoPrune, kDefaultUnmeasuredHoldTicks, kCap);
+  t.update(M{match("/held", "/held", "inactive")});  // streak 1, well below grace(5)
+  ASSERT_EQ(t.tracked_count(), 1u);
+  for (int i = 0; i < 3; ++i) {
+    t.update(M{});  // "/held" leaves for good, past the absence grace - HELD, never matures
+  }
+
+  // "/live" needs the only slot. "/held" is departed, so it is collapsed rather than "/live"
+  // being refused - but "/held" was never content, so nothing may be fabricated for it.
+  auto report = t.update(M{match("/live", "/live", "inactive")});
+  ASSERT_EQ(t.tracked_count(), 1u) << "the slot was never freed - a departed entry blocked a present node";
+  EXPECT_FALSE(report.tracking_saturated) << "a departed, below-grace entry blocked a present node's slot";
+  EXPECT_TRUE(report.affected.empty())
+      << "the collapsed below-grace entry fabricated a violation it never earned ('/live' itself is "
+         "only at streak 1, well below grace(5)): "
+      << AggregatedFault::describe(report.affected);
 }
 
 // ---- Entries matching nothing: unrelated per-entry mechanism, unaffected by this slice ----

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
@@ -38,14 +38,18 @@ using ros2_medkit_graph_watchdog::LifecycleExpectationTracker;
 using ros2_medkit_graph_watchdog::LifecycleMatch;
 using M = std::vector<LifecycleMatch>;
 
-// Violations are keyed by the NODE, so a match carries both the config entry that
-// matched and the node's stable fqn. `armed` defaults true, matching LifecycleMatch's own
-// default: a call that does not pass it exercises a node the presence detector could
-// report, and only a test about the never-armed split passes `false` explicitly.
-LifecycleMatch match(const std::string & entry, const std::string & fqn, std::optional<std::string> state,
-                     bool armed = true) {
-  return LifecycleMatch{entry, fqn, std::move(state), armed};
+// Violations are keyed by the NODE, so a match carries both the config entry that matched and
+// the node's stable fqn. Whether the presence detector owns a node's departure is NOT part of a
+// match: it is the separate `presence_owned` set update() takes, so a test that wants a node
+// owned passes one (see kOwnedA) and a test that passes nothing is exercising a node nobody
+// tracks - the case where this detector must keep reporting.
+LifecycleMatch match(const std::string & entry, const std::string & fqn, std::optional<std::string> state) {
+  return LifecycleMatch{entry, fqn, std::move(state)};
 }
+
+// The presence detector's published key set, for the rows whose subject is a node it tracks.
+// Keyed by fqn, exactly as node_death publishes it.
+const std::set<std::string> kOwnedA{"/a"};
 
 // ---- Violation streak: unchanged behaviour from before this slice's redesign ----
 
@@ -273,24 +277,24 @@ TEST(LifecycleExpectation, InactiveAlternatingWithNotManagedAcrossAbsenceGapsCou
   constexpr int kGrace = 3;
   LifecycleExpectationTracker t({"a"}, kGrace, kDefaultAbsenceGrace);
   for (int matched_tick = 1; matched_tick <= kGrace; ++matched_tick) {
-    auto measured = t.update(M{match("a", "/a", "inactive")});
+    auto measured = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);
     EXPECT_TRUE(measured.affected.empty())
         << "matched tick " << matched_tick << " crossed grace(" << kGrace << ") early";
     for (int i = 0; i < kGap; ++i) {
-      EXPECT_TRUE(t.update(M{}).affected.empty())
+      EXPECT_TRUE(t.update(M{}, &kOwnedA).affected.empty())
           << "matched tick " << matched_tick << ", absence gap " << i << ": crossed on an ABSENT tick";
     }
-    auto unmanaged = t.update(M{match("a", "/a", std::nullopt)});
+    auto unmanaged = t.update(M{match("a", "/a", std::nullopt)}, &kOwnedA);
     EXPECT_TRUE(unmanaged.affected.empty())
         << "matched tick " << matched_tick << ": a not-managed read crossed grace on its own";
     EXPECT_EQ(unmanaged.pending_violation.count("/a"), 1u)
         << "matched tick " << matched_tick << ": the streak was RESET by a not-managed tick instead of held";
     for (int i = 0; i < kGap; ++i) {
-      EXPECT_TRUE(t.update(M{}).affected.empty())
+      EXPECT_TRUE(t.update(M{}, &kOwnedA).affected.empty())
           << "matched tick " << matched_tick << ", trailing gap " << i << ": crossed on an ABSENT tick";
     }
   }
-  auto crossed = t.update(M{match("a", "/a", "inactive")});  // the (grace + 1)-th matched inactive read
+  auto crossed = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);  // the (grace + 1)-th matched inactive read
   EXPECT_EQ(crossed.affected.count("/a"), 1u)
       << "never crossed grace after exactly grace + 1 matched inactive reads - the not-managed legs and "
          "absence gaps in between must have contributed nothing to either side of the count";
@@ -601,13 +605,13 @@ TEST(LifecycleExpectation, InactiveInterleavedWithAbsenceRunsNeverCrossesGraceFr
     constexpr int kGrace = 3;
     LifecycleExpectationTracker t({"a"}, kGrace, kDefaultAbsenceGrace);
     for (int matched_tick = 1; matched_tick <= kGrace; ++matched_tick) {
-      auto present = t.update(M{match("a", "/a", "inactive")});
+      auto present = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);
       EXPECT_TRUE(present.affected.empty()) << "run_length=" << run_length << ": matched tick " << matched_tick
                                             << " crossed grace(" << kGrace << ") early";
       EXPECT_TRUE(present.unreadable_affected.empty() && present.not_managed_affected.empty())
           << "run_length=" << run_length << ": a MEASURED read must never feed an unmeasured code";
       for (int i = 0; i < run_length; ++i) {
-        auto absent = t.update(M{});
+        auto absent = t.update(M{}, &kOwnedA);
         EXPECT_TRUE(absent.affected.empty()) << "run_length=" << run_length
                                              << ": crossed grace on an ABSENT tick - a below-grace violation "
                                                 "must never mature while nobody can observe the node";
@@ -616,7 +620,7 @@ TEST(LifecycleExpectation, InactiveInterleavedWithAbsenceRunsNeverCrossesGraceFr
     // The (grace + 1)-th matched tick, after grace full interleaved cycles that must have
     // contributed nothing: this crosses if and only if every absence run above truly added
     // zero to the streak.
-    auto crossed = t.update(M{match("a", "/a", "inactive")});
+    auto crossed = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);
     EXPECT_EQ(crossed.affected.count("/a"), 1u)
         << "run_length=" << run_length
         << ": never crossed after exactly grace + 1 matched ticks - an "
@@ -637,7 +641,7 @@ TEST(LifecycleExpectation, NeverArmedNodeMaturesFromAbsenceAloneAndStaysGone) {
   constexpr int kGrace = 5;
   constexpr int kAbsenceGrace = 2;
   LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
-  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty())
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty())
       << "sanity: one present tick, streak 1 <= grace";
 
   // Node vanishes forever. Inside the blink tolerance nothing moves - a never-armed node
@@ -679,12 +683,12 @@ TEST(LifecycleExpectation, ArmedNodeBelowGraceThenGoneStillDoesNotMatureFromAbse
   constexpr int kGrace = 5;
   constexpr int kAbsenceGrace = 2;
   LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
-  ASSERT_TRUE(t.update(M{match("a", "/a", "active", /*armed=*/true)}).affected.empty()) << "sanity: arms the node";
-  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty())
+  ASSERT_TRUE(t.update(M{match("a", "/a", "active")}, &kOwnedA).affected.empty()) << "sanity: arms the node";
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive")}, &kOwnedA).affected.empty())
       << "sanity: one inactive tick, streak 1 <= grace";
 
   for (int i = 0; i < kAbsenceGrace + 20; ++i) {
-    auto report = t.update(M{});
+    auto report = t.update(M{}, &kOwnedA);
     EXPECT_TRUE(report.affected.empty()) << "iteration " << i
                                          << ": a node the presence detector could report must never have "
                                             "its below-grace streak matured by absence alone";
@@ -702,8 +706,8 @@ TEST(LifecycleExpectation, NeverArmedNodeResumesRatherThanRestartingAfterReturni
   constexpr int kGrace = 5;
   constexpr int kAbsenceGrace = 2;
   LifecycleExpectationTracker t({"a"}, kGrace, kAbsenceGrace);
-  t.update(M{match("a", "/a", "inactive", /*armed=*/false)});                                // streak 1
-  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty());  // streak 2
+  t.update(M{match("a", "/a", "inactive")});                                // streak 1
+  ASSERT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty());  // streak 2
 
   // Vanishes long enough to pass the blink and advance on absence alone a few times, but
   // stops short of grace: 2 held (absent_ticks 1..kAbsenceGrace) + 1 advancing tick
@@ -714,9 +718,9 @@ TEST(LifecycleExpectation, NeverArmedNodeResumesRatherThanRestartingAfterReturni
 
   // Node returns, still inactive. If absence above had genuinely advanced the streak to 3
   // (not restarted it), exactly 2 more matched ticks reach grace(5) and the 3rd crosses.
-  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty()) << "streak 3 -> 4";
-  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive", /*armed=*/false)}).affected.empty()) << "streak 4 -> 5 == grace";
-  auto crossed = t.update(M{match("a", "/a", "inactive", /*armed=*/false)});  // streak 5 -> 6 > grace
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "streak 3 -> 4";
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "streak 4 -> 5 == grace";
+  auto crossed = t.update(M{match("a", "/a", "inactive")});  // streak 5 -> 6 > grace
   EXPECT_EQ(crossed.affected.count("/a"), 1u)
       << "the streak restarted at zero across the absence run instead of resuming what absence "
          "had already advanced - a node that departs and returns while never armed would then "
@@ -1099,16 +1103,16 @@ TEST(LifecycleExpectation, MaturedStreakSurvivesAbsenceUnconditionally) {
 TEST(LifecycleExpectation, BelowGraceStreakHeldByAbsenceResumesRatherThanRestartsOnReturn) {
   constexpr int kGrace = 3;
   LifecycleExpectationTracker t({"a"}, kGrace, /*absence_grace=*/1);
-  auto first = t.update(M{match("a", "/a", "inactive")});  // streak 1 <= grace
+  auto first = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);  // streak 1 <= grace
   ASSERT_EQ(first.pending_violation.count("/a"), 1u);
 
   for (int i = 0; i < 30; ++i) {
-    t.update(M{});  // absent, well past absence_grace: held at streak 1 the whole time
+    t.update(M{}, &kOwnedA);  // absent, well past absence_grace: held at streak 1 the whole time
   }
 
-  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "resumed streak 2 <= grace";
-  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty()) << "resumed streak 3 == grace";
-  auto confirmed = t.update(M{match("a", "/a", "inactive")});  // resumed streak 4 > grace
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}, &kOwnedA).affected.empty()) << "resumed streak 2 <= grace";
+  EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}, &kOwnedA).affected.empty()) << "resumed streak 3 == grace";
+  auto confirmed = t.update(M{match("a", "/a", "inactive")}, &kOwnedA);  // resumed streak 4 > grace
   ASSERT_EQ(confirmed.affected.count("/a"), 1u)
       << "the streak restarted from zero on return instead of resuming where the absence had held it";
   EXPECT_EQ(confirmed.newly_affected, (std::vector<std::string>{"/a"}));
@@ -1122,10 +1126,10 @@ TEST(LifecycleExpectation, BelowGraceStreakHeldByAbsenceResumesRatherThanRestart
 // gathered while nobody could observe the node at all.
 TEST(LifecycleExpectation, BelowGraceStreakStaysPendingForeverWhileAbsentAndNeverBecomesContent) {
   LifecycleExpectationTracker t({"a"}, /*grace=*/3, /*absence_grace=*/2);
-  EXPECT_EQ(t.update(M{match("a", "/a", "inactive")}).pending.count("/a"), 1u);  // streak 1 <= grace
+  EXPECT_EQ(t.update(M{match("a", "/a", "inactive")}, &kOwnedA).pending.count("/a"), 1u);  // streak 1 <= grace
 
   for (int i = 0; i < 50; ++i) {
-    auto report = t.update(M{});  // absent, past absence_grace for every iteration but the first two
+    auto report = t.update(M{}, &kOwnedA);  // absent, past absence_grace for every iteration but the first two
     EXPECT_EQ(report.pending.count("/a"), 1u) << "iteration " << i
                                               << ": the hold ended without the node ever being measured active or "
                                                  "confirmed inactive";

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_shutdown_suppressor.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_shutdown_suppressor.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Drives a REAL ReliabilityGate (needs a real rclcpp::Node for its LifecycleWatcher), fed
+// through its set_departed_lifecycle_state_for_test() seam rather than a live managed
+// node - that seam exists precisely so a suppressor test can drive
+// departed_lifecycle_state_of() without a real GetState/transition_event round trip.
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include "ros2_medkit_graph_watchdog/lifecycle_shutdown_suppressor.hpp"
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::LifecycleShutdownSuppressor;
+using ros2_medkit_graph_watchdog::ReliabilityGate;
+
+class LifecycleShutdownSuppressorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+  }
+
+  void SetUp() override {
+    node_ = std::make_shared<rclcpp::Node>("lifecycle_shutdown_suppressor_test_node");
+    gate_ = std::make_unique<ReliabilityGate>(0, node_.get(), &mtx_);
+  }
+
+  void TearDown() override {
+    gate_.reset();
+    node_.reset();
+  }
+
+  DetectorContext ctx_with_gate() {
+    DetectorContext ctx;
+    ctx.gate = gate_.get();
+    return ctx;
+  }
+
+  rclcpp::Node::SharedPtr node_;
+  std::mutex mtx_;
+  std::unique_ptr<ReliabilityGate> gate_;
+};
+
+TEST_F(LifecycleShutdownSuppressorTest, NullGateAbstains) {
+  LifecycleShutdownSuppressor s;
+  DetectorContext ctx;  // ctx.gate stays nullptr
+  EXPECT_FALSE(s.suppresses("/anything", ctx));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, AFqnThatNeverDepartedAbstains) {
+  LifecycleShutdownSuppressor s;
+  EXPECT_FALSE(s.suppresses("/never/departed", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, ShuttingdownLabelAloneSuppresses) {
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/clean", "shuttingdown");
+  EXPECT_TRUE(s.suppresses("/clean", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, FinalizedWithAnObservedTransitionAndNoErrorSuppresses) {
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/clean", "finalized", /*saw_transition=*/true,
+                                               /*error_terminated=*/false);
+  EXPECT_TRUE(s.suppresses("/clean", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, FinalizedWithoutAnObservedTransitionIsNotSuppressed) {
+  // An unobserved "finalized" cannot be told apart from a node that failed on_error before
+  // this watcher ever saw a transition - the departure stays unclassified, so it is
+  // reported rather than trusted.
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/unseen", "finalized", /*saw_transition=*/false,
+                                               /*error_terminated=*/false);
+  EXPECT_FALSE(s.suppresses("/unseen", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, FinalizedThroughTheErrorBranchIsNotSuppressed) {
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/crashed", "finalized", /*saw_transition=*/true,
+                                               /*error_terminated=*/true);
+  EXPECT_FALSE(s.suppresses("/crashed", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, UnconfiguredIsNeverTreatedAsClean) {
+  // unconfigured is also the resting state of a failed configure() or a node that never
+  // activated at all - treating it as clean would hide exactly that startup failure.
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/never/started", "unconfigured");
+  EXPECT_FALSE(s.suppresses("/never/started", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, InactiveIsNotSuppressed) {
+  // A managed node paused mid-lifecycle (not shut down at all) is not a clean departure.
+  LifecycleShutdownSuppressor s;
+  gate_->set_departed_lifecycle_state_for_test("/paused", "inactive");
+  EXPECT_FALSE(s.suppresses("/paused", ctx_with_gate()));
+}
+
+TEST_F(LifecycleShutdownSuppressorTest, IsDurable) {
+  LifecycleShutdownSuppressor s;
+  EXPECT_TRUE(s.durable());
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
@@ -373,6 +373,78 @@ TEST_F(LifecycleWatcherTest, ReseedBudgetIsNotChargedForAJobTheTickBudgetSkipped
       << "; a job the per-tick budget skipped must keep its attempts";
 }
 
+// The sharp form of the claim above, and the one the whole presence-ownership bound rests on:
+// not "some job kept its attempts" but "exactly the read that RAN was charged". Two managed
+// nodes, neither answering: the first read overruns the 150ms per-tick budget on its own
+// (~500ms reader timeout), the loop breaks, and the second node is left queued and unread. Its
+// budget must be untouched, not merely non-zero. An aggregate over eight nodes cannot say that
+// - a loop that charged half its queue would still leave the total above the floor - and an
+// implementation that charged every SELECTED job would drain a node that was never asked
+// anything, which is precisely the fact the bound reads as "we asked and failed".
+TEST_F(LifecycleWatcherTest, OnlyTheJobWhoseReadRanIsChargedWhenTheTickBudgetCutsTheQueue) {
+  const std::vector<std::string> ids{"/q0", "/q1"};
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+
+  w.update(managed_nodes_snapshot(ids), /*tick=*/1);  // both new: subscribed, full budget
+  for (const auto & id : ids) {
+    ASSERT_EQ(w.reseeds_remaining_for_test(id), ros2_medkit_graph_watchdog::LifecycleWatcher::kReseedAttempts)
+        << id << " must start with the full self-heal budget";
+  }
+
+  w.update(managed_nodes_snapshot(ids), /*tick=*/2);  // both selected; only one read fits
+  const int spent0 =
+      ros2_medkit_graph_watchdog::LifecycleWatcher::kReseedAttempts - w.reseeds_remaining_for_test("/q0");
+  const int spent1 =
+      ros2_medkit_graph_watchdog::LifecycleWatcher::kReseedAttempts - w.reseeds_remaining_for_test("/q1");
+  EXPECT_EQ(spent0 + spent1, 1) << "exactly one GetState can have run inside the per-tick blocking "
+                                   "budget, so exactly one attempt may have been charged - "
+                                   "/q0 spent "
+                                << spent0 << ", /q1 spent " << spent1;
+}
+
+// What the departed-lifecycle record - the only input LifecycleShutdownSuppressor has - is
+// actually keyed on. Not the node being gone, and not App::is_online: an entry departs when its
+// GetState path stops appearing in App::services, which is what update() builds current_paths
+// from. That distinction decides whether a clean shutdown can be suppressed at all, and the
+// shape it matters for is a manifest-bound app: the App survives its node, keeping its id and
+// fqn, and only its runtime-derived collections empty out.
+//
+// So the manifest shape is driven here directly - the app stays in the snapshot, goes offline,
+// and loses its services - and the record must be written all the same. ManifestParser::parse_app
+// reads no services/topics/actions at all, so a manifest app's services can only ever come from
+// a live runtime match (RuntimeLinker::enrich_app), which is exactly what stops existing the
+// tick the node dies.
+TEST_F(LifecycleWatcherTest, DepartureIsRecordedWhenTheServicesGoEvenWhileTheAppRemains) {
+  ros2_medkit_graph_watchdog::LifecycleWatcher w(node_.get(), &mtx_);
+
+  auto managed = managed_node_snapshot("/mf_app");
+  managed.apps.front().is_online = true;
+  w.update(managed, /*tick=*/1);
+  w.set_state_for_test("/mf_app", "shuttingdown");
+  ASSERT_TRUE(w.state_of("/mf_app").has_value()) << "the app must be tracked before it departs";
+  ASSERT_FALSE(w.departed_state_of("/mf_app").has_value())
+      << "nothing has departed yet, so a record here would make the assertion below vacuous";
+
+  // The node dies. The App itself survives (a manifest declares it), so the snapshot still
+  // carries the id and the fqn - only is_online and the runtime-derived services go.
+  ros2_medkit_gateway::IntrospectionInput after;
+  ros2_medkit_gateway::App app;
+  app.id = "/mf_app";
+  app.bound_fqn = "/mf_app";
+  app.is_online = false;
+  after.apps.push_back(app);
+  w.update(after, /*tick=*/2);
+
+  EXPECT_FALSE(w.state_of("/mf_app").has_value())
+      << "an app with no GetState service left is not a managed lifecycle node any more";
+  const auto departed = w.departed_state_of("/mf_app");
+  ASSERT_TRUE(departed.has_value())
+      << "no departure was recorded for an app that stopped advertising its lifecycle services, "
+         "so LifecycleShutdownSuppressor would have nothing to read and a clean shutdown an "
+         "operator opted to suppress would be reported as a death";
+  EXPECT_EQ(departed->label, "shuttingdown");
+}
+
 // fqn capture + departed-lifecycle retention: a tracked node's stable fqn
 // (App::effective_fqn(), captured at first sighting) is what departed_state_of() is
 // keyed by, and its last-known label stays retrievable through that fqn for exactly

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
@@ -1,0 +1,1261 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Drives the REAL mechanism: a real NodeDeathDetector (pulled from the registry, exactly
+// as test_qos_mismatch_integration.cpp and test_lifecycle_expectation_integration.cpp do
+// for their own detectors) against hand-built IntrospectionInput snapshots and a REAL
+// ReliabilityGate, raising/clearing through a real ReportFault service round-trip to a
+// fake fault_manager. NOT a full-gateway e2e; this proves the detector + suppression
+// framework end to end within their own scope.
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rcutils/logging.h>
+#include <ros2_medkit_msgs/msg/fault.hpp>
+#include <ros2_medkit_msgs/srv/report_fault.hpp>
+
+#include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
+#include "ros2_medkit_graph_watchdog/detector.hpp"
+#include "ros2_medkit_graph_watchdog/detector_config_keys.hpp"
+#include "ros2_medkit_graph_watchdog/detector_registry.hpp"
+#include "ros2_medkit_graph_watchdog/graph_fault_codes.hpp"
+#include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
+
+using ros2_medkit_gateway::App;
+using ros2_medkit_gateway::IntrospectionInput;
+using ros2_medkit_graph_watchdog::Detector;
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::DetectorMode;
+using ros2_medkit_graph_watchdog::DetectorRegistry;
+using ros2_medkit_graph_watchdog::ReliabilityGate;
+using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeDisappeared;
+using ReportFault = ros2_medkit_msgs::srv::ReportFault;
+using namespace std::chrono_literals;
+
+namespace {
+// The detector class is file-local in node_death_detector.cpp but self-registers via
+// REGISTER_DETECTOR, which runs when that .cpp is linked into this test.
+std::unique_ptr<Detector> make_node_death() {
+  for (auto & d : DetectorRegistry::instance().create_all()) {
+    if (d->id() == "node_death") {
+      return std::move(d);
+    }
+  }
+  return nullptr;
+}
+
+// Aggregated fault source: no Component in the test snapshot, so graph_source_id() falls
+// back to this literal (see aggregated_fault.hpp).
+constexpr const char * kGraphSource = "graph_watchdog";
+
+/// Captures rcutils log output for as long as it is alive and restores the console handler
+/// on every exit path.
+class LogCapture {
+ public:
+  LogCapture() {
+    active().store(this);
+    rcutils_logging_set_output_handler(&LogCapture::handler);
+  }
+  ~LogCapture() {
+    rcutils_logging_set_output_handler(rcutils_logging_console_output_handler);
+    active().store(nullptr);
+  }
+  LogCapture(const LogCapture &) = delete;
+  LogCapture & operator=(const LogCapture &) = delete;
+  LogCapture(LogCapture &&) = delete;
+  LogCapture & operator=(LogCapture &&) = delete;
+
+  int count(const std::string & needle) const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    int n = 0;
+    for (const auto & line : lines_) {
+      if (line.find(needle) != std::string::npos) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+ private:
+  static std::atomic<LogCapture *> & active() {
+    static std::atomic<LogCapture *> current{nullptr};
+    return current;
+  }
+
+  static void handler(const rcutils_log_location_t * /*location*/, int /*severity*/, const char * /*name*/,
+                      rcutils_time_point_value_t /*timestamp*/, const char * format, va_list * args) {
+    char buf[1024];
+    va_list copy;
+    va_copy(copy, *args);
+    // The format string and args arrive from the logging call site through the handler
+    // signature - there is no literal to write here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    vsnprintf(buf, sizeof(buf), format, copy);
+#pragma GCC diagnostic pop
+    va_end(copy);
+    LogCapture * capture = active().load();
+    if (capture == nullptr) {
+      return;
+    }
+    std::lock_guard<std::mutex> lk(capture->mutex_);
+    capture->lines_.emplace_back(buf);
+  }
+
+  mutable std::mutex mutex_;
+  std::vector<std::string> lines_;
+};
+}  // namespace
+
+class NodeDeathIntegrationTest : public ::testing::Test {
+ protected:
+  // The ROS plumbing (both nodes, the executor, its spin thread, the fake service and the
+  // client) is built ONCE for this whole binary, in SetUpTestSuite() - not per TEST_F, the
+  // way every sibling integration test in this package builds it. None of this file's ~27
+  // cases needs its OWN node identity: what makes a case independent is its own detector
+  // instance and its own config, both already fresh per test, and the fixture's own
+  // received_/snapshot_ state, cleared in SetUp() below. A full rclcpp::Node + executor +
+  // OS thread create/destroy cycle is comparatively expensive and asynchronous on the DDS
+  // side, and every sibling integration test in this package happens to run few enough
+  // cases, each spending multiple SECONDS of its own on polling loops, that the cost never
+  // shows up. This file's cases run in single-digit milliseconds with nothing to wait on,
+  // so cycling that same plumbing ~27 times over in a few hundred milliseconds is a rate no
+  // other test in this package produces - and doing so measurably stalled this binary
+  // indefinitely at an arbitrary case, confirmed to move to a different case (never a fixed
+  // one) across repeated runs of the identical binary with nothing else on the machine.
+  // Building it once removes the cycling entirely rather than merely slowing it down.
+  static void SetUpTestSuite() {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+    gateway_ = std::make_shared<rclcpp::Node>("nd_it_gateway");
+    sink_ = std::make_shared<rclcpp::Node>("nd_it_sink");
+    srv_ = sink_->create_service<ReportFault>(
+        "/fault_manager/report_fault",
+        [](const std::shared_ptr<ReportFault::Request> & req, const std::shared_ptr<ReportFault::Response> & resp) {
+          {
+            std::lock_guard<std::mutex> lk(mtx_);
+            received_.push_back(*req);
+          }
+          resp->accepted = true;  // ReportFault.srv response field is `bool accepted`
+        });
+    client_ = gateway_->create_client<ReportFault>("/fault_manager/report_fault");
+    // Constructed here, not as a default-initialized static member: MultiThreadedExecutor's
+    // constructor needs a valid rclcpp context (it creates its own guard condition), and a
+    // static member's default initializer runs at static-initialization time - before
+    // main(), so before rclcpp::init() above ever has a chance to run.
+    exec_ = std::make_unique<rclcpp::executors::MultiThreadedExecutor>(rclcpp::ExecutorOptions(), 2);
+    exec_->add_node(gateway_);
+    exec_->add_node(sink_);
+    spin_ = std::thread([]() {
+      exec_->spin();
+    });
+    ASSERT_TRUE(client_->wait_for_service(5s));
+  }
+
+  static void TearDownTestSuite() {
+    exec_->cancel();
+    if (spin_.joinable()) {
+      spin_.join();
+    }
+    exec_->remove_node(gateway_);
+    exec_->remove_node(sink_);
+    exec_.reset();
+    client_.reset();
+    srv_.reset();
+    sink_.reset();
+    gateway_.reset();
+  }
+
+  // Per-test isolation for the shared plumbing above: a stale response delivered late from
+  // a PREVIOUS case must never be read as evidence by the NEXT one.
+  void SetUp() override {
+    std::lock_guard<std::mutex> lk(mtx_);
+    received_.clear();
+  }
+
+  DetectorContext make_ctx(ReliabilityGate * gate) {
+    DetectorContext ctx;
+    ctx.gateway_node = gateway_.get();
+    ctx.node_mutex = &node_mutex_;
+    ctx.mode = DetectorMode::Raise;
+    ctx.gate = gate;
+    ctx.fault_client = client_;
+    ctx.snapshot = &snapshot_;
+    return ctx;
+  }
+
+  static App app_of(const std::string & id, bool online = true, const std::string & source = "runtime") {
+    App a;
+    a.id = id;
+    a.is_online = online;
+    a.source = source;
+    a.bound_fqn = "/" + id;
+    return a;
+  }
+
+  /// A permanently-present, never-under-test App any case whose subject departs must still
+  /// carry in its snapshot alongside the departure.
+  ///
+  /// A live gateway's entity snapshot is never actually empty just because one node exits -
+  /// the graph_watchdog App itself, the fault_manager's own node and whatever else is
+  /// running are still in it. ReliabilityGate::update() reads that as a real signal: an
+  /// EMPTY snapshot re-arms the global bringup grace (graph_seen_ = false), documented and
+  /// deliberate for a genuine full-stack restart. The aggregated fault's own source_id
+  /// ("graph_watchdog", see graph_source_id()) is never itself an app in any test snapshot,
+  /// so it is always evaluated through that SAME global grace inside raise_fault() - and a
+  /// snapshot that drops to truly empty the instant the app under test departs would
+  /// silently re-gate every raise this file checks for, for a reason that has nothing to do
+  /// with node_death or any suppressor. Real gateways never produce that snapshot shape, so
+  /// no test here should either.
+  static App anchor_app() {
+    return app_of("anchor");
+  }
+
+  void set_apps(const std::vector<App> & apps) {
+    snapshot_.apps = apps;
+  }
+
+  std::size_t count_faults(const std::string & source_id, uint8_t event_type) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    std::size_t n = 0;
+    for (const auto & r : received_) {
+      if (r.source_id == source_id && r.fault_code == kNodeDisappeared && r.event_type == event_type) {
+        ++n;
+      }
+    }
+    return n;
+  }
+
+  bool any_failed_desc_contains(const std::string & source_id, const std::vector<std::string> & needles) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    for (const auto & r : received_) {
+      if (r.source_id != source_id || r.fault_code != kNodeDisappeared ||
+          r.event_type != ReportFault::Request::EVENT_FAILED) {
+        continue;
+      }
+      bool all = true;
+      for (const auto & needle : needles) {
+        if (r.description.find(needle) == std::string::npos) {
+          all = false;
+          break;
+        }
+      }
+      if (all) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Configure a fresh node_death, tick it once with an empty snapshot against a real
+  /// node, and report whether the captured log carries `needle` - the shared shape every
+  /// C1/C2/C3 case below needs.
+  bool configure_warns(const nlohmann::json & config, const std::string & needle) {
+    auto det = make_node_death();
+    if (!det) {
+      return false;
+    }
+    det->configure(config);
+    LogCapture capture;
+    IntrospectionInput empty;
+    DetectorContext ctx;
+    ctx.gateway_node = gateway_.get();
+    ctx.snapshot = &empty;
+    det->tick(ctx);
+    return capture.count(needle) > 0;
+  }
+
+  // Suite-scoped ROS plumbing (see SetUpTestSuite()'s own doc for why this is not
+  // per-fixture-instance). `inline` (C++17): each is defined here, once, with no separate
+  // out-of-class definition. The executor's thread count is explicit, not the default (0):
+  // MultiThreadedExecutor's own header documents 0 as "the number of cpu cores found
+  // (minimum of 2)" - this fixture's actual concurrency need is at most two (the fake
+  // service callback and the client's own response callback).
+  static inline rclcpp::Node::SharedPtr gateway_, sink_;
+  static inline rclcpp::Service<ReportFault>::SharedPtr srv_;
+  static inline rclcpp::Client<ReportFault>::SharedPtr client_;
+  // unique_ptr, not a by-value member: see SetUpTestSuite()'s own note on why this cannot
+  // be constructed via a default member initializer.
+  static inline std::unique_ptr<rclcpp::executors::MultiThreadedExecutor> exec_;
+  static inline std::thread spin_;
+  static inline std::mutex mtx_;  // guards received_ (both the service callback and every reader below)
+  static inline std::vector<ReportFault::Request> received_;
+
+  // Per-test state: fresh for every TEST_F, unlike the plumbing above.
+  std::mutex node_mutex_;
+  IntrospectionInput snapshot_;
+};
+
+// =============================================================================================
+// N9: peer-aggregated apps are never tracked.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, N9_PeerAggregatedAppsAreNeverTracked) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  // No anchor app here: this test's own assertions are all negative
+  // (tracked_count_for_test()==0, no FAILED report) and so are unaffected by whether
+  // ReliabilityGate's global bringup grace re-arms on an empty snapshot - see anchor_app()'s
+  // own doc for why a case that checks a POSITIVE raise needs one and this one does not.
+  set_apps({app_of("peer_app", /*online=*/true, /*source=*/"peer:robot2")});
+  for (int i = 1; i <= 5; ++i) {
+    gate.update(snapshot_, static_cast<std::uint64_t>(i));
+    det->tick(ctx);
+  }
+  EXPECT_EQ(det->tracked_count_for_test(), 0u) << "a peer app must never enter the tracked map";
+
+  set_apps({});  // peer app "departs" - if it had ever been tracked, this would report it dead
+  for (int i = 6; i <= 12; ++i) {
+    gate.update(snapshot_, static_cast<std::uint64_t>(i));
+    det->tick(ctx);
+    std::this_thread::sleep_for(5ms);
+  }
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(det->tracked_count_for_test(), 0u);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u);
+}
+
+TEST_F(NodeDeathIntegrationTest, IsOnlineFalseIsNeverTracked) {
+  // The manifest/hybrid case the class doc describes: an App present in the snapshot but
+  // not (yet) online must never be armed, however many sweeps see it.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("manifest_app", /*online=*/false)});
+  for (int i = 1; i <= 10; ++i) {
+    gate.update(snapshot_, static_cast<std::uint64_t>(i));
+    det->tick(ctx);
+  }
+  EXPECT_EQ(det->tracked_count_for_test(), 0u);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u);
+}
+
+// =============================================================================================
+// status_json() exposes tracked_count on GET /x-medkit-watchdog (detectors.node_death) - the
+// field the ros2cli_ignored e2e row reads to prove tracked state does not grow across renamed-
+// node churn cycles. Without this override the field is simply absent (Detector's own default),
+// which that row's own comment treats as a condition to skip the comparison under rather than
+// fail on - so this is required for that row to check anything at all.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, StatusJsonExposesTrackedCountMatchingTheTestSeam) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  // Before any tick: present from construction, not only after the first sweep.
+  auto status = det->status_json();
+  ASSERT_TRUE(status.is_object());
+  ASSERT_TRUE(status.contains("tracked_count"));
+  EXPECT_EQ(status.at("tracked_count").get<std::size_t>(), 0u);
+
+  set_apps({app_of("a"), app_of("b")});
+  gate.update(snapshot_, 1);
+  det->tick(ctx);
+
+  status = det->status_json();
+  EXPECT_EQ(status.at("tracked_count").get<std::size_t>(), 2u);
+  EXPECT_EQ(status.at("tracked_count").get<std::size_t>(), det->tracked_count_for_test());
+}
+
+TEST_F(NodeDeathIntegrationTest, StatusJsonTrackedCountStaysStableAcrossNeverArmingChurn) {
+  // Mirrors the e2e row's own claim: N churn cycles of never-armed apps (present for one
+  // tick each, then gone) must never move tracked_count - the SAME property N11 pins
+  // through tracked_count_for_test(), checked here through the PUBLIC status route instead.
+  ReliabilityGate gate(/*warmup_cycles=*/3, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("survivor")});
+  for (std::uint64_t t = 1; t <= 4; ++t) {  // 4 ticks: armed at t=4 (4-1>=3)
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  const auto before = det->status_json().at("tracked_count").get<std::size_t>();
+  ASSERT_EQ(before, 1u);
+
+  for (int cycle = 0; cycle < 5; ++cycle) {
+    set_apps({app_of("survivor"), app_of("churn_" + std::to_string(cycle))});
+    gate.update(snapshot_, static_cast<std::uint64_t>(5 + cycle));
+    det->tick(ctx);
+  }
+
+  const auto after = det->status_json().at("tracked_count").get<std::size_t>();
+  EXPECT_EQ(before, after) << "five renamed-node cycles must not move tracked_count";
+}
+
+// =============================================================================================
+// N11: the tracked map stays bounded under churn, and shrinks once a durable veto reclaims
+// it (also corroborating S5's "a durable veto may reclaim bookkeeping" through the real
+// detector, not just the pure tracker - test_node_liveness_tracker.cpp's own
+// NodeLivenessTrackerPrune cases prove both halves of S5 precisely, at the framework level).
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, N11_TrackedCountStaysBoundedUnderChurnAndShrinksAfterReclaim) {
+  ReliabilityGate gate(/*warmup_cycles=*/3, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000},  // floor(3000ms) == 0, so miss_grace=0 is legal
+                  {"miss_grace", 0},
+                  {"prune_grace", 2},
+                  {"allowlist", nlohmann::json::array({"/victim"})},
+                  {"suppress", nlohmann::json::array({"allowlist"})}});
+  auto ctx = make_ctx(&gate);
+
+  std::size_t max_seen = 0;
+  std::uint64_t tick = 0;
+  const auto run_tick = [&](const std::vector<App> & apps) {
+    ++tick;
+    set_apps(apps);
+    gate.update(snapshot_, tick);
+    det->tick(ctx);
+    max_seen = std::max(max_seen, det->tracked_count_for_test());
+  };
+
+  // Arm the two survivors. is_armed() requires (tick - first_seen) >= warmup_cycles, so
+  // first_seen's own tick (1) plus warmup_cycles(3) MORE ticks - 4 calls, not 3 - before the
+  // gate considers them armed (see WarmupTracker::is_armed()).
+  for (int i = 0; i < 4; ++i) {
+    run_tick({app_of("alive_a"), app_of("alive_b")});
+  }
+  ASSERT_EQ(det->tracked_count_for_test(), 2u);
+
+  // 100 ticks of churn. alive_a/alive_b stay present throughout. "victim" is present for
+  // the first 4 ticks (enough to arm under warmup_cycles=3: present at ticks 5-8, armed at
+  // tick 8 where 8-5>=3), then permanently gone. Every tick also carries ONE uniquely-named
+  // "noise" app present for exactly that one tick alone and never again - well under
+  // warmup_cycles, so none of the ~100 distinct noise apps can ever arm.
+  for (int i = 0; i < 100; ++i) {
+    std::vector<App> apps{app_of("alive_a"), app_of("alive_b"), app_of("noise_" + std::to_string(i))};
+    if (i < 4) {
+      apps.push_back(app_of("victim"));
+    }
+    run_tick(apps);
+  }
+
+  EXPECT_LE(max_seen, 3u) << "noise apps (never armed) and the victim's own eventual reclaim "
+                             "must never push tracked_count past the 3 entities that were ever "
+                             "genuinely armed";
+  EXPECT_GE(max_seen, 3u) << "the victim must have been tracked at some point, or this test "
+                             "would trivially pass by never tracking it at all";
+
+  // prune_ticks = max(prune_grace=2, miss_grace(0)+1=1) = 2. The victim, durably suppressed
+  // by the allowlist on every tick it is dead, must be reclaimed well before the churn loop
+  // above even finished - confirmed here with a few more clean ticks.
+  for (int i = 0; i < 10; ++i) {
+    run_tick({app_of("alive_a"), app_of("alive_b")});
+  }
+  EXPECT_EQ(det->tracked_count_for_test(), 2u) << "the allowlisted, durably-suppressed victim must have been reclaimed";
+  std::this_thread::sleep_for(50ms);
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"/victim"}))
+      << "an allowlisted death must never be reported in the first place";
+}
+
+// N11's own churn above never varies scale past NodeLivenessTracker's tracked_key_cap - its
+// noise apps stay well under warmup_cycles, so none of them are ever armed at all, and the
+// one entry that IS tracked and reclaimed (/victim) is reclaimed via prune()'s
+// suppression-streak path, not the cap. An unsuppressed death has NO other reclaim path -
+// prune() requires a durable suppressor - so this row exists specifically to prove the cap
+// itself engages end to end through configure(), not merely inside the tracker in isolation
+// (see test_node_liveness_tracker.cpp's own NodeLivenessTrackerCap suite for that).
+TEST_F(NodeDeathIntegrationTest, N11_TrackedNodeCapBoundsUnsuppressedChurnAndKeepsTheFaultRaised) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}, {"tracked_node_cap", 3}});
+  auto ctx = make_ctx(&gate);
+
+  std::size_t max_seen = 0;
+  std::uint64_t tick = 0;
+  const auto run_tick = [&](const std::vector<App> & apps) {
+    ++tick;
+    set_apps(apps);
+    gate.update(snapshot_, tick);
+    det->tick(ctx);
+    max_seen = std::max(max_seen, det->tracked_count_for_test());
+  };
+
+  // 20 distinct, unsuppressed identities - no allowlist, no suppress configured. Each is
+  // armed on its own tick (PRESENT, so it never competes for the departed cap that tick),
+  // then given a tick fully absent, where it matures instantly (miss_grace=0) and becomes a
+  // departed-cap candidate. warmup_cycles=0 makes the fully-empty ticks harmless - the
+  // global bringup grace re-arms on the very next non-empty tick regardless.
+  for (int i = 0; i < 20; ++i) {
+    run_tick({app_of("churn_" + std::to_string(i))});
+    run_tick({});
+  }
+
+  // kCap + 1, not kCap: a present/armed key is never refused a slot or evicted for one (see
+  // node_liveness_tracker.hpp's class doc) - only the DEPARTED subset is bounded. This
+  // churn's own admission tick therefore transiently coexists with a departed set already
+  // at the cap: kCap matured entries plus the one brand-new present arrival, until THAT one
+  // departs on the very next tick and the departed set's own collapse brings it back to
+  // kCap. Without the cap this would grow past 20, unbounded for the life of the process.
+  constexpr std::size_t kCap = 3;
+  EXPECT_LE(max_seen, kCap + 1) << "tracked_node_cap must actually engage under scale past it";
+  std::this_thread::sleep_for(50ms);
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"more node(s) disappeared"}))
+      << "identities the cap forced out of individual tracking must still count as content, "
+         "or a death the cap collapsed would silently heal instead of staying raised";
+}
+
+// =============================================================================================
+// Cap redesign regressions. Both sit PAST tracked_node_cap, in the two directions a cap that
+// bounds the wrong thing gets wrong: a graph LARGER than the cap (every death must still be
+// reported), and departed-set CHURN below miss_grace (capacity pressure must never fabricate a
+// death). See node_liveness_tracker.hpp's own class doc for the ruling these pin.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, CapC1_GraphLargerThanTheDefaultCapStillReportsADeathAmongItsPresentMajority) {
+  // Reproduces the sequence that exposes the defect: at the shipped default tracked_node_cap
+  // (512), 513 armed nodes used to leave only one survivor once make_room() evicted every
+  // present entry to admit the newcomer - and evicting a present entry can permanently lose
+  // any death landing in the eviction window, because only ONLINE nodes re-enter `armed`.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});  // default tracked_node_cap (512)
+  auto ctx = make_ctx(&gate);
+
+  // 513 armed, present nodes - one more than the default cap - lexically ordered zero-padded
+  // ids so the very first admitted is also lexically first, reproducing the same eviction
+  // order the defect above depends on.
+  std::vector<App> apps;
+  apps.reserve(514);
+  for (int i = 0; i < 513; ++i) {
+    std::string idx = std::to_string(i);
+    idx.insert(idx.begin(), 3 - idx.size(), '0');
+    apps.push_back(app_of("n" + idx));
+  }
+  apps.push_back(anchor_app());
+  set_apps(apps);
+  gate.update(snapshot_, 1);
+  det->tick(ctx);
+  ASSERT_EQ(det->tracked_count_for_test(), 514u)
+      << "every armed/present node must be tracked - none refused for capacity, however many "
+         "there are";
+
+  // Kill only the first one; every other node (512 of them) plus the anchor stay present.
+  apps.erase(apps.begin());
+  set_apps(apps);
+  gate.update(snapshot_, 2);
+  det->tick(ctx);  // misses(1) > miss_grace(0): dead
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"n000"}))
+      << "the one node that actually died among 513 present ones must still be reported - a "
+         "cap that evicts present entries to make room can lose exactly this death";
+}
+
+TEST_F(NodeDeathIntegrationTest, CapC2_ChurnUnderCapPressureNeverFabricatesADeathBeforeMissGrace) {
+  // Reproduces the sequence that exposes the defect: at cap(2) with three entries carrying
+  // only one below-grace miss each, a make_room() that collapsed every non-idle entry used
+  // to fold all three into the collapsed count, raising GRAPH_NODE_DISAPPEARED before any
+  // of them had actually crossed miss_grace, and unhealably (their identities were erased).
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 2}, {"tracked_node_cap", 2}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("a"), app_of("b"), app_of("c"), anchor_app()});
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // arms a, b, c
+
+  set_apps({anchor_app()});  // a, b, c all depart on the same tick
+  gate.update(snapshot_, 2);
+  det->tick(ctx);  // each misses 1 of 2 (miss_grace) - below grace, but the departed COUNT
+                   // (3) exceeds tracked_node_cap(2): the exact capacity pressure that used
+                   // to force make_room() to collapse entries before grace.
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "none of a/b/c has crossed miss_grace yet - capacity pressure alone must never "
+         "report any of them dead early";
+  EXPECT_EQ(det->tracked_count_for_test(), 4u)
+      << "the anchor (idle) plus all three of a/b/c must still be individually tracked - none "
+         "had matured, so none was an eligible collapse candidate despite the departed count "
+         "exceeding the cap";
+
+  // "/a" returns, relieving the pressure before anything matured; "/b" and "/c" stay gone and
+  // now genuinely cross miss_grace - proving the pressure above did not silently erase either
+  // identity (which would make it un-reportable, since only ONLINE nodes re-enter `armed`).
+  set_apps({app_of("a"), anchor_app()});
+  gate.update(snapshot_, 3);
+  det->tick(ctx);  // b, c miss 2 == miss_grace, not yet; a is present again (idle)
+  gate.update(snapshot_, 4);
+  det->tick(ctx);  // b, c miss 3 > miss_grace: genuinely, individually dead - the departed
+                   // count (2) no longer exceeds the cap(2), so nothing is collapsed
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/b"}));
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/c"}));
+  EXPECT_EQ(det->tracked_count_for_test(), 4u) << "anchor and a (idle), b and c (departed) - none collapsed";
+}
+
+TEST_F(NodeDeathIntegrationTest, CapCollapsedDeathClearsOnceTheGraphRecoversAndTheDetectorIsReconfigured) {
+  // A cap-forced collapse is a confirmed death that can no longer be named individually - it
+  // still keeps GRAPH_NODE_DISAPPEARED raised, by design (collapsed_dead_count_ is monotone
+  // within one tracker lifetime: the identities are gone, so there is no way to tell which of
+  // possibly-several collapsed departures came back). What was untested is whether such a
+  // fault can EVER clear again once the graph genuinely recovers - proven here through the
+  // same reconfigure path ReconfigureWhileAbsentDoesNotWithholdAnEarnedClearOnceTheNodeReturns
+  // already proves for an ordinary (uncollapsed) outstanding fault: a live reconfigure rebuilds
+  // tracker_ (and so collapsed_dead_count_) from scratch while preserving ever_raised_, so a
+  // clean re-observation of an all-present graph clears it.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}, {"tracked_node_cap", 1}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("a"), app_of("b"), anchor_app()});
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // arms a, b
+
+  set_apps({anchor_app()});  // a, b both depart
+  gate.update(snapshot_, 2);
+  det->tick(ctx);  // both miss 1 > miss_grace(0): matured; departed count(2) > cap(1): collapsed
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_EQ(det->tracked_count_for_test(), 1u)
+      << "precondition: both identities collapsed - only the anchor (idle, uncapped) remains";
+  ASSERT_TRUE(any_failed_desc_contains(kGraphSource, {"more node(s) disappeared"}))
+      << "precondition: the collapse must itself have been reported as a genuine raise";
+
+  set_apps({app_of("a"), app_of("b"), anchor_app()});  // the graph recovers: both return
+  gate.update(snapshot_, 3);
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "merely returning must NOT by itself clear a collapsed death - collapsed_dead_count_ "
+         "stays raised until an operator actually acts on the cap-saturation warning";
+
+  // The operator's actual remedy: reconfigure (raising tracked_node_cap, say - the cap value
+  // itself does not matter here, only that configure() rebuilds tracker_ from scratch).
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}, {"tracked_node_cap", 16}});
+  gate.update(snapshot_, 4);  // a, b are present in this same, unchanged snapshot
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "once reconfigured, a clean re-observation of an all-present graph must clear the "
+         "fault - ever_raised_ survives reconfigure (see ReconfigureWhileAbsentDoesNot... "
+         "above) precisely so this recovery path is not permanently stuck";
+}
+
+// =============================================================================================
+// C1: config sweep - miss_grace / prune_grace endpoints and degenerate values,
+// tick_interval_ms edge values, the prune_grace clamp, and the 3000ms floor's own boundary.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceAcceptsTheLowerBoundZero) {
+  // tick_interval_ms=3000 -> floor is 0, so miss_grace=0 needs no bump.
+  EXPECT_FALSE(configure_warns({{"tick_interval_ms", 3000}, {"miss_grace", 0}}, "'miss_grace'"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceAcceptsTheUpperBoundThirtySixHundred) {
+  EXPECT_FALSE(configure_warns({{"tick_interval_ms", 3000}, {"miss_grace", 3600}}, "'miss_grace' must"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceRejectsNegativeOne) {
+  EXPECT_TRUE(configure_warns({{"miss_grace", -1}}, "'miss_grace' must be an integer"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceRejectsOnePastTheUpperBound) {
+  EXPECT_TRUE(configure_warns({{"miss_grace", 3601}}, "'miss_grace' must be an integer"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_PruneGraceAcceptsTheLowerBoundZero) {
+  EXPECT_FALSE(configure_warns({{"prune_grace", 0}}, "'prune_grace' must"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_PruneGraceAcceptsTheUpperBoundThirtySixHundred) {
+  EXPECT_FALSE(configure_warns({{"prune_grace", 3600}}, "'prune_grace' must"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_PruneGraceRejectsNegativeOne) {
+  EXPECT_TRUE(configure_warns({{"prune_grace", -1}}, "'prune_grace' must be an integer"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_PruneGraceRejectsOnePastTheUpperBound) {
+  EXPECT_TRUE(configure_warns({{"prune_grace", 3601}}, "'prune_grace' must be an integer"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_TickIntervalMsZeroIsRejectedAndWarns) {
+  EXPECT_TRUE(configure_warns({{"tick_interval_ms", 0}}, "'tick_interval_ms'"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_TickIntervalMsNegativeIsRejectedAndWarns) {
+  EXPECT_TRUE(configure_warns({{"tick_interval_ms", -200}}, "'tick_interval_ms'"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_TickIntervalMsOneIsAcceptedAndFloorsMissGraceHeavily) {
+  // At a 1ms tick the floor is (3000+1-1)/1 - 1 = 2999 ticks - the default miss_grace(2) is
+  // nowhere close, so this must warn about the bump rather than accept the default quietly.
+  EXPECT_TRUE(configure_warns({{"tick_interval_ms", 1}}, "'miss_grace'"));
+}
+
+TEST(MinNodeDeathMissGrace, DoesNotOverflowAtTickIntervalMsDocumentedValidCeiling) {
+  // tick_interval_ms's own documented-valid ceiling (node_death_detector.cpp's configure():
+  // "must be a positive integer up to INT_MAX") - kMinNodeDeathWindowMs + tick_interval_ms
+  // overflows a 32-bit int here before the division ever runs unless computed in a wider
+  // type, undefined behaviour at a value the config contract explicitly accepts. The
+  // returned floor must still be small and non-negative, not a wraparound artifact.
+  const int floor = ros2_medkit_graph_watchdog::min_node_death_miss_grace(std::numeric_limits<int>::max());
+  EXPECT_GE(floor, 0);
+  EXPECT_LT(floor, 10) << "at a multi-billion-ms tick, kMinNodeDeathWindowMs is already spanned "
+                          "by a single tick, so the floor must be tiny";
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceExactlyAtTheFloorIsAcceptedWithoutWarning) {
+  // At the 1000ms default tick the floor is (3000+999)/1000 - 1 = 2, exactly the default -
+  // the row either side of the floor this case and the next one pin.
+  EXPECT_FALSE(configure_warns({{"tick_interval_ms", 1000}, {"miss_grace", 2}}, "'miss_grace'"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_MissGraceOneBelowTheFloorWarnsAndIsBumped) {
+  EXPECT_TRUE(configure_warns({{"tick_interval_ms", 1000}, {"miss_grace", 1}}, "'miss_grace'"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C1_PruneGraceBelowMissGracePlusOneIsSilentlyClampedUp) {
+  // The clamp is not a rejection (no warning is owed for it - prune_grace=0 is itself a
+  // perfectly legal value), so this is a BEHAVIOURAL proof, in two halves: an allowlisted,
+  // durably dead key must not be reclaimed before miss_grace + 1 = 3 consecutive suppressed
+  // ticks, even though prune_grace=0 was configured (which would reclaim after just 1 if
+  // unclamped) - AND it must actually BE reclaimed once that clamped horizon passes, or this
+  // row could not tell the claimed clamp from prune() being broken entirely (neither would
+  // move tracked_count off 1 at the first-eligible tick either).
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000},
+                  {"miss_grace", 2},
+                  {"prune_grace", 0},
+                  {"allowlist", nlohmann::json::array({"/x"})},
+                  {"suppress", nlohmann::json::array({"allowlist"})}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("x")});
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // arm
+  set_apps({});
+  for (std::uint64_t t = 2; t <= 4; ++t) {  // misses 1, 2, 3 (dead once misses > 2)
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  ASSERT_EQ(det->tracked_count_for_test(), 1u) << "the clamp must not have reclaimed it yet "
+                                                  "at the very tick it first became eligible";
+
+  // prune_ticks = max(prune_grace=0, miss_grace(2)+1=3) = 3. Suppression is first evaluated
+  // at t=4 (streak 1); reclaim once the streak exceeds 3, i.e. streak 4 at t=7. Ticked to 9
+  // for margin.
+  for (std::uint64_t t = 5; t <= 9; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  EXPECT_EQ(det->tracked_count_for_test(), 0u)
+      << "past the clamped horizon the durably-suppressed key must actually be reclaimed - a "
+         "clamp that silently became 'never prune' would leave this at 1 forever";
+}
+
+// =============================================================================================
+// X2: the 3000ms floor makes two otherwise-identical configurations behave DIFFERENTLY, not
+// merely both eventually raise.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, X2_TheFloorMakesAConfiguredMissGraceBehaveDifferentlyFromOneAboveIt) {
+  const int tick_interval_ms = 200;  // floor here is (3000+199)/200 - 1 = 14 ticks
+
+  auto det_below = make_node_death();
+  ASSERT_TRUE(det_below);
+  det_below->configure({{"tick_interval_ms", tick_interval_ms}, {"miss_grace", 1}});  // bumped to 14
+
+  auto det_above = make_node_death();
+  ASSERT_TRUE(det_above);
+  det_above->configure({{"tick_interval_ms", tick_interval_ms}, {"miss_grace", 20}});  // already above 14
+
+  ReliabilityGate gate_below(0, gateway_.get(), &node_mutex_);
+  ReliabilityGate gate_above(0, gateway_.get(), &node_mutex_);
+  IntrospectionInput snap_below, snap_above;
+
+  DetectorContext ctx_below;
+  ctx_below.gateway_node = gateway_.get();
+  ctx_below.node_mutex = &node_mutex_;
+  ctx_below.mode = DetectorMode::Raise;
+  ctx_below.gate = &gate_below;
+  ctx_below.fault_client = client_;
+  ctx_below.snapshot = &snap_below;
+  DetectorContext ctx_above = ctx_below;
+  ctx_above.gate = &gate_above;
+  ctx_above.snapshot = &snap_above;
+
+  snap_below.apps = {app_of("floor_below_node"), anchor_app()};
+  snap_above.apps = {app_of("floor_above_node"), anchor_app()};
+  gate_below.update(snap_below, 1);
+  det_below->tick(ctx_below);
+  gate_above.update(snap_above, 1);
+  det_above->tick(ctx_above);
+
+  snap_below.apps = {anchor_app()};
+  snap_above.apps = {anchor_app()};
+
+  int below_raised_at = -1;
+  int above_raised_at = -1;
+  for (int tick = 2; tick <= 25 && (below_raised_at < 0 || above_raised_at < 0); ++tick) {
+    gate_below.update(snap_below, static_cast<std::uint64_t>(tick));
+    det_below->tick(ctx_below);
+    gate_above.update(snap_above, static_cast<std::uint64_t>(tick));
+    det_above->tick(ctx_above);
+    std::this_thread::sleep_for(5ms);
+    if (below_raised_at < 0 && any_failed_desc_contains(kGraphSource, {"floor_below_node"})) {
+      below_raised_at = tick;
+    }
+    if (above_raised_at < 0 && any_failed_desc_contains(kGraphSource, {"floor_above_node"})) {
+      above_raised_at = tick;
+    }
+  }
+
+  ASSERT_GT(below_raised_at, 0) << "the floor-bumped detector never reported the death at all";
+  ASSERT_GT(above_raised_at, 0) << "the already-above-floor detector never reported the death at all";
+  // Absent from tick 2 onward: reported once misses (tick - 1) exceeds the EFFECTIVE
+  // miss_grace, i.e. at tick = effective_miss_grace + 2.
+  EXPECT_EQ(below_raised_at, 16) << "the floor must have raised the effective miss_grace to "
+                                    "14, not left it at the configured 1";
+  EXPECT_EQ(above_raised_at, 22) << "20 is already above the floor and must be used as-is";
+  EXPECT_NE(below_raised_at, above_raised_at)
+      << "the two configurations must behave DIFFERENTLY, not merely both eventually raise";
+}
+
+// =============================================================================================
+// C2: malformed allowlist/suppress warn; an allowlist that `suppress` does not name has no
+// effect and says so at WARN severity - naming an entry on the allowlist is not, by itself,
+// a request to suppress it.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, C2_AllowlistWrongTopLevelTypeWarns) {
+  EXPECT_TRUE(configure_warns({{"allowlist", "not-an-array"}}, "'allowlist' must be an array"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_AllowlistBadElementWarns) {
+  EXPECT_TRUE(configure_warns({{"allowlist", nlohmann::json::array({42, "/ok"})}}, "'allowlist' entries must"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_SuppressWrongTopLevelTypeWarns) {
+  EXPECT_TRUE(configure_warns({{"suppress", "not-an-array"}}, "'suppress' must be an array"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_SuppressBadElementWarns) {
+  EXPECT_TRUE(configure_warns({{"suppress", nlohmann::json::array({42, "allowlist"})}}, "'suppress' entries must"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_UnknownSuppressEntryWarnsNamingIt) {
+  EXPECT_TRUE(configure_warns({{"suppress", nlohmann::json::array({"bogus_mechanism"})}}, "bogus_mechanism"));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_AllowlistNotNamedInSuppressWarnsAndDoesNotSuppress) {
+  EXPECT_TRUE(configure_warns({{"allowlist", nlohmann::json::array({"/x"})}}, "inert"));
+
+  // Behavioural half of the above: an allowlist entry that `suppress` does not name must
+  // never actually suppress, whatever the ported source did.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}, {"allowlist", nlohmann::json::array({"/x"})}});
+  auto ctx = make_ctx(&gate);
+  set_apps({app_of("x"), anchor_app()});
+  gate.update(snapshot_, 1);
+  det->tick(ctx);
+  set_apps({anchor_app()});
+  for (std::uint64_t t = 2; t <= 3; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  std::this_thread::sleep_for(100ms);
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/x"}))
+      << "an allowlist that suppress does not name must not suppress by itself";
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_TrackedNodeCapBelowRangeWarnsAndKeepsTheDefault) {
+  EXPECT_TRUE(configure_warns({{"tracked_node_cap", 0}}, "'tracked_node_cap' must be an integer in 1.."));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_TrackedNodeCapAboveRangeWarnsAndKeepsTheDefault) {
+  EXPECT_TRUE(configure_warns({{"tracked_node_cap", 16385}}, "'tracked_node_cap' must be an integer in 1.."));
+}
+
+TEST_F(NodeDeathIntegrationTest, C2_TrackedNodeCapFarAboveIntMaxIsRejectedNotWrapped) {
+  // The wide-then-validate pattern every other numeric key here uses: get<int>() on this
+  // value would truncate it to 0 before any range check ever ran, and 0 would then read as
+  // "below range" only by accident - the real risk is a value that truncates to something
+  // INSIDE 1..16384 and is silently accepted as a completely different cap than what was
+  // configured.
+  EXPECT_TRUE(configure_warns({{"tracked_node_cap", 4294967296LL}}, "'tracked_node_cap' must be an integer in 1.."));
+}
+
+// =============================================================================================
+// C3: an unknown config key warns naming it.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, C3_UnknownConfigKeyWarnsNamingIt) {
+  EXPECT_TRUE(configure_warns({{"miz_grace", 5}}, "miz_grace"));
+}
+
+// =============================================================================================
+// The plugin's GraphWatchdogPlugin::compute_departed_retention_ticks() sizes the gate's
+// departed-lifecycle retention window for exactly this pair of properties. Both tests
+// construct the gate with the SAME value that function would compute for this config (a
+// 200ms tick with an unconfigured, floor-bumped miss_grace and prune_grace=3), proving the
+// formula is sufficient rather than merely asserting it in a comment.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, CleanShutdownDepartureAtMissGraceBoundaryIsSuppressed) {
+  const int tick_interval_ms = 200;
+  const int floored_miss_grace = 14;  // detector_config_keys::min_node_death_miss_grace(200)
+  const int prune_ticks = 15;         // max(prune_grace=3, floored_miss_grace+1=15)
+  const int retention_ticks = prune_ticks + floored_miss_grace + 1;  // 30, the plugin's own formula
+
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_, retention_ticks);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure(
+      {{"tick_interval_ms", tick_interval_ms}, {"prune_grace", 3}, {"suppress", nlohmann::json::array({"lifecycle"})}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("clean"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms it (present, warmup_cycles=0)
+  gate.set_departed_lifecycle_state_for_test("/clean", "finalized", /*saw_transition=*/true,
+                                             /*error_terminated=*/false);
+  set_apps({anchor_app()});
+
+  // Absent from tick 1: dead once misses(tick) > 14, i.e. at tick 15 - the boundary where
+  // node_death evaluates suppression against this key for the very first time.
+  for (std::uint64_t t = 1; t <= 15; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "a clean departure must not be reported even at the very first tick suppression is "
+         "evaluated for it";
+}
+
+TEST_F(NodeDeathIntegrationTest, CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention) {
+  const int tick_interval_ms = 200;
+  const int floored_miss_grace = 14;
+  const int prune_ticks = 15;
+  const int retention_ticks = prune_ticks + floored_miss_grace + 1;  // 30
+
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_, retention_ticks);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure(
+      {{"tick_interval_ms", tick_interval_ms}, {"prune_grace", 3}, {"suppress", nlohmann::json::array({"lifecycle"})}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("clean"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);
+  gate.set_departed_lifecycle_state_for_test("/clean", "finalized", /*saw_transition=*/true,
+                                             /*error_terminated=*/false);
+  set_apps({anchor_app()});
+
+  // Boundary at tick 15 (streak starts there), reclaimed once the streak exceeds
+  // prune_ticks(15), i.e. streak 16 at tick 15+15=30. Ticked to 35 for margin.
+  for (std::uint64_t t = 1; t <= 35; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  std::this_thread::sleep_for(50ms);
+  // 1, not 0: anchor_app() stays present and armed for the whole run and is never pruned -
+  // only "/clean" is ever eligible for reclaim.
+  EXPECT_EQ(det->tracked_count_for_test(), 1u)
+      << "a permanently clean departure must be RECLAIMED (forgotten), not merely stay "
+         "suppressed forever";
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "the departed-lifecycle label must survive at least until the reclaim tick - if the "
+         "gate's retention window under-runs node_death's own reclaim tick, the label expires "
+         "first and this cleanly-shut-down node gets re-raised instead of silently reclaimed";
+}
+
+// =============================================================================================
+// AllowlistSuppressor's id form: a bare-name collision gives two nodes the same leaf, so an
+// allowlist entry written in the collision-prefixed id shape must suppress only the node that
+// id actually names - never its bare-name sibling, which is reachable only through the exact
+// FQN or bare-leaf forms proven directly on AllowlistSuppressor in test_allowlist_suppressor.cpp.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, AllowlistIdFormSuppressesOnlyTheCollisionPrefixedNode) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  // The id form specifically: neither node's bare leaf ("calibration") nor either full fqn
+  // is on this list, so a suppression must be reaching the durable, id-shaped entry via
+  // AllowlistSuppressor::allows() - the id captured while each node was still present (see
+  // node_death_detector.cpp's tick()) - not via suppresses()'s own exact/bare-leaf checks.
+  det->configure({{"tick_interval_ms", 3000},  // floor(3000ms) == 0, so miss_grace=0 is legal
+                  {"miss_grace", 0},
+                  {"allowlist", nlohmann::json::array({"coll_a_calibration"})},
+                  {"suppress", nlohmann::json::array({"allowlist"})}});
+  auto ctx = make_ctx(&gate);
+
+  // Two nodes sharing the bare leaf "calibration" in different namespaces - the shape
+  // ros2_runtime_introspection.cpp's own collision rule produces: same-bare-name nodes each
+  // get a namespace-prefixed id, while their fqn (namespace + bare leaf) stays exactly what
+  // it always was. Built by hand rather than via app_of(), which only ever derives bound_fqn
+  // from id itself and so cannot produce an id that DIFFERS from the fqn's own leaf.
+  App node_a;
+  node_a.id = "coll_a_calibration";
+  node_a.bound_fqn = "/coll_a/calibration";
+  node_a.is_online = true;
+  node_a.source = "runtime";
+  App node_b;
+  node_b.id = "coll_b_calibration";
+  node_b.bound_fqn = "/coll_b/calibration";
+  node_b.is_online = true;
+  node_b.source = "runtime";
+
+  set_apps({node_a, node_b, anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms both (present, warmup_cycles=0) and captures each one's id verdict
+
+  set_apps({anchor_app()});  // both depart on the same tick
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // misses(1) > miss_grace(0): both would be dead absent suppression
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_TRUE(any_failed_desc_contains(kGraphSource, {"/coll_b/calibration"}))
+      << "the sibling the allowlist entry does not name must still be reported dead - "
+         "otherwise this test cannot tell a working id-match from a suppressor that "
+         "swallows everything";
+  EXPECT_FALSE(any_failed_desc_contains(kGraphSource, {"/coll_a/calibration"}))
+      << "an allowlist entry naming the collision-prefixed id must suppress exactly the node "
+         "that id names";
+}
+
+// =============================================================================================
+// The ungated-clear guard (ever_raised_): ctx.clear_fault() carries no reliability-gate check
+// of its own, so this detector may only clear GRAPH_NODE_DISAPPEARED once it has itself
+// genuinely raised it at least once - never merely because SOMETHING, anything, is tracked.
+// =============================================================================================
+
+TEST_F(NodeDeathIntegrationTest, UngatedClearStaysSuppressedWhileAnUnrelatedNodeArmsAlone) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});  // floor(3000ms) == 0
+  auto ctx = make_ctx(&gate);
+
+  // "other" arms and stays present for every tick - it never dies, so report.dead is never
+  // non-empty because of it. It stands in for anything elsewhere in the graph (the gateway's
+  // own App among real candidates) that becomes tracked without being what a stored,
+  // outstanding fault is actually about - tracker_.tracked_count() going non-zero here must
+  // not be read as "safe to clear".
+  for (std::uint64_t t = 0; t < 10; ++t) {
+    set_apps({app_of("other"), anchor_app()});
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  ASSERT_GT(det->tracked_count_for_test(), 0u)
+      << "precondition this test needs: something IS tracked, without this detector having "
+         "ever raised anything";
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "a fresh instance that has never itself raised GRAPH_NODE_DISAPPEARED must never "
+         "clear it either, however many unrelated entities become tracked";
+}
+
+TEST_F(NodeDeathIntegrationTest, ClearFlowsOnceThisInstanceHasGenuinelyRaised) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms "victim"
+
+  set_apps({anchor_app()});  // victim departs
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // misses(1) > miss_grace(0): genuinely dead, genuinely raised
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "precondition: this instance must have genuinely raised before the recovery below "
+         "can prove anything about clearing";
+
+  set_apps({app_of("victim"), anchor_app()});  // victim returns
+  gate.update(snapshot_, 2);
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "a genuine recovery after this instance has itself raised must still clear - the "
+         "ungated-clear guard must suppress an UNEARNED clear, not an earned one";
+}
+
+TEST_F(NodeDeathIntegrationTest, EverRaisedTracksDeliveryNotIntentSoAnUndeliveredRaiseNeverEarnsAClear) {
+  // ever_raised_ must be set from emit_ordered()'s own return (did raise_fault() actually
+  // call async_send_request()), not from report.dead's mere non-emptiness. Advisory mode is
+  // the simplest of several ways raise_fault() can decline to send despite a non-empty
+  // report (mode_emits, no client, empty source_id, the reliability gate, and a
+  // not-yet-ready service all take the identical silent-decline path) - any one of them
+  // proves the same gap, since ever_raised_ has no way to tell them apart from a genuine
+  // send without reading raise_fault()'s own return value.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+  ctx.mode = DetectorMode::Advisory;  // every raise_fault()/clear_fault() call declines to send
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms "victim"
+
+  set_apps({anchor_app()});  // victim departs
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // report.dead is non-empty, but Advisory mode declines to send it
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "precondition: Advisory mode must have genuinely suppressed the raise";
+
+  // Switch to Raise mode and let victim return. If ever_raised_ had already been set from
+  // report.dead's mere non-emptiness on the tick above (the bug this test pins), it would
+  // read true here and this recovery would emit an unearned PASSED for an occurrence the
+  // fault manager never heard about in the first place.
+  ctx.mode = DetectorMode::Raise;
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 2);
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "no FAILED for this occurrence ever reached the wire, so no PASSED may either";
+}
+
+TEST_F(NodeDeathIntegrationTest, AdvisoryModeStillObservesAndAccumulatesMissesWithoutEmittingAnything) {
+  // README's own contract: "advisory = observe, do not push". The sibling test above proves
+  // the "do not push" half; this proves the "observe" half is not a no-op masquerading as
+  // one - a detector that skipped tracker_.update() entirely in Advisory mode would ALSO
+  // send nothing, and would be indistinguishable from a correct one by that test alone.
+  //
+  // Proof: accumulate misses PAST miss_grace while in Advisory (so the node is genuinely
+  // dead from the tracker's own point of view, just never reported), then switch to Raise
+  // mode WITHOUT letting the node return. A detector that truly kept observing raises on
+  // this very first Raise-mode tick, because the miss count already crossed the threshold
+  // during the Advisory window; one that had paused observation would need miss_grace + 1
+  // MORE ticks from here to reach the same threshold from zero.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 2}});
+  auto ctx = make_ctx(&gate);
+  ctx.mode = DetectorMode::Advisory;
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms "victim"
+
+  set_apps({anchor_app()});                 // victim departs
+  for (std::uint64_t t = 1; t <= 3; ++t) {  // misses 1, 2, 3 (> miss_grace(2)): genuinely dead
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  EXPECT_EQ(det->tracked_count_for_test(), 2u)
+      << "Advisory mode must still track victim and anchor exactly as Raise mode would";
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "precondition: Advisory mode must have genuinely suppressed the raise so far";
+
+  ctx.mode = DetectorMode::Raise;
+  gate.update(snapshot_, 4);  // victim still absent - no recovery here
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "the very first Raise-mode tick must already raise, proving the miss count had "
+         "already crossed miss_grace DURING the Advisory window rather than starting fresh";
+}
+
+TEST_F(NodeDeathIntegrationTest, ReconfigureWhileAbsentDoesNotWithholdAnEarnedClearOnceTheNodeReturns) {
+  // ever_raised_ is a fact about this PROCESS's history, not about the currently-loaded
+  // config - configure() rebuilds tracker_ fresh (an operator editing the allowlist, say,
+  // with a death still outstanding and absent), and if ever_raised_ reset along with it, the
+  // freshly-rebuilt tracker could never re-create evidence for a node it has not itself
+  // re-observed, leaving the standing fault able to get neither a further FAILED nor a
+  // PASSED for the rest of the process's life once the node genuinely returns.
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);  // arms "victim"
+
+  set_apps({anchor_app()});  // victim departs
+  gate.update(snapshot_, 1);
+  det->tick(ctx);  // genuinely raised
+
+  std::this_thread::sleep_for(50ms);
+  ASSERT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "precondition: this instance must have genuinely raised before the reconfigure below";
+
+  // Reconfigure WHILE the node is still absent - tracker_ is rebuilt empty, and this
+  // (otherwise identical) config has never itself observed "victim" at all.
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+
+  set_apps({app_of("victim"), anchor_app()});  // victim returns
+  gate.update(snapshot_, 2);
+  det->tick(ctx);
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "a genuine recovery after a live reconfigure must still clear - the standing fault "
+         "must not be stuck unable to ever heal for the rest of the process's life";
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
@@ -1105,6 +1105,52 @@ TEST_F(NodeDeathIntegrationTest, UngatedClearStaysSuppressedWhileAnUnrelatedNode
          "clear it either, however many unrelated entities become tracked";
 }
 
+// The fourth quadrant of the restart matrix, and a LIMITATION rather than a property worth
+// having: gateway restarts AND the node returns. The fresh instance sees the node present,
+// armed and not missing, so report.dead is empty, ever_raised_ stays false, and no PASSED is
+// ever emitted - a fault CONFIRMED before the restart therefore stays CONFIRMED, and with the
+// sqlite backend it survives every reboot until an operator acknowledges it.
+//
+// Why it is not simply fixed here: the guard exists because a fresh instance cannot tell "the
+// node came back" from "I never saw that node". Answering that needs the KEYS the outstanding
+// record names, and they are not reachable. /fault_manager/list_faults would tell this detector
+// that a GRAPH_NODE_DISAPPEARED record is outstanding and that it is among its reporting
+// sources, but not which nodes it names: fault_manager aggregates one record per fault_code,
+// and this detector merges every dead key into that one record's description, capped at
+// AggregatedFault::kMaxDescriptionChars with the remainder collapsed into a count. Acting on
+// the record's mere existence would clear it for a node that is still dead and simply never
+// re-observed, which is the ungated heal the sibling tests above forbid.
+//
+// So this pins the behaviour rather than asserting a fix: it is what the README's restart
+// section documents, and it must not change silently.
+TEST_F(NodeDeathIntegrationTest, RestartedInstanceNeverClearsAFaultItDidNotRaiseEvenAsTheNodeReturns) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  // A brand-new detector object is exactly what a gateway restart produces - see configure()'s
+  // own note on why ever_raised_ needs no reset. Nothing here ever kills "victim": this
+  // instance's whole life is the healthy graph a returned node presents.
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});
+  auto ctx = make_ctx(&gate);
+
+  for (std::uint64_t t = 0; t < 20; ++t) {
+    set_apps({app_of("victim"), anchor_app()});
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  ASSERT_GT(det->tracked_count_for_test(), 0u)
+      << "the returned node must be tracked and healthy, or this test is not about the quadrant "
+         "where the node came back";
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_PASSED), 0u)
+      << "a fresh instance emitted PASSED for a fault it never raised - it cannot know which "
+         "node the stored record names, so this clear would be just as wrong for a node that "
+         "never came back";
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "nothing died here, so nothing may be reported either";
+}
+
 TEST_F(NodeDeathIntegrationTest, ClearFlowsOnceThisInstanceHasGenuinelyRaised) {
   ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
   auto det = make_node_death();

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
@@ -52,6 +52,7 @@ using ros2_medkit_graph_watchdog::Detector;
 using ros2_medkit_graph_watchdog::DetectorContext;
 using ros2_medkit_graph_watchdog::DetectorMode;
 using ros2_medkit_graph_watchdog::DetectorRegistry;
+using ros2_medkit_graph_watchdog::PresenceOwnership;
 using ros2_medkit_graph_watchdog::ReliabilityGate;
 using ros2_medkit_graph_watchdog::graph_fault_codes::kNodeDisappeared;
 using ReportFault = ros2_medkit_msgs::srv::ReportFault;
@@ -1149,6 +1150,155 @@ TEST_F(NodeDeathIntegrationTest, RestartedInstanceNeverClearsAFaultItDidNotRaise
          "never came back";
   EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
       << "nothing died here, so nothing may be reported either";
+}
+
+// What re-admits a key the detector has just handed back, and why the handover does not hold
+// without this: a dying managed node loses its lifecycle SERVICES from the snapshot, and a node
+// with no managed record reads as a plain node - which is kEarned. So the very act of dying
+// erases the measurement that disowned the node, and the key walks straight back in on the tick
+// before it departs.
+//
+// The sequence is the production one, driven here where it can be made exact: provisional
+// admission, a late non-active label, the release, then a sweep that still carries the App but
+// no longer carries its get_state service, then the departure.
+// The crash loop, which the README calls the case this detector most exists for. A managed node
+// that was measured active, died, and was reported comes back the way a respawned lifecycle
+// node always comes back: at "unconfigured", because nothing re-drives it. That reads kDisowned,
+// and the hand-back consults earned_ - which had been pruned to the PRESENT graph while the node
+// was away, so its earned ground was gone and the key was handed back. The fault healed on the
+// return, correctly, and then the detector was tracking nothing: the second death, and every one
+// after it, went unreported.
+//
+// earned_ is bookkeeping that belongs to a tracked KEY, so it has to live as long as the tracker
+// keeps that key - which is what NodeLivenessTracker::known_keys() is for, and what bounds it.
+TEST_F(NodeDeathIntegrationTest, AnEarnedKeyKeepsItsGroundAcrossTheOutageSoTheNextDeathIsReported) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});  // floor(3000ms) == 0
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("looper"), anchor_app()});
+  gate.update(snapshot_, 0);
+  gate.set_lifecycle_state_for_test("looper", "active");
+  det->tick(ctx);  // measured active: earned, admitted
+  ASSERT_EQ(gate.presence_ownership("looper"), PresenceOwnership::kEarned);
+
+  set_apps({anchor_app()});  // first death
+  gate.update(snapshot_, 1);
+  det->tick(ctx);
+  std::this_thread::sleep_for(50ms);
+  const auto after_first = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  ASSERT_GT(after_first, 0u) << "the first death was never reported, so there is no loop here yet";
+
+  // It respawns, and a respawned lifecycle node reads unconfigured until something activates it.
+  set_apps({app_of("looper"), anchor_app()});
+  gate.update(snapshot_, 2);
+  gate.set_lifecycle_state_for_test("looper", "unconfigured");
+  det->tick(ctx);
+  det->tick(ctx);  // a second tick: the outage-era miss count is cleared by now
+
+  set_apps({anchor_app()});  // and it crashes again
+  gate.update(snapshot_, 3);
+  det->tick(ctx);
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), after_first)
+      << "the second death of a crash-looping node was reported by nobody - the key was handed "
+         "back on the respawn because its earned ground had been pruned during the outage, and "
+         "a detector that reports the first death and then goes quiet is the failure this one "
+         "exists to prevent";
+}
+
+// The other side of AReleasedKeyIsNotReAdmittedWhenItsLifecycleRecordVanishes below: the
+// refusal is a WINDOW, not a life sentence. A node that stops being managed - drops its
+// lifecycle services and keeps running as an ordinary node - shows the same "no record at all"
+// shape a dying one does, and holding the refusal for as long as that lasts would leave its
+// eventual death reported by nobody: this detector has no key for it, and lifecycle_expectation
+// only ever looks at require_active entries. Past miss_grace + 1 record-less PRESENT ticks -
+// this detector's own "absent this long means dead" window, which a genuinely dying node cannot
+// outlive - the key comes back.
+TEST_F(NodeDeathIntegrationTest, AReleasedKeyIsTakenBackOnceItOutlivesTheDeathWindowWithoutARecord) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});  // floor(3000ms) == 0, so the hold is 1 tick
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  gate.set_lifecycle_state_for_test("victim", "", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kProvisional);
+  det->tick(ctx);  // admitted provisionally
+
+  gate.set_lifecycle_state_for_test("victim", "inactive", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kDisowned);
+  det->tick(ctx);  // handed back
+
+  // The record goes while the node stays ONLINE and present - the shape this detector must not
+  // read as "the node became mine", for one window.
+  gate.update(snapshot_, 1);
+  ASSERT_FALSE(gate.lifecycle_state_of("victim").has_value());
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kEarned)
+      << "with no record at all the gate must answer kEarned here, or the branch under test is "
+         "never reached";
+  det->tick(ctx);  // inside the window: still refused
+
+  // And now it outlives the window while still present, which no dying node can do.
+  det->tick(ctx);
+  det->tick(ctx);
+
+  set_apps({anchor_app()});
+  gate.update(snapshot_, 2);
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  det->tick(ctx);  // misses(1) > miss_grace(0)
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_GT(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "a node that stopped being managed and then died was reported by nobody - this detector "
+         "refused it for the rest of its life over a lifecycle record that had been gone for "
+         "longer than any death takes";
+}
+
+TEST_F(NodeDeathIntegrationTest, AReleasedKeyIsNotReAdmittedWhenItsLifecycleRecordVanishes) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 0}});  // floor(3000ms) == 0
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  // Injected AFTER the update: a service-less app is dropped from the watcher by every update,
+  // so an entry staged before it would not survive to be read.
+  gate.set_lifecycle_state_for_test("victim", "", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kProvisional)
+      << "the key has to be admitted on PROVISIONAL grounds, or there is nothing here to hand "
+         "back and the sequence below tests nothing";
+  det->tick(ctx);  // admits it
+
+  gate.set_lifecycle_state_for_test("victim", "inactive", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kDisowned);
+  det->tick(ctx);  // hands it back
+
+  // The node begins to die. Its services leave the snapshot while the App is still in it, so
+  // the watcher drops the record - and the gate, seeing no lifecycle at all, answers kEarned.
+  gate.update(snapshot_, 1);
+  ASSERT_FALSE(gate.lifecycle_state_of("victim").has_value())
+      << "the watcher must have dropped the record here, or this test is not driving the sweep "
+         "that erases the disowning measurement";
+  ASSERT_TRUE(gate.allows_raise("victim"));
+  det->tick(ctx);
+
+  set_apps({anchor_app()});  // and now the App itself goes
+  gate.update(snapshot_, 2);
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  det->tick(ctx);  // misses(1) > miss_grace(0)
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "the key was handed back to lifecycle_expectation and then reported dead anyway - "
+         "losing a lifecycle record is not a measurement that the node became this detector's, "
+         "it is the loss of the one that said it was not";
 }
 
 TEST_F(NodeDeathIntegrationTest, ClearFlowsOnceThisInstanceHasGenuinelyRaised) {

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_death_integration.cpp
@@ -980,6 +980,62 @@ TEST_F(NodeDeathIntegrationTest, CleanShutdownDepartureAtMissGraceBoundaryIsSupp
          "evaluated for it";
 }
 
+// The same reclaim boundary, with the one thing the row above holds at zero: the gap between a
+// dying node's lifecycle SERVICES leaving the graph and its App entry following them. That gap
+// is real and documented (see the kDisowned branch in node_death_detector.cpp - a dying managed
+// node loses its services a sweep before its App), and the retention window is anchored on the
+// FIRST of those two events while node_death's reclaim tick counts from the SECOND. So every
+// tick of lead comes straight out of the single tick of margin the window is sized with, and
+// past one tick of lead the label expires BEFORE the reclaim: the suppressor abstains, the veto
+// lifts, prune()'s consecutive-suppression streak resets to zero, and - the label now being gone
+// for good - the key can never be suppressed again. A cleanly shut-down node is then named in
+// GRAPH_NODE_DISAPPEARED for the life of the process, which is the exact outcome the retention
+// formula's own comment says it exists to prevent.
+TEST_F(NodeDeathIntegrationTest, CleanShutdownIsStillSuppressedWhenItsServicesLeaveBeforeItsApp) {
+  const int tick_interval_ms = 200;
+  const int floored_miss_grace = 14;
+  const int prune_ticks = 15;
+  const int retention_ticks = prune_ticks + floored_miss_grace + 1;  // 30, exactly as shipped
+  // How many ticks the App outlives its own lifecycle services. Two, not one, so the case is a
+  // tick clear of the boundary rather than sitting on it.
+  const std::uint64_t kServiceLeadTicks = 2;
+
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_, retention_ticks);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  det->configure(
+      {{"tick_interval_ms", tick_interval_ms}, {"prune_grace", 3}, {"suppress", nlohmann::json::array({"lifecycle"})}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("clean"), anchor_app()});
+  gate.update(snapshot_, 0);
+  det->tick(ctx);
+  // The services go first, recorded at tick 0 - this is what starts the retention clock.
+  gate.set_departed_lifecycle_state_for_test("/clean", "finalized", /*saw_transition=*/true,
+                                             /*error_terminated=*/false);
+
+  // ...and the App itself is still there for another couple of sweeps, so node_death's own miss
+  // count - and with it the reclaim tick - starts that much later than the retention clock did.
+  for (std::uint64_t t = 1; t <= kServiceLeadTicks; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  set_apps({anchor_app()});
+
+  for (std::uint64_t t = kServiceLeadTicks + 1; t <= 40; ++t) {
+    gate.update(snapshot_, t);
+    det->tick(ctx);
+  }
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), 0u)
+      << "the label expired before node_death's reclaim tick because the retention clock started "
+         "when the SERVICES left, not when the App did - so a cleanly shut-down node was named in "
+         "GRAPH_NODE_DISAPPEARED, and with the label gone it can never be suppressed again";
+  EXPECT_EQ(det->tracked_count_for_test(), 1u)
+      << "only the anchor may remain: a permanently clean departure must be RECLAIMED, and a "
+         "veto that lifts even once resets the streak that reclaim depends on";
+}
+
 TEST_F(NodeDeathIntegrationTest, CleanShutdownDepartureIsReclaimedNotReRaisedPastRetention) {
   const int tick_interval_ms = 200;
   const int floored_miss_grace = 14;
@@ -1217,6 +1273,65 @@ TEST_F(NodeDeathIntegrationTest, AnEarnedKeyKeepsItsGroundAcrossTheOutageSoTheNe
 // only ever looks at require_active entries. Past miss_grace + 1 record-less PRESENT ticks -
 // this detector's own "absent this long means dead" window, which a genuinely dying node cannot
 // outlive - the key comes back.
+// The window has to survive a node going OFFLINE while staying in the snapshot. A manifest or
+// hybrid App keeps its entry with `is_online` cleared once its process stops, and this detector
+// skips such an app for TRACKING - correctly, liveness is the bound node running. But "not
+// tracked this tick" is not "left the graph", and pruning the withheld key on that basis erases
+// the window: the first tick back online walks the key straight in, with none of the record-less
+// present ticks it was supposed to wait out. A node whose lifecycle services vanished as part of
+// dying, and whose App flickers online once before disappearing, would then be reported by this
+// detector after being handed explicitly to lifecycle_expectation.
+TEST_F(NodeDeathIntegrationTest, AnOfflineFlickerDoesNotEraseTheWithheldKeysWindow) {
+  ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
+  auto det = make_node_death();
+  ASSERT_TRUE(det);
+  // A hold of miss_grace + 1 == 6 ticks, wide enough that the two record-less online ticks this
+  // case spends cannot reach it on their own - so a readmission here can only come from the
+  // window having been erased.
+  det->configure({{"tick_interval_ms", 3000}, {"miss_grace", 5}});
+  auto ctx = make_ctx(&gate);
+
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 0);
+  gate.set_lifecycle_state_for_test("victim", "", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kProvisional);
+  det->tick(ctx);  // admitted provisionally
+
+  gate.set_lifecycle_state_for_test("victim", "inactive", 0);
+  ASSERT_EQ(gate.presence_ownership("victim"), PresenceOwnership::kDisowned);
+  det->tick(ctx);  // handed back
+
+  gate.update(snapshot_, 1);  // services gone: no record at all, still online
+  ASSERT_FALSE(gate.lifecycle_state_of("victim").has_value());
+  det->tick(ctx);  // one record-less online tick, far short of the hold
+
+  // OFFLINE but still in the snapshot. Nothing is observed about the node on this tick, so the
+  // window must neither advance nor be thrown away.
+  set_apps({app_of("victim", /*online=*/false), anchor_app()});
+  gate.update(snapshot_, 2);
+  det->tick(ctx);
+
+  // Back online, still with no record. This is the tick the erased-window bug readmits on.
+  set_apps({app_of("victim"), anchor_app()});
+  gate.update(snapshot_, 3);
+  det->tick(ctx);
+
+  set_apps({anchor_app()});  // and now it really goes
+  gate.update(snapshot_, 4);
+  const auto failed_before = count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED);
+  for (int i = 0; i < 8; ++i) {  // well past miss_grace(5)
+    det->tick(ctx);
+  }
+
+  std::this_thread::sleep_for(50ms);
+  EXPECT_EQ(count_faults(kGraphSource, ReportFault::Request::EVENT_FAILED), failed_before)
+      << "an offline tick erased the withheld key and its window, so the flicker back online "
+         "re-admitted a node the graph had measured as another detector's - and this detector "
+         "then reported a death it had explicitly handed away";
+  EXPECT_EQ(det->tracked_count_for_test(), 1u)
+      << "only the anchor may be tracked here; the withheld key must not have been admitted";
+}
+
 TEST_F(NodeDeathIntegrationTest, AReleasedKeyIsTakenBackOnceItOutlivesTheDeathWindowWithoutARecord) {
   ReliabilityGate gate(/*warmup_cycles=*/0, gateway_.get(), &node_mutex_);
   auto det = make_node_death();

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_liveness_tracker.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_node_liveness_tracker.cpp
@@ -1,0 +1,329 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Pure logic: no rclcpp::Node, no rclcpp::init() anywhere in this file - both
+// NodeLivenessTracker and AggregatedFault::describe_ordered() are ROS-free.
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_graph_watchdog/aggregated_fault.hpp"
+#include "ros2_medkit_graph_watchdog/node_liveness_tracker.hpp"
+
+using ros2_medkit_graph_watchdog::AggregatedFault;
+using ros2_medkit_graph_watchdog::NodeLivenessTracker;
+
+// ---- update(): the presence/absence state machine ----------------------------------------
+
+TEST(NodeLivenessTrackerUpdate, PresentButNeverArmedIsNeverTracked) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  auto report = tracker.update({"/a"}, /*armed=*/{});
+  EXPECT_TRUE(report.dead.empty());
+  EXPECT_EQ(tracker.tracked_count(), 0u);
+}
+
+TEST(NodeLivenessTrackerUpdate, OnceArmedPresenceAloneKeepsItAlive) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  tracker.update({"/a"}, {"/a"});            // arms it
+  auto report = tracker.update({"/a"}, {});  // still present; arm state no longer matters
+  EXPECT_TRUE(report.dead.empty());
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+}
+
+TEST(NodeLivenessTrackerUpdate, ArmedThenAbsentIsReportedOnlyPastMissGrace) {
+  NodeLivenessTracker tracker(/*miss_grace=*/2);
+  tracker.update({"/a"}, {"/a"});
+  EXPECT_TRUE(tracker.update({}, {}).dead.empty()) << "miss 1";
+  EXPECT_TRUE(tracker.update({}, {}).dead.empty()) << "miss 2 == miss_grace, not yet";
+  auto report = tracker.update({}, {});  // miss 3 > miss_grace
+  ASSERT_EQ(report.dead.count("/a"), 1u);
+  EXPECT_NE(report.dead.at("/a").find("/a"), std::string::npos) << "the detail must name the key";
+}
+
+TEST(NodeLivenessTrackerUpdate, ReturningAfterBeingReportedDeadClearsIt) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  tracker.update({"/a"}, {"/a"});
+  ASSERT_EQ(tracker.update({}, {}).dead.count("/a"), 1u);
+  auto report = tracker.update({"/a"}, {});  // it came back
+  EXPECT_TRUE(report.dead.empty());
+}
+
+TEST(NodeLivenessTrackerUpdate, AnUnsuppressedDeathIsNeverForgottenWithoutPrune) {
+  // The anti-false-heal guarantee update() alone provides: a dead, never-pruned key stays
+  // reported however many further ticks pass.
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  tracker.update({"/a"}, {"/a"});
+  for (int i = 0; i < 50; ++i) {
+    EXPECT_EQ(tracker.update({}, {}).dead.count("/a"), 1u) << "tick " << i;
+  }
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+}
+
+TEST(NodeLivenessTrackerUpdate, KeysByFreshnessOrdersTheMostRecentDeathFirst) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  tracker.update({"/old", "/new"}, {"/old", "/new"});
+  tracker.update({"/new"}, {});          // /old dies now (miss 1); /new stays present
+  auto report = tracker.update({}, {});  // /old miss 2; /new miss 1 (just died - freshest)
+  ASSERT_EQ(report.dead.size(), 2u);
+  ASSERT_EQ(report.keys_by_freshness.size(), 2u);
+  EXPECT_EQ(report.keys_by_freshness.front(), "/new");
+  EXPECT_EQ(report.keys_by_freshness.back(), "/old");
+}
+
+TEST(NodeLivenessTrackerUpdate, TwoIdsWithTheSameMissCountBreakTiesByKey) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  tracker.update({"/b", "/a"}, {"/b", "/a"});
+  auto report = tracker.update({}, {});  // both die on the same tick, same miss count
+  ASSERT_EQ(report.keys_by_freshness.size(), 2u);
+  EXPECT_EQ(report.keys_by_freshness.front(), "/a") << "ties break lexicographically, deterministically";
+}
+
+// ---- prune(): S5 - only a veto that never lifts may safely reclaim -----------------------
+
+TEST(NodeLivenessTrackerPrune, APermanentlySuppressedKeyIsReclaimedOnceItsStreakPassesPruneTicks) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0, /*prune_ticks=*/2);
+  tracker.update({}, {"/durable"});
+  ASSERT_EQ(tracker.update({}, {}).dead.count("/durable"), 1u);
+  ASSERT_EQ(tracker.tracked_count(), 1u);
+
+  tracker.prune({"/durable"});  // streak 1
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+  tracker.prune({"/durable"});  // streak 2 == prune_ticks: not yet past it
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+  tracker.prune({"/durable"});  // streak 3 > prune_ticks(2): reclaimed
+  EXPECT_EQ(tracker.tracked_count(), 0u);
+}
+
+TEST(NodeLivenessTrackerPrune, AVetoThatLiftsEvenOnceResetsTheStreakAndDelaysReclaim) {
+  // This is the property that makes it SAFE for a detector to feed prune() only its
+  // durable suppressors' verdicts: a condition-based (non-durable) veto can stop matching
+  // on any tick, and when it does, the streak must restart from zero rather than merely
+  // pause - or a key could be reclaimed by ACCUMULATED, non-consecutive suppressed ticks
+  // even though the condition was false in between, which is exactly the false-heal
+  // suppressor.hpp's durable() doc warns against.
+  NodeLivenessTracker tracker(/*miss_grace=*/0, /*prune_ticks=*/2);
+  tracker.update({}, {"/lifts"});
+  ASSERT_EQ(tracker.update({}, {}).dead.count("/lifts"), 1u);
+
+  tracker.prune({"/lifts"});  // streak 1
+  tracker.prune({});          // the veto lifts for one call -> streak resets to 0
+  tracker.prune({"/lifts"});  // streak 1 again
+  tracker.prune({"/lifts"});  // streak 2
+  EXPECT_EQ(tracker.tracked_count(), 1u)
+      << "two consecutive suppressed calls after a lift must not equal three from a permanent veto";
+  tracker.prune({"/lifts"});  // streak 3 > prune_ticks(2): only now reclaimed
+  EXPECT_EQ(tracker.tracked_count(), 0u);
+}
+
+TEST(NodeLivenessTrackerPrune, AnUnsuppressedDeathIsNeverReclaimedNoMatterHowManyPruneCalls) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0, /*prune_ticks=*/2);
+  tracker.update({}, {"/never_suppressed"});
+  ASSERT_EQ(tracker.update({}, {}).dead.count("/never_suppressed"), 1u);
+  for (int i = 0; i < 20; ++i) {
+    tracker.prune({});  // nothing is ever suppressed
+  }
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+}
+
+TEST(NodeLivenessTrackerPrune, PruneNeverErasesAKeyFromAReportAlreadyHandedBack) {
+  // Every real caller runs prune() strictly AFTER update() within the same tick - this
+  // pins that pruning can never retroactively take back a key this tick's own report
+  // already earned.
+  NodeLivenessTracker tracker(/*miss_grace=*/0, /*prune_ticks=*/0);
+  tracker.update({}, {"/a"});
+  auto report = tracker.update({}, {});
+  ASSERT_EQ(report.dead.count("/a"), 1u);
+  tracker.prune({"/a"});  // reclaims it for the NEXT tick, not this one
+  EXPECT_EQ(report.dead.count("/a"), 1u);
+}
+
+// ---- D1: the capped description survives a fresh entry among many stale ones -------------
+
+TEST(NodeLivenessTrackerFreshness, AFreshDeathSurvivesTheDescriptionCapAmongManyStaleOnes) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  std::set<std::string> stale_ids;
+  // Ten long, alphabetically-EARLY ids already exceed kMaxDescriptionChars by themselves -
+  // proves the freshness ordering actually matters, not merely that a short text happens
+  // to fit regardless of order.
+  for (int i = 0; i < 10; ++i) {
+    stale_ids.insert("/aaa_stale_node_padded_to_be_long_enough_" + std::to_string(1000 + i));
+  }
+  // Armed and immediately dead: absent from `present` on the very tick they are armed
+  // already counts as one miss, which exceeds miss_grace(0).
+  tracker.update({}, stale_ids);
+
+  // A fresh id that sorts alphabetically LAST, armed a tick later while still present (so
+  // it is not dead yet), then departs on the tick after - the genuinely most recent death.
+  const std::string fresh_id = "/zzz_fresh_node";
+  tracker.update({fresh_id}, {fresh_id});
+  auto report = tracker.update({}, {});
+  ASSERT_EQ(report.dead.count(fresh_id), 1u);
+  ASSERT_FALSE(report.keys_by_freshness.empty());
+  EXPECT_EQ(report.keys_by_freshness.front(), fresh_id);
+
+  const std::string description = AggregatedFault::describe_ordered(report.dead, report.keys_by_freshness);
+  EXPECT_LE(description.size(), AggregatedFault::kMaxDescriptionChars);
+  EXPECT_NE(description.find(fresh_id), std::string::npos)
+      << "a fresh death must survive the capped description even though it sorts last "
+         "alphabetically among the stale entries";
+}
+
+TEST(NodeLivenessTrackerFreshness, PlainLexicographicOrderWouldHaveCutTheFreshEntry) {
+  // The control case for the test above: build the SAME description from `dead` alone (the
+  // uncapped, alphabetical helper's own default order), proving the fresh id really would
+  // have been lost without keys_by_freshness - this is not a description that happens to
+  // fit either way.
+  NodeLivenessTracker tracker(/*miss_grace=*/0);
+  std::set<std::string> stale_ids;
+  for (int i = 0; i < 10; ++i) {
+    stale_ids.insert("/aaa_stale_node_padded_to_be_long_enough_" + std::to_string(1000 + i));
+  }
+  tracker.update({}, stale_ids);
+  const std::string fresh_id = "/zzz_fresh_node";
+  tracker.update({fresh_id}, {fresh_id});
+  auto report = tracker.update({}, {});
+
+  const std::string lexicographic = AggregatedFault::describe(report.dead);
+  EXPECT_EQ(lexicographic.find(fresh_id), std::string::npos)
+      << "this pins that the freshness ordering is load-bearing: without it, the "
+         "alphabetically-last fresh id is the one the cap would have cut";
+}
+
+// ---- tracked_key_cap: the bound that keeps the DEPARTED subset of known_/misses_/
+// suppressed_streak_ from growing without limit under identity churn. A present entry never
+// counts against it and is never evicted to make room - see node_liveness_tracker.hpp's own
+// class doc for why this tracker's cap does not mirror LifecycleExpectationTracker's.
+
+TEST(NodeLivenessTrackerCap, TrackedCountNeverExceedsTheConfiguredCapUnderChurn) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/5);
+  std::size_t max_seen = 0;
+  // 200 distinct, never-repeating identities, never present again once armed - every one
+  // instantly departed (miss_grace=0), so this exercises exactly the DEPARTED-subset cap at a
+  // scale that pushes past it, with no present entries in the mix to blur the measurement.
+  for (int i = 0; i < 200; ++i) {
+    tracker.update({}, {"/churn_" + std::to_string(i)});
+    max_seen = std::max(max_seen, tracker.tracked_count());
+  }
+  EXPECT_LE(max_seen, 5u) << "the cap must actually engage under scale past it, not merely "
+                             "exist unexercised";
+}
+
+TEST(NodeLivenessTrackerCap, PresentEntriesExceedingTheCapAreAllStillIndividuallyReportableOnDeath) {
+  // C1 regression, at the tracker level: the earlier shape of this cap evicted PRESENT
+  // entries to admit a newcomer once the map (not merely the departed subset) reached
+  // tracked_key_cap - at 513 armed nodes against the default 512, only one survived. A
+  // present key must never be refused a slot or evicted for one, at any map size.
+  NodeLivenessTracker tracker(/*miss_grace=*/0, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/5);
+  std::set<std::string> ids;
+  for (int i = 0; i < 50; ++i) {
+    ids.insert("/n" + std::to_string(i));
+  }
+  auto report = tracker.update(ids, ids);  // 50 present, armed keys - ten times the cap
+  EXPECT_TRUE(report.dead.empty());
+  EXPECT_EQ(tracker.tracked_count(), 50u) << "a cap on the DEPARTED subset must never refuse "
+                                             "or evict a present key, however many there are";
+
+  ids.erase(ids.begin());  // kill exactly one of the fifty
+  report = tracker.update(ids, ids);
+  EXPECT_EQ(report.dead.size(), 1u) << "the one node that actually died must be reported - "
+                                       "the other 49, still present, never competed for the "
+                                       "departed cap at all";
+}
+
+TEST(NodeLivenessTrackerCap, ImmatureDepartedEntriesAreNeverCollapsedOrReportedUnderCapPressure) {
+  // C2 regression, at the tracker level: the earlier shape of this cap collapsed every
+  // NON-idle entry to make room, which included entries carrying only one below-grace miss -
+  // fabricating a death the node had not actually earned, permanently (the identity is
+  // erased, so the node returning cannot un-report it). An entry that has not crossed
+  // miss_grace_ must never be a collapse candidate, however much departed-set pressure exists.
+  NodeLivenessTracker tracker(/*miss_grace=*/2, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/1);
+  tracker.update({"/a", "/b"}, {"/a", "/b"});  // both present, armed
+  auto report = tracker.update({}, {});        // both miss 1 of 2 - departed count(2) > cap(1)
+  EXPECT_TRUE(report.dead.empty()) << "neither has crossed miss_grace yet";
+  EXPECT_EQ(report.dead.count(NodeLivenessTracker::kCollapsedKey), 0u)
+      << "capacity pressure from two BELOW-GRACE entries must never manufacture a collapsed "
+         "death - the earlier shape of this cap did exactly that";
+  EXPECT_EQ(tracker.tracked_count(), 2u) << "both identities must survive the pressure "
+                                            "untouched, so they can still mature genuinely";
+  EXPECT_TRUE(report.tracking_saturated) << "the departed set (2) still exceeds the cap (1) "
+                                            "even though nothing was eligible to collapse - an "
+                                            "accurate, non-fabricating pressure signal";
+}
+
+TEST(NodeLivenessTrackerCap, MaturedDepartedEntriesAreCollapsedIntoACountUnderCapPressure) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/1);
+  tracker.update({}, {"/victim"});
+  ASSERT_EQ(tracker.update({}, {}).dead.count("/victim"), 1u);
+  ASSERT_EQ(tracker.tracked_count(), 1u);
+
+  // "/newcomer" arms already absent - departed on its very first tick, same as "/victim" was.
+  // Both are MATURED (miss_grace=0), and the departed set (2) now exceeds the cap (1): there
+  // is no present entry to spare (there never is, for this tracker) and no immature entry to
+  // leave alone either, so admitting the newcomer must collapse matured entries instead of
+  // refusing it.
+  auto report = tracker.update({}, {"/newcomer"});
+  EXPECT_EQ(tracker.tracked_count(), 0u) << "cap(1) is below kMaxNamedDepartedEntries, so even "
+                                            "the two-stage collapse cannot leave either one "
+                                            "individually named";
+  EXPECT_EQ(report.dead.count("/victim"), 0u);
+  EXPECT_EQ(report.dead.count("/newcomer"), 0u);
+  ASSERT_EQ(report.dead.count(NodeLivenessTracker::kCollapsedKey), 1u)
+      << "both confirmed deaths must still count as content, or the cap forcing them out of "
+         "individual tracking would silently heal the fault instead of collapsing it";
+  EXPECT_NE(report.dead.at(NodeLivenessTracker::kCollapsedKey).find('2'), std::string::npos);
+  ASSERT_FALSE(report.keys_by_freshness.empty());
+  EXPECT_EQ(report.keys_by_freshness.front(), NodeLivenessTracker::kCollapsedKey)
+      << "the collapsed count must never be the entry a capped description cuts, since it is "
+         "the one line telling the operator identities are being lost at all";
+}
+
+TEST(NodeLivenessTrackerCap, CollapsedCountIsMonotoneAndKeepsAccumulating) {
+  NodeLivenessTracker tracker(/*miss_grace=*/0, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/1);
+  tracker.update({}, {"/first"});
+  tracker.update({}, {});                               // "/first" confirmed dead, occupies the only slot
+  auto after_second = tracker.update({}, {"/second"});  // "/second" arms already-departed: both collapse
+  ASSERT_EQ(after_second.dead.count(NodeLivenessTracker::kCollapsedKey), 1u);
+  EXPECT_NE(after_second.dead.at(NodeLivenessTracker::kCollapsedKey).find('2'), std::string::npos);
+  ASSERT_EQ(tracker.tracked_count(), 0u);
+
+  auto after_third = tracker.update({}, {"/third"});  // one free slot: "/third" stays named alone
+  EXPECT_EQ(tracker.tracked_count(), 1u);
+  EXPECT_NE(after_third.dead.at(NodeLivenessTracker::kCollapsedKey).find('2'), std::string::npos)
+      << "the count from the first collapse must persist even on a tick that collapses nothing new";
+
+  auto after_fourth = tracker.update({}, {"/fourth"});  // "/fourth" arms already-departed: collapses both
+  ASSERT_EQ(after_fourth.dead.count(NodeLivenessTracker::kCollapsedKey), 1u);
+  EXPECT_NE(after_fourth.dead.at(NodeLivenessTracker::kCollapsedKey).find('4'), std::string::npos)
+      << "two more distinct identities have now been collapsed - the count must not have reset "
+         "when the slot changed hands again";
+}
+
+TEST(NodeLivenessTrackerCap, AtZeroMissGraceEveryDepartedEntryIsInstantlyMaturedSoSaturationNeverFires) {
+  // NOT a general property of this tracker - see
+  // ImmatureDepartedEntriesAreNeverCollapsedOrReportedUnderCapPressure above for the case
+  // that DOES saturate. At miss_grace=0 every departed entry matures on its very first
+  // missed tick, so there is never an immature entry the cap has to leave alone: collapsing
+  // every matured entry always succeeds in bringing the departed set back under the cap.
+  NodeLivenessTracker tracker(/*miss_grace=*/0, NodeLivenessTracker::kNoPrune, /*tracked_key_cap=*/1);
+  bool ever_saturated = false;
+  for (int i = 0; i < 50; ++i) {
+    // Two brand-new, simultaneously-arming keys every tick, cap=1: the tightest possible
+    // squeeze this tracker can be put under.
+    auto report = tracker.update({}, {"/a_" + std::to_string(i), "/b_" + std::to_string(i)});
+    ever_saturated = ever_saturated || report.tracking_saturated;
+  }
+  EXPECT_FALSE(ever_saturated);
+}

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_reliability_gate.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_reliability_gate.cpp
@@ -13,14 +13,25 @@
 // limitations under the License.
 #include <gtest/gtest.h>
 
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nlohmann/json.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "ros2_medkit_gateway/core/providers/introspection_provider.hpp"
 #include "ros2_medkit_graph_watchdog/detector.hpp"  // reliability_allows() free function
+#include "ros2_medkit_graph_watchdog/presence_ownership.hpp"
 #include "ros2_medkit_graph_watchdog/reliability_gate.hpp"
 
 using ros2_medkit_gateway::App;
 using ros2_medkit_gateway::IntrospectionInput;
+using ros2_medkit_gateway::ServiceInfo;
+using ros2_medkit_graph_watchdog::LifecycleWatcher;
+using ros2_medkit_graph_watchdog::presence_ownership;
+using ros2_medkit_graph_watchdog::PresenceOwnership;
 using ros2_medkit_graph_watchdog::reliability_allows;
 using ros2_medkit_graph_watchdog::ReliabilityGate;
 
@@ -43,6 +54,64 @@ class ReliabilityGateTest : public ::testing::Test {
       in.apps.push_back(a);
     }
     return in;
+  }
+  /// A snapshot whose single App looks MANAGED to the gateway's discovery layer: it
+  /// advertises services of the GetState and ChangeState types, which is the whole of the
+  /// test find_lifecycle_get_state_path() applies. No such service exists in this process,
+  /// so the watcher's seed times out and the tracked entry keeps its empty label - a
+  /// genuinely unmeasured managed node over a real LifecycleWatcher and a real ROS graph,
+  /// not an injected one.
+  static IntrospectionInput managed_snap(const std::string & id) {
+    ServiceInfo get_state;
+    get_state.full_path = id + "/get_state";
+    get_state.type = "lifecycle_msgs/srv/GetState";
+    ServiceInfo change_state;
+    change_state.full_path = id + "/change_state";
+    change_state.type = "lifecycle_msgs/srv/ChangeState";
+
+    App app;
+    app.id = id;
+    app.bound_fqn = id;
+    app.services = {get_state, change_state};
+
+    IntrospectionInput in;
+    in.apps.push_back(app);
+    return in;
+  }
+  /// One snapshot carrying a PLAIN app and a managed-looking one, so a single status_json()
+  /// payload has to distinguish them. Built as one snapshot rather than two updates because
+  /// the claim is about telling the two apart in the SAME payload.
+  static IntrospectionInput mixed_snap(const std::string & plain_id, const std::string & managed_id) {
+    auto in = managed_snap(managed_id);
+    App plain;
+    plain.id = plain_id;
+    plain.bound_fqn = plain_id;
+    in.apps.push_back(plain);
+    return in;
+  }
+  /// One field of the status_json() entry for `id`, or null when the entity is absent.
+  static nlohmann::json entity_field(const ReliabilityGate & gate, const std::string & id, const std::string & field) {
+    const auto status = gate.status_json();
+    for (const auto & entity : status["x-medkit-watchdog"]["entities"]) {
+      if (entity["id"] == id) {
+        return entity.value(field, nlohmann::json(nullptr));
+      }
+    }
+    return nlohmann::json(nullptr);
+  }
+  /// The (armed, lifecycle) pair status_json() reports for `id`, or nullopt when the entity
+  /// is absent from the payload. The pair is the instrument this file's ownership tests need:
+  /// `armed` alone cannot tell a plain node from a managed one whose state was never read,
+  /// which is exactly the distinction under test.
+  static std::optional<std::pair<bool, nlohmann::json>> armed_and_lifecycle(const ReliabilityGate & gate,
+                                                                            const std::string & id) {
+    const auto status = gate.status_json();
+    for (const auto & entity : status["x-medkit-watchdog"]["entities"]) {
+      if (entity["id"] == id) {
+        return std::make_pair(entity["armed"].get<bool>(), entity["lifecycle"]);
+      }
+    }
+    return std::nullopt;
   }
   rclcpp::Node::SharedPtr node_;
   std::mutex mtx_;
@@ -119,4 +188,253 @@ TEST_F(ReliabilityGateTest, MirrorsGateArmedState) {
   EXPECT_FALSE(reliability_allows(&g, "/a"));  // not armed yet (0 elapsed)
   g.update(snap({"/a"}), 8);                   // 3 elapsed -> armed
   EXPECT_TRUE(reliability_allows(&g, "/a"));
+}
+
+// === presence ownership: two grounds, and only one of them is sticky ===
+
+// The defect this predicate exists for, over a REAL watcher and a REAL graph: a managed node
+// whose GetState has not answered yet keeps an empty label, the gate's permissive answer arms
+// it anyway, and node_death used to admit it on that answer alone - taking ownership of a
+// departure it could not yet attribute, and switching off the one detector that could.
+TEST_F(ReliabilityGateTest, UnmeasuredManagedNodeIsArmedButNotOwnedByPresence) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(managed_snap("/unmeasured"), 5);
+  g.update(managed_snap("/unmeasured"), 8);  // 3 elapsed -> armed
+  // Freshly discovered and unanswered: an empty label with the watcher's attempts still to
+  // spend. The settled form of the same label is a different answer - see the sweep below.
+  g.set_lifecycle_state_for_test("/unmeasured", "", LifecycleWatcher::kReseedAttempts);
+
+  ASSERT_TRUE(g.allows_raise("/unmeasured"))
+      << "the gate's permissive answer for an unread label is deliberate and must not change: "
+         "param_drift is app-keyed and depends on it";
+  EXPECT_EQ(g.presence_ownership("/unmeasured"), PresenceOwnership::kUnclaimed)
+      << "a managed node the watcher has not finished asking about cannot be owned by the "
+         "presence detector - the measurement may be one tick away - and it has not been "
+         "disowned either, because nothing has been measured at all";
+
+  // The instrument, not a paraphrase of it: armed alone reads the same for a plain node and
+  // for a managed one nobody has measured, so the claim is only visible in the PAIR.
+  const auto pair = armed_and_lifecycle(g, "/unmeasured");
+  ASSERT_TRUE(pair.has_value()) << "the gate never reported the entity at all";
+  EXPECT_TRUE(pair->first);
+  EXPECT_EQ(pair->second, nlohmann::json(""))
+      << "the watcher must hold a TRACKED entry with an empty label here (asked, still waiting), "
+         "not the null a non-managed node reports - otherwise this test proves nothing";
+}
+
+// Every state the watcher can report about an app, each one its own case, and each with the
+// GROUND the answer rests on. A state the predicate treats specially and no test sets is a
+// gap, so the sweep is exhaustive by construction: no managed record at all, an empty label
+// in BOTH of its forms, and the four primary labels a lifecycle node can sit in.
+//
+// The empty label is two cases because the bound is what makes it two. While the watcher still
+// has GetState attempts to spend the ignorance can still resolve, and taking ownership then
+// would race a measurement. Once the budget is spent nothing will ASK again, and refusing
+// there hands the departure to a detector that only looks at nodes an operator named in
+// `require_active` - so the node is owned, but on a ground that a later label revokes.
+TEST_F(ReliabilityGateTest, PresenceOwnershipSweepsEveryLifecycleStateTheWatcherCanReport) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/plain", "/m"}), 5);
+  g.update(snap({"/plain", "/m"}), 8);  // 3 elapsed -> both armed
+
+  // No managed record: a plain node, whose departure the presence detector owns outright, and
+  // owns EARNED - there is no lifecycle here that could ever say otherwise.
+  EXPECT_FALSE(g.lifecycle_state_of("/plain").has_value());
+  EXPECT_EQ(g.presence_ownership("/plain"), PresenceOwnership::kEarned);
+
+  struct Case {
+    const char * label;
+    int reseeds_remaining;
+    PresenceOwnership owned;
+  };
+  const Case cases[] = {{"", LifecycleWatcher::kReseedAttempts, PresenceOwnership::kUnclaimed},
+                        {"", 0, PresenceOwnership::kProvisional},
+                        {"active", 0, PresenceOwnership::kEarned},
+                        {"inactive", LifecycleWatcher::kReseedAttempts, PresenceOwnership::kDisowned},
+                        {"unconfigured", LifecycleWatcher::kReseedAttempts, PresenceOwnership::kDisowned},
+                        {"finalized", LifecycleWatcher::kReseedAttempts, PresenceOwnership::kDisowned}};
+  for (const auto & c : cases) {
+    g.set_lifecycle_state_for_test("/m", c.label, c.reseeds_remaining);
+    EXPECT_EQ(g.presence_ownership("/m"), c.owned)
+        << "lifecycle label '" << c.label << "' with " << c.reseeds_remaining << " re-seed attempt(s) left";
+    const auto pair = armed_and_lifecycle(g, "/m");
+    ASSERT_TRUE(pair.has_value());
+    EXPECT_TRUE(pair->first) << "warmup is elapsed for the whole sweep, so `armed` must not move "
+                                "with the label - only ownership does";
+    EXPECT_EQ(pair->second, nlohmann::json(c.label));
+  }
+}
+
+// The instrument the whole e2e suite reads has to tell the two apart on the wire, not only
+// through lifecycle_state_of(): a status_json() that serialised "no managed record" and
+// "asked, never answered" identically would satisfy every ownership case above while making
+// every e2e assertion on the pair meaningless. One payload, both entities, opposite values.
+// `measurement_pending` is asserted alongside for the same reason: an unread label means two
+// different things and nothing else on the route separates them.
+TEST_F(ReliabilityGateTest, StatusJsonSerialisesNoRecordAndAnUnreadLabelDifferently) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(mixed_snap("/plain", "/managed"), 5);
+  g.update(mixed_snap("/plain", "/managed"), 8);
+
+  const auto plain = armed_and_lifecycle(g, "/plain");
+  ASSERT_TRUE(plain.has_value()) << "the gate never reported the plain entity at all";
+  EXPECT_EQ(plain->second, nlohmann::json(nullptr))
+      << "a node with no managed record must serialise as null, not as an empty string";
+  EXPECT_EQ(entity_field(g, "/plain", "measurement_pending"), nlohmann::json(false))
+      << "there is nothing to measure on a node with no lifecycle at all";
+
+  const auto managed = armed_and_lifecycle(g, "/managed");
+  ASSERT_TRUE(managed.has_value()) << "the gate never reported the managed entity at all";
+  EXPECT_EQ(managed->second, nlohmann::json(""))
+      << "a tracked node whose GetState never answered must serialise as \"\" - asked, and still "
+         "waiting - which is a different fact from having no lifecycle at all";
+}
+
+// The bound, driven by the REAL watcher over a real graph rather than an injected budget: the
+// same node is refused while the watcher still has attempts to spend and owned once it has
+// spent them. Nothing here sets a label; the only thing that changes across the loop is how
+// many GetState calls have actually been issued and failed.
+//
+// The budget is OBSERVED at both ends, never inferred from how many ticks have gone by: a
+// watcher that handed out entries with no attempts at all, and issued no read ever, would
+// otherwise satisfy every ownership assertion in this file while never asking a node anything.
+TEST_F(ReliabilityGateTest, UnansweredManagedNodeIsOwnedOnlyOnceTheReseedBudgetIsSpent) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(managed_snap("/unanswered"), 5);  // discovered: entry created, seeded, unanswered
+  ASSERT_EQ(g.lifecycle_reseeds_remaining_for_test("/unanswered"), LifecycleWatcher::kReseedAttempts)
+      << "a newly tracked node must START with the full self-heal budget - if entries were "
+         "handed out already spent, the flip below would prove nothing about asking";
+  g.update(managed_snap("/unanswered"), 8);  // 3 elapsed -> armed
+  ASSERT_TRUE(g.allows_raise("/unanswered"));
+  ASSERT_EQ(g.lifecycle_state_of("/unanswered"), std::optional<std::string>(""))
+      << "the fixture must be TRACKED with an unread label, or this test measures nothing";
+  ASSERT_EQ(entity_field(g, "/unanswered", "measurement_pending"), nlohmann::json(true))
+      << "the status route must say the watcher still intends to ask, or an operator cannot "
+         "tell this node from one nothing will ever ask about again";
+
+  // Bounded: kReseedAttempts issued reads, plus a margin for a tick whose blocking budget
+  // cut the job before it ran (that tick is deliberately not charged - see update()).
+  const int kMaxTicks = LifecycleWatcher::kReseedAttempts + 6;
+  int left = g.lifecycle_reseeds_remaining_for_test("/unanswered");
+  ASSERT_GT(left, 0) << "the arming tick spent the whole budget, so there is no transient half "
+                        "of this claim left to observe";
+  for (int i = 0; i < kMaxTicks && left > 0; ++i) {
+    EXPECT_EQ(g.presence_ownership("/unanswered"), PresenceOwnership::kUnclaimed)
+        << "still " << left << " re-seed attempt(s) left, so the ignorance can still resolve";
+    g.update(managed_snap("/unanswered"), static_cast<uint64_t>(9 + i));
+    const int now_left = g.lifecycle_reseeds_remaining_for_test("/unanswered");
+    ASSERT_GE(now_left, 0) << "the entry stopped being tracked mid-test";
+    ASSERT_LE(now_left, left) << "a re-seed budget must never grow while the node stays tracked";
+    left = now_left;
+  }
+  ASSERT_EQ(left, 0) << "the re-seed budget never ran out in " << kMaxTicks
+                     << " ticks, so the settled half of this claim was never reached";
+  EXPECT_EQ(g.presence_ownership("/unanswered"), PresenceOwnership::kProvisional)
+      << "the watcher has asked and failed every time it ever will; refusing ownership here "
+         "leaves this node's death to a detector that only looks at `require_active` entries";
+  EXPECT_EQ(entity_field(g, "/unanswered", "measurement_pending"), nlohmann::json(false))
+      << "the route has to say the asking is over, since that is the whole of why the node is "
+         "owned at all";
+}
+
+// Not a node that starts one way and stays there: a label ARRIVES on a node that had none,
+// and later goes away again (a re-bind to a dead binding leaves the entry tracked with its
+// label cleared). The answer has to follow the current knowledge on every tick, because the
+// callers that latch it latch the GROUND, and a latch built on a stale ground is the defect
+// one level up.
+TEST_F(ReliabilityGateTest, PresenceOwnershipFollowsALabelThatArrivesAndVanishes) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(managed_snap("/flip"), 5);
+  g.update(managed_snap("/flip"), 8);  // armed, still unmeasured
+  ASSERT_TRUE(g.allows_raise("/flip"));
+  g.set_lifecycle_state_for_test("/flip", "", LifecycleWatcher::kReseedAttempts);
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kUnclaimed);
+
+  g.set_lifecycle_state_for_test("/flip", "active");  // a transition_event finally arrives
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kEarned);
+
+  // Re-bound to a binding that answers nothing: the entry is re-seeded from scratch, so the
+  // knowledge is gone AND the budget is back - transient ignorance again, not settled.
+  g.set_lifecycle_state_for_test("/flip", "", LifecycleWatcher::kReseedAttempts);
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kUnclaimed);
+  EXPECT_TRUE(g.allows_raise("/flip")) << "the permissive answer is unchanged by any of this";
+
+  // The same empty label with the budget spent is a different GROUND, not merely a different
+  // answer: owned, but only until something says otherwise.
+  g.set_lifecycle_state_for_test("/flip", "", 0);
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kProvisional);
+
+  // And that something is a real label. The subscription outlives the seed budget, so this is
+  // the sequence the bound alone would have missed: provisional owner, then the graph says the
+  // node was inactive all along.
+  g.set_lifecycle_state_for_test("/flip", "inactive", 0);
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kDisowned);
+
+  g.set_lifecycle_state_for_test("/flip", "active");
+  EXPECT_EQ(g.presence_ownership("/flip"), PresenceOwnership::kEarned);
+}
+
+// Ownership is a conjunction, and the warmup half is the other conjunct: an entity that is
+// not armed yet is not owned, whatever its lifecycle says. Without this a predicate that only
+// looked at the label would pass every other test in this file.
+TEST_F(ReliabilityGateTest, PresenceOwnershipStillRequiresArming) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(snap({"/plain"}), 5);  // 0 elapsed -> not armed
+  EXPECT_FALSE(g.allows_raise("/plain"));
+  EXPECT_EQ(g.presence_ownership("/plain"), PresenceOwnership::kUnclaimed)
+      << "not armed is UNCLAIMED, never disowned: nothing has been measured about this node, "
+         "and a caller that already holds the key must not read this as a reason to drop it";
+  g.update(snap({"/plain"}), 8);  // 3 elapsed -> armed
+  EXPECT_EQ(g.presence_ownership("/plain"), PresenceOwnership::kEarned);
+}
+
+// The order the two negative answers are decided in, which is the whole of what separates
+// "nothing is known yet" from "the graph says this node is someone else's". node_ok() already
+// refuses a managed non-active node, so asking allows_raise() first would answer the same for
+// a node measured `inactive` and for one that has simply not armed yet - and a caller that
+// releases keys on the negative answer would then drop every node that restarts, because a
+// returning node is un-armed for its whole re-warm.
+TEST_F(ReliabilityGateTest, NotArmedAndMeasuredElsewhereAreDifferentAnswers) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  // The measured one is MANAGED, so its tracked entry (and the injected label with it) survives
+  // the second update below - a service-less app is dropped from the watcher by every update.
+  g.update(mixed_snap("/warming", "/measured"), 5);  // 0 elapsed: neither is armed
+  g.set_lifecycle_state_for_test("/measured", "inactive");
+
+  ASSERT_FALSE(g.allows_raise("/warming")) << "neither entity may be armed here, or this test "
+                                              "cannot show which of the two facts decided it";
+  ASSERT_FALSE(g.allows_raise("/measured"));
+  EXPECT_EQ(g.presence_ownership("/warming"), PresenceOwnership::kUnclaimed)
+      << "a node with no lifecycle record that has not armed yet has been measured as nothing";
+  EXPECT_EQ(g.presence_ownership("/measured"), PresenceOwnership::kDisowned)
+      << "a measured non-active label is knowledge about who this node belongs to, and it must "
+         "outrank the warmup state rather than being hidden behind it";
+
+  // And once armed, the un-measured one is owned outright while the measured one is not.
+  g.update(mixed_snap("/warming", "/measured"), 8);
+  EXPECT_EQ(g.presence_ownership("/warming"), PresenceOwnership::kEarned);
+  EXPECT_EQ(g.presence_ownership("/measured"), PresenceOwnership::kDisowned)
+      << "the label survives a re-seed that cannot answer, so the verdict must survive it too";
+}
+
+// A null gate (not yet wired by the plugin) must not suppress tracking either - same
+// convention as reliability_allows(), and the detectors call both the same way. kEarned, not
+// kProvisional: with no watcher behind it, nothing could ever withdraw a provisional grant.
+TEST(PresenceOwnershipFreeFunction, NullGateAlwaysOwnsOutright) {
+  EXPECT_EQ(presence_ownership(nullptr, "x"), PresenceOwnership::kEarned);
+}
+
+// The free function must mirror the member for a real gate, on every ground - a wrapper that
+// dropped the gate and always returned kEarned would pass the null-gate test above on its own.
+TEST_F(ReliabilityGateTest, PresenceOwnershipFreeFunctionMirrorsTheGate) {
+  ReliabilityGate g(3, node_.get(), &mtx_);
+  g.update(managed_snap("/mirror"), 5);
+  EXPECT_EQ(presence_ownership(&g, "/mirror"), PresenceOwnership::kUnclaimed);  // not armed yet
+  g.update(managed_snap("/mirror"), 8);                                         // armed, still unmeasured
+  g.set_lifecycle_state_for_test("/mirror", "", LifecycleWatcher::kReseedAttempts);
+  EXPECT_EQ(presence_ownership(&g, "/mirror"), PresenceOwnership::kUnclaimed);
+  g.set_lifecycle_state_for_test("/mirror", "", 0);
+  EXPECT_EQ(presence_ownership(&g, "/mirror"), PresenceOwnership::kProvisional);
+  g.set_lifecycle_state_for_test("/mirror", "active");
+  EXPECT_EQ(presence_ownership(&g, "/mirror"), PresenceOwnership::kEarned);
 }

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_suppressor.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_suppressor.cpp
@@ -1,0 +1,108 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Pure interface/logic tests: the Suppressor contract and apply_suppressors() over
+// hand-built stand-in suppressors. No rclcpp::init() needed anywhere here - every
+// DetectorContext used is default-constructed (all pointers null), which the interface
+// contract already requires a Suppressor to tolerate (see suppresses()'s own doc).
+#include <gtest/gtest.h>
+
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_graph_watchdog/suppressor.hpp"
+
+using ros2_medkit_graph_watchdog::apply_suppressors;
+using ros2_medkit_graph_watchdog::DetectorContext;
+using ros2_medkit_graph_watchdog::Suppressor;
+
+namespace {
+/// Votes yes for every key in `veto`, abstains otherwise. `durable_flag` lets a test
+/// stand in for either shape the interface describes without needing a real suppressor.
+class FixedSuppressor : public Suppressor {
+ public:
+  explicit FixedSuppressor(std::set<std::string> veto, bool durable_flag = false)
+    : veto_(std::move(veto)), durable_flag_(durable_flag) {
+  }
+  bool suppresses(const std::string & entity_key, const DetectorContext & /*ctx*/) const override {
+    return veto_.count(entity_key) > 0;
+  }
+  bool durable() const override {
+    return durable_flag_;
+  }
+
+ private:
+  std::set<std::string> veto_;
+  bool durable_flag_;
+};
+}  // namespace
+
+TEST(SuppressorInterface, DurableDefaultsFalse) {
+  FixedSuppressor s({"/a"});
+  EXPECT_FALSE(s.durable());
+}
+
+TEST(SuppressorInterface, DurableCanBeOverriddenTrue) {
+  FixedSuppressor s({"/a"}, /*durable_flag=*/true);
+  EXPECT_TRUE(s.durable());
+}
+
+TEST(ApplySuppressors, EmptyChainSuppressesNothing) {
+  std::map<std::string, std::string> affected{{"/a", "reason a"}, {"/b", "reason b"}};
+  DetectorContext ctx;
+  EXPECT_EQ(apply_suppressors(affected, {}, ctx), 0u);
+  EXPECT_EQ(affected.size(), 2u);
+}
+
+TEST(ApplySuppressors, DropsOnlyTheVetoedKeys) {
+  std::map<std::string, std::string> affected{{"/a", "reason a"}, {"/b", "reason b"}, {"/c", "reason c"}};
+  FixedSuppressor vetoes_b({"/b"});
+  DetectorContext ctx;
+  const std::vector<const Suppressor *> chain{&vetoes_b};
+  EXPECT_EQ(apply_suppressors(affected, chain, ctx), 1u);
+  EXPECT_EQ(affected.count("/a"), 1u);
+  EXPECT_EQ(affected.count("/b"), 0u);
+  EXPECT_EQ(affected.count("/c"), 1u);
+}
+
+TEST(ApplySuppressors, AnySingleSuppressorInTheChainIsEnough) {
+  std::map<std::string, std::string> affected{{"/a", "reason a"}, {"/b", "reason b"}};
+  FixedSuppressor abstains_on_everything({});
+  FixedSuppressor vetoes_b({"/b"});
+  DetectorContext ctx;
+  const std::vector<const Suppressor *> chain{&abstains_on_everything, &vetoes_b};
+  apply_suppressors(affected, chain, ctx);
+  EXPECT_EQ(affected.count("/a"), 1u);
+  EXPECT_EQ(affected.count("/b"), 0u);
+}
+
+TEST(ApplySuppressors, ANullEntryInTheChainIsSkippedNotDereferenced) {
+  std::map<std::string, std::string> affected{{"/a", "reason a"}};
+  DetectorContext ctx;
+  const std::vector<const Suppressor *> chain{nullptr};
+  EXPECT_EQ(apply_suppressors(affected, chain, ctx), 0u);
+  EXPECT_EQ(affected.size(), 1u);
+}
+
+TEST(ApplySuppressors, ReturnsTheDroppedCount) {
+  std::map<std::string, std::string> affected{{"/a", "x"}, {"/b", "y"}, {"/c", "z"}};
+  FixedSuppressor vetoes_everything({"/a", "/b", "/c"});
+  DetectorContext ctx;
+  const std::vector<const Suppressor *> chain{&vetoes_everything};
+  EXPECT_EQ(apply_suppressors(affected, chain, ctx), 3u);
+  EXPECT_TRUE(affected.empty());
+}


### PR DESCRIPTION
# Pull Request

## Summary

A node dies and nothing reports it. The node cannot report it itself, and the other detectors
cannot see it: `qos_mismatch` needs both sides present to compare profiles, `orphan` looks at a
topic whose publisher took the topic with it, and `lifecycle_expectation` only watches nodes the
operator listed as required-active.

This adds `node_death`, which raises `GRAPH_NODE_DISAPPEARED` for a node that was alive and armed
and stopped being alive, together with the suppression framework the umbrella issue asks to be
opt-in and explicit.

**Alive is not membership in the entity snapshot.** In runtime discovery a dead node leaves the
snapshot, so the two look the same; in manifest and hybrid discovery the manifest keeps the App
and only clears its online flag, so a detector counting membership would make a manifest node
immortal. Tracking is keyed on the stable fully qualified name rather than the app id, because an
id is recomputed each sweep and gains a namespace prefix once a bare-name collision exists, so a
live node held under its old id would be reported as gone.

**The grace period is wall clock, not ticks.** The entity cache is rebuilt on a debounced graph
event, so every tick between two refreshes sees the same snapshot and one absent cache generation
is counted again on each of them. At a fast tick a two-tick tolerance is shorter than one refresh
cycle, so the window has a floor in milliseconds and says so when it raises the configured value.

**Suppression is opt-in.** Nothing is suppressed unless `suppress` names it. A configured
`allowlist` that `suppress` does not name has no effect and warns that it has none. Two
suppressors ship: an operator allowlist, and clean lifecycle shutdown. A suppressor also declares
whether its veto is durable, because only a durable veto may reclaim tracker bookkeeping - a veto
that can lift later would otherwise lose a real fault for good once the condition ends.

## Also in this change: the absence boundary

`GRAPH_NODE_INACTIVE` says a required node is not active. `GRAPH_NODE_DISAPPEARED` says a node is
gone. Both can be true of one node, they have different repairs, and both standing at once is
correct - this change does not remove that.

What changed is narrower. Sustained absence used to mature a violation that had not yet been
reported, so a node observed non-active for a few ticks and then killed acquired an inactive fault
built entirely from evidence gathered after it could no longer be observed. That rule existed
because no presence detector existed to own departures. Now one does, so absence continues a
violation that has already matured and no longer creates one that has not.

With one exception, which is the part worth reviewing closely: the reliability gate refuses to arm
a managed node that never reads `active`, and `node_death` only tracks armed nodes. For such a
node the handover has no receiver, so absence may still mature its violation - otherwise a
required node that comes up unconfigured and dies is reported by nothing at all. The split is
keyed on whether the node was ever armed, latched rather than recomputed, because a managed node
legitimately reads not-armed again after an ordinary deactivate while `node_death` is still
tracking it.

## Known limitation

A second node's death, while the fault from the first is still outstanding, is added to the
fault's description but arrives as an update to an already-confirmed record: no state transition,
no freeze frame and no recording of its own. Acknowledging the fault between the two deaths avoids
this, because a report arriving after an acknowledgement is counted as a new occurrence and gets
its own evidence.

Two ways of forcing it from the detector were measured and rejected rather than skipped. Sending a
clear and a raise back to back does nothing: a single opposite-direction report cannot move the
fault manager's hysteresis latch, so the raise lands on the already-confirmed branch. Calling the
clear service instead is worse than not doing it, because it deletes the per-topic readings
captured for that fault and by default clears every symptom the correlation engine attributes to
it. A correct fix belongs in the fault manager, as an operation that re-confirms a record without
clearing it. This is documented in the package README and design doc.

## Also in this change: presence ownership rests on knowledge

Two detectors divide one job, and until now the division was decided by a fact the plugin did not
have. `GRAPH_NODE_DISAPPEARED` is raised for a node the reliability gate has armed; the gate arms a
managed node whose lifecycle state reads `active`, and it also arms one whose state has never been
measured, because it deliberately treats an unknown state as "do not gate" so that a node nobody
can read is not silenced across every other detector. Those two answers are not the same fact, and
the second was being latched permanently into the flag `lifecycle_expectation` consults before it
lets absence mature a violation. A required node that never configured could therefore be reported
by the presence detector and, by the same latch, not reported by the only detector that could still
have described what was wrong with it.

The division now asks a second, stricter question, and the gate itself is unchanged. Ownership is
`earned` when the node is not managed at all or its label reads `active`; it is withheld while the
state is merely unread and the watcher still has re-seed attempts left; and once those attempts are
spent it is `provisional` rather than earned - the node is owned, because otherwise nothing would
ever report its departure, but that grant yields the moment a real label finally arrives. A grant
made on knowledge latches, because a later deactivate does not hand the node back. A grant made on
ignorance does not, because the reason for it stops being true the instant somebody else can report
the node.

One consequence is worth stating rather than leaving to be found: a node that departs during its own
warmup is reported by nobody. That is the bringup-quiesce trade-off behaving as designed, it
predates this change, and it is written down where the boundary is described.

## Also in this change: the sanitizer test budget

The sanitizer jobs walk the workspace one package at a time under a single 45-minute budget for
the whole step. This package's end-to-end suite runs 24 minutes of that under instrumentation, up
from 10:38 on `main`, so the step stopped fitting: the TSan run was cut inside the package that
follows this one, and ASan finished the same run with 20 seconds to spare. No single scenario is
responsible - the slowest is 106 s and the rest is a 30-50 s tail across 73 targets, because these
tests wait on grace windows, respawn delays and restart loops rather than compute.

`quality.yml` now tests this package in a job of its own, once per sanitizer, and `ci.yml` does the
same over humble and lyrical, where the same cap applies to the step rather than to the job: lyrical
was cut inside this package and humble finished with three minutes to spare. The sweeps skip it. The job builds only the chain up to the package, which still includes the
integration-test package the scenarios launch from, and restores the matching sweep's ccache
instead of saving a second copy of the same objects. Instrumentation, the timeout multiplier and
the sanitizer options are unchanged from the sweep it left, and the job is not path-filtered,
because the plugin drives the gateway, the fault manager and discovery, so the changes most likely
to break it are outside its own tree.

The scenarios' own wall-clock budgets now scale with `MEDKIT_TEST_TIME_SCALE`, which the sanitizer
jobs already set to the factor they apply to every declared CTest timeout. A budget asserted inside
a test is invisible to that rewrite, so an instrumented graph that is slow to forget a departed node
blows one and the failure reads as a detector that never reported. Only give-up bounds scale: poll
intervals, enforced respawn delays and the sustained-observation windows keep their values, and the
scale is 1.0 whenever the variable is unset, so the normal jobs are unchanged.

---

## Issue

- closes #624

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

The tests were written and merged before the detector, so every scenario was watched failing for
the right reason first, and the suite is what the implementation had to satisfy rather than a
description of it.

**73 ctest targets, all green, of which 42 are end-to-end** against a real gateway, a real fault
manager and a real ROS graph. 23 of those scenarios are new here.

The end-to-end set covers: a process that exits, its return and the clearing that follows, a
managed node that deactivates but keeps running, a manifest node that never came online, CLI-
convention node names, two nodes sharing a bare name in different namespaces, a fast tick against
a stale cache generation, a node restarting repeatedly across a window, a gateway restart with a
death outstanding, each suppressor including the inert-allowlist warning, pruning that must not
heal a fault that is still true, and each side of the absence boundary.

Every scenario that asserts an ABSENCE gates on the plugin being armed first and uses a helper
that fails when the fault surface is unreachable, so it cannot pass against a stack where the
plugin never loaded. Two such helpers are added here, each with a test that points it at a surface
which dies mid-window and fails if the helper still passes.

The whole suite was also run with the plugin path pointed at a file that does not exist: every
scenario fails, naming the load failure.

Reviewers can check the boundary with `ctest -R "node_death_boundary_e2e"`, the suppressors with
`ctest -R "node_death_suppression_e2e"`, and the tracker's bound with
`ctest -R "test_node_liveness_tracker"`.

No route is added or changed. The only public surface difference is additive content inside the
existing `x-medkit-watchdog` payload, which gains a `node_death` block.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed



