### PR TITLE
Support substitution for fault manager yaml file

### DIFF
--- a/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
+++ b/src/ros2_medkit_fault_manager/launch/fault_manager.launch.py
@@ -19,6 +19,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.descriptions import ParameterFile
 
 
 def generate_launch_description():
@@ -26,6 +27,11 @@ def generate_launch_description():
         get_package_share_directory('ros2_medkit_fault_manager'),
         'config',
         'fault_manager.yaml',
+    )
+
+    configured_params = ParameterFile(
+        LaunchConfiguration('params_file'),
+        allow_substs=True,
     )
 
     return LaunchDescription([
@@ -49,6 +55,6 @@ def generate_launch_description():
             name='fault_manager',
             namespace=LaunchConfiguration('namespace'),
             output='screen',
-            parameters=[LaunchConfiguration('params_file')],
+            parameters=[configured_params],
         ),
     ])

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -1328,6 +1328,7 @@ std::unique_ptr<correlation::CorrelationEngine> FaultManagerNode::create_correla
   }
 
   try {
+    RCLCPP_INFO(get_logger(), "Loading correlation config from: %s", config_file.c_str());
     auto config = correlation::parse_config_file(config_file);
 
     if (!config.enabled) {


### PR DESCRIPTION
# Pull Request

## Summary

Allow launch substitution for fault manager parameter file.

For example I want to do this:

```yaml
fault_manager:
  ros__parameters:
    database_path: /tmp/ros2_medkit/faults.db
    healing_enabled: true
    correlation.config_file: $(find-pkg-share my_robot)/config/fault_correlation.yaml
```

otherwise the correlation config file was read as `$(find-pkg-share my_robot)/config/fault_correlation.yaml` by the fault manager.

---

## Issue

Link the related issue (required):

- Resolves #633 

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

local testing

---

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
