### PR TITLE
fix(linux-introspection): report cgroup limits on v1, v2 and hybrid hosts, under both cgroup namespace modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,19 @@ jobs:
         include:
           - ros_distro: humble
             os_image: ubuntu:jammy
+            # build-and-test compiles the same sources with the same flags on this
+            # distro, so its cache is the superset this job restores from.
+            ccache_prefix: ccache-humble-
           - ros_distro: lyrical
             os_image: ubuntu:resolute
+            ccache_prefix: ccache-lyrical-
+          - ros_distro: jazzy
+            os_image: ubuntu:noble
+            # ccache-jazzy-test-, not ccache-jazzy-. The shorter prefix also matches
+            # ccache-jazzy-asan-, -tsan-, -lint- and -tidy-, and restore-keys takes the
+            # most recently created match, so it would restore whichever other Jazzy job
+            # finished last. jazzy-test carries the measurement behind that.
+            ccache_prefix: ccache-jazzy-test-
     container:
       image: ${{ matrix.os_image }}
     timeout-minutes: 90
@@ -181,16 +192,16 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /root/.cache/ccache
-          key: ccache-${{ matrix.ros_distro }}-${{ github.sha }}
+          key: ${{ matrix.ccache_prefix }}${{ github.sha }}
           restore-keys: |
-            ccache-${{ matrix.ros_distro }}-
+            ${{ matrix.ccache_prefix }}
 
       - name: Install dependencies
         run: |
           apt-get update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
-          if [ "${{ matrix.ros_distro }}" = "humble" ]; then
-            apt-get install -y ros-humble-rmw-cyclonedds-cpp
+          if [ "${{ matrix.ros_distro }}" = "humble" ] || [ "${{ matrix.ros_distro }}" = "jazzy" ]; then
+            apt-get install -y ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp
           fi
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           rosdep update
@@ -221,8 +232,10 @@ jobs:
         timeout-minutes: 45
         env:
           # The DDS choice belongs to the distro, not to this package - see the long note in
-          # build-and-test for why humble is forced onto CycloneDDS and lyrical is not.
-          RMW_IMPLEMENTATION: ${{ matrix.ros_distro == 'humble' && 'rmw_cyclonedds_cpp' || '' }}
+          # build-and-test for why humble is forced onto CycloneDDS and lyrical is not, and
+          # the note in jazzy-test for the FastRTPS discovery-teardown use-after-free that
+          # puts jazzy on the same implementation.
+          RMW_IMPLEMENTATION: ${{ (matrix.ros_distro == 'humble' || matrix.ros_distro == 'jazzy') && 'rmw_cyclonedds_cpp' || '' }}
         run: |
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           colcon test --return-code-on-test-failure \
@@ -256,10 +269,11 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ubuntu:noble
-    # The more generous of the two timeouts this job replaces (build had 60,
-    # test had 45). One job now covers both phases, and a cold ccache makes the
-    # build phase the variable one, so keep the headroom rather than the sum.
-    timeout-minutes: 60
+    # 90, like build-and-test and graph-watchdog. This job covers both the build
+    # and the test phase, a cold ccache makes the build phase the variable one,
+    # and at 60 it had been finishing in 54 to 56 minutes on main - close enough
+    # to the cap that a slow runner timed it out with no failing test to name.
+    timeout-minutes: 90
     defaults:
       run:
         shell: bash
@@ -332,8 +346,11 @@ jobs:
           RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
         run: |
           source /opt/ros/jazzy/setup.bash
+          # ros2_medkit_graph_watchdog is tested in graph-watchdog, on this distro too.
+          # Its end-to-end suite is 24 minutes, which is most of what stood between this
+          # job and its cap.
           colcon test --return-code-on-test-failure \
-            --packages-skip ros2_medkit_opcua \
+            --packages-skip ros2_medkit_opcua ros2_medkit_graph_watchdog \
             --ctest-args -LE linter \
             --event-handlers console_direct+
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             log/
             build/*/test_results/
 
-  # ros2_medkit_graph_watchdog on the two distros build-and-test covers, in a job of its own.
+  # ros2_medkit_graph_watchdog on every distro, in a job of its own.
   # Same reasoning as sanitizer-graph-watchdog in quality.yml: the package's end-to-end suite runs
   # 24 minutes, the sweep it left had 3 minutes of headroom on humble and none at all on lyrical,
   # and a suite that grows with every new detector should not decide whether the packages behind it
@@ -185,10 +185,11 @@ jobs:
         run: apt-get install -y ccache
 
       - name: Restore ccache
-        # Restore, never save. This job compiles a subset of the sources build-and-test compiles,
-        # with the same flags, so that job's cache is a superset of what this one needs and serves
-        # its misses. A second copy would spend the repository's Actions cache quota twice over for
-        # one set of objects.
+        # Restore, never save. This job compiles a subset of the sources the distro's own
+        # sweep compiles, with the same flags, so that job's cache is a superset of what this
+        # one needs and serves its misses. A second copy would spend the repository's Actions
+        # cache quota twice over for one set of objects. The producer is build-and-test on
+        # humble and lyrical, and jazzy-test on jazzy, which is what ccache_prefix names.
         uses: actions/cache/restore@v4
         with:
           path: /root/.cache/ccache

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2837,8 +2837,9 @@ Requires: ``systemd_introspection`` plugin and ``libsystemd``.
 Container Introspection (x-medkit-container)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Requires: ``container_introspection`` plugin. Only supports cgroup v2
-(Ubuntu 22.04+, Fedora 31+).
+Requires: ``container_introspection`` plugin. Supports the unified cgroup
+hierarchy (v2), the legacy one (v1), and hybrid hosts, under both the
+``host`` and ``private`` cgroup namespace modes.
 
 ``GET /api/v1/apps/{id}/x-medkit-container``
    Get container information for the app's process.
@@ -2851,15 +2852,28 @@ Requires: ``container_introspection`` plugin. Only supports cgroup v2
         "container_id": "a1b2c3d4e5f6...",
         "runtime": "docker",
         "memory_limit_bytes": 1073741824,
+        "memory_limit_state": "limited",
         "cpu_quota_us": 100000,
-        "cpu_period_us": 100000
+        "cpu_period_us": 100000,
+        "cpu_quota_state": "limited"
       }
 
    Fields ``memory_limit_bytes``, ``cpu_quota_us``, and ``cpu_period_us`` are only present
-   when the container has resource limits configured.
+   when a limit was actually read. ``memory_limit_state`` and ``cpu_quota_state`` are
+   always present and carry one of ``limited``, ``unlimited``, ``unreadable`` or
+   ``unavailable``, so a client can tell an unconstrained container from one whose limit
+   files could not be read. ``cpu_quota_state`` covers the quota and its period together.
+
+   ``cpu_quota_us`` is the CFS bandwidth limit. It does not reflect the set of CPUs the
+   container is pinned to (``--cpuset-cpus``), which is visible only through
+   ``sched_getaffinity()``; the effective CPU budget needs both.
+
+   ``container_id`` is empty when the cgroup namespace hides it (``--cgroupns=private``
+   reports the namespace root as the path). The container is still recognised from the
+   markers its runtime leaves behind, and the limits are still reported.
 
    - **404:** Process not found or not running in a container
-   - **503:** Failed to read cgroup information
+   - **503:** The cgroup of the process could not be determined at all
 
 ``GET /api/v1/components/{id}/x-medkit-container``
    Aggregate container info for all apps in the component. Containers are

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2858,8 +2858,9 @@ hierarchy (v2), the legacy one (v1), and hybrid hosts, under both the
         "cpu_quota_state": "limited"
       }
 
-   Fields ``memory_limit_bytes``, ``cpu_quota_us``, and ``cpu_period_us`` are only present
-   when a limit was actually read. ``memory_limit_state`` and ``cpu_quota_state`` are
+   Fields ``memory_limit_bytes`` and ``cpu_quota_us`` are present only when a limit is in
+   force. ``cpu_period_us`` is present whenever the CPU limit was read at all, including
+   when the quota is unlimited. ``memory_limit_state`` and ``cpu_quota_state`` are
    always present and carry one of ``limited``, ``unlimited``, ``unreadable`` or
    ``unavailable``, so a client can tell an unconstrained container from one whose limit
    files could not be read. ``cpu_quota_state`` covers the quota and its period together.

--- a/docs/tutorials/linux-introspection.rst
+++ b/docs/tutorials/linux-introspection.rst
@@ -12,7 +12,9 @@ Apps and Components.
   unit properties (ActiveState, SubState, NRestarts, WatchdogUSec) via sd-bus. Requires
   ``libsystemd``.
 - **container** - detects containerization via cgroup path analysis. Supports Docker,
-  podman, and containerd. Reads cgroup v2 resource limits (``memory.max``, ``cpu.max``).
+  podman, and containerd. Reads resource limits from the unified hierarchy
+  (``memory.max``, ``cpu.max``) and from the legacy one (``memory.limit_in_bytes``,
+  ``cpu.cfs_quota_us``, ``cpu.cfs_period_us``).
 
 Each plugin maintains its own PID cache that maps ROS 2 node fully-qualified names to
 Linux PIDs by scanning ``/proc``. The cache refreshes on each discovery cycle and on
@@ -24,8 +26,10 @@ Requirements
 - **procfs**: Linux only (reads ``/proc`` filesystem). No extra dependencies.
 - **systemd**: requires ``libsystemd-dev`` at build time, systemd at runtime. Skipped
   automatically if ``libsystemd`` is not found during the build.
-- **container**: requires cgroup v2, which is the default on modern kernels (Ubuntu 22.04+,
-  Fedora 31+).
+- **container**: Linux only. Works on the unified cgroup hierarchy (v2, the default on
+  Ubuntu 22.04+ and Fedora 31+), on the legacy hierarchy (v1), and on hybrid hosts that
+  mount both. Both cgroup namespace modes (``--cgroupns=host`` and ``--cgroupns=private``)
+  are handled.
 
 Building
 --------
@@ -217,15 +221,27 @@ Returns container metadata for a node running inside a container:
      "container_id": "a1b2c3d4e5f6...",
      "runtime": "docker",
      "memory_limit_bytes": 536870912,
+     "memory_limit_state": "limited",
      "cpu_quota_us": 100000,
-     "cpu_period_us": 100000
+     "cpu_period_us": 100000,
+     "cpu_quota_state": "limited"
    }
 
 .. note::
 
    The ``memory_limit_bytes``, ``cpu_quota_us``, and ``cpu_period_us`` fields are only
-   present when cgroup v2 resource limits are set. If no limits are configured, these
-   fields are omitted from the response.
+   present when a limit was actually read. ``memory_limit_state`` and ``cpu_quota_state``
+   are always present and say why a number is missing:
+
+   - ``limited`` - a limit is in force, and the numeric field carries it
+   - ``unlimited`` - the container may use the whole machine
+   - ``unreadable`` - a limit file was found but its contents could not be parsed
+   - ``unavailable`` - no limit file exists in any supported cgroup layout
+
+   The distinction matters: an unreadable limit file reported as "no limit" would look
+   exactly like an unconstrained container. The CPU limit is the quota together with its
+   period, so ``cpu_quota_state`` covers both and ``cpu_period_us`` has no state of its
+   own; the period is reported even when the quota is ``unlimited``.
 
 **GET /components/{id}/x-medkit-container**
 
@@ -243,8 +259,10 @@ Returns aggregated container info for all child Apps, deduplicated by container 
          "container_id": "a1b2c3d4e5f6...",
          "runtime": "docker",
          "memory_limit_bytes": 536870912,
+         "memory_limit_state": "limited",
          "cpu_quota_us": 100000,
          "cpu_period_us": 100000,
+         "cpu_quota_state": "limited",
          "node_ids": ["temp_sensor", "rpm_sensor"]
        }
      ]
@@ -275,8 +293,11 @@ validation errors (404 for unknown entities) are handled automatically by
 | 404 | ``x-medkit-not-containerized``        | Node's process is not running inside a        |
 |     |                                       | container (no container cgroup path detected).|
 +-----+---------------------------------------+-----------------------------------------------+
-| 503 | ``x-medkit-cgroup-read-failed``       | Failed to read cgroup info for the container. |
-|     |                                       | Check cgroup v2 filesystem access.            |
+| 503 | ``x-medkit-cgroup-read-failed``       | The cgroup of the process could not be        |
+|     |                                       | determined at all. Check access to            |
+|     |                                       | ``/proc/{pid}/cgroup``. A limit that could    |
+|     |                                       | not be read is reported as a state on a 200,  |
+|     |                                       | not as this error.                            |
 +-----+---------------------------------------+-----------------------------------------------+
 
 .. note::
@@ -369,17 +390,28 @@ Without system bus access, the systemd plugin will return 503 errors for all que
 Container detection
 ~~~~~~~~~~~~~~~~~~~
 
-The container plugin relies on cgroup v2 path analysis. To verify your system uses
-cgroup v2:
+The container plugin relies on cgroup path analysis. To see which hierarchy your
+system mounts:
 
 .. code-block:: bash
 
-   mount | grep cgroup2
-   # Should show: cgroup2 on /sys/fs/cgroup type cgroup2 (...)
+   mount | grep cgroup
+   # unified (v2): cgroup2 on /sys/fs/cgroup type cgroup2 (...)
+   # legacy (v1):  cgroup on /sys/fs/cgroup/memory type cgroup (...)
 
    # Or check a process's cgroup path
    cat /proc/self/cgroup
-   # cgroup v2 output: "0::/user.slice/..."
+   # unified (v2): "0::/user.slice/..."
+   # legacy (v1):  "12:memory:/docker/<id>" - one line per hierarchy
+
+Both are supported, as is the hybrid layout that mounts the legacy controllers at the
+top level and the unified hierarchy beside them at ``/sys/fs/cgroup/unified``.
+
+The reported path is relative to the cgroup namespace of the container, so where the
+limit files sit depends on the namespace mode: ``--cgroupns=private`` mounts the
+container's own cgroup at the mount point, while ``--cgroupns=host`` exposes the whole
+hierarchy and the reported path leads into it. The plugin looks in both places and does
+not need to be told which mode is in use.
 
 Supported container runtimes and their cgroup path patterns:
 
@@ -389,3 +421,20 @@ Supported container runtimes and their cgroup path patterns:
 
 If your runtime uses a different cgroup path format, the plugin will not detect the
 container. The ``runtime`` field in the response indicates the detected runtime.
+
+Under ``--cgroupns=private`` the reported cgroup path is the namespace root and carries
+no container ID at all. The plugin then falls back to the markers a runtime leaves
+behind - ``/.dockerenv``, ``/run/.containerenv``, or an overlay filesystem mounted as the
+process's root - so the limits are still reported, with ``container_id`` empty. A process
+that is not in a container matches none of these and still gets
+``404 x-medkit-not-containerized``.
+
+CPU limits and cpusets
+~~~~~~~~~~~~~~~~~~~~~~
+
+``cpu_quota_us`` and ``cpu_period_us`` describe the CFS bandwidth limit
+(``--cpus``/``--cpu-quota``) and nothing else. A container pinned to a subset of the
+machine with ``--cpuset-cpus`` has no quota at all, so it is reported as
+``"cpu_quota_state": "unlimited"`` even though it cannot use every core. The cpuset is
+visible only through ``sched_getaffinity()``; a caller that wants the effective CPU
+budget has to combine the two.

--- a/docs/tutorials/linux-introspection.rst
+++ b/docs/tutorials/linux-introspection.rst
@@ -424,10 +424,21 @@ container. The ``runtime`` field in the response indicates the detected runtime.
 
 Under ``--cgroupns=private`` the reported cgroup path is the namespace root and carries
 no container ID at all. The plugin then falls back to the markers a runtime leaves
-behind - ``/.dockerenv``, ``/run/.containerenv``, or an overlay filesystem mounted as the
-process's root - so the limits are still reported, with ``container_id`` empty. A process
-that is not in a container matches none of these and still gets
-``404 x-medkit-not-containerized``.
+behind, read through the inspected process's own root (``/proc/<pid>/root``) so that a
+containerized gateway does not answer for processes outside it:
+
+- ``/.dockerenv`` (Docker) or ``/run/.containerenv`` (Podman), which also name the runtime
+- ``/run/systemd/container`` (systemd-nspawn and others)
+- an overlay filesystem mounted as the process's root, but only together with a cgroup
+  path of ``/``. An overlay root on its own proves nothing, because whole distributions
+  boot that way
+
+The limits are still reported, with ``container_id`` empty. A process that matches none of
+these gets ``404 x-medkit-not-containerized``.
+
+A runtime that leaves no marker and does not use an overlay root - containerd or CRI-O on
+a btrfs or ZFS snapshotter, for example - is not detected under a private namespace, and
+its apps are reported as non-containerized.
 
 CPU limits and cpusets
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/README.md
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/README.md
@@ -14,7 +14,11 @@ Maps ROS 2 nodes to OS processes and reports CPU, memory, systemd unit status, a
 ## Key Components
 
 - **ProcReader** - Parses procfs files for process metrics with configurable proc root
-- **CgroupReader** - Reads cgroup v2 hierarchy for container/service context
+- **CgroupReader** - Reads the unified (v2), legacy (v1) and hybrid cgroup hierarchies for
+  container/service context, under both cgroup namespace modes. Each limit is reported
+  together with the outcome of reading it, so "unlimited" and "could not be read" stay
+  distinguishable. A container whose ID the cgroup namespace hides is recognised from the
+  markers its runtime leaves behind
 - **SystemdUtils** - Queries systemd via D-Bus for service metadata
 - **PidCache** - TTL-based cache mapping ROS 2 node names to Linux PIDs
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/README.md
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/README.md
@@ -26,11 +26,17 @@ Maps ROS 2 nodes to OS processes and reports CPU, memory, systemd unit status, a
 
 Configure via `gateway_params.yaml` plugin parameters:
 
+Each plugin is configured on its own. `proc_root` is the prefix that contains `proc/` and
+`sys/`, so the default `/` is what a normal deployment wants; pointing it at `/proc` makes
+the plugin look for `/proc/proc/<pid>`.
+
 ```yaml
-plugins: ["linux_introspection"]
-plugins.linux_introspection.path: "/path/to/libros2_medkit_linux_introspection.so"
-plugins.linux_introspection.pid_cache_ttl_sec: 30
-plugins.linux_introspection.proc_root: "/proc"
+plugins: ["procfs", "systemd", "container"]
+plugins.procfs.path: "/path/to/libprocfs_introspection.so"
+plugins.systemd.path: "/path/to/libsystemd_introspection.so"
+plugins.container.path: "/path/to/libcontainer_introspection.so"
+plugins.container.pid_cache_ttl_seconds: 30
+plugins.container.proc_root: "/"
 ```
 
 ## Documentation

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/design/index.rst
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/design/index.rst
@@ -155,6 +155,13 @@ Plugins
 
    - Registers ``x-medkit-container`` capability on Apps and Components
    - Reads ``/proc/{pid}/cgroup`` to extract container ID and runtime (Docker, containerd, Podman)
+   - Handles the unified (v2), legacy (v1) and hybrid hierarchies, and looks for the limit
+     files both at the bare mount point (``cgroupns=private``) and at the mount point joined
+     with the reported path (``cgroupns=host``)
+   - Reports each limit with a ``LimitState`` (``limited``, ``unlimited``, ``unreadable``,
+     ``unavailable``) so a failed read cannot be mistaken for an unconstrained container
+   - Recognises a container even when the cgroup namespace hides its ID, from
+     ``/.dockerenv``, ``/run/.containerenv`` or an overlay root filesystem
    - Component-level endpoint aggregates containers, deduplicating by container ID
    - Returns 404 for entities not running in a container (not an error - just bare-metal)
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/include/ros2_medkit_linux_introspection/cgroup_reader.hpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/include/ros2_medkit_linux_introspection/cgroup_reader.hpp
@@ -22,19 +22,116 @@
 
 namespace ros2_medkit_linux_introspection {
 
+/// Outcome of reading one cgroup limit.
+///
+/// "No limit is in force" and "the limit could not be read" are different facts
+/// about a container: only the first one means the container may use the whole
+/// machine, so they are reported as different states rather than both as an
+/// absent value.
+enum class LimitState {
+  kUnavailable,  ///< No file for this limit exists in any supported cgroup layout
+  kUnreadable,   ///< A file exists but its contents could not be parsed
+  kUnlimited,    ///< The cgroup reports no limit ("max" on v2, -1 on v1)
+  kLimited,      ///< A numeric limit is in force
+};
+
+/// Wire form of a LimitState: "unavailable", "unreadable", "unlimited" or "limited".
+std::string limit_state_to_string(LimitState state);
+
+/// One cgroup limit together with the outcome of reading it.
+///
+/// The value is present if and only if the state is LimitState::kLimited, an
+/// invariant the named constructors are the only way to establish.
+template <typename T>
+class CgroupLimit {
+ public:
+  CgroupLimit() = default;
+
+  static CgroupLimit limited(T value) {
+    CgroupLimit limit;
+    limit.state_ = LimitState::kLimited;
+    limit.value_ = value;
+    return limit;
+  }
+
+  static CgroupLimit unlimited() {
+    return CgroupLimit(LimitState::kUnlimited);
+  }
+
+  static CgroupLimit unreadable() {
+    return CgroupLimit(LimitState::kUnreadable);
+  }
+
+  static CgroupLimit unavailable() {
+    return CgroupLimit(LimitState::kUnavailable);
+  }
+
+  LimitState state() const {
+    return state_;
+  }
+
+  const std::optional<T> & value() const {
+    return value_;
+  }
+
+ private:
+  explicit CgroupLimit(LimitState state) : state_(state) {
+  }
+
+  LimitState state_{LimitState::kUnavailable};
+  std::optional<T> value_;
+};
+
 struct CgroupInfo {
   std::string cgroup_path;
   std::string container_id;       // 64-char hex from cgroup path, or empty
   std::string container_runtime;  // "docker", "podman", "containerd", or empty
-  std::optional<uint64_t> memory_limit_bytes;
-  std::optional<int64_t> cpu_quota_us;
+
+  /// Whether the process runs inside a container.
+  ///
+  /// Not the same as having a container id: under ``cgroupns=private`` the
+  /// reported cgroup path is the namespace root and carries no id, so the path
+  /// alone cannot answer the question and a runtime marker does instead. A
+  /// container is therefore reported with an empty ``container_id``.
+  bool containerized{false};
+
+  /// Memory limit in bytes, from ``memory.max`` (v2) or ``memory.limit_in_bytes`` (v1).
+  CgroupLimit<uint64_t> memory_limit;
+
+  /// CPU bandwidth quota in microseconds of CPU time per period, from ``cpu.max``
+  /// (v2) or ``cpu.cfs_quota_us`` (v1).
+  ///
+  /// This is the CFS bandwidth limit and nothing else. It does not reflect the
+  /// set of CPUs a container is pinned to (``--cpuset-cpus``); that is visible
+  /// only through sched_getaffinity(). A caller that wants the effective CPU
+  /// budget needs both numbers.
+  CgroupLimit<int64_t> cpu_quota;
+
+  /// Period the quota is measured over, in microseconds. It is read together
+  /// with the quota and carries no state of its own, so it is set whenever the
+  /// CPU limit was read at all - including when the quota itself is unlimited.
   std::optional<int64_t> cpu_period_us;
 };
 
-/// Detect if PID runs inside a container (based on cgroup path)
+/// Detect if PID runs inside a container.
+///
+/// Prefers the container id carried by the cgroup path. When the cgroup
+/// namespace hides that id, falls back to the markers a runtime leaves behind:
+/// ``/.dockerenv``, ``/run/.containerenv``, or an overlay filesystem mounted as
+/// the process's root.
 bool is_containerized(pid_t pid, const std::string & root = "/");
 
-/// Read cgroup info for a PID
+/// Read cgroup info for a PID.
+///
+/// Handles the unified (v2) and legacy (v1) hierarchies as well as the hybrid
+/// layout that mounts both, and both cgroup namespace modes: the interface
+/// files are looked for at the bare mount point, where ``cgroupns=private``
+/// puts the process's own cgroup, and at the mount point joined with the
+/// reported path, where ``cgroupns=host`` puts it.
+///
+/// Fails only when the cgroup of the process cannot be determined at all. A
+/// limit that could not be read is reported through its LimitState, not as a
+/// missing limit.
 tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::string & root = "/");
 
 /// Extract container ID from a cgroup path string

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/include/ros2_medkit_linux_introspection/container_utils.hpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/include/ros2_medkit_linux_introspection/container_utils.hpp
@@ -21,17 +21,27 @@
 namespace ros2_medkit_linux_introspection {
 
 /// Convert CgroupInfo to JSON for the container plugin HTTP response.
-/// Optional fields (memory_limit_bytes, cpu_quota_us, cpu_period_us) are
-/// omitted from the JSON when not set.
+///
+/// The numeric fields (memory_limit_bytes, cpu_quota_us, cpu_period_us) are
+/// present only when a value was read, so a client that reads no limit still
+/// has to know why. That is what memory_limit_state and cpu_quota_state carry:
+/// "limited", "unlimited", "unreadable" or "unavailable", always present.
+///
+/// The CPU limit is the quota and its period together, so cpu_quota_state
+/// covers both and cpu_period_us has no state of its own.
 inline nlohmann::json cgroup_info_to_json(const CgroupInfo & info) {
   nlohmann::json j;
   j["container_id"] = info.container_id;
   j["runtime"] = info.container_runtime;
-  if (info.memory_limit_bytes) {
-    j["memory_limit_bytes"] = *info.memory_limit_bytes;
+
+  j["memory_limit_state"] = limit_state_to_string(info.memory_limit.state());
+  if (info.memory_limit.value()) {
+    j["memory_limit_bytes"] = *info.memory_limit.value();
   }
-  if (info.cpu_quota_us) {
-    j["cpu_quota_us"] = *info.cpu_quota_us;
+
+  j["cpu_quota_state"] = limit_state_to_string(info.cpu_quota.state());
+  if (info.cpu_quota.value()) {
+    j["cpu_quota_us"] = *info.cpu_quota.value();
   }
   if (info.cpu_period_us) {
     j["cpu_period_us"] = *info.cpu_period_us;

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/container_plugin.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/container_plugin.cpp
@@ -24,9 +24,11 @@
 
 #include <nlohmann/json.hpp>
 
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <string>
+#include <system_error>
 
 using namespace ros2_medkit_gateway;  // NOLINT(build/namespaces)
 
@@ -87,6 +89,19 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
   }
 
  private:
+  /// Identifier of the mount namespace a PID belongs to, e.g. "[4026532563]",
+  /// or empty when it cannot be read. Processes in one container share it.
+  std::string mount_namespace_of(pid_t pid) const {
+    std::error_code ec;
+    auto link = std::filesystem::read_symlink(proc_root_ + "/proc/" + std::to_string(pid) + "/ns/mnt", ec);
+    if (ec) {
+      return {};
+    }
+    auto target = link.string();
+    auto open = target.find('[');
+    return open == std::string::npos ? std::string{} : target.substr(open);
+  }
+
   PluginContext * ctx_{nullptr};
   std::unique_ptr<ros2_medkit_linux_introspection::PidCache> pid_cache_ =
       std::make_unique<ros2_medkit_linux_introspection::PidCache>();
@@ -127,10 +142,12 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
     }
 
     auto child_apps = ctx_->get_child_apps(entity_id);
-    // Deduplicate by container_id. Under cgroupns=private every app reports an
-    // empty id and they all collapse into one entry, which is what they are:
-    // the single container whose id the namespace hides.
+    // Deduplicate by container_id. An empty id is not an identity: when the
+    // cgroup namespace hides it, two apps may well be in different containers
+    // and there is nothing to tell them apart, so each keeps its own entry
+    // rather than being merged into one that reports a single set of limits.
     std::map<std::string, nlohmann::json> containers;
+    size_t unidentified = 0;
 
     for (const auto & app : child_apps) {
       auto pid_opt = pid_cache_->lookup(app.fqn, proc_root_);
@@ -143,7 +160,15 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
         continue;
       }
 
-      auto & cid = cgroup_info->container_id;
+      auto cid = cgroup_info->container_id;
+      if (cid.empty()) {
+        // Fall back to the process's mount namespace, which is per-container:
+        // apps in one container share it, apps in different ones do not. When
+        // it cannot be read, a unique key keeps them apart rather than merging
+        // on no evidence.
+        auto ns = mount_namespace_of(*pid_opt);
+        cid = ns.empty() ? "unidentified-" + std::to_string(unidentified++) : "mnt-" + ns;
+      }
       if (containers.find(cid) == containers.end()) {
         auto j = ros2_medkit_linux_introspection::cgroup_info_to_json(*cgroup_info);
         j["node_ids"] = nlohmann::json::array();

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/container_plugin.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/container_plugin.cpp
@@ -77,7 +77,7 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
       }
 
       auto cgroup_info = ros2_medkit_linux_introspection::read_cgroup_info(*pid_opt, proc_root_);
-      if (!cgroup_info || cgroup_info->container_id.empty()) {
+      if (!cgroup_info || !cgroup_info->containerized) {
         continue;
       }
 
@@ -111,7 +111,7 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
       return;
     }
 
-    if (cgroup_info->container_id.empty()) {
+    if (!cgroup_info->containerized) {
       res.send_error(404, "x-medkit-not-containerized", "Entity " + entity_id + " is not running in a container");
       return;
     }
@@ -127,7 +127,10 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
     }
 
     auto child_apps = ctx_->get_child_apps(entity_id);
-    std::map<std::string, nlohmann::json> containers;  // Deduplicate by container_id
+    // Deduplicate by container_id. Under cgroupns=private every app reports an
+    // empty id and they all collapse into one entry, which is what they are:
+    // the single container whose id the namespace hides.
+    std::map<std::string, nlohmann::json> containers;
 
     for (const auto & app : child_apps) {
       auto pid_opt = pid_cache_->lookup(app.fqn, proc_root_);
@@ -136,7 +139,7 @@ class ContainerPlugin : public GatewayPlugin, public IntrospectionProvider {
       }
 
       auto cgroup_info = ros2_medkit_linux_introspection::read_cgroup_info(*pid_opt, proc_root_);
-      if (!cgroup_info || cgroup_info->container_id.empty()) {
+      if (!cgroup_info || !cgroup_info->containerized) {
         continue;
       }
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
@@ -15,10 +15,13 @@
 #include "ros2_medkit_linux_introspection/cgroup_reader.hpp"
 
 #include <cctype>
+#include <cerrno>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <regex>
 #include <sstream>
+#include <unistd.h>
 #include <utility>
 #include <vector>
 
@@ -54,15 +57,26 @@ struct LimitFile {
 
 LimitFile read_limit_file(const std::string & path) {
   LimitFile result;
-  std::ifstream f(path);
-  if (f.is_open()) {
-    result.exists = true;
-    result.opened = true;
-    std::getline(f, result.line);
+  // errno on the single open call separates "no such file" from "present but
+  // it would not open". Opening and then asking whether the path exists is two
+  // steps, and a file that disappears between them reads as absent when it was
+  // really a failed read.
+  int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0) {
+    result.exists = (errno != ENOENT);
     return result;
   }
-  std::error_code ec;
-  result.exists = std::filesystem::exists(path, ec);
+  result.exists = true;
+  result.opened = true;
+
+  std::string buffer(4096, '\0');
+  auto count = ::read(fd, buffer.data(), buffer.size());
+  ::close(fd);
+  if (count > 0) {
+    buffer.resize(static_cast<size_t>(count));
+    auto newline = buffer.find('\n');
+    result.line = newline == std::string::npos ? buffer : buffer.substr(0, newline);
+  }
   return result;
 }
 
@@ -333,7 +347,11 @@ bool mount_carries_controller(const CgroupMount & mount, const std::string & con
 void append_mount_dirs(std::vector<std::string> & dirs, const CgroupMount & mount, const std::string & cgroup_path) {
   if (mount.mount_root != "/" && !mount.mount_root.empty() && cgroup_path.rfind(mount.mount_root, 0) == 0) {
     auto relative = cgroup_path.substr(mount.mount_root.size());
-    dirs.push_back(relative.empty() ? mount.mount_point : mount.mount_point + relative);
+    // The prefix has to end on a component boundary, or /docker/parent matches
+    // /docker/parent2/child and names a cgroup this mount does not expose.
+    if (relative.empty() || relative.front() == '/') {
+      dirs.push_back(relative.empty() ? mount.mount_point : mount.mount_point + relative);
+    }
   }
   if (!cgroup_path.empty() && cgroup_path != "/") {
     dirs.push_back(mount.mount_point + cgroup_path);
@@ -377,6 +395,25 @@ struct CpuLimit {
 };
 
 CpuLimit better_of(const CpuLimit & first, const CpuLimit & second) {
+  return first.quota.state() == LimitState::kUnavailable ? second : first;
+}
+
+// Merges the answers from two different hierarchies. A controller is mounted on
+// the unified hierarchy or on a legacy one, never both, so the hierarchy that
+// does not carry it reports no limit rather than nothing at all. Preferring a
+// real limit keeps that empty answer from deciding.
+template <typename T>
+CgroupLimit<T> across_hierarchies(const CgroupLimit<T> & first, const CgroupLimit<T> & second) {
+  if (second.state() == LimitState::kLimited && first.state() != LimitState::kLimited) {
+    return second;
+  }
+  return first.state() == LimitState::kUnavailable ? second : first;
+}
+
+CpuLimit across_hierarchies(const CpuLimit & first, const CpuLimit & second) {
+  if (second.quota.state() == LimitState::kLimited && first.quota.state() != LimitState::kLimited) {
+    return second;
+  }
   return first.quota.state() == LimitState::kUnavailable ? second : first;
 }
 
@@ -551,14 +588,17 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
     }
   }
 
-  CpuLimit cpu;
-
   // The conventional mount points come first because they are the ones a
   // gateway can reach when it does not share the target's mount namespace.
   // The mounts read from the target's own mountinfo are tried after them, so a
   // host that puts its controllers somewhere else is still covered and a
   // cross-namespace path that resolves to nothing here simply does not match.
   const auto mounts = read_cgroup_mounts(pid, root);
+
+  CgroupLimit<uint64_t> memory_v2;
+  CgroupLimit<uint64_t> memory_v1;
+  CpuLimit cpu_v2;
+  CpuLimit cpu_v1;
 
   if (!paths.unified.empty()) {
     std::vector<std::string> dirs;
@@ -573,8 +613,8 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
       }
     }
     for (const auto & dir : dirs) {
-      info.memory_limit = better_of(info.memory_limit, read_memory_v2(dir));
-      cpu = better_of(cpu, read_cpu_v2(dir));
+      memory_v2 = better_of(memory_v2, read_memory_v2(dir));
+      cpu_v2 = better_of(cpu_v2, read_cpu_v2(dir));
     }
   }
 
@@ -591,7 +631,7 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
       }
     }
     for (const auto & dir : dirs) {
-      info.memory_limit = better_of(info.memory_limit, read_memory_v1(dir));
+      memory_v1 = better_of(memory_v1, read_memory_v1(dir));
     }
   }
 
@@ -608,10 +648,12 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
       }
     }
     for (const auto & dir : dirs) {
-      cpu = better_of(cpu, read_cpu_v1(dir));
+      cpu_v1 = better_of(cpu_v1, read_cpu_v1(dir));
     }
   }
 
+  info.memory_limit = across_hierarchies(memory_v2, memory_v1);
+  auto cpu = across_hierarchies(cpu_v2, cpu_v1);
   info.cpu_quota = cpu.quota;
   info.cpu_period_us = cpu.period_us;
   return info;

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
@@ -138,11 +138,13 @@ CgroupPaths read_cgroup_paths(pid_t pid, const std::string & root) {
   return paths;
 }
 
-// A container's root filesystem is an overlay mount; a host's is not. This is
-// per-process, so it still answers for a PID other than our own.
+// Whether the process's own root filesystem is an overlay mount. Read from the
+// process's mountinfo, so it answers for a PID other than our own. The last
+// entry mounted at "/" is the visible one when mounts are stacked.
 bool has_overlay_root(pid_t pid, const std::string & root) {
   std::ifstream f(root + "/proc/" + std::to_string(pid) + "/mountinfo");
   std::string line;
+  bool overlay = false;
   while (std::getline(f, line)) {
     // "<id> <parent> <maj:min> <mount root> <mount point> <options> [tags] - <fstype> <source> ..."
     auto separator = line.find(" - ");
@@ -163,9 +165,9 @@ bool has_overlay_root(pid_t pid, const std::string & root) {
     if (!(tail >> fstype)) {
       continue;
     }
-    return fstype == "overlay";
+    overlay = (fstype == "overlay");
   }
-  return false;
+  return overlay;
 }
 
 // What a container runtime leaves behind when the cgroup path cannot name it.
@@ -174,15 +176,27 @@ struct ContainerMarker {
   std::string runtime;  // empty when the marker does not identify a runtime
 };
 
-ContainerMarker detect_container_marker(pid_t pid, const std::string & root) {
+// The marker files describe the filesystem of the INSPECTED process, so they
+// are read through its own root rather than the gateway's - a gateway that is
+// itself containerized would otherwise answer for every PID it can see.
+ContainerMarker detect_container_marker(pid_t pid, const std::string & root, const std::string & cgroup_path) {
+  const auto process_root = root + "/proc/" + std::to_string(pid) + "/root";
   std::error_code ec;
-  if (std::filesystem::exists(root + "/.dockerenv", ec)) {
+  if (std::filesystem::exists(process_root + "/.dockerenv", ec)) {
     return {true, "docker"};
   }
-  if (std::filesystem::exists(root + "/run/.containerenv", ec)) {
+  if (std::filesystem::exists(process_root + "/run/.containerenv", ec)) {
     return {true, "podman"};
   }
-  if (has_overlay_root(pid, root)) {
+  if (std::filesystem::exists(process_root + "/run/systemd/container", ec)) {
+    return {true, {}};
+  }
+
+  // An overlay root on its own proves nothing: whole distributions boot that
+  // way. It only says "container" together with a cgroup path that has been
+  // rewritten to the namespace root, which a process outside a cgroup
+  // namespace never reports.
+  if (cgroup_path == "/" && has_overlay_root(pid, root)) {
     return {true, {}};
   }
   return {};
@@ -416,10 +430,11 @@ std::string detect_runtime(const std::string & cgroup_path) {
 
 bool is_containerized(pid_t pid, const std::string & root) {
   auto paths = read_cgroup_paths(pid, root);
-  if (!extract_container_id(select_reported_path(paths)).empty()) {
+  auto cgroup_path = select_reported_path(paths);
+  if (!extract_container_id(cgroup_path).empty()) {
     return true;
   }
-  return detect_container_marker(pid, root).present;
+  return detect_container_marker(pid, root, cgroup_path).present;
 }
 
 tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::string & root) {
@@ -435,7 +450,7 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
   info.container_runtime = detect_runtime(cgroup_path);
   info.containerized = !info.container_id.empty();
   if (!info.containerized) {
-    auto marker = detect_container_marker(pid, root);
+    auto marker = detect_container_marker(pid, root, cgroup_path);
     info.containerized = marker.present;
     if (info.container_runtime.empty()) {
       info.container_runtime = marker.runtime;

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
@@ -42,17 +42,28 @@ std::string trim(const std::string & text) {
   return text.substr(begin, end - begin + 1);
 }
 
-// Returns nullopt when the file cannot be opened, and the (possibly empty)
-// first line when it can - the caller has to tell "no such limit file" from
-// "the limit file holds something we cannot parse".
-std::optional<std::string> read_first_line(const std::string & path) {
-  std::ifstream f(path);
-  if (!f.is_open()) {
-    return std::nullopt;
-  }
+// The outcome of looking at one limit file. "Not there" and "there but it
+// would not open" are different answers: the second is a failed read, and
+// reporting it as an absent limit is the confusion this reader exists to
+// remove.
+struct LimitFile {
+  bool exists{false};
+  bool opened{false};
   std::string line;
-  std::getline(f, line);
-  return line;
+};
+
+LimitFile read_limit_file(const std::string & path) {
+  LimitFile result;
+  std::ifstream f(path);
+  if (f.is_open()) {
+    result.exists = true;
+    result.opened = true;
+    std::getline(f, result.line);
+    return result;
+  }
+  std::error_code ec;
+  result.exists = std::filesystem::exists(path, ec);
+  return result;
 }
 
 std::optional<uint64_t> parse_u64(const std::string & text) {
@@ -215,6 +226,18 @@ std::optional<std::string> controller_path(const CgroupPaths & paths, const std:
 // hybrid host the unified line is often the bare root while the container is
 // named only on the v1 hierarchies, so a root unified path yields to those.
 std::string select_reported_path(const CgroupPaths & paths) {
+  // A path that names a container wins, whichever hierarchy carries it. The
+  // controllers the limits come from are not always the ones holding the id:
+  // a partly delegated v1 host can name the container on "pids" alone.
+  if (!extract_container_id(paths.unified).empty()) {
+    return paths.unified;
+  }
+  for (const auto & [name, path] : paths.v1) {
+    (void)name;
+    if (!extract_container_id(path).empty()) {
+      return path;
+    }
+  }
   if (!paths.unified.empty() && paths.unified != "/") {
     return paths.unified;
   }
@@ -246,6 +269,78 @@ std::vector<std::string> candidate_dirs(const std::string & mount, const std::st
   return dirs;
 }
 
+// A cgroup filesystem as the inspected process sees it.
+struct CgroupMount {
+  std::string mount_point;
+  std::string mount_root;  // the subtree of the hierarchy this mount exposes
+  std::string options;     // super options, which name the v1 controllers
+  bool unified{false};
+};
+
+// cgroup v1 does not require a controller to be mounted at a directory named
+// after it, and co-mounts may list controllers in any order, so the mount
+// points have to be read rather than guessed.
+std::vector<CgroupMount> read_cgroup_mounts(pid_t pid, const std::string & root) {
+  std::vector<CgroupMount> mounts;
+  std::ifstream f(root + "/proc/" + std::to_string(pid) + "/mountinfo");
+  std::string line;
+  while (std::getline(f, line)) {
+    auto separator = line.find(" - ");
+    if (separator == std::string::npos) {
+      continue;
+    }
+    std::istringstream head(line.substr(0, separator));
+    std::string field;
+    std::string mount_root;
+    std::string mount_point;
+    if (!(head >> field >> field >> field >> mount_root >> mount_point)) {
+      continue;
+    }
+    std::istringstream tail(line.substr(separator + 3));
+    std::string fstype;
+    std::string source;
+    std::string options;
+    if (!(tail >> fstype >> source >> options)) {
+      continue;
+    }
+    if (fstype != "cgroup" && fstype != "cgroup2") {
+      continue;
+    }
+    mounts.push_back({root + mount_point, mount_root, options, fstype == "cgroup2"});
+  }
+  return mounts;
+}
+
+bool mount_carries_controller(const CgroupMount & mount, const std::string & controller) {
+  // Super options are comma separated and include the controller names.
+  size_t start = 0;
+  while (start <= mount.options.size()) {
+    auto comma = mount.options.find(',', start);
+    auto name = comma == std::string::npos ? mount.options.substr(start) : mount.options.substr(start, comma - start);
+    if (name == controller) {
+      return true;
+    }
+    if (comma == std::string::npos) {
+      break;
+    }
+    start = comma + 1;
+  }
+  return false;
+}
+
+// Where a cgroup path is visible under a mount that exposes only part of the
+// hierarchy: the exposed subtree is stripped off the front of the path.
+void append_mount_dirs(std::vector<std::string> & dirs, const CgroupMount & mount, const std::string & cgroup_path) {
+  if (mount.mount_root != "/" && !mount.mount_root.empty() && cgroup_path.rfind(mount.mount_root, 0) == 0) {
+    auto relative = cgroup_path.substr(mount.mount_root.size());
+    dirs.push_back(relative.empty() ? mount.mount_point : mount.mount_point + relative);
+  }
+  if (!cgroup_path.empty() && cgroup_path != "/") {
+    dirs.push_back(mount.mount_point + cgroup_path);
+  }
+  dirs.push_back(mount.mount_point);
+}
+
 std::vector<std::string> unified_mounts(const std::string & root) {
   // The hybrid layout keeps the legacy controllers at the top level and mounts
   // the unified hierarchy beside them.
@@ -262,28 +357,16 @@ std::vector<std::string> v1_mounts(const std::string & root, const std::string &
   return mounts;
 }
 
-int rank(LimitState state) {
-  switch (state) {
-    case LimitState::kLimited:
-      return 3;
-    case LimitState::kUnlimited:
-      return 2;
-    case LimitState::kUnreadable:
-      return 1;
-    case LimitState::kUnavailable:
-      return 0;
-  }
-  return 0;
-}
-
-// Merges what two candidate locations said about the same limit, keeping the
-// most informative answer and, on a tie, the more specific location. A location
-// that reports no limit does not end the search: the root of a cgroup v1
-// hierarchy always reads as unlimited and would otherwise mask a limit set on
-// the container's own cgroup further down.
+// Keeps the answer from the most specific candidate that had a file at all.
+// Candidates are visited most specific first, so a location with nothing there
+// falls through to the next one, while a location that HAS the file decides -
+// including when what it holds cannot be parsed. Letting an unlimited reading
+// from a fallback location override an unreadable one from the process's own
+// cgroup would report "no limit" for a limit nobody managed to read, which is
+// the confusion this reader exists to remove.
 template <typename T>
 CgroupLimit<T> better_of(const CgroupLimit<T> & first, const CgroupLimit<T> & second) {
-  return rank(second.state()) > rank(first.state()) ? second : first;
+  return first.state() == LimitState::kUnavailable ? second : first;
 }
 
 // The CPU limit is the quota together with the period it is measured over; the
@@ -294,15 +377,18 @@ struct CpuLimit {
 };
 
 CpuLimit better_of(const CpuLimit & first, const CpuLimit & second) {
-  return rank(second.quota.state()) > rank(first.quota.state()) ? second : first;
+  return first.quota.state() == LimitState::kUnavailable ? second : first;
 }
 
 CgroupLimit<uint64_t> read_memory_v2(const std::string & dir) {
-  auto content = read_first_line(dir + "/memory.max");
-  if (!content) {
+  auto file = read_limit_file(dir + "/memory.max");
+  if (!file.exists) {
     return CgroupLimit<uint64_t>::unavailable();
   }
-  auto text = trim(*content);
+  if (!file.opened) {
+    return CgroupLimit<uint64_t>::unreadable();
+  }
+  auto text = trim(file.line);
   if (text == "max") {
     return CgroupLimit<uint64_t>::unlimited();
   }
@@ -314,11 +400,14 @@ CgroupLimit<uint64_t> read_memory_v2(const std::string & dir) {
 }
 
 CgroupLimit<uint64_t> read_memory_v1(const std::string & dir) {
-  auto content = read_first_line(dir + "/memory.limit_in_bytes");
-  if (!content) {
+  auto file = read_limit_file(dir + "/memory.limit_in_bytes");
+  if (!file.exists) {
     return CgroupLimit<uint64_t>::unavailable();
   }
-  auto value = parse_u64(trim(*content));
+  if (!file.opened) {
+    return CgroupLimit<uint64_t>::unreadable();
+  }
+  auto value = parse_u64(trim(file.line));
   if (!value) {
     return CgroupLimit<uint64_t>::unreadable();
   }
@@ -329,16 +418,21 @@ CgroupLimit<uint64_t> read_memory_v1(const std::string & dir) {
 }
 
 CpuLimit read_cpu_v2(const std::string & dir) {
-  auto content = read_first_line(dir + "/cpu.max");
-  if (!content) {
+  auto file = read_limit_file(dir + "/cpu.max");
+  if (!file.exists) {
     return {CgroupLimit<int64_t>::unavailable(), std::nullopt};
   }
+  if (!file.opened) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
 
-  // "<quota> <period>", where the quota may be the keyword "max".
-  std::istringstream ss(*content);
+  // The format is exactly two fields, "<quota> <period>", where the quota may
+  // be the keyword "max". Anything after them is not this file.
+  std::istringstream ss(file.line);
   std::string quota_text;
   std::string period_text;
-  if (!(ss >> quota_text) || !(ss >> period_text)) {
+  std::string trailing;
+  if (!(ss >> quota_text) || !(ss >> period_text) || (ss >> trailing)) {
     return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
   }
 
@@ -357,24 +451,24 @@ CpuLimit read_cpu_v2(const std::string & dir) {
 }
 
 CpuLimit read_cpu_v1(const std::string & dir) {
-  auto quota_content = read_first_line(dir + "/cpu.cfs_quota_us");
-  auto period_content = read_first_line(dir + "/cpu.cfs_period_us");
-  if (!quota_content && !period_content) {
+  auto quota_file = read_limit_file(dir + "/cpu.cfs_quota_us");
+  auto period_file = read_limit_file(dir + "/cpu.cfs_period_us");
+  if (!quota_file.exists && !period_file.exists) {
     return {CgroupLimit<int64_t>::unavailable(), std::nullopt};
   }
 
   std::optional<int64_t> period;
-  if (period_content) {
-    period = parse_i64(trim(*period_content));
+  if (period_file.opened) {
+    period = parse_i64(trim(period_file.line));
     if (period && *period <= 0) {
       period.reset();
     }
   }
-  if (!quota_content || !period) {
+  if (!quota_file.opened || !period) {
     return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
   }
 
-  auto quota = parse_i64(trim(*quota_content));
+  auto quota = parse_i64(trim(quota_file.line));
   if (!quota) {
     return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
   }
@@ -459,28 +553,62 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
 
   CpuLimit cpu;
 
+  // The conventional mount points come first because they are the ones a
+  // gateway can reach when it does not share the target's mount namespace.
+  // The mounts read from the target's own mountinfo are tried after them, so a
+  // host that puts its controllers somewhere else is still covered and a
+  // cross-namespace path that resolves to nothing here simply does not match.
+  const auto mounts = read_cgroup_mounts(pid, root);
+
   if (!paths.unified.empty()) {
+    std::vector<std::string> dirs;
     for (const auto & mount : unified_mounts(root)) {
       for (const auto & dir : candidate_dirs(mount, paths.unified)) {
-        info.memory_limit = better_of(info.memory_limit, read_memory_v2(dir));
-        cpu = better_of(cpu, read_cpu_v2(dir));
+        dirs.push_back(dir);
       }
+    }
+    for (const auto & mount : mounts) {
+      if (mount.unified) {
+        append_mount_dirs(dirs, mount, paths.unified);
+      }
+    }
+    for (const auto & dir : dirs) {
+      info.memory_limit = better_of(info.memory_limit, read_memory_v2(dir));
+      cpu = better_of(cpu, read_cpu_v2(dir));
     }
   }
 
   if (auto memory_path = controller_path(paths, "memory")) {
+    std::vector<std::string> dirs;
     for (const auto & mount : v1_mounts(root, "memory")) {
       for (const auto & dir : candidate_dirs(mount, *memory_path)) {
-        info.memory_limit = better_of(info.memory_limit, read_memory_v1(dir));
+        dirs.push_back(dir);
       }
+    }
+    for (const auto & mount : mounts) {
+      if (!mount.unified && mount_carries_controller(mount, "memory")) {
+        append_mount_dirs(dirs, mount, *memory_path);
+      }
+    }
+    for (const auto & dir : dirs) {
+      info.memory_limit = better_of(info.memory_limit, read_memory_v1(dir));
     }
   }
 
   if (auto cpu_path = controller_path(paths, "cpu")) {
+    std::vector<std::string> dirs;
     for (const auto & mount : v1_mounts(root, "cpu")) {
       for (const auto & dir : candidate_dirs(mount, *cpu_path)) {
-        cpu = better_of(cpu, read_cpu_v1(dir));
+        dirs.push_back(dir);
       }
+    }
+    for (const auto & mount : mounts) {
+      if (!mount.unified && mount_carries_controller(mount, "cpu")) {
+        append_mount_dirs(dirs, mount, *cpu_path);
+      }
+    }
+    for (const auto & dir : dirs) {
+      cpu = better_of(cpu, read_cpu_v1(dir));
     }
   }
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
@@ -52,16 +52,22 @@ std::string trim(const std::string & text) {
 struct LimitFile {
   bool exists{false};
   bool opened{false};
+  bool complete{false};  // the first line ended at a newline or at end of file
   std::string line;
 };
 
+// A limit file holds one short line. Anything longer than this is not one, and
+// stopping there keeps a pathological path from being read without bound.
+constexpr size_t kMaxLimitFileBytes = 4096;
+
 LimitFile read_limit_file(const std::string & path) {
   LimitFile result;
-  // errno on the single open call separates "no such file" from "present but
-  // it would not open". Opening and then asking whether the path exists is two
-  // steps, and a file that disappears between them reads as absent when it was
-  // really a failed read.
-  int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC);
+  // errno on the open separates "no such file" from "present but it would not
+  // open", in one step: asking afterwards whether the path exists is a second
+  // step, and a file that disappears in between reads as absent when it was
+  // really a failed read. O_NONBLOCK so that a path which turns out to be a
+  // FIFO cannot park the calling HTTP worker for the life of the process.
+  int fd = ::open(path.c_str(), O_RDONLY | O_CLOEXEC | O_NONBLOCK);
   if (fd < 0) {
     result.exists = (errno != ENOENT);
     return result;
@@ -69,14 +75,30 @@ LimitFile read_limit_file(const std::string & path) {
   result.exists = true;
   result.opened = true;
 
-  std::string buffer(4096, '\0');
-  auto count = ::read(fd, buffer.data(), buffer.size());
-  ::close(fd);
-  if (count > 0) {
-    buffer.resize(static_cast<size_t>(count));
-    auto newline = buffer.find('\n');
-    result.line = newline == std::string::npos ? buffer : buffer.substr(0, newline);
+  std::string content;
+  char chunk[256];
+  while (content.size() < kMaxLimitFileBytes) {
+    auto count = ::read(fd, chunk, sizeof(chunk));
+    if (count < 0) {
+      if (errno == EINTR) {
+        continue;  // a signal, not an answer about the file
+      }
+      break;  // EISDIR, EAGAIN on an empty FIFO, a real read error
+    }
+    if (count == 0) {
+      result.complete = true;  // end of file
+      break;
+    }
+    content.append(chunk, static_cast<size_t>(count));
+    if (content.find('\n') != std::string::npos) {
+      result.complete = true;
+      break;
+    }
   }
+  ::close(fd);
+
+  auto newline = content.find('\n');
+  result.line = newline == std::string::npos ? content : content.substr(0, newline);
   return result;
 }
 
@@ -345,8 +367,12 @@ bool mount_carries_controller(const CgroupMount & mount, const std::string & con
 // Where a cgroup path is visible under a mount that exposes only part of the
 // hierarchy: the exposed subtree is stripped off the front of the path.
 void append_mount_dirs(std::vector<std::string> & dirs, const CgroupMount & mount, const std::string & cgroup_path) {
-  if (mount.mount_root != "/" && !mount.mount_root.empty() && cgroup_path.rfind(mount.mount_root, 0) == 0) {
-    auto relative = cgroup_path.substr(mount.mount_root.size());
+  auto mount_root = mount.mount_root;
+  while (mount_root.size() > 1 && mount_root.back() == '/') {
+    mount_root.pop_back();  // "/docker/parent/" names the same subtree
+  }
+  if (mount_root != "/" && !mount_root.empty() && cgroup_path.rfind(mount_root, 0) == 0) {
+    auto relative = cgroup_path.substr(mount_root.size());
     // The prefix has to end on a component boundary, or /docker/parent matches
     // /docker/parent2/child and names a cgroup this mount does not expose.
     if (relative.empty() || relative.front() == '/') {
@@ -398,23 +424,24 @@ CpuLimit better_of(const CpuLimit & first, const CpuLimit & second) {
   return first.quota.state() == LimitState::kUnavailable ? second : first;
 }
 
-// Merges the answers from two different hierarchies. A controller is mounted on
-// the unified hierarchy or on a legacy one, never both, so the hierarchy that
-// does not carry it reports no limit rather than nothing at all. Preferring a
-// real limit keeps that empty answer from deciding.
+// Picks the hierarchy that owns the controller. /proc/<pid>/cgroup listing the
+// controller on a legacy hierarchy is what makes it legacy; otherwise it is on
+// the unified one. Choosing by which answer looks more informative instead
+// would let a reading from the hierarchy the controller is NOT on decide, and
+// report someone else's limit for this process.
 template <typename T>
-CgroupLimit<T> across_hierarchies(const CgroupLimit<T> & first, const CgroupLimit<T> & second) {
-  if (second.state() == LimitState::kLimited && first.state() != LimitState::kLimited) {
-    return second;
-  }
-  return first.state() == LimitState::kUnavailable ? second : first;
+CgroupLimit<T> owned_by(bool legacy_owns, const CgroupLimit<T> & unified, const CgroupLimit<T> & legacy) {
+  const auto & owner = legacy_owns ? legacy : unified;
+  const auto & other = legacy_owns ? unified : legacy;
+  // Nothing at all where the owner should be is the one case worth looking
+  // elsewhere for: an unusual mount layout rather than a different answer.
+  return owner.state() == LimitState::kUnavailable ? other : owner;
 }
 
-CpuLimit across_hierarchies(const CpuLimit & first, const CpuLimit & second) {
-  if (second.quota.state() == LimitState::kLimited && first.quota.state() != LimitState::kLimited) {
-    return second;
-  }
-  return first.quota.state() == LimitState::kUnavailable ? second : first;
+CpuLimit owned_by(bool legacy_owns, const CpuLimit & unified, const CpuLimit & legacy) {
+  const auto & owner = legacy_owns ? legacy : unified;
+  const auto & other = legacy_owns ? unified : legacy;
+  return owner.quota.state() == LimitState::kUnavailable ? other : owner;
 }
 
 CgroupLimit<uint64_t> read_memory_v2(const std::string & dir) {
@@ -422,7 +449,7 @@ CgroupLimit<uint64_t> read_memory_v2(const std::string & dir) {
   if (!file.exists) {
     return CgroupLimit<uint64_t>::unavailable();
   }
-  if (!file.opened) {
+  if (!file.opened || !file.complete) {
     return CgroupLimit<uint64_t>::unreadable();
   }
   auto text = trim(file.line);
@@ -441,7 +468,7 @@ CgroupLimit<uint64_t> read_memory_v1(const std::string & dir) {
   if (!file.exists) {
     return CgroupLimit<uint64_t>::unavailable();
   }
-  if (!file.opened) {
+  if (!file.opened || !file.complete) {
     return CgroupLimit<uint64_t>::unreadable();
   }
   auto value = parse_u64(trim(file.line));
@@ -459,7 +486,7 @@ CpuLimit read_cpu_v2(const std::string & dir) {
   if (!file.exists) {
     return {CgroupLimit<int64_t>::unavailable(), std::nullopt};
   }
-  if (!file.opened) {
+  if (!file.opened || !file.complete) {
     return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
   }
 
@@ -495,13 +522,13 @@ CpuLimit read_cpu_v1(const std::string & dir) {
   }
 
   std::optional<int64_t> period;
-  if (period_file.opened) {
+  if (period_file.opened && period_file.complete) {
     period = parse_i64(trim(period_file.line));
     if (period && *period <= 0) {
       period.reset();
     }
   }
-  if (!quota_file.opened || !period) {
+  if (!quota_file.opened || !quota_file.complete || !period) {
     return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
   }
 
@@ -652,8 +679,8 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
     }
   }
 
-  info.memory_limit = across_hierarchies(memory_v2, memory_v1);
-  auto cpu = across_hierarchies(cpu_v2, cpu_v1);
+  info.memory_limit = owned_by(controller_path(paths, "memory").has_value(), memory_v2, memory_v1);
+  auto cpu = owned_by(controller_path(paths, "cpu").has_value(), cpu_v2, cpu_v1);
   info.cpu_quota = cpu.quota;
   info.cpu_period_us = cpu.period_us;
   return info;

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/cgroup_reader.cpp
@@ -14,39 +14,380 @@
 
 #include "ros2_medkit_linux_introspection/cgroup_reader.hpp"
 
+#include <cctype>
+#include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <regex>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 namespace ros2_medkit_linux_introspection {
 
 namespace {
 
-std::string read_first_line(const std::string & path) {
-  std::ifstream f(path);
-  std::string line;
-  if (f.is_open()) {
-    std::getline(f, line);
+// cgroup v1 has no "max" keyword: an unlimited memory controller reports a
+// sentinel near the largest representable byte count, and its exact value
+// depends on the page size, so anything in that region counts as no limit.
+constexpr uint64_t kV1MemoryUnlimited = uint64_t{1} << 62;
+
+const char * const kWhitespace = " \t\r\n";
+
+std::string trim(const std::string & text) {
+  auto begin = text.find_first_not_of(kWhitespace);
+  if (begin == std::string::npos) {
+    return {};
   }
+  auto end = text.find_last_not_of(kWhitespace);
+  return text.substr(begin, end - begin + 1);
+}
+
+// Returns nullopt when the file cannot be opened, and the (possibly empty)
+// first line when it can - the caller has to tell "no such limit file" from
+// "the limit file holds something we cannot parse".
+std::optional<std::string> read_first_line(const std::string & path) {
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    return std::nullopt;
+  }
+  std::string line;
+  std::getline(f, line);
   return line;
 }
 
-// Read cgroup path from /proc/{pid}/cgroup (cgroup v2: single line "0::<path>")
-std::string read_cgroup_path(pid_t pid, const std::string & root) {
-  auto path = root + "/proc/" + std::to_string(pid) + "/cgroup";
-  std::ifstream f(path);
+std::optional<uint64_t> parse_u64(const std::string & text) {
+  // std::stoull accepts a leading minus and wraps it around, which would turn
+  // an error value into a plausible byte count.
+  if (text.empty() || text.front() == '-') {
+    return std::nullopt;
+  }
+  try {
+    size_t consumed = 0;
+    auto value = std::stoull(text, &consumed);
+    if (consumed != text.size()) {
+      return std::nullopt;
+    }
+    return static_cast<uint64_t>(value);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+}
+
+std::optional<int64_t> parse_i64(const std::string & text) {
+  if (text.empty()) {
+    return std::nullopt;
+  }
+  try {
+    size_t consumed = 0;
+    auto value = std::stoll(text, &consumed);
+    if (consumed != text.size()) {
+      return std::nullopt;
+    }
+    return static_cast<int64_t>(value);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+}
+
+// The cgroup a process belongs to, as reported by /proc/{pid}/cgroup. A host
+// mounts the unified hierarchy, the legacy per-controller ones, or both.
+struct CgroupPaths {
+  std::string unified;                                  // path from the "0::" line
+  std::vector<std::pair<std::string, std::string>> v1;  // controller -> path, in file order
+};
+
+CgroupPaths read_cgroup_paths(pid_t pid, const std::string & root) {
+  CgroupPaths paths;
+  std::ifstream f(root + "/proc/" + std::to_string(pid) + "/cgroup");
   std::string line;
   while (std::getline(f, line)) {
-    // cgroup v2 format: "0::<path>"
-    if (line.rfind("0::", 0) == 0) {
-      return line.substr(3);
+    // Both layouts write "<hierarchy-id>:<controllers>:<path>". The unified
+    // hierarchy is the one with an empty controller list; every other line
+    // belongs to a v1 hierarchy and names the controllers mounted on it.
+    auto first = line.find(':');
+    if (first == std::string::npos) {
+      continue;
     }
+    auto second = line.find(':', first + 1);
+    if (second == std::string::npos) {
+      continue;
+    }
+    auto controllers = line.substr(first + 1, second - first - 1);
+    auto path = trim(line.substr(second + 1));
+    if (path.empty()) {
+      continue;
+    }
+    if (controllers.empty()) {
+      paths.unified = path;
+      continue;
+    }
+    // A v1 hierarchy can carry several co-mounted controllers, e.g. "cpu,cpuacct".
+    size_t start = 0;
+    while (start <= controllers.size()) {
+      auto comma = controllers.find(',', start);
+      auto name = comma == std::string::npos ? controllers.substr(start) : controllers.substr(start, comma - start);
+      if (!name.empty()) {
+        paths.v1.emplace_back(name, path);
+      }
+      if (comma == std::string::npos) {
+        break;
+      }
+      start = comma + 1;
+    }
+  }
+  return paths;
+}
+
+// A container's root filesystem is an overlay mount; a host's is not. This is
+// per-process, so it still answers for a PID other than our own.
+bool has_overlay_root(pid_t pid, const std::string & root) {
+  std::ifstream f(root + "/proc/" + std::to_string(pid) + "/mountinfo");
+  std::string line;
+  while (std::getline(f, line)) {
+    // "<id> <parent> <maj:min> <mount root> <mount point> <options> [tags] - <fstype> <source> ..."
+    auto separator = line.find(" - ");
+    if (separator == std::string::npos) {
+      continue;
+    }
+    std::istringstream head(line.substr(0, separator));
+    std::string field;
+    std::string mount_point;
+    if (!(head >> field >> field >> field >> field >> mount_point)) {
+      continue;
+    }
+    if (mount_point != "/") {
+      continue;
+    }
+    std::istringstream tail(line.substr(separator + 3));
+    std::string fstype;
+    if (!(tail >> fstype)) {
+      continue;
+    }
+    return fstype == "overlay";
+  }
+  return false;
+}
+
+// What a container runtime leaves behind when the cgroup path cannot name it.
+struct ContainerMarker {
+  bool present{false};
+  std::string runtime;  // empty when the marker does not identify a runtime
+};
+
+ContainerMarker detect_container_marker(pid_t pid, const std::string & root) {
+  std::error_code ec;
+  if (std::filesystem::exists(root + "/.dockerenv", ec)) {
+    return {true, "docker"};
+  }
+  if (std::filesystem::exists(root + "/run/.containerenv", ec)) {
+    return {true, "podman"};
+  }
+  if (has_overlay_root(pid, root)) {
+    return {true, {}};
   }
   return {};
 }
 
+std::optional<std::string> controller_path(const CgroupPaths & paths, const std::string & controller) {
+  for (const auto & [name, path] : paths.v1) {
+    if (name == controller) {
+      return path;
+    }
+  }
+  return std::nullopt;
+}
+
+// The single path reported to callers and searched for a container id. On a
+// hybrid host the unified line is often the bare root while the container is
+// named only on the v1 hierarchies, so a root unified path yields to those.
+std::string select_reported_path(const CgroupPaths & paths) {
+  if (!paths.unified.empty() && paths.unified != "/") {
+    return paths.unified;
+  }
+  for (const auto * preferred : {"memory", "cpu", "cpuacct"}) {
+    if (auto path = controller_path(paths, preferred); path && *path != "/") {
+      return *path;
+    }
+  }
+  if (!paths.unified.empty()) {
+    return paths.unified;
+  }
+  if (!paths.v1.empty()) {
+    return paths.v1.front().second;
+  }
+  return {};
+}
+
+// Where a controller's interface files can sit, most specific first. Under
+// cgroupns=host the mount point holds the whole hierarchy and the reported path
+// leads to the process's own cgroup; under cgroupns=private that cgroup is the
+// mount point itself and the reported path resolves nowhere. Trying both covers
+// either mode without having to detect which one is in use.
+std::vector<std::string> candidate_dirs(const std::string & mount, const std::string & cgroup_path) {
+  std::vector<std::string> dirs;
+  if (!cgroup_path.empty() && cgroup_path != "/") {
+    dirs.push_back(mount + cgroup_path);
+  }
+  dirs.push_back(mount);
+  return dirs;
+}
+
+std::vector<std::string> unified_mounts(const std::string & root) {
+  // The hybrid layout keeps the legacy controllers at the top level and mounts
+  // the unified hierarchy beside them.
+  return {root + "/sys/fs/cgroup", root + "/sys/fs/cgroup/unified"};
+}
+
+std::vector<std::string> v1_mounts(const std::string & root, const std::string & controller) {
+  std::vector<std::string> mounts{root + "/sys/fs/cgroup/" + controller};
+  if (controller == "cpu") {
+    // Distributions co-mount cpu with cpuacct and leave "cpu" as a symlink to
+    // that directory, which not every image preserves.
+    mounts.push_back(root + "/sys/fs/cgroup/cpu,cpuacct");
+  }
+  return mounts;
+}
+
+int rank(LimitState state) {
+  switch (state) {
+    case LimitState::kLimited:
+      return 3;
+    case LimitState::kUnlimited:
+      return 2;
+    case LimitState::kUnreadable:
+      return 1;
+    case LimitState::kUnavailable:
+      return 0;
+  }
+  return 0;
+}
+
+// Merges what two candidate locations said about the same limit, keeping the
+// most informative answer and, on a tie, the more specific location. A location
+// that reports no limit does not end the search: the root of a cgroup v1
+// hierarchy always reads as unlimited and would otherwise mask a limit set on
+// the container's own cgroup further down.
+template <typename T>
+CgroupLimit<T> better_of(const CgroupLimit<T> & first, const CgroupLimit<T> & second) {
+  return rank(second.state()) > rank(first.state()) ? second : first;
+}
+
+// The CPU limit is the quota together with the period it is measured over; the
+// period alone says nothing, so the two travel as one reading.
+struct CpuLimit {
+  CgroupLimit<int64_t> quota;
+  std::optional<int64_t> period_us;
+};
+
+CpuLimit better_of(const CpuLimit & first, const CpuLimit & second) {
+  return rank(second.quota.state()) > rank(first.quota.state()) ? second : first;
+}
+
+CgroupLimit<uint64_t> read_memory_v2(const std::string & dir) {
+  auto content = read_first_line(dir + "/memory.max");
+  if (!content) {
+    return CgroupLimit<uint64_t>::unavailable();
+  }
+  auto text = trim(*content);
+  if (text == "max") {
+    return CgroupLimit<uint64_t>::unlimited();
+  }
+  auto value = parse_u64(text);
+  if (!value) {
+    return CgroupLimit<uint64_t>::unreadable();
+  }
+  return CgroupLimit<uint64_t>::limited(*value);
+}
+
+CgroupLimit<uint64_t> read_memory_v1(const std::string & dir) {
+  auto content = read_first_line(dir + "/memory.limit_in_bytes");
+  if (!content) {
+    return CgroupLimit<uint64_t>::unavailable();
+  }
+  auto value = parse_u64(trim(*content));
+  if (!value) {
+    return CgroupLimit<uint64_t>::unreadable();
+  }
+  if (*value >= kV1MemoryUnlimited) {
+    return CgroupLimit<uint64_t>::unlimited();
+  }
+  return CgroupLimit<uint64_t>::limited(*value);
+}
+
+CpuLimit read_cpu_v2(const std::string & dir) {
+  auto content = read_first_line(dir + "/cpu.max");
+  if (!content) {
+    return {CgroupLimit<int64_t>::unavailable(), std::nullopt};
+  }
+
+  // "<quota> <period>", where the quota may be the keyword "max".
+  std::istringstream ss(*content);
+  std::string quota_text;
+  std::string period_text;
+  if (!(ss >> quota_text) || !(ss >> period_text)) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+
+  auto period = parse_i64(period_text);
+  if (!period || *period <= 0) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+  if (quota_text == "max") {
+    return {CgroupLimit<int64_t>::unlimited(), *period};
+  }
+  auto quota = parse_i64(quota_text);
+  if (!quota || *quota <= 0) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+  return {CgroupLimit<int64_t>::limited(*quota), *period};
+}
+
+CpuLimit read_cpu_v1(const std::string & dir) {
+  auto quota_content = read_first_line(dir + "/cpu.cfs_quota_us");
+  auto period_content = read_first_line(dir + "/cpu.cfs_period_us");
+  if (!quota_content && !period_content) {
+    return {CgroupLimit<int64_t>::unavailable(), std::nullopt};
+  }
+
+  std::optional<int64_t> period;
+  if (period_content) {
+    period = parse_i64(trim(*period_content));
+    if (period && *period <= 0) {
+      period.reset();
+    }
+  }
+  if (!quota_content || !period) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+
+  auto quota = parse_i64(trim(*quota_content));
+  if (!quota) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+  if (*quota == -1) {
+    return {CgroupLimit<int64_t>::unlimited(), period};
+  }
+  if (*quota <= 0) {
+    return {CgroupLimit<int64_t>::unreadable(), std::nullopt};
+  }
+  return {CgroupLimit<int64_t>::limited(*quota), period};
+}
+
 }  // namespace
+
+std::string limit_state_to_string(LimitState state) {
+  switch (state) {
+    case LimitState::kLimited:
+      return "limited";
+    case LimitState::kUnlimited:
+      return "unlimited";
+    case LimitState::kUnreadable:
+      return "unreadable";
+    case LimitState::kUnavailable:
+      return "unavailable";
+  }
+  return "unavailable";
+}
 
 std::string extract_container_id(const std::string & cgroup_path) {
   // Docker: /docker-<64hex>.scope or /docker/<64hex>
@@ -74,12 +415,16 @@ std::string detect_runtime(const std::string & cgroup_path) {
 }
 
 bool is_containerized(pid_t pid, const std::string & root) {
-  auto cgroup_path = read_cgroup_path(pid, root);
-  return !extract_container_id(cgroup_path).empty();
+  auto paths = read_cgroup_paths(pid, root);
+  if (!extract_container_id(select_reported_path(paths)).empty()) {
+    return true;
+  }
+  return detect_container_marker(pid, root).present;
 }
 
 tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::string & root) {
-  auto cgroup_path = read_cgroup_path(pid, root);
+  auto paths = read_cgroup_paths(pid, root);
+  auto cgroup_path = select_reported_path(paths);
   if (cgroup_path.empty()) {
     return tl::make_unexpected("Cannot read cgroup for PID " + std::to_string(pid));
   }
@@ -88,41 +433,44 @@ tl::expected<CgroupInfo, std::string> read_cgroup_info(pid_t pid, const std::str
   info.cgroup_path = cgroup_path;
   info.container_id = extract_container_id(cgroup_path);
   info.container_runtime = detect_runtime(cgroup_path);
-
-  // Read resource limits from cgroup v2 filesystem
-  auto cgroup_fs_path = root + "/sys/fs/cgroup" + cgroup_path;
-
-  // memory.max
-  auto mem_max = read_first_line(cgroup_fs_path + "/memory.max");
-  if (!mem_max.empty() && mem_max != "max") {
-    try {
-      info.memory_limit_bytes = std::stoull(mem_max);
-    } catch (const std::exception & e) {
-      std::cerr << "[ros2_medkit_linux_introspection] Failed to parse memory.max value '" << mem_max
-                << "': " << e.what() << std::endl;
+  info.containerized = !info.container_id.empty();
+  if (!info.containerized) {
+    auto marker = detect_container_marker(pid, root);
+    info.containerized = marker.present;
+    if (info.container_runtime.empty()) {
+      info.container_runtime = marker.runtime;
     }
   }
 
-  // cpu.max (format: "quota period" or "max period")
-  auto cpu_max = read_first_line(cgroup_fs_path + "/cpu.max");
-  if (!cpu_max.empty()) {
-    std::istringstream ss(cpu_max);
-    std::string quota_str;
-    int64_t period = 0;
-    ss >> quota_str >> period;
-    if (quota_str != "max") {
-      try {
-        info.cpu_quota_us = std::stoll(quota_str);
-      } catch (const std::exception & e) {
-        std::cerr << "[ros2_medkit_linux_introspection] Failed to parse cpu.max quota '" << quota_str
-                  << "': " << e.what() << std::endl;
+  CpuLimit cpu;
+
+  if (!paths.unified.empty()) {
+    for (const auto & mount : unified_mounts(root)) {
+      for (const auto & dir : candidate_dirs(mount, paths.unified)) {
+        info.memory_limit = better_of(info.memory_limit, read_memory_v2(dir));
+        cpu = better_of(cpu, read_cpu_v2(dir));
       }
     }
-    if (period > 0) {
-      info.cpu_period_us = period;
+  }
+
+  if (auto memory_path = controller_path(paths, "memory")) {
+    for (const auto & mount : v1_mounts(root, "memory")) {
+      for (const auto & dir : candidate_dirs(mount, *memory_path)) {
+        info.memory_limit = better_of(info.memory_limit, read_memory_v1(dir));
+      }
     }
   }
 
+  if (auto cpu_path = controller_path(paths, "cpu")) {
+    for (const auto & mount : v1_mounts(root, "cpu")) {
+      for (const auto & dir : candidate_dirs(mount, *cpu_path)) {
+        cpu = better_of(cpu, read_cpu_v1(dir));
+      }
+    }
+  }
+
+  info.cpu_quota = cpu.quota;
+  info.cpu_period_us = cpu.period_us;
   return info;
 }
 

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/proc_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/src/linux_utils/proc_reader.cpp
@@ -48,7 +48,12 @@ std::string read_file_contents(const std::string & path) {
   if (!f.is_open()) {
     return {};
   }
-  return {std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>()};
+  // Read through the stream buffer rather than a pair of istreambuf_iterators:
+  // the iterator form makes GCC lose track of the buffer pointers and report a
+  // null dereference in <streambuf> that cannot happen on an open stream.
+  std::ostringstream contents;
+  contents << f.rdbuf();
+  return contents.str();
 }
 
 // Parse VmRSS and VmSize from /proc/{pid}/status
@@ -344,7 +349,12 @@ void PidCache::refresh(const std::string & root) {
     std::string node_name;
     std::string node_ns;
     if (parse_ros_args(cmdline_path, node_name, node_ns)) {
-      auto fqn = (node_ns == "/" || node_ns.empty()) ? "/" + node_name : node_ns + "/" + node_name;
+      std::string fqn;
+      if (node_ns != "/" && !node_ns.empty()) {
+        fqn = node_ns;
+      }
+      fqn += "/";
+      fqn += node_name;
       char * end = nullptr;
       long pid_val = std::strtol(entry->d_name, &end, 10);
       if (end != entry->d_name && *end == '\0' && pid_val > 0) {

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
@@ -233,7 +233,7 @@ TEST_F(CgroupTree, V2PrivateNamespaceNestedPathPrefersOwnCgroup) {
 // @verifies REQ_INTEROP_003
 TEST_F(CgroupTree, PrivateNamespaceDetectedByDockerMarker) {
   write_proc_cgroup(42, "0::/\n");
-  write_file(".dockerenv", "");
+  write_file("proc/42/root/.dockerenv", "");
   write_file("sys/fs/cgroup/memory.max", "536870912\n");
   write_file("sys/fs/cgroup/cpu.max", "100000 100000\n");
 
@@ -254,7 +254,7 @@ TEST_F(CgroupTree, PrivateNamespaceDetectedByDockerMarker) {
 // @verifies REQ_INTEROP_003
 TEST_F(CgroupTree, PrivateNamespaceDetectedByPodmanMarker) {
   write_proc_cgroup(42, "0::/\n");
-  write_file("run/.containerenv", "");
+  write_file("proc/42/root/run/.containerenv", "");
 
   EXPECT_TRUE(is_containerized(42, root()));
   auto info = read();
@@ -304,11 +304,51 @@ TEST_F(CgroupTree, OverlayBelowRootIsNotAContainer) {
   EXPECT_FALSE(is_containerized(42, root()));
 }
 
+// The marker belongs to the inspected process, not to whoever is reading. A
+// gateway that is itself in a container must not report every process it can
+// see as containerized.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, MarkerAtTheReadersRootDoesNotContainerizeAHostProcess) {
+  write_proc_cgroup(42, "0::/user.slice/user-1000.slice/session-1.scope\n");
+  write_file(".dockerenv", "");
+  write_file("run/.containerenv", "");
+  write_file("proc/42/mountinfo", "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n");
+
+  EXPECT_FALSE(is_containerized(42, root()));
+  auto info = read();
+  EXPECT_FALSE(info.containerized);
+  EXPECT_TRUE(info.container_runtime.empty());
+}
+
+// An overlay root is how whole distributions boot, so on its own it says
+// nothing. Only a cgroup path rewritten to the namespace root makes it a
+// container signal.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, OverlayRootWithAHostCgroupPathIsNotAContainer) {
+  write_proc_cgroup(42, "0::/user.slice/user-1000.slice/session-1.scope\n");
+  write_file("proc/42/mountinfo", "1700 461 0:154 / / rw,relatime - overlay overlay rw\n");
+
+  EXPECT_FALSE(is_containerized(42, root()));
+  EXPECT_FALSE(read().containerized);
+}
+
+// When mounts are stacked at "/", the visible root is the last one listed.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, StackedOverlayRootIsStillDetected) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "99 25 0:154 / / rw,relatime - overlay overlay rw\n");
+
+  EXPECT_TRUE(is_containerized(42, root()));
+  EXPECT_TRUE(read().containerized);
+}
+
 // A container id in the path stays the answer, and keeps naming the runtime.
 // @verifies REQ_INTEROP_003
 TEST_F(CgroupTree, CgroupPathIdWinsOverMarker) {
   write_proc_cgroup(42, docker_v2_line());
-  write_file("run/.containerenv", "");
+  write_file("proc/42/root/run/.containerenv", "");
 
   auto info = read();
   EXPECT_TRUE(info.containerized);

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
@@ -15,10 +15,70 @@
 #include <filesystem>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <string>
 #include "ros2_medkit_linux_introspection/cgroup_reader.hpp"
 
 namespace fs = std::filesystem;
 using namespace ros2_medkit_linux_introspection;
+
+namespace {
+
+constexpr const char * kDockerId = "aabb112233445566aabb112233445566aabb112233445566aabb112233445566";
+
+// cgroup v1 spells "no memory limit" as a sentinel near the top of the value
+// range rather than a keyword; the reader treats anything from 2^62 up as no
+// limit, so both sides of that boundary are pinned here.
+constexpr uint64_t kV1UnlimitedSentinel = 9223372036854771712ULL;
+constexpr uint64_t kV1UnlimitedBoundary = 4611686018427387904ULL;  // 2^62
+
+// Builds a synthetic /proc and /sys tree so a layout can be exercised without
+// the host having to be in it.
+class CgroupTree : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    const auto * info = ::testing::UnitTest::GetInstance()->current_test_info();
+    root_ = fs::temp_directory_path() /
+            ("medkit_cgroup_" + std::string(info->test_suite_name()) + "_" + std::string(info->name()));
+    fs::remove_all(root_);
+    fs::create_directories(root_);
+  }
+
+  void TearDown() override {
+    fs::remove_all(root_);
+  }
+
+  void write_proc_cgroup(pid_t pid, const std::string & content) {
+    auto dir = root_ / "proc" / std::to_string(pid);
+    fs::create_directories(dir);
+    std::ofstream f(dir / "cgroup");
+    f << content;
+  }
+
+  void write_file(const std::string & relative, const std::string & content) {
+    auto path = root_ / relative;
+    fs::create_directories(path.parent_path());
+    std::ofstream f(path);
+    f << content;
+  }
+
+  std::string root() const {
+    return root_.string();
+  }
+
+  CgroupInfo read(pid_t pid = 42) {
+    auto result = read_cgroup_info(pid, root());
+    EXPECT_TRUE(result.has_value()) << (result ? "" : result.error());
+    return result ? *result : CgroupInfo{};
+  }
+
+  fs::path root_;
+};
+
+std::string docker_v2_line() {
+  return std::string("0::/docker/") + kDockerId + "\n";
+}
+
+}  // namespace
 
 // @verifies REQ_INTEROP_003
 TEST(CgroupReader, ExtractDockerContainerId) {
@@ -54,6 +114,13 @@ TEST(CgroupReader, ExtractNoContainerId) {
 }
 
 // @verifies REQ_INTEROP_003
+TEST(CgroupReader, ExtractDockerOldStyleContainerId) {
+  std::string path = "/docker/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+  auto id = extract_container_id(path);
+  EXPECT_EQ(id, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2");
+}
+
+// @verifies REQ_INTEROP_003
 TEST(CgroupReader, DetectRuntime) {
   EXPECT_EQ(detect_runtime("/system.slice/docker-abc123.scope"), "docker");
   EXPECT_EQ(detect_runtime("/user.slice/libpod-abc123.scope"), "podman");
@@ -62,176 +129,517 @@ TEST(CgroupReader, DetectRuntime) {
 }
 
 // @verifies REQ_INTEROP_003
-TEST(CgroupReader, IsContainerizedSyntheticProc) {
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup";
-  fs::create_directories(tmpdir / "proc" / "42");
-
-  // Process inside Docker container
-  {
-    std::ofstream f(tmpdir / "proc" / "42" / "cgroup");
-    f << "0::/system.slice/"
-         "docker-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.scope\n";
-  }
-
-  EXPECT_TRUE(is_containerized(42, tmpdir.string()));
-
-  // Process on host
-  fs::create_directories(tmpdir / "proc" / "43");
-  {
-    std::ofstream f(tmpdir / "proc" / "43" / "cgroup");
-    f << "0::/user.slice/user-1000.slice/session-1.scope\n";
-  }
-
-  EXPECT_FALSE(is_containerized(43, tmpdir.string()));
-
-  fs::remove_all(tmpdir);
+TEST(CgroupReader, LimitStateStrings) {
+  EXPECT_EQ(limit_state_to_string(LimitState::kLimited), "limited");
+  EXPECT_EQ(limit_state_to_string(LimitState::kUnlimited), "unlimited");
+  EXPECT_EQ(limit_state_to_string(LimitState::kUnreadable), "unreadable");
+  EXPECT_EQ(limit_state_to_string(LimitState::kUnavailable), "unavailable");
 }
 
 // @verifies REQ_INTEROP_003
-TEST(CgroupReader, ReadCgroupInfoWithResourceLimits) {
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup_limits";
-  fs::create_directories(tmpdir / "proc" / "42");
-  fs::create_directories(tmpdir / "sys" / "fs" / "cgroup" / "system.slice" /
-                         "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope");
+TEST(CgroupReader, CgroupLimitHoldsValueOnlyWhenLimited) {
+  EXPECT_EQ(CgroupLimit<uint64_t>().state(), LimitState::kUnavailable);
+  EXPECT_FALSE(CgroupLimit<uint64_t>().value().has_value());
+  EXPECT_FALSE(CgroupLimit<uint64_t>::unlimited().value().has_value());
+  EXPECT_FALSE(CgroupLimit<uint64_t>::unreadable().value().has_value());
+  EXPECT_FALSE(CgroupLimit<uint64_t>::unavailable().value().has_value());
 
-  // cgroup file
-  {
-    std::ofstream f(tmpdir / "proc" / "42" / "cgroup");
-    f << "0::/system.slice/"
-         "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope\n";
-  }
+  auto limited = CgroupLimit<uint64_t>::limited(uint64_t{4096});
+  EXPECT_EQ(limited.state(), LimitState::kLimited);
+  ASSERT_TRUE(limited.value().has_value());
+  EXPECT_EQ(*limited.value(), 4096u);
+}
 
-  auto cgroup_dir = tmpdir / "sys" / "fs" / "cgroup" / "system.slice" /
-                    "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope";
+// --- Layout sweep: cgroup v2 -------------------------------------------------
 
-  // memory.max
-  {
-    std::ofstream f(cgroup_dir / "memory.max");
-    f << "1073741824\n";
-  }
+// cgroupns=host reports the path of the container's cgroup inside the whole
+// hierarchy, and the limit files sit under the mount point joined with it.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2HostNamespaceJoinedPath) {
+  write_proc_cgroup(42, docker_v2_line());
+  write_file(std::string("sys/fs/cgroup/docker/") + kDockerId + "/memory.max", "536870912\n");
+  write_file(std::string("sys/fs/cgroup/docker/") + kDockerId + "/cpu.max", "50000 100000\n");
 
-  // cpu.max (quota period)
-  {
-    std::ofstream f(cgroup_dir / "cpu.max");
-    f << "100000 100000\n";
-  }
+  // The bare mount point holds nothing, exactly as on a host where the root
+  // cgroup carries no limit files.
+  ASSERT_FALSE(fs::exists(root_ / "sys/fs/cgroup/memory.max"));
 
-  auto result = read_cgroup_info(42, tmpdir.string());
-  ASSERT_TRUE(result.has_value()) << result.error();
-
-  auto & info = result.value();
-  EXPECT_EQ(info.container_id, "aabb112233445566aabb112233445566aabb112233445566aabb112233445566");
+  auto info = read();
+  EXPECT_EQ(info.container_id, kDockerId);
   EXPECT_EQ(info.container_runtime, "docker");
-  ASSERT_TRUE(info.memory_limit_bytes.has_value());
-  EXPECT_EQ(info.memory_limit_bytes.value(), 1073741824u);
-  ASSERT_TRUE(info.cpu_quota_us.has_value());
-  EXPECT_EQ(info.cpu_quota_us.value(), 100000);
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
   ASSERT_TRUE(info.cpu_period_us.has_value());
-  EXPECT_EQ(info.cpu_period_us.value(), 100000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
 
-  fs::remove_all(tmpdir);
+// cgroupns=private mounts the container's own cgroup at the mount point and
+// reports "/" for it.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2PrivateNamespaceRootPath) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "536870912\n");
+  write_file("sys/fs/cgroup/cpu.max", "50000 100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cgroup_path, "/");
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
+
+// The case the joined-path-only reader missed: a private namespace whose
+// reported path is not "/", with the limit files at the bare mount point.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2PrivateNamespaceNonRootPath) {
+  write_proc_cgroup(42, "0::/system.slice/ros_node.service\n");
+  write_file("sys/fs/cgroup/memory.max", "268435456\n");
+  write_file("sys/fs/cgroup/cpu.max", "25000 100000\n");
+
+  ASSERT_FALSE(fs::exists(root_ / "sys/fs/cgroup/system.slice/ros_node.service"));
+
+  auto info = read();
+  EXPECT_EQ(info.cgroup_path, "/system.slice/ros_node.service");
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  EXPECT_EQ(*info.cpu_quota.value(), 25000);
+}
+
+// When the reported path does resolve under the mount point, that cgroup is the
+// one the process is in and its limits win over the mount point's.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2PrivateNamespaceNestedPathPrefersOwnCgroup) {
+  write_proc_cgroup(42, "0::/system.slice/ros_node.service\n");
+  write_file("sys/fs/cgroup/memory.max", "536870912\n");
+  write_file("sys/fs/cgroup/system.slice/ros_node.service/memory.max", "268435456\n");
+
+  auto info = read();
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+}
+
+// --- Containerization when the cgroup path hides the id ----------------------
+
+// cgroupns=private reports "/" for the cgroup, so the path carries no container
+// id at all. The limits are still there and the process is still in a
+// container - the runtime marker is what says so.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, PrivateNamespaceDetectedByDockerMarker) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file(".dockerenv", "");
+  write_file("sys/fs/cgroup/memory.max", "536870912\n");
+  write_file("sys/fs/cgroup/cpu.max", "100000 100000\n");
+
+  EXPECT_TRUE(is_containerized(42, root()));
+
+  auto info = read();
+  EXPECT_TRUE(info.containerized);
+  EXPECT_TRUE(info.container_id.empty());
+  EXPECT_EQ(info.container_runtime, "docker");
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  EXPECT_EQ(*info.cpu_quota.value(), 100000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
 }
 
 // @verifies REQ_INTEROP_003
-TEST(CgroupReader, ReadCgroupInfoUnlimitedResources) {
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup_unlimited";
-  fs::create_directories(tmpdir / "proc" / "42");
-  fs::create_directories(tmpdir / "sys" / "fs" / "cgroup" / "system.slice" /
-                         "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope");
+TEST_F(CgroupTree, PrivateNamespaceDetectedByPodmanMarker) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("run/.containerenv", "");
 
-  // cgroup file
-  {
-    std::ofstream f(tmpdir / "proc" / "42" / "cgroup");
-    f << "0::/system.slice/"
-         "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope\n";
-  }
+  EXPECT_TRUE(is_containerized(42, root()));
+  auto info = read();
+  EXPECT_TRUE(info.containerized);
+  EXPECT_EQ(info.container_runtime, "podman");
+}
 
-  auto cgroup_dir = tmpdir / "sys" / "fs" / "cgroup" / "system.slice" /
-                    "docker-aabb112233445566aabb112233445566aabb112233445566aabb112233445566.scope";
+// With no marker file, an overlay mounted as the process's root still says the
+// process is in a container.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, PrivateNamespaceDetectedByOverlayRoot) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("proc/42/mountinfo",
+             "1700 461 0:154 / / rw,relatime - overlay overlay rw,lowerdir=/a,upperdir=/b\n"
+             "1706 1705 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n");
 
-  // memory.max = "max" means unlimited
-  {
-    std::ofstream f(cgroup_dir / "memory.max");
-    f << "max\n";
-  }
+  EXPECT_TRUE(is_containerized(42, root()));
+  auto info = read();
+  EXPECT_TRUE(info.containerized);
+  // The overlay says "a container" but names no runtime.
+  EXPECT_TRUE(info.container_runtime.empty());
+}
 
-  // cpu.max = "max 100000" means unlimited quota
-  {
-    std::ofstream f(cgroup_dir / "cpu.max");
-    f << "max 100000\n";
-  }
+// A host root filesystem is not an overlay, and no marker file is there.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, HostProcessIsNotContainerized) {
+  write_proc_cgroup(42, "0::/user.slice/user-1000.slice/session-1.scope\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "26 25 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n");
 
-  auto result = read_cgroup_info(42, tmpdir.string());
-  ASSERT_TRUE(result.has_value()) << result.error();
+  EXPECT_FALSE(is_containerized(42, root()));
+  auto info = read();
+  EXPECT_FALSE(info.containerized);
+  EXPECT_TRUE(info.container_id.empty());
+}
 
-  auto & info = result.value();
-  // memory_limit_bytes should not be set when "max"
-  EXPECT_FALSE(info.memory_limit_bytes.has_value());
-  // cpu_quota_us should not be set when "max", but period should be
-  EXPECT_FALSE(info.cpu_quota_us.has_value());
+// An overlay mounted somewhere other than the root says nothing about the
+// process being in a container.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, OverlayBelowRootIsNotAContainer) {
+  write_proc_cgroup(42, "0::/user.slice/user-1000.slice/session-1.scope\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "77 25 0:99 / /var/lib/docker/overlay2/x rw,relatime - overlay overlay rw\n");
+
+  EXPECT_FALSE(is_containerized(42, root()));
+}
+
+// A container id in the path stays the answer, and keeps naming the runtime.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, CgroupPathIdWinsOverMarker) {
+  write_proc_cgroup(42, docker_v2_line());
+  write_file("run/.containerenv", "");
+
+  auto info = read();
+  EXPECT_TRUE(info.containerized);
+  EXPECT_EQ(info.container_id, kDockerId);
+  EXPECT_EQ(info.container_runtime, "docker");
+}
+
+// --- Layout sweep: cgroup v1 -------------------------------------------------
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1HostNamespaceJoinedPath) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n" + "11:cpu,cpuacct:/docker/" + kDockerId +
+                            "\n" + "10:pids:/docker/" + kDockerId + "\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "536870912\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_quota_us", "50000\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.container_id, kDockerId);
+  EXPECT_EQ(info.container_runtime, "docker");
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
   ASSERT_TRUE(info.cpu_period_us.has_value());
-  EXPECT_EQ(info.cpu_period_us.value(), 100000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
 
-  fs::remove_all(tmpdir);
+// Docker on cgroup v1 bind-mounts the container's own cgroup directory over
+// /sys/fs/cgroup/<controller>, so inside the container the reported path leads
+// nowhere and the files are at the mount point itself.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1InsideContainerBareMountPoint) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n" + "11:cpu,cpuacct:/docker/" + kDockerId +
+                            "\n");
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", "536870912\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "50000\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.container_id, kDockerId);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+}
+
+// The root of a v1 hierarchy always reads as unlimited. When the reported path
+// leads to a cgroup that does carry a limit, that limit is the answer - a
+// fallback location must not be able to report a limited container as free.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1RootFilesDoNotMaskContainerLimit) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n" + "11:cpu,cpuacct:/docker/" + kDockerId +
+                            "\n");
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", std::to_string(kV1UnlimitedSentinel) + "\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "-1\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "100000\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "536870912\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_quota_us", "50000\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+}
+
+// The plain "cpu" mount point is a symlink to the co-mounted directory on most
+// distributions, and only one of the two names is guaranteed to be there.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1CpuControllerMountedWithoutCpuacct) {
+  write_proc_cgroup(42, "12:memory:/\n11:cpu:/\n");
+  write_file("sys/fs/cgroup/cpu/cpu.cfs_quota_us", "50000\n");
+  write_file("sys/fs/cgroup/cpu/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
 }
 
 // @verifies REQ_INTEROP_003
-TEST(CgroupReader, ReadCgroupInfoMissingResourceFiles) {
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup_nores";
-  fs::create_directories(tmpdir / "proc" / "42");
+TEST_F(CgroupTree, V1IsContainerized) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n" + "11:cpu,cpuacct:/docker/" + kDockerId +
+                            "\n");
+  EXPECT_TRUE(is_containerized(42, root()));
 
-  // cgroup file points to path with no resource files
-  {
-    std::ofstream f(tmpdir / "proc" / "42" / "cgroup");
-    f << "0::/user.slice/user-1000.slice/session-1.scope\n";
-  }
+  write_proc_cgroup(43, "12:memory:/user.slice/user-1000.slice/session-1.scope\n");
+  EXPECT_FALSE(is_containerized(43, root()));
+}
 
-  auto result = read_cgroup_info(42, tmpdir.string());
-  ASSERT_TRUE(result.has_value()) << result.error();
+// --- Layout sweep: hybrid ----------------------------------------------------
 
-  auto & info = result.value();
+// A hybrid host mounts both hierarchies. The unified line is the bare root
+// there, so the container is named only on the v1 hierarchies.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, HybridUnifiedRootFallsBackToV1Path) {
+  write_proc_cgroup(42, std::string("0::/\n") + "12:memory:/docker/" + kDockerId + "\n" + "11:cpu,cpuacct:/docker/" +
+                            kDockerId + "\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "536870912\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_quota_us", "50000\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cgroup_path, std::string("/docker/") + kDockerId);
+  EXPECT_EQ(info.container_id, kDockerId);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+}
+
+// The hybrid layout keeps the legacy controllers at the top level and mounts
+// the unified hierarchy beside them.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, HybridUnifiedMountedBesideLegacyControllers) {
+  write_proc_cgroup(42, docker_v2_line() + "12:memory:/docker/" + kDockerId + "\n");
+  write_file(std::string("sys/fs/cgroup/unified/docker/") + kDockerId + "/memory.max", "268435456\n");
+  write_file(std::string("sys/fs/cgroup/unified/docker/") + kDockerId + "/cpu.max", "25000 100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.container_id, kDockerId);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 25000);
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
+
+// --- Unlimited vs unreadable vs absent ---------------------------------------
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2UnlimitedIsNotAbsent) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "max\n");
+  write_file("sys/fs/cgroup/cpu.max", "max 100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnlimited);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnlimited);
+  EXPECT_FALSE(info.cpu_quota.value().has_value());
+  // The period is still a fact about the cgroup even with no quota on it.
+  ASSERT_TRUE(info.cpu_period_us.has_value());
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V2UnreadableIsNotUnlimited) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "not-a-number\n");
+  write_file("sys/fs/cgroup/cpu.max", "not-a-number either\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.cpu_period_us.has_value());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, AbsentLimitFilesAreUnavailable) {
+  write_proc_cgroup(42, "0::/user.slice/user-1000.slice/session-1.scope\n");
+
+  auto info = read();
   EXPECT_TRUE(info.container_id.empty());
   EXPECT_TRUE(info.container_runtime.empty());
-  EXPECT_FALSE(info.memory_limit_bytes.has_value());
-  EXPECT_FALSE(info.cpu_quota_us.has_value());
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnavailable);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnavailable);
   EXPECT_FALSE(info.cpu_period_us.has_value());
+}
 
-  fs::remove_all(tmpdir);
+// The three outcomes have to stay distinguishable from one another, which is
+// the whole reason the state is reported separately from the value.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, UnlimitedUnreadableAndAbsentAreThreeResults) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "max\n");
+  auto unlimited = read().memory_limit.state();
+
+  write_file("sys/fs/cgroup/memory.max", "garbage\n");
+  auto unreadable = read().memory_limit.state();
+
+  fs::remove(root_ / "sys/fs/cgroup/memory.max");
+  auto absent = read().memory_limit.state();
+
+  EXPECT_EQ(unlimited, LimitState::kUnlimited);
+  EXPECT_EQ(unreadable, LimitState::kUnreadable);
+  EXPECT_EQ(absent, LimitState::kUnavailable);
+  EXPECT_NE(unlimited, unreadable);
+  EXPECT_NE(unreadable, absent);
+  EXPECT_NE(unlimited, absent);
+}
+
+// --- Malformed contents ------------------------------------------------------
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, EmptyLimitFilesAreUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "");
+  write_file("sys/fs/cgroup/cpu.max", "");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+}
+
+// A quota with no period is not a bandwidth limit: the period is what the next
+// caller would divide by.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, CpuMaxWithoutPeriodIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/cpu.max", "50000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.cpu_quota.value().has_value());
+  EXPECT_FALSE(info.cpu_period_us.has_value());
 }
 
 // @verifies REQ_INTEROP_003
-TEST(CgroupReader, ReadCgroupInfoMissingCgroupFile) {
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup_nocg";
-  fs::create_directories(tmpdir / "proc" / "42");
-  // No cgroup file at all
+TEST_F(CgroupTree, CpuMaxWithZeroPeriodIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/cpu.max", "50000 0\n");
 
-  auto result = read_cgroup_info(42, tmpdir.string());
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.cpu_period_us.has_value());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1ZeroPeriodIsUnreadable) {
+  write_proc_cgroup(42, "11:cpu,cpuacct:/\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "50000\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "0\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.cpu_period_us.has_value());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1QuotaWithoutPeriodFileIsUnreadable) {
+  write_proc_cgroup(42, "11:cpu,cpuacct:/\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "50000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, ValueBeyondTypeRangeIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "999999999999999999999999999999\n");
+  write_file("sys/fs/cgroup/cpu.max", "999999999999999999999999999999 100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+}
+
+// A negative byte count is an error value, not a very large limit.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, NegativeMemoryLimitIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "-1\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, TrailingGarbageAfterNumberIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "536870912bytes\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1UnlimitedSentinelBoundary) {
+  write_proc_cgroup(42, "12:memory:/\n");
+
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", std::to_string(kV1UnlimitedSentinel) + "\n");
+  EXPECT_EQ(read().memory_limit.state(), LimitState::kUnlimited);
+
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", std::to_string(kV1UnlimitedBoundary) + "\n");
+  EXPECT_EQ(read().memory_limit.state(), LimitState::kUnlimited);
+
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", std::to_string(kV1UnlimitedBoundary - 1) + "\n");
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), kV1UnlimitedBoundary - 1);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1QuotaMinusOneIsUnlimited) {
+  write_proc_cgroup(42, "11:cpu,cpuacct:/\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us", "-1\n");
+  write_file("sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnlimited);
+  EXPECT_FALSE(info.cpu_quota.value().has_value());
+  ASSERT_TRUE(info.cpu_period_us.has_value());
+  EXPECT_EQ(*info.cpu_period_us, 100000);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, MalformedProcCgroupLinesAreIgnored) {
+  write_proc_cgroup(42, std::string("this line has no colons\n") + "5:only:two:colons:is:fine:/docker/" + kDockerId +
+                            "\n" + "\n" + "0::" + "\n");
+
+  // The "0::" line carries no path and is dropped; the v1 line still resolves.
+  auto info = read();
+  EXPECT_EQ(info.cgroup_path, std::string("two:colons:is:fine:/docker/") + kDockerId);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, MissingCgroupFileIsAnError) {
+  fs::create_directories(root_ / "proc" / "42");
+
+  auto result = read_cgroup_info(42, root());
   ASSERT_FALSE(result.has_value());
   EXPECT_FALSE(result.error().empty());
-
-  fs::remove_all(tmpdir);
-}
-
-// @verifies REQ_INTEROP_003
-TEST(CgroupReader, ExtractDockerOldStyleContainerId) {
-  std::string path = "/docker/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-  auto id = extract_container_id(path);
-  EXPECT_EQ(id, "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2");
-}
-
-// @verifies REQ_INTEROP_003
-TEST(CgroupReader, CgroupV1FormatNotSupported) {
-  // cgroup v1 uses "hierarchy-ID:controller-list:cgroup-path" format.
-  // Our reader only supports cgroup v2 ("0::<path>").
-  // This test documents the intentional limitation.
-  auto tmpdir = fs::temp_directory_path() / "test_cgroup_v1";
-  fs::create_directories(tmpdir / "proc" / "42");
-  {
-    std::ofstream f(tmpdir / "proc" / "42" / "cgroup");
-    f << "12:memory:/docker/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n"
-      << "11:cpu:/docker/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n";
-  }
-  // cgroup v1 format is not supported - returns false
-  EXPECT_FALSE(is_containerized(42, tmpdir.string()));
-  fs::remove_all(tmpdir);
 }

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
@@ -675,6 +675,89 @@ TEST_F(CgroupTree, MalformedProcCgroupLinesAreIgnored) {
   EXPECT_EQ(info.cgroup_path, std::string("two:colons:is:fine:/docker/") + kDockerId);
 }
 
+// A fallback location that says "no limit" must not overwrite an unreadable
+// answer from the process's own cgroup. Reporting no limit for a limit nobody
+// could read is the failure this reader exists to remove.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, UnreadableOwnCgroupIsNotMaskedByAnUnlimitedFallback) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "garbage\n");
+  write_file("sys/fs/cgroup/memory/memory.limit_in_bytes", std::to_string(kV1UnlimitedSentinel) + "\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+}
+
+// cpu.max holds exactly two fields. Anything after them is not this file.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, CpuMaxWithATrailingTokenIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/cpu.max", "50000 100000 garbage\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.cpu_quota.value().has_value());
+  EXPECT_FALSE(info.cpu_period_us.has_value());
+}
+
+// A limit file that is there but yields nothing readable is a failed read, not
+// an absent limit. A permission-based fixture cannot be used here because root
+// bypasses it, and the tests run as root in CI.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, PresentButUnreadableLimitFileIsNotReportedAsAbsent) {
+  write_proc_cgroup(42, "0::/\n");
+  fs::create_directories(root_ / "sys/fs/cgroup/memory.max");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_NE(info.memory_limit.state(), LimitState::kUnavailable);
+}
+
+// The container id can sit on a hierarchy other than the ones the limits come
+// from, so every reported path is searched for one.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, ContainerIdIsFoundOnANonPreferredHierarchy) {
+  write_proc_cgroup(42, std::string("12:memory:/\n11:cpu,cpuacct:/\n10:pids:/docker/") + kDockerId + "\n");
+
+  auto info = read();
+  EXPECT_EQ(info.container_id, kDockerId);
+  EXPECT_EQ(info.container_runtime, "docker");
+  EXPECT_TRUE(info.containerized);
+}
+
+// cgroup v1 does not require a controller to be mounted at a directory named
+// after it, so the mount points are read from the process's mountinfo.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1ControllerAtACustomMountPoint) {
+  write_proc_cgroup(42, std::string("12:memory:/docker/") + kDockerId + "\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "30 25 0:26 / /sys/fs/cgroup/odd rw,relatime - cgroup cgroup rw,memory\n");
+  write_file(std::string("sys/fs/cgroup/odd/docker/") + kDockerId + "/memory.limit_in_bytes", "536870912\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+}
+
+// A mount that exposes only part of the hierarchy shows a cgroup path with
+// that subtree stripped off the front.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, V1MountExposingASubtreeStripsItFromThePath) {
+  write_proc_cgroup(42, "12:memory:/docker/parent/child\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "30 25 0:26 /docker/parent /sys/fs/cgroup/memory rw,relatime - cgroup cgroup rw,memory\n");
+  write_file("sys/fs/cgroup/memory/child/memory.limit_in_bytes", "268435456\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+}
+
 // @verifies REQ_INTEROP_003
 TEST_F(CgroupTree, MissingCgroupFileIsAnError) {
   fs::create_directories(root_ / "proc" / "42");

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
@@ -758,6 +758,76 @@ TEST_F(CgroupTree, V1MountExposingASubtreeStripsItFromThePath) {
   EXPECT_EQ(*info.memory_limit.value(), 268435456u);
 }
 
+// A controller lives on one hierarchy. The other one reporting no limit must
+// not outrank the real limit the process actually has.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, UnlimitedUnifiedDoesNotOutrankALimitedLegacyController) {
+  write_proc_cgroup(42, std::string("0::/\n12:memory:/docker/") + kDockerId + "\n");
+  write_file("sys/fs/cgroup/memory.max", "max\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "536870912\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, UnlimitedUnifiedCpuDoesNotOutrankALimitedLegacyQuota) {
+  write_proc_cgroup(42, std::string("0::/\n11:cpu,cpuacct:/docker/") + kDockerId + "\n");
+  write_file("sys/fs/cgroup/cpu.max", "max 100000\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_quota_us", "50000\n");
+  write_file(std::string("sys/fs/cgroup/cpu,cpuacct/docker/") + kDockerId + "/cpu.cfs_period_us", "100000\n");
+
+  auto info = read();
+  EXPECT_EQ(info.cpu_quota.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.cpu_quota.value().has_value());
+  EXPECT_EQ(*info.cpu_quota.value(), 50000);
+}
+
+// A mount root only matches on a component boundary: /docker/parent must not
+// swallow /docker/parent2, which is a different cgroup.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, MountRootMatchesOnlyWholePathComponents) {
+  write_proc_cgroup(42, "12:memory:/docker/parent2/child\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "30 25 0:26 /docker/parent /sys/fs/cgroup/memory rw,relatime - cgroup cgroup rw,memory\n");
+  // What the bad prefix strip would have built, holding a limit that belongs to
+  // a cgroup this mount does not expose.
+  write_file("sys/fs/cgroup/memory2/child/memory.limit_in_bytes", "999999999\n");
+
+  auto info = read();
+  EXPECT_NE(info.memory_limit.state(), LimitState::kLimited);
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, SystemdNspawnMarkerIsDetected) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("proc/42/root/run/systemd/container", "systemd-nspawn\n");
+
+  EXPECT_TRUE(is_containerized(42, root()));
+  auto info = read();
+  EXPECT_TRUE(info.containerized);
+  EXPECT_TRUE(info.container_runtime.empty());
+}
+
+// The unified hierarchy can be mounted somewhere other than /sys/fs/cgroup, and
+// can expose only part of itself, exactly like a legacy controller.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, UnifiedHierarchyAtACustomMountPointWithASubtreeRoot) {
+  write_proc_cgroup(42, "0::/tenant/workload\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "30 25 0:26 /tenant /custom/unified rw,relatime - cgroup2 cgroup rw\n");
+  write_file("custom/unified/workload/memory.max", "268435456\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+}
+
 // @verifies REQ_INTEROP_003
 TEST_F(CgroupTree, MissingCgroupFileIsAnError) {
   fs::create_directories(root_ / "proc" / "42");

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_cgroup_reader.cpp
@@ -16,6 +16,8 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include "ros2_medkit_linux_introspection/cgroup_reader.hpp"
 
 namespace fs = std::filesystem;
@@ -826,6 +828,117 @@ TEST_F(CgroupTree, UnifiedHierarchyAtACustomMountPointWithASubtreeRoot) {
   EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
   ASSERT_TRUE(info.memory_limit.value().has_value());
   EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+}
+
+// A path whose parent is a regular file fails to open with ENOTDIR, not
+// ENOENT. That is a file we could not read, not a limit that is not there, and
+// unlike a permission fixture it behaves the same when the tests run as root.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, OpenFailureOtherThanMissingIsUnreadable) {
+  write_proc_cgroup(42, std::string("0::/docker/") + kDockerId + "\n");
+  // "docker" is a file, so ".../docker/<id>/memory.max" cannot be walked.
+  write_file("sys/fs/cgroup/docker", "not a directory\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_NE(info.memory_limit.state(), LimitState::kUnavailable);
+}
+
+// A first line that never ends inside the bytes we are willing to read is not a
+// limit. Parsing the prefix would turn "536870912<spaces>garbage" into a valid
+// 512 MiB limit.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, LimitFileWithoutALineEndingWithinTheCapIsUnreadable) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "536870912" + std::string(8192, ' ') + "garbage\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+}
+
+// A limit file with no trailing newline is still a complete first line.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, LimitFileWithoutATrailingNewlineIsRead) {
+  write_proc_cgroup(42, "0::/\n");
+  write_file("sys/fs/cgroup/memory.max", "536870912");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
+}
+
+// A mount root is the same subtree whether or not it is written with a
+// trailing slash.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, MountRootWithATrailingSlashStillMatches) {
+  write_proc_cgroup(42, "12:memory:/docker/parent/child\n");
+  write_file("proc/42/mountinfo",
+             "25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n"
+             "30 25 0:26 /docker/parent/ /sys/fs/cgroup/memory rw,relatime - cgroup cgroup rw,memory\n");
+  write_file("sys/fs/cgroup/memory/child/memory.limit_in_bytes", "268435456\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 268435456u);
+}
+
+// The hierarchy that owns the controller answers, even when the other one has
+// a readable file. Choosing by which answer looks better would report a limit
+// belonging to a cgroup this process is not in.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, LegacyOwnedControllerAnswersEvenWhenUnifiedIsReadable) {
+  write_proc_cgroup(42, std::string("0::/\n12:memory:/docker/") + kDockerId + "\n");
+  write_file("sys/fs/cgroup/memory.max", "999999999\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes", "garbage\n");
+
+  auto info = read();
+  // The legacy controller owns memory here, and its file cannot be parsed.
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+  EXPECT_FALSE(info.memory_limit.value().has_value());
+}
+
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, LegacyOwnedControllerReportsUnlimitedOverAUnifiedNumber) {
+  write_proc_cgroup(42, std::string("0::/\n12:memory:/docker/") + kDockerId + "\n");
+  write_file("sys/fs/cgroup/memory.max", "999999999\n");
+  write_file(std::string("sys/fs/cgroup/memory/docker/") + kDockerId + "/memory.limit_in_bytes",
+             std::to_string(kV1UnlimitedSentinel) + "\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnlimited);
+}
+
+// A limit path that turns out to be a FIFO with no writer must not park the
+// caller. Opening one without O_NONBLOCK blocks until a writer appears, which
+// for an HTTP worker means never. If this ever regresses the test does not
+// fail, it hangs, and its ctest timeout reports it.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, LimitPathThatIsAFifoDoesNotBlock) {
+  write_proc_cgroup(42, "0::/\n");
+  fs::create_directories(root_ / "sys/fs/cgroup");
+  auto fifo = (root_ / "sys/fs/cgroup/memory.max").string();
+  ASSERT_EQ(::mkfifo(fifo.c_str(), 0600), 0);
+
+  auto info = read();
+  // It is there and it gave us nothing, which is a failed read.
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kUnreadable);
+}
+
+// The first line can be longer than one read returns. Stopping at the first
+// chunk would take the prefix for the whole line.
+// @verifies REQ_INTEROP_003
+TEST_F(CgroupTree, FirstLineLongerThanOneReadIsAccumulated) {
+  write_proc_cgroup(42, "0::/\n");
+  // Leading blanks push the number past any single-chunk read; trim drops them.
+  write_file("sys/fs/cgroup/memory.max", std::string(1024, ' ') + "536870912\n");
+
+  auto info = read();
+  EXPECT_EQ(info.memory_limit.state(), LimitState::kLimited);
+  ASSERT_TRUE(info.memory_limit.value().has_value());
+  EXPECT_EQ(*info.memory_limit.value(), 536870912u);
 }
 
 // @verifies REQ_INTEROP_003

--- a/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_container_plugin.cpp
+++ b/src/ros2_medkit_discovery_plugins/ros2_medkit_linux_introspection/test/test_container_plugin.cpp
@@ -22,15 +22,17 @@ TEST(ContainerPlugin, CgroupInfoToJsonAllFields) {
   CgroupInfo info;
   info.container_id = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
   info.container_runtime = "docker";
-  info.memory_limit_bytes = 1073741824;
-  info.cpu_quota_us = 100000;
+  info.memory_limit = CgroupLimit<uint64_t>::limited(uint64_t{1073741824});
+  info.cpu_quota = CgroupLimit<int64_t>::limited(100000);
   info.cpu_period_us = 100000;
 
   auto j = cgroup_info_to_json(info);
   EXPECT_EQ(j["container_id"], info.container_id);
   EXPECT_EQ(j["runtime"], "docker");
   EXPECT_EQ(j["memory_limit_bytes"], 1073741824u);
+  EXPECT_EQ(j["memory_limit_state"], "limited");
   EXPECT_EQ(j["cpu_quota_us"], 100000);
+  EXPECT_EQ(j["cpu_quota_state"], "limited");
   EXPECT_EQ(j["cpu_period_us"], 100000);
 }
 
@@ -39,7 +41,7 @@ TEST(ContainerPlugin, CgroupInfoToJsonMissingOptionals) {
   CgroupInfo info;
   info.container_id = "deadbeef12345678deadbeef12345678deadbeef12345678deadbeef12345678";
   info.container_runtime = "containerd";
-  // Leave optionals unset
+  // Leave the limits at their default state
 
   auto j = cgroup_info_to_json(info);
   EXPECT_EQ(j["container_id"], info.container_id);
@@ -47,6 +49,33 @@ TEST(ContainerPlugin, CgroupInfoToJsonMissingOptionals) {
   EXPECT_FALSE(j.contains("memory_limit_bytes"));
   EXPECT_FALSE(j.contains("cpu_quota_us"));
   EXPECT_FALSE(j.contains("cpu_period_us"));
+  EXPECT_EQ(j["memory_limit_state"], "unavailable");
+  EXPECT_EQ(j["cpu_quota_state"], "unavailable");
+}
+
+// An unlimited container and one whose limit files could not be read both carry
+// no number, and the state is the only thing that tells them apart.
+// @verifies REQ_INTEROP_003
+TEST(ContainerPlugin, CgroupInfoToJsonUnlimitedIsNotUnreadable) {
+  CgroupInfo unlimited;
+  unlimited.memory_limit = CgroupLimit<uint64_t>::unlimited();
+  unlimited.cpu_quota = CgroupLimit<int64_t>::unlimited();
+  unlimited.cpu_period_us = 100000;
+
+  CgroupInfo unreadable;
+  unreadable.memory_limit = CgroupLimit<uint64_t>::unreadable();
+  unreadable.cpu_quota = CgroupLimit<int64_t>::unreadable();
+
+  auto j_unlimited = cgroup_info_to_json(unlimited);
+  auto j_unreadable = cgroup_info_to_json(unreadable);
+
+  EXPECT_FALSE(j_unlimited.contains("memory_limit_bytes"));
+  EXPECT_FALSE(j_unreadable.contains("memory_limit_bytes"));
+  EXPECT_EQ(j_unlimited["memory_limit_state"], "unlimited");
+  EXPECT_EQ(j_unreadable["memory_limit_state"], "unreadable");
+  EXPECT_EQ(j_unlimited["cpu_quota_state"], "unlimited");
+  EXPECT_EQ(j_unreadable["cpu_quota_state"], "unreadable");
+  EXPECT_NE(j_unlimited["memory_limit_state"], j_unreadable["memory_limit_state"]);
 }
 
 // @verifies REQ_INTEROP_003

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cgroup_fixtures.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cgroup_fixtures.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Synthetic ``/proc`` and ``/sys`` trees for the container introspection plugin.
+
+Every file the plugin reads is resolved under its configured ``proc_root``, so a
+tree written here lets a real gateway answer real HTTP requests for cgroup
+layouts the host kernel does not provide. That matters because no supported CI
+distribution ships a cgroup v1 or hybrid hierarchy: a unified-only kernel has no
+v1 controllers to mount, so those layouts are reachable no other way.
+
+The tree carries the file *contents*; the gateway, the plugin, the PID cache,
+the routing and the JSON serialisation are all real.
+"""
+
+import os
+
+# A root filesystem that is not a container: a block device, no overlay.
+HOST_MOUNTINFO = (
+    '25 1 259:2 / / rw,relatime - ext4 /dev/nvme0n1p2 rw\n'
+    '26 25 0:25 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n'
+)
+
+# What a container's root looks like: an overlay mounted at "/".
+OVERLAY_MOUNTINFO = (
+    '1700 461 0:154 / / rw,relatime - overlay overlay rw,lowerdir=/a,upperdir=/b\n'
+    '1706 1705 0:25 / /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw\n'
+)
+
+# 64 lowercase hex characters, the shape every runtime uses for a container ID.
+DOCKER_ID = 'aabb112233445566' * 4
+
+MIB = 1024 * 1024
+
+
+def write_file(root, relative, content):
+    """Write ``content`` at ``relative`` under ``root``, creating parents."""
+    path = os.path.join(root, relative.lstrip('/'))
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'w') as handle:
+        handle.write(content)
+    return path
+
+
+def write_process(root, pid, fqn, cgroup, mountinfo=HOST_MOUNTINFO, markers=()):
+    """Write a ``/proc/<pid>`` entry the PID cache resolves to ``fqn``.
+
+    No process needs to exist at ``pid``: the cache scans ``<root>/proc`` for
+    numeric directories and reads ``cmdline`` for ``__ns:=`` and ``__node:=``.
+    ``markers`` are paths inside the process's own root, e.g. ``.dockerenv``.
+    """
+    namespace, _, name = fqn.rpartition('/')
+    args = [
+        'demo_node',
+        '--ros-args',
+        '-r',
+        '__ns:={}'.format(namespace or '/'),
+        '-r',
+        '__node:={}'.format(name),
+    ]
+    write_file(root, 'proc/{}/cmdline'.format(pid), '\0'.join(args) + '\0')
+    write_file(root, 'proc/{}/cgroup'.format(pid), cgroup)
+    write_file(root, 'proc/{}/mountinfo'.format(pid), mountinfo)
+    for marker in markers:
+        write_file(root, 'proc/{}/root/{}'.format(pid, marker.lstrip('/')), '')
+
+
+def v1_cgroup(path):
+    """Build a ``/proc/<pid>/cgroup`` in the legacy format, one line per hierarchy."""
+    return '12:memory:{p}\n11:cpu,cpuacct:{p}\n10:pids:{p}\n'.format(p=path)
+
+
+def v2_cgroup(path):
+    """Build a ``/proc/<pid>/cgroup`` in the unified format: a single ``0::`` line."""
+    return '0::{}\n'.format(path)
+
+
+def hybrid_cgroup(unified_path, v1_path):
+    """Build a cgroup file with both hierarchies, as on a partly migrated host."""
+    return '{}{}'.format(v2_cgroup(unified_path), v1_cgroup(v1_path))
+
+
+def v1_limits(root, cgroup_dir, memory_bytes=None, quota_us=None, period_us=100000):
+    """Write legacy controller files for the cgroup at ``cgroup_dir``.
+
+    ``cgroup_dir`` is empty for the mount point itself, which is where a
+    container sees its own cgroup when the controller is bind-mounted over it.
+    """
+    if memory_bytes is not None:
+        write_file(
+            root,
+            'sys/fs/cgroup/memory{}/memory.limit_in_bytes'.format(cgroup_dir),
+            '{}\n'.format(memory_bytes),
+        )
+    if quota_us is not None:
+        write_file(
+            root,
+            'sys/fs/cgroup/cpu,cpuacct{}/cpu.cfs_quota_us'.format(cgroup_dir),
+            '{}\n'.format(quota_us),
+        )
+        write_file(
+            root,
+            'sys/fs/cgroup/cpu,cpuacct{}/cpu.cfs_period_us'.format(cgroup_dir),
+            '{}\n'.format(period_us),
+        )
+
+
+def v2_limits(root, cgroup_dir, memory=None, cpu=None, mount='sys/fs/cgroup'):
+    """Write unified interface files for the cgroup at ``cgroup_dir``.
+
+    ``mount`` is ``sys/fs/cgroup/unified`` on a hybrid host, where the unified
+    hierarchy sits beside the legacy controllers rather than replacing them.
+    """
+    if memory is not None:
+        write_file(root, '{}{}/memory.max'.format(mount, cgroup_dir), '{}\n'.format(memory))
+    if cpu is not None:
+        write_file(root, '{}{}/cpu.max'.format(mount, cgroup_dir), '{}\n'.format(cpu))

--- a/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cgroup_fixtures.py
+++ b/src/ros2_medkit_integration_tests/ros2_medkit_test_utils/cgroup_fixtures.py
@@ -54,12 +54,18 @@ def write_file(root, relative, content):
     return path
 
 
-def write_process(root, pid, fqn, cgroup, mountinfo=HOST_MOUNTINFO, markers=()):
+def write_process(
+    root, pid, fqn, cgroup, mountinfo=HOST_MOUNTINFO, markers=(), mount_namespace=None
+):
     """Write a ``/proc/<pid>`` entry the PID cache resolves to ``fqn``.
 
     No process needs to exist at ``pid``: the cache scans ``<root>/proc`` for
     numeric directories and reads ``cmdline`` for ``__ns:=`` and ``__node:=``.
     ``markers`` are paths inside the process's own root, e.g. ``.dockerenv``.
+
+    ``mount_namespace`` is the inode number behind ``/proc/<pid>/ns/mnt``, which
+    is what tells two containers apart once the cgroup namespace has hidden
+    their IDs. Processes given the same number look like one container.
     """
     namespace, _, name = fqn.rpartition('/')
     args = [
@@ -75,6 +81,15 @@ def write_process(root, pid, fqn, cgroup, mountinfo=HOST_MOUNTINFO, markers=()):
     write_file(root, 'proc/{}/mountinfo'.format(pid), mountinfo)
     for marker in markers:
         write_file(root, 'proc/{}/root/{}'.format(pid, marker.lstrip('/')), '')
+
+    if mount_namespace is not None:
+        # The kernel makes this a magic symlink reading "mnt:[<inode>]". Only
+        # the link text is read, so a target that resolves nowhere is fine.
+        link_dir = os.path.join(root, 'proc', str(pid), 'ns')
+        os.makedirs(link_dir, exist_ok=True)
+        link = os.path.join(link_dir, 'mnt')
+        if not os.path.islink(link):
+            os.symlink('mnt:[{}]'.format(mount_namespace), link)
 
 
 def v1_cgroup(path):

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.container
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.container
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy source tree
 WORKDIR ${COLCON_WS}
-COPY cmake/ ${COLCON_WS}/cmake/
+COPY src/ros2_medkit_cmake/ ${COLCON_WS}/src/ros2_medkit_cmake/
 COPY src/ros2_medkit_gateway/ ${COLCON_WS}/src/ros2_medkit_gateway/
 COPY src/ros2_medkit_serialization/ ${COLCON_WS}/src/ros2_medkit_serialization/
 COPY src/ros2_medkit_msgs/ ${COLCON_WS}/src/ros2_medkit_msgs/
@@ -53,13 +53,25 @@ COPY src/ros2_medkit_fault_reporter/ ${COLCON_WS}/src/ros2_medkit_fault_reporter
 COPY src/ros2_medkit_diagnostic_bridge/ ${COLCON_WS}/src/ros2_medkit_diagnostic_bridge/
 COPY src/ros2_medkit_integration_tests/ ${COLCON_WS}/src/ros2_medkit_integration_tests/
 COPY src/ros2_medkit_discovery_plugins/ ${COLCON_WS}/src/ros2_medkit_discovery_plugins/
+COPY src/ros2_medkit_plugins/ros2_medkit_graph_provider/ ${COLCON_WS}/src/ros2_medkit_plugins/ros2_medkit_graph_provider/
+COPY src/ros2_medkit_action_status_bridge/ ${COLCON_WS}/src/ros2_medkit_action_status_bridge/
+COPY src/ros2_medkit_log_bridge/ ${COLCON_WS}/src/ros2_medkit_log_bridge/
 
-# Build everything (skip test targets to speed up the image build)
-RUN bash -c "source /opt/ros/jazzy/setup.bash && \
+# Build everything (skip test targets to speed up the image build).
+# The apt lists are wiped by the layer above, and rosdep shells out to apt, so
+# they have to be refreshed here or every dependency it resolves fails to
+# install. The image builds with BUILD_TESTING=OFF, so test-only dependencies
+# are not resolved at all - one of them is not published as a package.
+# No --symlink-install: the runtime stage copies the install tree out of this
+# one, and symlinks into a build tree that stage does not have resolve nowhere.
+RUN apt-get update && bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y \
+      --dependency-types buildtool --dependency-types build \
+      --dependency-types build_export --dependency-types buildtool_export --dependency-types exec \
       --skip-keys='ament_cmake_clang_format ament_cmake_clang_tidy test_msgs sqlite3' && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    colcon build --cmake-args -DBUILD_TESTING=OFF" \
+    && rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
 # Stage 2: Runtime

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.systemd
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.systemd
@@ -43,7 +43,7 @@ RUN apt-get update && apt-get install -y \
 
 # Copy source tree
 WORKDIR ${COLCON_WS}
-COPY cmake/ ${COLCON_WS}/cmake/
+COPY src/ros2_medkit_cmake/ ${COLCON_WS}/src/ros2_medkit_cmake/
 COPY src/ros2_medkit_gateway/ ${COLCON_WS}/src/ros2_medkit_gateway/
 COPY src/ros2_medkit_serialization/ ${COLCON_WS}/src/ros2_medkit_serialization/
 COPY src/ros2_medkit_msgs/ ${COLCON_WS}/src/ros2_medkit_msgs/
@@ -52,13 +52,25 @@ COPY src/ros2_medkit_fault_reporter/ ${COLCON_WS}/src/ros2_medkit_fault_reporter
 COPY src/ros2_medkit_diagnostic_bridge/ ${COLCON_WS}/src/ros2_medkit_diagnostic_bridge/
 COPY src/ros2_medkit_integration_tests/ ${COLCON_WS}/src/ros2_medkit_integration_tests/
 COPY src/ros2_medkit_discovery_plugins/ ${COLCON_WS}/src/ros2_medkit_discovery_plugins/
+COPY src/ros2_medkit_plugins/ros2_medkit_graph_provider/ ${COLCON_WS}/src/ros2_medkit_plugins/ros2_medkit_graph_provider/
+COPY src/ros2_medkit_action_status_bridge/ ${COLCON_WS}/src/ros2_medkit_action_status_bridge/
+COPY src/ros2_medkit_log_bridge/ ${COLCON_WS}/src/ros2_medkit_log_bridge/
 
-# Build everything (skip test targets to speed up the image build)
-RUN bash -c "source /opt/ros/jazzy/setup.bash && \
+# Build everything (skip test targets to speed up the image build).
+# The apt lists are wiped by the layer above, and rosdep shells out to apt, so
+# they have to be refreshed here or every dependency it resolves fails to
+# install. The image builds with BUILD_TESTING=OFF, so test-only dependencies
+# are not resolved at all - one of them is not published as a package.
+# No --symlink-install: the runtime stage copies the install tree out of this
+# one, and symlinks into a build tree that stage does not have resolve nowhere.
+RUN apt-get update && bash -c "source /opt/ros/jazzy/setup.bash && \
     rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y \
+      --dependency-types buildtool --dependency-types build \
+      --dependency-types build_export --dependency-types buildtool_export --dependency-types exec \
       --skip-keys='ament_cmake_clang_format ament_cmake_clang_tidy test_msgs sqlite3' && \
-    colcon build --symlink-install --cmake-args -DBUILD_TESTING=OFF"
+    colcon build --cmake-args -DBUILD_TESTING=OFF" \
+    && rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
 # Stage 2: Runtime with systemd

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/docker-compose.container.yml
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/docker-compose.container.yml
@@ -15,14 +15,45 @@
 # Docker Compose for container introspection plugin integration tests.
 # Runs gateway + demo nodes inside a resource-limited Docker container.
 # The container plugin detects containerization via cgroup paths.
+#
+# The same image runs under both cgroup namespace modes, because the mode
+# decides where the limit files sit: private mounts the container's own cgroup
+# at /sys/fs/cgroup, host exposes the whole hierarchy and the path reported in
+# /proc/self/cgroup leads into it. Both must report the limits set below.
 
 services:
   gateway-container:
     build:
-      context: ../../../..  # worktree root (ros2_medkit)
+      context: ../../../../..  # worktree root (ros2_medkit)
       dockerfile: src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.container
+    image: ros2-medkit-container-introspection:test
     ports:
       - "9210:8080"
+    cgroup: private
+    environment:
+      # Both services publish demo nodes on the same compose network, so each
+      # needs its own domain or a gateway discovers the other's nodes and
+      # cannot resolve a PID for them.
+      ROS_DOMAIN_ID: "91"
+    mem_limit: 512m
+    cpus: 1.0
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/api/v1/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 20s
+
+  gateway-container-hostns:
+    image: ros2-medkit-container-introspection:test
+    pull_policy: never  # built by gateway-container, never published
+    depends_on:
+      - gateway-container
+    ports:
+      - "9211:8080"
+    cgroup: host
+    environment:
+      ROS_DOMAIN_ID: "92"
     mem_limit: 512m
     cpus: 1.0
     healthcheck:

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/docker-compose.systemd.yml
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/docker-compose.systemd.yml
@@ -23,7 +23,7 @@
 services:
   gateway-systemd:
     build:
-      context: ../../../..  # worktree root (ros2_medkit)
+      context: ../../../../..  # worktree root (ros2_medkit)
       dockerfile: src/ros2_medkit_integration_tests/test/docker/introspection/Dockerfile.systemd
     privileged: true  # Required for systemd as PID 1
     ports:
@@ -33,7 +33,7 @@ services:
       - /run/lock
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns: host
+    cgroup: host
     stop_signal: SIGRTMIN+3  # Proper systemd shutdown signal
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/api/v1/health"]

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/run_docker_tests.sh
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/run_docker_tests.sh
@@ -30,7 +30,8 @@
 #
 # Port allocations (outside colcon test port range 9100+):
 #   - 9200: systemd test gateway
-#   - 9210: container test gateway
+#   - 9210: container test gateway, private cgroup namespace
+#   - 9211: container test gateway, host cgroup namespace
 
 set -euo pipefail
 
@@ -114,19 +115,21 @@ run_container_tests() {
     docker compose -f docker-compose.container.yml build
 
     echo ""
-    echo "--- Starting container ---"
+    echo "--- Starting containers (private and host cgroup namespaces) ---"
     docker compose -f docker-compose.container.yml up -d
 
-    if ! wait_for_healthy docker-compose.container.yml gateway-container 60; then
-        echo "FAIL: container did not start properly"
-        docker compose -f docker-compose.container.yml logs
-        docker compose -f docker-compose.container.yml down
-        return 1
-    fi
+    for service in gateway-container gateway-container-hostns; do
+        if ! wait_for_healthy docker-compose.container.yml "$service" 60; then
+            echo "FAIL: $service did not start properly"
+            docker compose -f docker-compose.container.yml logs
+            docker compose -f docker-compose.container.yml down
+            return 1
+        fi
+    done
 
     echo ""
     echo "--- Running container tests ---"
-    if pytest test_container_introspection.py -v; then
+    if pytest test_container_introspection.py test_container_cgroup_layouts.py -v; then
         echo "PASS: container tests"
     else
         echo "FAIL: container tests"

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/test_container_cgroup_layouts.py
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/test_container_cgroup_layouts.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container limit reporting under both cgroup namespace modes.
+
+The cgroup namespace mode decides where the limit files sit: `private` mounts
+the container's own cgroup at /sys/fs/cgroup and reports a path relative to it,
+`host` exposes the whole hierarchy and the reported path leads into it. The
+limits configured on the container are the same either way, so the values the
+gateway reports have to be the same too.
+
+These tests run OUTSIDE the containers, against the two gateways started by
+docker-compose.container.yml:
+
+    docker compose -f docker-compose.container.yml up -d
+
+Both containers are built from the same image and carry the same limits; only
+the namespace mode differs.
+"""
+
+import os
+import re
+import time
+
+import pytest
+import requests
+
+# Limits set on both services in docker-compose.container.yml.
+MEM_LIMIT_BYTES = 536870912  # mem_limit: 512m
+CPU_LIMIT_RATIO = 1.0  # cpus: 1.0
+
+GATEWAYS = {
+    'private': os.environ.get(
+        'CONTAINER_TEST_PRIVATE_URL', 'http://localhost:9210/api/v1'
+    ),
+    'host': os.environ.get(
+        'CONTAINER_TEST_HOSTNS_URL', 'http://localhost:9211/api/v1'
+    ),
+}
+
+STARTUP_TIMEOUT = 60
+POLL_INTERVAL = 1
+POLL_RETRIES = 20
+
+
+def _wait_for_gateway(base_url):
+    deadline = time.monotonic() + STARTUP_TIMEOUT
+    while time.monotonic() < deadline:
+        try:
+            r = requests.get(f'{base_url}/health', timeout=2)
+            if r.status_code == 200:
+                r2 = requests.get(f'{base_url}/apps', timeout=2)
+                if r2.status_code == 200 and r2.json().get('items'):
+                    return
+        except requests.RequestException:
+            pass
+        time.sleep(1)
+    pytest.fail(f'Gateway at {base_url} not ready after {STARTUP_TIMEOUT}s')
+
+
+def _fetch_container_info(mode, base_url):
+    """Container info from an app of one gateway that the endpoint answers for.
+
+    The gateway node is discovered as an App as well, but its own process is
+    not in the PID cache, so the first entry of /apps is not usable here.
+    """
+    _wait_for_gateway(base_url)
+
+    for _ in range(POLL_RETRIES):
+        apps = (
+            requests.get(f'{base_url}/apps', timeout=5).json().get('items', [])
+        )
+        assert apps, f'No apps discovered on the {mode} gateway'
+        for app in apps:
+            r = requests.get(
+                f"{base_url}/apps/{app['id']}/x-medkit-container", timeout=5
+            )
+            if r.status_code == 200:
+                return r.json()
+        time.sleep(POLL_INTERVAL)
+
+    pytest.fail(f'No app reported container info on the {mode} gateway')
+
+
+@pytest.fixture(params=sorted(GATEWAYS), scope='module')
+def container_info(request):
+    """Container info from one of the two gateways."""
+    mode = request.param
+    return mode, _fetch_container_info(mode, GATEWAYS[mode])
+
+
+class TestCgroupNamespaceModes:
+    """The reported limits must not depend on the cgroup namespace mode."""
+
+    def test_container_is_detected(self, container_info):
+        """The container is recognised under either namespace mode.
+
+        The host namespace exposes the container ID in the cgroup path; the
+        private namespace reports the namespace root instead, so the ID is
+        empty and a runtime marker is what identifies the container.
+
+        @verifies REQ_INTEROP_003
+        """
+        mode, data = container_info
+        if mode == 'host':
+            assert re.match(r'^[0-9a-f]{64}$', data['container_id']), (
+                f'{mode}: expected a 64-char hex container id, got '
+                f"{data['container_id']!r}"
+            )
+        else:
+            assert data['container_id'] == '', (
+                f'{mode}: expected an empty container id, got '
+                f"{data['container_id']!r}"
+            )
+        assert data['runtime'] == 'docker', (
+            f"{mode}: expected runtime 'docker', got {data['runtime']!r}"
+        )
+
+    def test_memory_limit_matches_configured(self, container_info):
+        """The reported memory limit is the one set on the container.
+
+        @verifies REQ_INTEROP_003
+        """
+        mode, data = container_info
+        assert data['memory_limit_state'] == 'limited', (
+            f'{mode}: memory limit reported as '
+            f"{data['memory_limit_state']!r}, expected 'limited' - the "
+            f'container is capped at {MEM_LIMIT_BYTES} bytes'
+        )
+        assert data['memory_limit_bytes'] == MEM_LIMIT_BYTES, (
+            f'{mode}: expected {MEM_LIMIT_BYTES} bytes, got '
+            f"{data['memory_limit_bytes']}"
+        )
+
+    def test_cpu_limit_matches_configured(self, container_info):
+        """The reported CPU quota is the one set on the container.
+
+        @verifies REQ_INTEROP_003
+        """
+        mode, data = container_info
+        assert data['cpu_quota_state'] == 'limited', (
+            f"{mode}: CPU quota reported as {data['cpu_quota_state']!r}, "
+            f"expected 'limited' - the container is capped at "
+            f'{CPU_LIMIT_RATIO} CPU'
+        )
+        ratio = data['cpu_quota_us'] / data['cpu_period_us']
+        assert abs(ratio - CPU_LIMIT_RATIO) < 0.01, (
+            f'{mode}: expected a CPU ratio of {CPU_LIMIT_RATIO}, got {ratio} '
+            f"(quota={data['cpu_quota_us']}, period={data['cpu_period_us']})"
+        )
+
+    def test_limit_states_are_always_reported(self, container_info):
+        """A client can always tell why a limit value is missing.
+
+        @verifies REQ_INTEROP_003
+        """
+        mode, data = container_info
+        valid = {'limited', 'unlimited', 'unreadable', 'unavailable'}
+        for field in ('memory_limit_state', 'cpu_quota_state'):
+            assert field in data, f'{mode}: {field} missing from {data}'
+            assert data[field] in valid, (
+                f'{mode}: {field} is {data[field]!r}, expected one of {valid}'
+            )
+
+    def test_value_present_exactly_when_limited(self, container_info):
+        """A numeric limit is present if and only if the state says so.
+
+        @verifies REQ_INTEROP_003
+        """
+        mode, data = container_info
+        assert ('memory_limit_bytes' in data) == (
+            data['memory_limit_state'] == 'limited'
+        ), f'{mode}: memory value and state disagree: {data}'
+        assert ('cpu_quota_us' in data) == (
+            data['cpu_quota_state'] == 'limited'
+        ), f'{mode}: CPU value and state disagree: {data}'
+
+
+def test_both_namespace_modes_agree():
+    """Both namespace modes report the same limits for the same settings.
+
+    This is the regression the joined-path-only reader could not survive: one
+    mode reported the limits and the other reported none.
+
+    @verifies REQ_INTEROP_003
+    """
+    reported = {}
+    for mode, base_url in GATEWAYS.items():
+        data = _fetch_container_info(mode, base_url)
+        reported[mode] = (
+            data['memory_limit_state'],
+            data.get('memory_limit_bytes'),
+            data['cpu_quota_state'],
+            data.get('cpu_quota_us'),
+            data.get('cpu_period_us'),
+        )
+
+    assert reported['private'] == reported['host'], (
+        f'Namespace modes disagree: private={reported["private"]}, '
+        f'host={reported["host"]}'
+    )

--- a/src/ros2_medkit_integration_tests/test/docker/introspection/test_container_introspection.py
+++ b/src/ros2_medkit_integration_tests/test/docker/introspection/test_container_introspection.py
@@ -69,9 +69,30 @@ def _get_app_ids():
     return [item['id'] for item in items]
 
 
+_container_app_id = None
+
+
 def _get_first_app_id():
-    """Get first discovered app ID."""
-    return _get_app_ids()[0]
+    """Get an app ID the container endpoint can answer for.
+
+    The gateway node is discovered as an App too, but its own process is not in
+    the PID cache, so the first entry of /apps is not usable here. Scan for one
+    that answers, and retry while the PID cache is still filling.
+    """
+    global _container_app_id
+    if _container_app_id is not None:
+        return _container_app_id
+
+    for _ in range(POLL_RETRIES):
+        for app_id in _get_app_ids():
+            r = requests.get(
+                f'{BASE_URL}/apps/{app_id}/x-medkit-container', timeout=5
+            )
+            if r.status_code == 200:
+                _container_app_id = app_id
+                return app_id
+        time.sleep(POLL_INTERVAL)
+    pytest.fail(f'No app reported container info at {BASE_URL}')
 
 
 def _get_first_component_id():
@@ -111,8 +132,13 @@ class TestContainerAppEndpoint:
         assert 'container_id' in data
         assert 'runtime' in data
 
-    def test_container_id_is_64_char_hex(self):
-        """Container ID should be a full 64-character hex SHA-256 hash.
+    def test_container_id_reflects_the_namespace_mode(self):
+        """Container ID is present only when the cgroup namespace exposes it.
+
+        This gateway runs with cgroup: private, where /proc/self/cgroup reports
+        the namespace root and carries no ID, so the field is empty. The
+        64-character form is exercised against the host-namespace gateway in
+        test_container_cgroup_layouts.py.
 
         @verifies REQ_INTEROP_003
         """
@@ -122,11 +148,8 @@ class TestContainerAppEndpoint:
         )
         assert status == 200
         cid = data['container_id']
-        assert len(cid) == 64, (
-            f'Expected 64-char container ID, got {len(cid)}: {cid}'
-        )
-        assert re.match(r'^[0-9a-f]{64}$', cid), (
-            f'Container ID is not valid hex: {cid}'
+        assert cid == '' or re.match(r'^[0-9a-f]{64}$', cid), (
+            f'Container ID is neither empty nor valid 64-char hex: {cid!r}'
         )
 
     def test_runtime_is_docker(self):

--- a/src/ros2_medkit_integration_tests/test/features/test_combined_introspection.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_combined_introspection.test.py
@@ -16,20 +16,34 @@
 """Integration tests for combined procfs + container introspection plugins.
 
 Validates that loading multiple introspection plugins simultaneously works
-correctly. On a non-containerized host, procfs should return 200 while
-container returns 404 - verifying route isolation between plugins.
+correctly: procfs returns 200 while container returns 404, verifying route
+isolation between plugins.
+
+The container plugin reads a synthetic tree describing a process on a plain
+host, so the 404 is a property of the test rather than of the machine. The
+tests themselves often run inside a container, where the gateway's own process
+really is containerized and the endpoint would correctly answer 200.
 """
 
+import atexit
 import os
+import shutil
+import tempfile
 import time
 import unittest
 
 import launch_testing
 import requests
 
+from ros2_medkit_test_utils.cgroup_fixtures import HOST_MOUNTINFO, v2_cgroup, write_process
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+HOST_PROC_ROOT = tempfile.mkdtemp(prefix='medkit_combined_host_')
+atexit.register(shutil.rmtree, HOST_PROC_ROOT, True)
+
+HOST_CGROUP = v2_cgroup('/user.slice/user-1000.slice/session-1.scope')
 
 
 def _get_plugin_path(plugin_so_name):
@@ -46,6 +60,14 @@ def generate_test_description():
     """Launch gateway with both procfs and container plugins."""
     procfs_path = _get_plugin_path('libprocfs_introspection.so')
     container_path = _get_plugin_path('libcontainer_introspection.so')
+
+    # Only the container plugin reads the synthetic tree; procfs keeps the real
+    # root so it still reports this machine's processes.
+    write_process(HOST_PROC_ROOT, 5101, '/powertrain/engine/temp_sensor', HOST_CGROUP,
+                  mountinfo=HOST_MOUNTINFO)
+    write_process(HOST_PROC_ROOT, 5102, '/powertrain/engine/rpm_sensor', HOST_CGROUP,
+                  mountinfo=HOST_MOUNTINFO)
+
     return create_test_launch(
         demo_nodes=['temp_sensor', 'rpm_sensor'],
         fault_manager=False,
@@ -53,6 +75,8 @@ def generate_test_description():
             'plugins': ['procfs', 'container'],
             'plugins.procfs.path': procfs_path,
             'plugins.container.path': container_path,
+            'plugins.container.proc_root': HOST_PROC_ROOT,
+            'plugins.container.pid_cache_ttl_seconds': 1,
         },
     )
 
@@ -142,7 +166,7 @@ class TestCombinedIntrospection(GatewayTestCase):
 
     def test_02_container_returns_404_on_host(self):
         """Container plugin returns 404 'not containerized' on a host system."""
-        app_id = self._get_any_app_id()
+        app_id = 'temp_sensor'
         r = self._poll_container_app(app_id)
 
         self.assertEqual(
@@ -160,7 +184,7 @@ class TestCombinedIntrospection(GatewayTestCase):
         Verify procfs still returns 200 even though container returns 404
         for the same entity - routes are isolated between plugins.
         """
-        app_id = self._get_any_app_id()
+        app_id = 'temp_sensor'
 
         # Container should be 404 (not containerized)
         container_resp = self._poll_container_app(app_id)

--- a/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
@@ -55,10 +55,15 @@ MEMORY_BYTES = 536870912
 QUOTA_US = 50000
 PERIOD_US = 100000
 
-# The cgroup the process is actually in, per v1 case.
+# The cgroup the process is actually in, per v1 case. The CPU quota differs too:
+# with one shared quota, a reader taking the wrong directory still returned the
+# expected number and every CPU assertion passed.
 V1_JOINED_BYTES = 536870912
+V1_JOINED_QUOTA = 50000
 V1_BARE_BYTES = 268435456
+V1_BARE_QUOTA = 25000
 V1_SECOND_BYTES = 111111168
+V1_SECOND_QUOTA = 12500
 
 # Further containers, so grouping has more than one entry to keep apart.
 OTHER_ID = 'ccdd445566778899' * 4
@@ -84,7 +89,7 @@ def _build_tree(root):
     # cgroup v1, gateway on the host: the reported path leads into the
     # hierarchy, so the limits sit under the mount point joined with it.
     write_process(root, 4101, '/powertrain/engine/temp_sensor', v1_cgroup(docker_path))
-    v1_limits(root, docker_path, memory_bytes=V1_JOINED_BYTES, quota_us=QUOTA_US,
+    v1_limits(root, docker_path, memory_bytes=V1_JOINED_BYTES, quota_us=V1_JOINED_QUOTA,
               period_us=PERIOD_US)
 
     # cgroup v1 seen from inside the container: Docker bind-mounts the
@@ -95,13 +100,14 @@ def _build_tree(root):
     inside_path = '/docker/' + INSIDE_ID
     write_process(root, 4102, '/powertrain/engine/rpm_sensor', v1_cgroup(inside_path),
                   mountinfo=OVERLAY_MOUNTINFO, markers=['.dockerenv'])
-    v1_limits(root, '', memory_bytes=V1_BARE_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+    v1_limits(root, '', memory_bytes=V1_BARE_BYTES, quota_us=V1_BARE_QUOTA,
+              period_us=PERIOD_US)
 
     # cgroup v1, second container, with its own number so the first container's
     # value cannot stand in for it.
     other_path = '/docker/' + OTHER_ID
     write_process(root, 4103, '/chassis/brakes/pressure_sensor', v1_cgroup(other_path))
-    v1_limits(root, other_path, memory_bytes=V1_SECOND_BYTES, quota_us=QUOTA_US,
+    v1_limits(root, other_path, memory_bytes=V1_SECOND_BYTES, quota_us=V1_SECOND_QUOTA,
               period_us=PERIOD_US)
 
     # Hybrid: the unified line is the bare root, so the container is named only
@@ -204,11 +210,11 @@ class TestContainerCgroupLayouts(GatewayTestCase):
             '/apps/{}/x-medkit-container'.format(app_id), _ready
         )
 
-    def _assert_limited(self, data, app_id, memory_bytes=MEMORY_BYTES):
+    def _assert_limited(self, data, app_id, memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US):
         self.assertEqual(data['memory_limit_state'], 'limited', app_id)
         self.assertEqual(data['memory_limit_bytes'], memory_bytes, app_id)
         self.assertEqual(data['cpu_quota_state'], 'limited', app_id)
-        self.assertEqual(data['cpu_quota_us'], QUOTA_US, app_id)
+        self.assertEqual(data['cpu_quota_us'], quota_us, app_id)
         self.assertEqual(data['cpu_period_us'], PERIOD_US, app_id)
 
     def test_01_v1_host_namespace_joined_path(self):
@@ -216,13 +222,13 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         data = self._container('temp_sensor')
         self.assertEqual(data['container_id'], DOCKER_ID)
         self.assertEqual(data['runtime'], 'docker')
-        self._assert_limited(data, 'temp_sensor', V1_JOINED_BYTES)
+        self._assert_limited(data, 'temp_sensor', V1_JOINED_BYTES, V1_JOINED_QUOTA)
 
     def test_02_v1_inside_container_bare_mount(self):
         """Legacy hierarchy where the reported path resolves nowhere inside the container."""
         data = self._container('rpm_sensor')
         self.assertEqual(data['container_id'], INSIDE_ID)
-        self._assert_limited(data, 'rpm_sensor', V1_BARE_BYTES)
+        self._assert_limited(data, 'rpm_sensor', V1_BARE_BYTES, V1_BARE_QUOTA)
 
     def test_03_v1_second_container_reports_its_own_limit(self):
         """A second container reports its own number, not the first one's.
@@ -233,13 +239,13 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         """
         data = self._container('pressure_sensor')
         self.assertEqual(data['container_id'], OTHER_ID)
-        self._assert_limited(data, 'pressure_sensor', V1_SECOND_BYTES)
+        self._assert_limited(data, 'pressure_sensor', V1_SECOND_BYTES, V1_SECOND_QUOTA)
 
     def test_04_hybrid_layout_reads_the_legacy_hierarchy(self):
         """With the unified line at the root, the container is named by cgroup v1."""
         data = self._container('status_sensor')
         self.assertEqual(data['container_id'], DOCKER_ID)
-        self._assert_limited(data, 'status_sensor', V1_JOINED_BYTES)
+        self._assert_limited(data, 'status_sensor', V1_JOINED_BYTES, V1_JOINED_QUOTA)
 
     def test_05_no_limit_configured_reports_unlimited(self):
         """An unconstrained container is 'unlimited', and carries no number."""

--- a/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
@@ -59,6 +59,13 @@ OTHER_ID = 'ccdd445566778899' * 4
 THIRD_ID = 'eeff001122334455' * 4
 FOURTH_ID = '0011223344556677' * 4
 
+# Two containers whose cgroup namespace hides their id. Nothing in the cgroup
+# path tells them apart, so only the mount namespace can.
+HIDDEN_NS_A = 4026531001
+HIDDEN_NS_B = 4026531002
+HIDDEN_A_BYTES = 111111168
+HIDDEN_B_BYTES = 222222336
+
 PROC_ROOT = tempfile.mkdtemp(prefix='medkit_cgroup_layouts_')
 atexit.register(shutil.rmtree, PROC_ROOT, True)
 
@@ -105,6 +112,23 @@ def _build_tree(root):
                   v2_cgroup('/user.slice/user-1000.slice/session-1.scope'),
                   mountinfo=HOST_MOUNTINFO)
 
+    # Two apps in one container whose id the cgroup namespace hides. They share
+    # a mount namespace, so they are one container.
+    for pid, fqn in ((4108, '/powertrain/engine/temp_monitor'),
+                     (4109, '/powertrain/engine/long_calibration')):
+        write_process(root, pid, fqn, v2_cgroup('/hidden-a'), mountinfo=OVERLAY_MOUNTINFO,
+                      markers=['.dockerenv'], mount_namespace=HIDDEN_NS_A)
+    v2_limits(root, '/hidden-a', memory=HIDDEN_A_BYTES,
+              cpu='{} {}'.format(QUOTA_US, PERIOD_US))
+
+    # A different container, also with its id hidden. Nothing but the mount
+    # namespace separates it from the pair above.
+    write_process(root, 4110, '/testrig/dual/dual_calibration', v2_cgroup('/hidden-b'),
+                  mountinfo=OVERLAY_MOUNTINFO, markers=['.dockerenv'],
+                  mount_namespace=HIDDEN_NS_B)
+    v2_limits(root, '/hidden-b', memory=HIDDEN_B_BYTES,
+              cpu='{} {}'.format(QUOTA_US, PERIOD_US))
+
 
 def _get_plugin_path(plugin_so_name):
     from ament_index_python.packages import get_package_prefix
@@ -124,6 +148,9 @@ def generate_test_description():
             'actuator',
             'calibration',
             'controller',
+            'temp_monitor',
+            'long_calibration',
+            'dual_calibration',
         ],
         fault_manager=False,
         gateway_params={
@@ -141,7 +168,7 @@ class TestContainerCgroupLayouts(GatewayTestCase):
     @verifies REQ_INTEROP_003
     """
 
-    MIN_EXPECTED_APPS = 7
+    MIN_EXPECTED_APPS = 10
     REQUIRED_APPS = {
         'temp_sensor',
         'rpm_sensor',
@@ -150,6 +177,9 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         'actuator',
         'calibration',
         'controller',
+        'temp_monitor',
+        'long_calibration',
+        'dual_calibration',
     }
 
     def _container(self, app_id):
@@ -235,12 +265,12 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         self.assertTrue(components, 'no components discovered')
 
         def _ready(data):
-            return data if len(data.get('containers', [])) >= 2 else None
+            return data if len(data.get('containers', [])) >= 6 else None
 
         data = self.poll_endpoint_until(
             '/components/{}/x-medkit-container'.format(components[0]['id']), _ready
         )
-        by_id = {c['container_id']: c for c in data['containers']}
+        by_id = {c['container_id']: c for c in data['containers'] if c['container_id']}
 
         self.assertIn(DOCKER_ID, by_id)
         self.assertIn(OTHER_ID, by_id)
@@ -256,6 +286,41 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         # controller is on the host and must not appear at all.
         for entry in data['containers']:
             self.assertNotIn('controller', entry['node_ids'])
+
+    def test_09_hidden_ids_group_by_mount_namespace(self):
+        """Containers whose id the namespace hides are still told apart.
+
+        An empty container id is not an identity. Two apps sharing a mount
+        namespace are one container; an app in another namespace is not, and
+        merging them would report one set of limits for both.
+
+        @verifies REQ_INTEROP_003
+        """
+        components = requests.get(
+            '{}/components'.format(self.BASE_URL), timeout=5
+        ).json().get('items', [])
+        self.assertTrue(components, 'no components discovered')
+
+        def _ready(data):
+            hidden = [c for c in data.get('containers', []) if not c['container_id']]
+            return data if len(hidden) >= 2 else None
+
+        data = self.poll_endpoint_until(
+            '/components/{}/x-medkit-container'.format(components[0]['id']), _ready
+        )
+        hidden = [c for c in data['containers'] if not c['container_id']]
+
+        self.assertEqual(
+            len(hidden), 2, 'expected two hidden-id containers, got {}'.format(hidden)
+        )
+        by_nodes = {frozenset(c['node_ids']): c for c in hidden}
+        pair = frozenset({'temp_monitor', 'long_calibration'})
+        alone = frozenset({'dual_calibration'})
+
+        self.assertIn(pair, by_nodes, 'apps sharing a mount namespace were split')
+        self.assertIn(alone, by_nodes, 'apps in different mount namespaces were merged')
+        self.assertEqual(by_nodes[pair]['memory_limit_bytes'], HIDDEN_A_BYTES)
+        self.assertEqual(by_nodes[alone]['memory_limit_bytes'], HIDDEN_B_BYTES)
 
 
 @launch_testing.post_shutdown_test()

--- a/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Container introspection over every supported cgroup layout.
+
+The gateway runs for real and answers real HTTP requests. Only the contents of
+``/proc`` and ``/sys`` are synthetic, supplied through the plugin's ``proc_root``
+setting. That is the only way to reach cgroup v1 and the hybrid layout at all:
+a unified-only kernel has no v1 controllers to mount, and every supported
+distribution boots unified.
+
+Each demo node is mapped to a different layout, so one gateway covers them all.
+"""
+
+import atexit
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+import launch_testing
+import requests
+
+from ros2_medkit_test_utils.cgroup_fixtures import (
+    DOCKER_ID,
+    HOST_MOUNTINFO,
+    hybrid_cgroup,
+    OVERLAY_MOUNTINFO,
+    v1_cgroup,
+    v1_limits,
+    v2_cgroup,
+    v2_limits,
+    write_process,
+)
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+# 512 MiB and half a CPU, the numbers every layout below is set to report.
+MEMORY_BYTES = 536870912
+QUOTA_US = 50000
+PERIOD_US = 100000
+
+# Further containers, so grouping has more than one entry to keep apart.
+OTHER_ID = 'ccdd445566778899' * 4
+THIRD_ID = 'eeff001122334455' * 4
+FOURTH_ID = '0011223344556677' * 4
+
+PROC_ROOT = tempfile.mkdtemp(prefix='medkit_cgroup_layouts_')
+atexit.register(shutil.rmtree, PROC_ROOT, True)
+
+
+def _build_tree(root):
+    """One synthetic tree holding a different cgroup layout per demo node."""
+    docker_path = '/docker/' + DOCKER_ID
+
+    # cgroup v1, gateway on the host: the reported path leads into the
+    # hierarchy, so the limits sit under the mount point joined with it.
+    write_process(root, 4101, '/powertrain/engine/temp_sensor', v1_cgroup(docker_path))
+    v1_limits(root, docker_path, memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+
+    # cgroup v1, same container, seen from inside it: Docker bind-mounts the
+    # container's own cgroup over /sys/fs/cgroup/<controller>, so the reported
+    # path resolves nowhere and the files are at the mount point itself.
+    write_process(root, 4102, '/powertrain/engine/rpm_sensor', v1_cgroup(docker_path),
+                  mountinfo=OVERLAY_MOUNTINFO, markers=['.dockerenv'])
+    v1_limits(root, '', memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+
+    # cgroup v1, second container. Its hierarchy root reads as unlimited, which
+    # must not mask the limit set on the container's own cgroup below it.
+    other_path = '/docker/' + OTHER_ID
+    write_process(root, 4103, '/chassis/brakes/pressure_sensor', v1_cgroup(other_path))
+    v1_limits(root, other_path, memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+
+    # Hybrid: the unified line is the bare root, so the container is named only
+    # on the legacy hierarchies and the limits come from there.
+    write_process(root, 4104, '/body/door/front_left/status_sensor',
+                  hybrid_cgroup('/', docker_path))
+
+    # cgroup v2 with no limits configured: unlimited, not missing.
+    scope = '/system.slice/docker-' + THIRD_ID + '.scope'
+    write_process(root, 4105, '/chassis/brakes/actuator', v2_cgroup(scope))
+    v2_limits(root, scope, memory='max', cpu='max {}'.format(PERIOD_US))
+
+    # cgroup v2 whose limit file cannot be parsed: unreadable, not unlimited.
+    calib_scope = '/system.slice/docker-' + FOURTH_ID + '.scope'
+    write_process(root, 4106, '/powertrain/engine/calibration', v2_cgroup(calib_scope))
+    v2_limits(root, calib_scope, memory='not-a-number', cpu='{} {}'.format(QUOTA_US, PERIOD_US))
+
+    # A process on a plain host: no container id, no marker, no overlay root.
+    write_process(root, 4107, '/body/lights/controller',
+                  v2_cgroup('/user.slice/user-1000.slice/session-1.scope'),
+                  mountinfo=HOST_MOUNTINFO)
+
+
+def _get_plugin_path(plugin_so_name):
+    from ament_index_python.packages import get_package_prefix
+
+    pkg_prefix = get_package_prefix('ros2_medkit_linux_introspection')
+    return os.path.join(pkg_prefix, 'lib', 'ros2_medkit_linux_introspection', plugin_so_name)
+
+
+def generate_test_description():
+    _build_tree(PROC_ROOT)
+    return create_test_launch(
+        demo_nodes=[
+            'temp_sensor',
+            'rpm_sensor',
+            'pressure_sensor',
+            'status_sensor',
+            'actuator',
+            'calibration',
+            'controller',
+        ],
+        fault_manager=False,
+        gateway_params={
+            'plugins': ['container'],
+            'plugins.container.path': _get_plugin_path('libcontainer_introspection.so'),
+            'plugins.container.proc_root': PROC_ROOT,
+            'plugins.container.pid_cache_ttl_seconds': 1,
+        },
+    )
+
+
+class TestContainerCgroupLayouts(GatewayTestCase):
+    """Every cgroup layout the reader supports, over the real HTTP endpoint.
+
+    @verifies REQ_INTEROP_003
+    """
+
+    MIN_EXPECTED_APPS = 7
+    REQUIRED_APPS = {
+        'temp_sensor',
+        'rpm_sensor',
+        'pressure_sensor',
+        'status_sensor',
+        'actuator',
+        'calibration',
+        'controller',
+    }
+
+    def _container(self, app_id):
+        """Poll the container endpoint until it answers, then return the body."""
+
+        def _ready(data):
+            return data if 'memory_limit_state' in data else None
+
+        return self.poll_endpoint_until(
+            '/apps/{}/x-medkit-container'.format(app_id), _ready
+        )
+
+    def _assert_limited(self, data, app_id):
+        self.assertEqual(data['memory_limit_state'], 'limited', app_id)
+        self.assertEqual(data['memory_limit_bytes'], MEMORY_BYTES, app_id)
+        self.assertEqual(data['cpu_quota_state'], 'limited', app_id)
+        self.assertEqual(data['cpu_quota_us'], QUOTA_US, app_id)
+        self.assertEqual(data['cpu_period_us'], PERIOD_US, app_id)
+
+    def test_01_v1_host_namespace_joined_path(self):
+        """Legacy hierarchy with the limits under the mount point plus the reported path."""
+        data = self._container('temp_sensor')
+        self.assertEqual(data['container_id'], DOCKER_ID)
+        self.assertEqual(data['runtime'], 'docker')
+        self._assert_limited(data, 'temp_sensor')
+
+    def test_02_v1_inside_container_bare_mount(self):
+        """Legacy hierarchy where the reported path resolves nowhere inside the container."""
+        data = self._container('rpm_sensor')
+        self.assertEqual(data['container_id'], DOCKER_ID)
+        self._assert_limited(data, 'rpm_sensor')
+
+    def test_03_v1_hierarchy_root_does_not_mask_the_limit(self):
+        """The always-unlimited v1 root must not win over the container's own cgroup."""
+        data = self._container('pressure_sensor')
+        self.assertEqual(data['container_id'], OTHER_ID)
+        self._assert_limited(data, 'pressure_sensor')
+
+    def test_04_hybrid_layout_reads_the_legacy_hierarchy(self):
+        """With the unified line at the root, the container is named by cgroup v1."""
+        data = self._container('status_sensor')
+        self.assertEqual(data['container_id'], DOCKER_ID)
+        self._assert_limited(data, 'status_sensor')
+
+    def test_05_no_limit_configured_reports_unlimited(self):
+        """An unconstrained container is 'unlimited', and carries no number."""
+        data = self._container('actuator')
+        self.assertEqual(data['memory_limit_state'], 'unlimited')
+        self.assertNotIn('memory_limit_bytes', data)
+        self.assertEqual(data['cpu_quota_state'], 'unlimited')
+        self.assertNotIn('cpu_quota_us', data)
+        # The period is still a fact about the cgroup with no quota on it.
+        self.assertEqual(data['cpu_period_us'], PERIOD_US)
+
+    def test_06_unparsable_limit_reports_unreadable(self):
+        """A limit file that cannot be parsed is not the same as no limit."""
+        data = self._container('calibration')
+        self.assertEqual(data['memory_limit_state'], 'unreadable')
+        self.assertNotIn('memory_limit_bytes', data)
+        # The CPU leg of the same container is fine, so it still reports.
+        self.assertEqual(data['cpu_quota_state'], 'limited')
+        self.assertEqual(data['cpu_quota_us'], QUOTA_US)
+
+    def test_07_host_process_is_not_containerized(self):
+        """A process on a plain host gets 404, not a report of the root cgroup."""
+        deadline = time.monotonic() + 20.0
+        body = {}
+        while time.monotonic() < deadline:
+            r = requests.get(
+                '{}/apps/controller/x-medkit-container'.format(self.BASE_URL), timeout=5
+            )
+            body = r.json()
+            if r.status_code == 404 and body.get('vendor_code') == 'x-medkit-not-containerized':
+                return
+            time.sleep(0.5)
+        self.fail('controller never settled on not-containerized, last body: {}'.format(body))
+
+    def test_08_component_groups_by_container(self):
+        """Apps in one container share an entry; different containers do not merge."""
+        components = requests.get(
+            '{}/components'.format(self.BASE_URL), timeout=5
+        ).json().get('items', [])
+        self.assertTrue(components, 'no components discovered')
+
+        def _ready(data):
+            return data if len(data.get('containers', [])) >= 2 else None
+
+        data = self.poll_endpoint_until(
+            '/components/{}/x-medkit-container'.format(components[0]['id']), _ready
+        )
+        by_id = {c['container_id']: c for c in data['containers']}
+
+        self.assertIn(DOCKER_ID, by_id)
+        self.assertIn(OTHER_ID, by_id)
+        # temp_sensor, rpm_sensor and status_sensor all report the same
+        # container, so they belong to one entry rather than three.
+        self.assertEqual(
+            set(by_id[DOCKER_ID]['node_ids']),
+            {'temp_sensor', 'rpm_sensor', 'status_sensor'},
+        )
+        self.assertEqual(by_id[DOCKER_ID]['memory_limit_bytes'], MEMORY_BYTES)
+        # A different container keeps its own entry and its own limits.
+        self.assertEqual(set(by_id[OTHER_ID]['node_ids']), {'pressure_sensor'})
+        # controller is on the host and must not appear at all.
+        for entry in data['containers']:
+            self.assertNotIn('controller', entry['node_ids'])
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+    """Check the gateway and demo nodes exited cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_container_cgroup_layouts.test.py
@@ -49,13 +49,20 @@ from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import create_test_launch
 
-# 512 MiB and half a CPU, the numbers every layout below is set to report.
+# Every candidate location gets its own number. Sharing one value would let the
+# reader pick the wrong directory and still produce the expected answer.
 MEMORY_BYTES = 536870912
 QUOTA_US = 50000
 PERIOD_US = 100000
 
+# The cgroup the process is actually in, per v1 case.
+V1_JOINED_BYTES = 536870912
+V1_BARE_BYTES = 268435456
+V1_SECOND_BYTES = 111111168
+
 # Further containers, so grouping has more than one entry to keep apart.
 OTHER_ID = 'ccdd445566778899' * 4
+INSIDE_ID = 'bbcc556677889900' * 4
 THIRD_ID = 'eeff001122334455' * 4
 FOURTH_ID = '0011223344556677' * 4
 
@@ -77,20 +84,25 @@ def _build_tree(root):
     # cgroup v1, gateway on the host: the reported path leads into the
     # hierarchy, so the limits sit under the mount point joined with it.
     write_process(root, 4101, '/powertrain/engine/temp_sensor', v1_cgroup(docker_path))
-    v1_limits(root, docker_path, memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+    v1_limits(root, docker_path, memory_bytes=V1_JOINED_BYTES, quota_us=QUOTA_US,
+              period_us=PERIOD_US)
 
-    # cgroup v1, same container, seen from inside it: Docker bind-mounts the
+    # cgroup v1 seen from inside the container: Docker bind-mounts the
     # container's own cgroup over /sys/fs/cgroup/<controller>, so the reported
-    # path resolves nowhere and the files are at the mount point itself.
-    write_process(root, 4102, '/powertrain/engine/rpm_sensor', v1_cgroup(docker_path),
+    # path resolves nowhere and the files sit at the mount point itself. Its
+    # number differs from every joined path, so reading the wrong candidate
+    # produces the wrong value rather than the expected one.
+    inside_path = '/docker/' + INSIDE_ID
+    write_process(root, 4102, '/powertrain/engine/rpm_sensor', v1_cgroup(inside_path),
                   mountinfo=OVERLAY_MOUNTINFO, markers=['.dockerenv'])
-    v1_limits(root, '', memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+    v1_limits(root, '', memory_bytes=V1_BARE_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
 
-    # cgroup v1, second container. Its hierarchy root reads as unlimited, which
-    # must not mask the limit set on the container's own cgroup below it.
+    # cgroup v1, second container, with its own number so the first container's
+    # value cannot stand in for it.
     other_path = '/docker/' + OTHER_ID
     write_process(root, 4103, '/chassis/brakes/pressure_sensor', v1_cgroup(other_path))
-    v1_limits(root, other_path, memory_bytes=MEMORY_BYTES, quota_us=QUOTA_US, period_us=PERIOD_US)
+    v1_limits(root, other_path, memory_bytes=V1_SECOND_BYTES, quota_us=QUOTA_US,
+              period_us=PERIOD_US)
 
     # Hybrid: the unified line is the bare root, so the container is named only
     # on the legacy hierarchies and the limits come from there.
@@ -192,9 +204,9 @@ class TestContainerCgroupLayouts(GatewayTestCase):
             '/apps/{}/x-medkit-container'.format(app_id), _ready
         )
 
-    def _assert_limited(self, data, app_id):
+    def _assert_limited(self, data, app_id, memory_bytes=MEMORY_BYTES):
         self.assertEqual(data['memory_limit_state'], 'limited', app_id)
-        self.assertEqual(data['memory_limit_bytes'], MEMORY_BYTES, app_id)
+        self.assertEqual(data['memory_limit_bytes'], memory_bytes, app_id)
         self.assertEqual(data['cpu_quota_state'], 'limited', app_id)
         self.assertEqual(data['cpu_quota_us'], QUOTA_US, app_id)
         self.assertEqual(data['cpu_period_us'], PERIOD_US, app_id)
@@ -204,25 +216,30 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         data = self._container('temp_sensor')
         self.assertEqual(data['container_id'], DOCKER_ID)
         self.assertEqual(data['runtime'], 'docker')
-        self._assert_limited(data, 'temp_sensor')
+        self._assert_limited(data, 'temp_sensor', V1_JOINED_BYTES)
 
     def test_02_v1_inside_container_bare_mount(self):
         """Legacy hierarchy where the reported path resolves nowhere inside the container."""
         data = self._container('rpm_sensor')
-        self.assertEqual(data['container_id'], DOCKER_ID)
-        self._assert_limited(data, 'rpm_sensor')
+        self.assertEqual(data['container_id'], INSIDE_ID)
+        self._assert_limited(data, 'rpm_sensor', V1_BARE_BYTES)
 
-    def test_03_v1_hierarchy_root_does_not_mask_the_limit(self):
-        """The always-unlimited v1 root must not win over the container's own cgroup."""
+    def test_03_v1_second_container_reports_its_own_limit(self):
+        """A second container reports its own number, not the first one's.
+
+        The always-unlimited hierarchy root is covered by the reader's own test
+        V1RootFilesDoNotMaskContainerLimit, which needs a tree where the root is
+        the sentinel; here the root is one container's cgroup.
+        """
         data = self._container('pressure_sensor')
         self.assertEqual(data['container_id'], OTHER_ID)
-        self._assert_limited(data, 'pressure_sensor')
+        self._assert_limited(data, 'pressure_sensor', V1_SECOND_BYTES)
 
     def test_04_hybrid_layout_reads_the_legacy_hierarchy(self):
         """With the unified line at the root, the container is named by cgroup v1."""
         data = self._container('status_sensor')
         self.assertEqual(data['container_id'], DOCKER_ID)
-        self._assert_limited(data, 'status_sensor')
+        self._assert_limited(data, 'status_sensor', V1_JOINED_BYTES)
 
     def test_05_no_limit_configured_reports_unlimited(self):
         """An unconstrained container is 'unlimited', and carries no number."""
@@ -270,17 +287,25 @@ class TestContainerCgroupLayouts(GatewayTestCase):
         data = self.poll_endpoint_until(
             '/components/{}/x-medkit-container'.format(components[0]['id']), _ready
         )
-        by_id = {c['container_id']: c for c in data['containers'] if c['container_id']}
+        identified = [c for c in data['containers'] if c['container_id']]
+        ids = [c['container_id'] for c in identified]
+        self.assertEqual(
+            len(ids), len(set(ids)), 'duplicate container entries: {}'.format(ids)
+        )
+        by_id = {c['container_id']: c for c in identified}
 
         self.assertIn(DOCKER_ID, by_id)
         self.assertIn(OTHER_ID, by_id)
-        # temp_sensor, rpm_sensor and status_sensor all report the same
-        # container, so they belong to one entry rather than three.
+        # temp_sensor and status_sensor report the same container, so they
+        # belong to one entry rather than two. rpm_sensor is a different
+        # container and keeps its own.
         self.assertEqual(
-            set(by_id[DOCKER_ID]['node_ids']),
-            {'temp_sensor', 'rpm_sensor', 'status_sensor'},
+            set(by_id[DOCKER_ID]['node_ids']), {'temp_sensor', 'status_sensor'}
         )
-        self.assertEqual(by_id[DOCKER_ID]['memory_limit_bytes'], MEMORY_BYTES)
+        self.assertIn(INSIDE_ID, by_id)
+        self.assertEqual(set(by_id[INSIDE_ID]['node_ids']), {'rpm_sensor'})
+        self.assertEqual(by_id[INSIDE_ID]['memory_limit_bytes'], V1_BARE_BYTES)
+        self.assertEqual(by_id[DOCKER_ID]['memory_limit_bytes'], V1_JOINED_BYTES)
         # A different container keeps its own entry and its own limits.
         self.assertEqual(set(by_id[OTHER_ID]['node_ids']), {'pressure_sensor'})
         # controller is on the host and must not appear at all.


### PR DESCRIPTION
## Summary

`cgroup_reader` reported container limits for only one of the three common cgroup
layouts. This makes it work on the unified hierarchy (v2), the legacy one (v1) and
hybrid hosts, under both `--cgroupns=host` and `--cgroupns=private`, and stops a failed
read from looking like a container with no limits.

**cgroup v1 is parsed.** `read_cgroup_path()` matched only `0::<path>`, so on a v1 host
no line matched and the read gave up. The `<id>:<controllers>:<path>` form is parsed now,
with `memory.limit_in_bytes` and `cpu.cfs_quota_us` / `cpu.cfs_period_us` for the legacy
controllers. Hosts that mount both hierarchies work too.

**Both namespace layouts are searched.** The path was built only as mount point plus
reported path. That is right for `cgroupns=host`. Under `cgroupns=private` the process's
own cgroup is the mount point itself, and the reported path leads nowhere. Both places
are tried now. The more specific one is preferred, and a location that reports no limit
does not stop the search. This matters on v1: the root of a v1 hierarchy always reads as
unlimited, so it would otherwise hide the limit set on the container's own cgroup.

**"No limit" and "could not read" are now different answers.** Each limit carries a state
next to its value: `limited`, `unlimited`, `unreadable` or `unavailable`. On the wire
these are `memory_limit_state` and `cpu_quota_state`, always present.

**A container is recognised when the namespace hides its ID.** Under `cgroupns=private`
the cgroup path is the namespace root and has no container ID, so the endpoint answered
404 even though the limits were readable. Detection now falls back to the markers a
runtime leaves behind, read through the inspected process's own root
(`/proc/<pid>/root`): `/.dockerenv`, `/run/.containerenv`, `/run/systemd/container`, or an
overlay root filesystem together with a cgroup path of `/`. Reading them through the
process's own root matters, otherwise a gateway that is itself in a container would report
every process it can see as containerized. An overlay root alone is not enough either,
because some distributions boot that way.

`cpu_quota_us` is the CFS bandwidth limit. It does not cover `--cpuset-cpus`, which only
`sched_getaffinity()` can see. That is written down at the field and in the docs, not
implemented.

### Behaviour changes for existing clients

- On a cgroup v1 host the app endpoint went from 503 to 200 with data.
- Under `cgroupns=private`, and on hybrid hosts, it went from 404 to 200. `container_id`
  is empty in that case, because there is no ID to report.
- Every 200 response has two more fields, `memory_limit_state` and `cpu_quota_state`.
- The component endpoint used to group by `container_id` alone. An empty ID is not an
  identity, so two apps in different containers were merged into one entry and one set of
  limits was dropped. Grouping now falls back to the process's mount namespace.

### Known limits of the detection

A runtime that leaves none of those markers and does not use an overlay root, for example
containerd or CRI-O on a btrfs or ZFS snapshotter, is not detected under a private cgroup
namespace. Its apps are reported as non-containerized. This is in the docs.

## Issue

- closes #604

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

## Testing

**New integration test, registered with ctest so CI runs it.**
`test/features/test_container_cgroup_layouts.test.py` starts a real gateway, loads the
real plugin and asserts over the real HTTP endpoint. The plugin's `proc_root` points at a
synthetic tree, so one gateway covers seven layouts, one per demo node:

| layout | asserted |
|---|---|
| v1, host namespace, joined path | 200, 64-hex ID, 536870912 bytes, 50000 us |
| v1, seen from inside the container, bare mount point | 200, its own ID, 268435456 bytes, 25000 us |
| v1, a second container | 200, its own ID, 111111168 bytes, 12500 us |
| hybrid, unified line at the root | 200, ID and limits from the legacy hierarchy |
| v2, no limits configured | 200, both states `unlimited`, no numbers, period still present |
| v2, limit file holds garbage | 200, `memory_limit_state` is `unreadable`, no number |
| plain host process | 404 `x-medkit-not-containerized` |

Every candidate directory holds a different memory value and a different CPU quota, so a
reader that picks the wrong one returns a wrong number rather than the expected one.
Putting the candidate order back the way it was fails four of these cases.

Plus the component endpoint: apps sharing a container are one entry, other containers stay
separate entries, containers whose ID the cgroup namespace hides are told apart by mount
namespace, duplicate entries for one ID fail, and the host process appears in none of
them.

This is the only way to reach v1 and hybrid at all. A unified-only kernel has no v1
controllers to mount, and every supported distribution boots unified. I checked on this
machine: `/proc/cgroups` puts every controller on hierarchy 0, and mounting the v1 memory
controller fails with `wrong fs type` even in a privileged container.

**Live run on real containers, cgroup v2, both namespace modes.** The container compose
file now starts the same image twice, once with `cgroup: private` and once with
`cgroup: host`, both with `mem_limit: 512m` and `cpus: 1.0`:

| mode | `/proc/self/cgroup` | memory | cpu quota/period | container_id |
|---|---|---|---|---|
| private | `0::/` | 536870912 | 100000 / 100000 | empty |
| host | `0::/docker/c46f96b3...` | 536870912 | 100000 / 100000 | `c46f96b3...` |

536870912 bytes is exactly the configured 512 MiB and 100000/100000 us is exactly 1.0 CPU,
under both modes. `pytest test_container_introspection.py test_container_cgroup_layouts.py`
gives 22 passed. Note this Docker harness is not run by any workflow, so these numbers come
from a manual run, unlike the ctest test above.

**Unit tests:** `colcon test --packages-select ros2_medkit_linux_introspection` gives 103
tests, 0 failures. They cover the layouts above plus malformed contents: empty file,
`cpu.max` without a period or with a token after it, zero period, a value past the type
range, a negative byte count, trailing garbage, both sides of the v1 unlimited sentinel,
a first line that never ends, a file with no trailing newline, a first line longer than
one read, an open failure that is not a missing file, and a limit path that is a FIFO.

Rather than spot-checking, every behaviour of the reader was deleted in turn to see which
tests notice. 16 of the 17 are held by at least one test. The one that is not is the
retry of an interrupted read: forcing that needs a signal delivered mid-read, and a test
that races for it would be worse than none. It is listed here instead.

What that measures is whether the tests can fail, not whether the synthetic trees match a
real v1 host. Nothing here establishes the second.

**Full integration suite** for `ros2_medkit_integration_tests` runs clean.
`test_combined_introspection` asserted a 404 that only held because container detection
was broken under a private namespace. CI jobs run inside containers, where the gateway
really is containerized, so that test now points the container plugin at a synthetic host
tree and no longer depends on where it runs.

Zero build warnings under `-Wall -Wextra -Wpedantic -Wshadow -Wconversion`, and
`run-clang-tidy` is clean on every changed source.

### Not covered by a real system

The v1 and hybrid layouts, the Podman, nspawn and overlay markers, mount points read from
mountinfo, and every state other than `limited` are covered against a synthetic tree, not
against a kernel that produced those files. The v2 layouts under both namespace modes are
the only ones verified against real containers.

The retry of an interrupted read has no test, as noted above.

### Docker test harness

The Docker introspection harness could not build or start, and no workflow runs it. It is
repaired here because it produces the live numbers above: `cgroupns` is not a Compose key,
the build context pointed one level below the repository root, the image copied a `cmake/`
directory that does not exist while missing three packages from the dependency closure,
`rosdep` ran after the apt lists had been deleted and resolved test-only dependencies for
an image built with `BUILD_TESTING=OFF`, `--symlink-install` left the runtime stage with
dangling links, and both test files picked the gateway's own node, whose process is not in
the PID cache.

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
