### PR TITLE
fix(aggregation): separate peer time budgets, report timeouts as timeouts, relay peer fault streams

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -3201,7 +3201,9 @@ Other extensions beyond SOVD:
 When aggregation is enabled, per-entity resource collection endpoints perform
 real-time fan-out to peer gateways. The affected endpoints are: data,
 operations, faults, configurations, logs, and the global ``GET /api/v1/faults``
-endpoint. The gateway sends the same request to all healthy peers, merges their
+endpoint. ``GET /api/v1/faults/stream`` also reaches every healthy peer, but it
+is not an ``items`` merge: it holds one connection open per peer for as long as
+a client is attached. See the fault-streaming section below. The gateway sends the same request to all healthy peers, merges their
 ``items`` arrays into the local response, and returns the combined result.
 
 If some peer requests fail during fan-out (peer unreachable or non-2xx
@@ -3213,12 +3215,98 @@ response), the response includes vendor metadata indicating partial results:
      "items": [],
      "x-medkit": {
        "partial": true,
-       "failed_peers": ["secondary_gateway"]
+       "failed_peers": ["secondary_gateway"],
+       "peer_failures": [{"peer": "secondary_gateway", "reason": "timeout"}]
      }
    }
 
+``failed_peers`` names which peers contributed nothing. ``peer_failures`` says
+why, one entry per name, with ``reason`` one of:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 80
+
+   * - ``reason``
+     - Meaning
+   * - ``timeout``
+     - A budget ran out. Which one is named in the message: the connect budget
+       means the peer never accepted the connection, a read or write budget
+       means it did and the gateway stopped waiting.
+   * - ``unreachable``
+     - No usable answer arrived: connection refused, no route, TLS or redirect
+       failure, or the peer died while the answer was arriving.
+   * - ``canceled``
+     - This gateway stopped the call, which happens during its own shutdown.
+   * - ``error-status``
+     - The peer answered with a status outside 2xx.
+   * - ``too-large``
+     - The peer's body passed the peer-response size limit.
+   * - ``invalid-response``
+     - The peer answered with something that is not the JSON the route
+       promises.
+
+Without ``peer_failures`` a client cannot tell a busy subsystem from a dead
+one, which is the whole of what a partial answer is asked.
+
 When all peers respond successfully, these fields are omitted. See the
 :doc:`aggregation configuration guide </config/aggregation>` for setup details.
+
+**A forwarded request that runs out of time.** ``GET``, ``POST``, ``PUT``,
+``DELETE`` and ``PATCH`` on a resource a peer owns are proxied to that peer.
+Two outcomes that used to be one:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 30 58
+
+   * - Status
+     - ``error_code``
+     - When
+   * - ``504``
+     - ``not-responding``
+     - A budget ran out before the peer answered. The message names which one
+       and its value, because the connect, read and write budgets are three
+       different keys and only one of them was the problem. The request may
+       still be running on the peer.
+   * - ``502``
+     - ``vendor-error`` / ``x-medkit-peer-unavailable``
+     - Nothing answered - refused, no route, or the peer died mid-answer.
+
+**A local operation that runs out of time.** ``POST
+/{entity}/operations/{op}/executions`` answers ``504`` ``not-responding`` when
+the backing ROS 2 service or action did not answer inside
+``service_call_timeout_sec``, with a message naming the endpoint and
+the budget; ``503`` when the endpoint is not on the graph at all; and ``500``
+for any other transport failure. Previously all three answered ``500`` with a
+fixed ``"Service call failed"`` / ``"Action execution failed"``, and a client
+had to match on the text in ``parameters.details`` to learn it was a timeout.
+
+**Fault streaming on an aggregating gateway.** ``GET /faults/stream`` on a
+gateway with peers relays their streams into its own. Each relayed event
+carries ``x-medkit.peer`` naming the gateway that raised the fault. The relay
+is open only while a client is attached, because it holds one SSE client slot
+on each peer and ``sse.max_clients`` defaults to 2. Replay via
+``Last-Event-ID`` covers this gateway's own ids: two peers number their events
+independently, so a reconnecting client resumes from what the aggregator has
+buffered rather than from each peer's own history. A request carrying
+``X-Medkit-No-Fan-Out`` is served from the local graph only, which is what
+stops a chain of aggregating gateways relaying one event round the loop.
+
+Because those relayed connections count against the peer's own
+``sse.max_clients``, ``GET /health`` now reports how much of that cap is in
+use:
+
+.. code-block:: json
+
+   {
+     "status": "healthy",
+     "x-medkit-sse": {"connected_clients": 1, "max_clients": 2}
+   }
+
+Without it, an operator refused a stream with ``503`` on a gateway nobody
+appears to be watching has nothing to look at. The object is omitted when the
+gateway has no SSE client tracker.
 
 ``GET /{entity}/configurations`` applies the same honesty to its *local*
 backing nodes. This only arises for entities backed by more than one ROS 2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,7 +153,11 @@ plantuml_output_format = 'svg'
 # Retry transient external failures (e.g. docs.ros.org read timeouts) instead of
 # failing the whole build on a single network blip.
 linkcheck_retries = 3
-linkcheck_timeout = 30
+# 60, not 30. docs.ros.org has taken longer than 30 s to answer and exhausted all three
+# retries, failing the whole docs build on a third-party site being slow rather than on
+# anything wrong with a link. Raising the per-attempt budget keeps a genuine 404 failing -
+# which is what this check is for - while a slow host costs time instead of a red build.
+linkcheck_timeout = 60
 linkcheck_ignore = [
     r'http://localhost:\d+',  # Ignore localhost URLs
     r'http://127\.0\.0\.1:\d+',

--- a/docs/config/aggregation.rst
+++ b/docs/config/aggregation.rst
@@ -59,9 +59,40 @@ Core Parameters
    * - ``aggregation.timeout_ms``
      - int
      - ``2000``
-     - HTTP timeout in milliseconds for all peer communication: health checks,
-       entity fetching, and request forwarding. Increase for high-latency
-       networks.
+     - Connect budget for every peer call, and the read budget for reading a
+       peer's description of itself: entity fetching and the collection fan-out
+       a client waits on across every peer at once. Increase for high-latency
+       networks. The health check is the exception: it caps both its budgets at
+       1000 ms, because an unresponsive peer is unhealthy whether the gateway
+       waits one second or five, and the wait bounds how long shutdown takes.
+       Range 100-600000; a value outside it is clamped to the nearest end, and
+       the clamp is logged when aggregation is enabled.
+   * - ``aggregation.forward_timeout_ms``
+     - int
+     - ``15000``
+     - Read budget for a forwarded request - an operation execution, or a read
+       of a large resource - on the gateway that owns it. What this waits for
+       is the peer doing that work, so it is sized above a peer gateway's own
+       ``service_call_timeout_sec`` default of 10 s. A value below
+       ``aggregation.timeout_ms`` is raised to it and the change is logged: a
+       forwarded request must not be cut off sooner than a metadata read.
+       Range 100-600000, clamped and logged as above.
+   * - ``aggregation.write_timeout_ms``
+     - int
+     - ``5000``
+     - Budget for pushing a request body to a peer. Raise it when forwarding
+       large uploads over a slow link. Range 100-600000, clamped and logged as
+       above.
+
+.. note::
+
+   These three are separate because they bound different things. One value
+   serving as connect, metadata read and forward read at once gives an
+   operation on a peer the budget of a listing, and the peer is then reported
+   as unavailable while it is still working. Raising that one value also
+   cannot reach the write budget, which is its own key: before it existed the
+   write timeout stayed at the HTTP client library's default and followed
+   nothing.
 
 mDNS Discovery Parameters
 --------------------------

--- a/docs/config/aggregation.rst
+++ b/docs/config/aggregation.rst
@@ -162,11 +162,22 @@ for peer communication.
        stream relay is the one that needs it: an aggregator holds one stream per
        peer, opened when the first local client attaches and shared by every
        client after it, so there is no single client whose token it could carry.
-       Leave it empty unless the peers require authentication; while it is
-       empty, such a peer refuses the relay and the aggregator's own
-       ``/faults/stream`` carries local events only. This is separate from
-       ``forward_auth``, which forwards an end user's token per request and has
-       no effect on the relay.
+       It is presented on every connection this gateway opens for itself: the
+       peer health check, the entity fetch behind aggregation, the relay, and
+       any forward whose caller sent no credential to pass on. Leave it empty
+       unless the peers require authentication; while it is empty, such a peer
+       answers 401, is recorded as offline, and contributes neither entities
+       nor events.
+
+       Sent **only to peers named in the configuration**. A peer discovered
+       over mDNS never receives it, because it is not one the operator vouched
+       for - so a discovered peer that requires authentication stays
+       unreachable rather than being handed this gateway's credential. The
+       value is redacted from the configurations API, like ``auth.jwt_secret``.
+
+       This is separate from ``forward_auth``, which forwards an end user's
+       token per request. Where both apply, a caller's own token wins, so
+       ``forward_auth`` goes on naming the end user to the peer.
    * - ``aggregation.require_tls``
      - bool
      - ``false``

--- a/docs/config/aggregation.rst
+++ b/docs/config/aggregation.rst
@@ -154,6 +154,19 @@ for peer communication.
        ``false`` (default), auth tokens are **never** sent to peers - this
        prevents token leakage to untrusted or mDNS-discovered peers. Only
        enable when all peers are trusted and share the same JWT configuration.
+   * - ``aggregation.peer_auth_header``
+     - string
+     - ``""``
+     - What this gateway presents as ``Authorization`` on connections it opens
+       on its **own** behalf rather than for a request it is serving. The fault
+       stream relay is the one that needs it: an aggregator holds one stream per
+       peer, opened when the first local client attaches and shared by every
+       client after it, so there is no single client whose token it could carry.
+       Leave it empty unless the peers require authentication; while it is
+       empty, such a peer refuses the relay and the aggregator's own
+       ``/faults/stream`` carries local events only. This is separate from
+       ``forward_auth``, which forwards an end user's token per request and has
+       no effect on the relay.
    * - ``aggregation.require_tls``
      - bool
      - ``false``

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -652,6 +652,15 @@ Example:
    dependencies. Topic discovery, sampling, publishing, service calls, and
    action operations are implemented in pure C++ using ros2_medkit_serialization.
 
+.. note::
+
+   Parameters whose value is a credential - ``auth.jwt_secret``,
+   ``auth.clients`` and ``aggregation.peer_auth_header`` - are reported by the
+   configurations API as ``***`` rather than their value. The parameter is
+   still listed, with its real type, so it stays discoverable; only the secret
+   is withheld. Set them through the node's configuration, and read them back
+   from there rather than over the API.
+
 SSE (Server-Sent Events)
 ------------------------
 

--- a/docs/config/server.rst
+++ b/docs/config/server.rst
@@ -677,6 +677,10 @@ Configure limits for SSE-based streaming (fault events and cyclic subscriptions)
      - int
      - ``3600``
      - Maximum allowed subscription duration in seconds. Requests exceeding this are rejected with HTTP 400. Range: 1 to 2147483647 (the value becomes an ``int``); outside it the value is refused with a warning and ``3600`` is used.
+   * - ``sse.keepalive_interval_sec``
+     - int
+     - ``30``
+     - How often an idle stream writes a keepalive comment. This is also how long a client that has gone away stays counted against ``sse.max_clients``, because a closed connection is only noticed on the next write: a gateway whose clients come and go faster than this interval can refuse a stream for a slot nobody is using. Lower it where streams are short-lived, at the cost of more traffic on idle ones. Range: 1-3600, clamped with a warning.
 
 Example:
 
@@ -688,6 +692,7 @@ Example:
          max_clients: 2
          max_subscriptions: 100
          max_duration_sec: 3600
+         keepalive_interval_sec: 30
 
 Triggers
 --------

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -1070,6 +1070,10 @@ if(BUILD_TESTING)
   medkit_add_gtest(test_stream_proxy test/test_stream_proxy.cpp)
   target_link_libraries(test_stream_proxy gateway_ros2)
 
+  medkit_add_gtest(test_peer_fault_relay test/test_peer_fault_relay.cpp)
+  target_link_libraries(test_peer_fault_relay gateway_ros2)
+  medkit_test_needs_no_domain(test_peer_fault_relay)
+
   # mDNS discovery tests (aggregation module)
   medkit_add_gtest(test_mdns_discovery test/test_mdns_discovery.cpp)
   target_link_libraries(test_mdns_discovery gateway_ros2)

--- a/src/ros2_medkit_gateway/config/gateway_params.secure.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.secure.yaml
@@ -114,4 +114,8 @@ ros2_medkit_gateway:
       enabled: false
       require_tls: true
       forward_auth: false
+      # This gateway's own credential for peer connections. Prefer it over
+      # forward_auth where peers authenticate: it never carries an end user's
+      # token, and it is not sent to mDNS-discovered peers at all.
+      peer_auth_header: ""
       peer_scheme: "https"

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -648,6 +648,19 @@ ros2_medkit_gateway:
       # Default: false (safe default - no token forwarding)
       forward_auth: false
 
+      # What this gateway presents as Authorization on connections it opens on
+      # its OWN behalf: the peer health check, the entity fetch, the fault-stream
+      # relay, and any forward whose caller sent no credential to pass on.
+      # Needed against peers that authenticate their reads - while it is empty
+      # such a peer answers 401, is recorded offline, and contributes neither
+      # entities nor events.
+      # Sent ONLY to peers named in peer_urls; a peer discovered over mDNS never
+      # receives it. Redacted from the configurations API, like auth.jwt_secret.
+      # Separate from forward_auth, which forwards an end user's token per
+      # request and has no effect on the relay.
+      # Default: "" (no credential)
+      peer_auth_header: ""
+
       # Security: Require TLS (https://) for all peer communication.
       # When true, peers with http:// URLs are rejected with an error log.
       # When false, http:// peers produce a warning about cleartext traffic.

--- a/src/ros2_medkit_gateway/config/gateway_params.yaml
+++ b/src/ros2_medkit_gateway/config/gateway_params.yaml
@@ -224,6 +224,15 @@ ros2_medkit_gateway:
       # Default: 3600 (1 hour)
       max_duration_sec: 3600
 
+      # Comment interval on an idle SSE stream, in seconds. Also how long the
+      # server takes to notice a client has gone: a closed socket is found on
+      # the next write. On an aggregating gateway that is how long a fault-stream
+      # relay keeps a client slot on a peer after nobody is watching.
+      # Shorten it behind a proxy that drops idle connections sooner than 30 s.
+      # Range 1-3600, clamped to the nearest end with a warning.
+      # Default: 30
+      keepalive_interval_sec: 30
+
     # Entity Cache Configuration
     entity_cache:
       # Pre-reserved capacity for the thread-safe entity cache.
@@ -592,10 +601,27 @@ ros2_medkit_gateway:
       # Default: false
       enabled: false
 
-      # HTTP timeout for peer requests (health checks, entity fetching, forwarding)
-      # in milliseconds
+      # Connect budget for every peer request, and the read budget for reading a
+      # peer's description of itself: health checks, entity fetching, and the
+      # collection fan-out a client waits on across every peer at once.
+      # Milliseconds. Range 100-600000, clamped to the nearest end with a warning.
       # Default: 2000
       timeout_ms: 2000
+
+      # Read budget for a forwarded request - an operation execution, or a read
+      # of a large resource - on the gateway that owns it. Sized above a peer
+      # gateway's own service_call_timeout_sec default of 10 s,
+      # because what this waits for is the peer doing that work.
+      # A value below timeout_ms is raised to it, with a warning.
+      # Milliseconds. Range 100-600000, clamped to the nearest end with a warning.
+      # Default: 15000
+      forward_timeout_ms: 15000
+
+      # Budget for pushing a request body to a peer. Raise for large uploads
+      # over a slow link.
+      # Milliseconds. Range 100-600000, clamped to the nearest end with a warning.
+      # Default: 5000
+      write_timeout_ms: 5000
 
       # Announce this gateway's presence via mDNS
       # Default: false (opt-in to avoid surprising network behavior)

--- a/src/ros2_medkit_gateway/design/aggregation.rst
+++ b/src/ros2_medkit_gateway/design/aggregation.rst
@@ -791,11 +791,40 @@ detection algorithm and the fall-back routing behaviour.
 Stream Proxy
 ~~~~~~~~~~~~
 
-For streaming connections (e.g., SSE fault subscriptions), the ``StreamProxy``
-interface provides transport-agnostic event proxying. The ``SSEStreamProxy``
-implementation connects to a peer's SSE endpoint and relays events back to the
-primary gateway's client. Each ``StreamEvent`` carries the ``peer_name`` so the
+For streaming connections, the ``StreamProxy`` interface provides
+transport-agnostic event proxying. The ``SSEStreamProxy`` implementation
+connects to a peer's SSE endpoint and relays events back to the primary
+gateway's client. Each ``StreamEvent`` carries the ``peer_name`` so the
 aggregator can attribute events to their source.
+
+``GET /faults/stream`` on an aggregating gateway uses it. An aggregator runs on
+its own ROS domain with its own ``fault_manager``, which no producer reports
+to, so a stream fed from the local graph alone is open, valid and silent - and
+a silent stream reads to a client exactly like a healthy system. ``GET
+/faults`` already fans out; ``PeerFaultRelay`` gives the stream the same
+answer.
+
+Lifecycle and the three constraints that shape it:
+
+* **Opened on the first client, closed with the last.** A relayed stream holds
+  one SSE client slot on every peer for as long as it is open, and
+  ``sse.max_clients`` defaults to 2. An aggregator nobody is watching therefore
+  holds none.
+* **Reconciled from the streaming loop.** Peers that appear or go away are
+  picked up on a later wakeup: the loop wakes on every event and at least once
+  per keepalive interval, and reconciliation itself runs at most once a second
+  so a burst of events does not become a burst of lock acquisitions. Only the
+  first attached client forces it immediately. No timer of its own.
+* **Loop suppression is the same mechanism the collections use.** The relay's
+  own request carries ``X-Medkit-No-Fan-Out``, and a stream request carrying
+  that header is served from the local graph only. Without it a chain of
+  aggregating gateways would relay one event round the loop.
+
+Each relayed event goes out under the aggregator's own event id, carrying the
+peer's payload with ``x-medkit.peer`` added. **Replay covers this gateway's own
+ids only.** Two peers number their events independently, so a ``Last-Event-ID``
+cannot address a position in a merged stream; a reconnecting client resumes
+from what the aggregator has buffered, not from each peer's own history.
 
 Deployment Topologies
 ---------------------
@@ -891,7 +920,14 @@ Key Classes
 ``StreamProxy`` / ``SSEStreamProxy``
     Transport-agnostic interface for proxying streaming connections to peers.
     ``SSEStreamProxy`` implements SSE-based event relaying with a background
-    reader thread.
+    reader thread that reconnects with exponential backoff.
+
+``PeerFaultRelay``
+    Holds one ``SSEStreamProxy`` per healthy peer for as long as a client is
+    attached to this gateway's ``/faults/stream``, and hands each event to the
+    handler that owns the local replay buffer. Takes its peer list through a
+    supplier callback rather than from ``AggregationManager`` directly, because
+    it lives in the ROS-neutral core.
 
 ``HostInfoProvider``
     Reads local host system info (hostname, OS, architecture) and produces a

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
@@ -75,6 +75,18 @@ struct AggregationConfig {
   bool discover{false};
   std::string mdns_service{"_medkit._tcp.local"};
 
+  /// What this gateway presents as Authorization on connections it makes on
+  /// its OWN behalf, rather than on behalf of a request it is serving. Empty
+  /// for none.
+  ///
+  /// The fault-stream relay is the case that needs it: one connection per peer,
+  /// opened when the first local client attaches and shared by every one after
+  /// it. There is no single client whose token it could carry, and carrying the
+  /// opener's would serve everybody else events fetched with those credentials
+  /// and break when that one client's token expired. forward_auth is the wrong
+  /// lever for it - that forwards an end user's token per request.
+  std::string peer_auth_header;
+
   /// Forward the client's Authorization header to peer gateways.
   /// Default: false (safe default - prevents token leakage to untrusted peers).
   bool forward_auth{false};
@@ -219,6 +231,13 @@ class AggregationManager {
   /// form a caller that has to open a connection needs, and it excludes the
   /// unhealthy peers that rendering deliberately includes.
   std::vector<PeerEndpoint> healthy_peer_endpoints() const;
+
+  /// The Authorization value this gateway presents to peers on its own behalf.
+  /// Empty when none is configured, in which case a peer that requires
+  /// authentication refuses the relay.
+  const std::string & peer_auth_header() const {
+    return config_.peer_auth_header;
+  }
 
   /**
    * @brief Fetch entities from all healthy peers, merge with local entities, and build routing table

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/aggregation/aggregation_manager.hpp
@@ -16,6 +16,7 @@
 
 #include <httplib.h>
 
+#include <algorithm>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <optional>
@@ -27,15 +28,49 @@
 
 #include "ros2_medkit_gateway/core/aggregation/classification.hpp"
 #include "ros2_medkit_gateway/core/aggregation/peer_client.hpp"
+#include "ros2_medkit_gateway/dto/aggregation.hpp"
 
 namespace ros2_medkit_gateway {
+
+/// A peer's name and where to reach it.
+struct PeerEndpoint {
+  std::string name;
+  std::string url;
+};
 
 /**
  * @brief Configuration for peer aggregation
  */
 struct AggregationConfig {
   bool enabled{false};
+
+  /// Connect budget for every peer call, and the read budget for the peer's
+  /// description of itself: discovery, health and collection fan-out.
   int timeout_ms{2000};
+
+  /// Read budget for a forwarded request. Sized above a peer gateway's own
+  /// `service_call_timeout_sec` default of 10 s, because what a
+  /// forward waits for is the peer doing that work.
+  int forward_timeout_ms{15000};
+
+  /// Write budget for every peer call.
+  int write_timeout_ms{5000};
+
+  /// The three budgets above in the shape PeerClient takes them.
+  ///
+  /// The connect budget is capped at kConnectCapMs rather than following
+  /// `timeout_ms`. A peer that cannot complete a TCP handshake in a second is
+  /// out of reach whatever the request wanted, and the cap also bounds how far
+  /// a `Read` failure can be misattributed: cpp-httplib reports one elapsed
+  /// time for connect plus read, so a handshake that ate most of a read budget
+  /// before the peer died would otherwise read as a timeout. With the cap that
+  /// window is a second instead of the whole metadata budget, and a handshake
+  /// slower than the cap fails as a connect timeout, which is named correctly.
+  PeerTimeouts peer_timeouts() const {
+    constexpr int kConnectCapMs = 1000;
+    return PeerTimeouts{std::min(timeout_ms, kConnectCapMs), timeout_ms, forward_timeout_ms, write_timeout_ms};
+  }
+
   bool announce{false};
   bool discover{false};
   std::string mdns_service{"_medkit._tcp.local"};
@@ -108,6 +143,14 @@ class AggregationManager {
     std::vector<std::string> item_peers;
     bool is_partial{false};                 ///< True if some peers failed
     std::vector<std::string> failed_peers;  ///< Names of peers that failed
+    /// Why each peer in `failed_peers` failed, same peers, one entry each.
+    ///
+    /// A name on its own says a peer contributed nothing and nothing more. A
+    /// peer that ran out of time, one that refused the connection, one that
+    /// answered 500, a body over the size limit and unparseable JSON produce
+    /// the same entry there, so a client cannot tell a busy subsystem from a
+    /// dead one - which is the whole of what a partial answer is asked.
+    std::vector<dto::PeerFailure> peer_failures;
   };
 
   /**
@@ -169,6 +212,13 @@ class AggregationManager {
    * @return Number of peers that report healthy status
    */
   size_t healthy_peer_count() const;
+
+  /// Name and base URL of every peer healthy at the last health check.
+  ///
+  /// `get_peer_status()` renders the same set as JSON for a client; this is the
+  /// form a caller that has to open a connection needs, and it excludes the
+  /// unhealthy peers that rendering deliberately includes.
+  std::vector<PeerEndpoint> healthy_peer_endpoints() const;
 
   /**
    * @brief Fetch entities from all healthy peers, merge with local entities, and build routing table

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_client.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_client.hpp
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <httplib.h>
 
 #include <atomic>
@@ -52,6 +54,96 @@ struct PeerEntities {
 };
 
 /**
+ * @brief Why a call to a peer produced no usable answer.
+ *
+ * `httplib::Result::operator bool()` is a null check, so a branch on the result
+ * alone renders a peer that ran out of time and a peer that refused the
+ * connection identically. They are not the same event: the first says the peer
+ * is working and this gateway stopped waiting, the second says nothing
+ * answered, and an operator reading "unavailable" about a peer that is serving
+ * the same request in five seconds is being told something false.
+ */
+enum class PeerFailureKind : uint8_t {
+  kNone,             ///< No failure.
+  kTimeout,          ///< A connect, read or write budget ran out. The peer may still be working.
+  kUnreachable,      ///< Nothing answered: refused, no route, DNS or TLS failure.
+  kCanceled,         ///< This gateway stopped the call, which happens during its own shutdown.
+  kErrorStatus,      ///< The peer answered, with a status outside 2xx.
+  kTooLarge,         ///< The body passed the peer-response size limit.
+  kInvalidResponse,  ///< The peer answered with something that is not the JSON the route promises.
+};
+
+/// A peer call that failed, and why. Kept together because every caller that
+/// reports the message also has to decide a status from the kind, and the two
+/// were previously separated by the error being a bare string.
+struct PeerError {
+  PeerFailureKind kind{PeerFailureKind::kUnreachable};
+  std::string message;
+};
+
+/// Classify a cpp-httplib transport error.
+///
+/// cpp-httplib reports both "the read budget ran out" and "the connection
+/// broke while the answer was arriving" as `Error::Read`, so the error alone
+/// cannot tell a peer that is still working from one that died mid-answer.
+/// `elapsed` against `budget` is what separates them: a call that came back
+/// inside its budget did not run out of it, whatever else went wrong.
+/// @param read_budget Budget for the read this call was making.
+/// @param write_budget Budget for pushing the request body.
+/// A write that ran out compares against the WRITE budget, which is its own and
+/// is smaller than the read budget by default; comparing it against the read
+/// budget classifies every write timeout as unreachable.
+PeerFailureKind classify_peer_error(httplib::Error error, std::chrono::milliseconds elapsed,
+                                    std::chrono::milliseconds read_budget, std::chrono::milliseconds write_budget);
+
+/// Which budget a failure was measured against, so a message can name the one
+/// that actually expired. A connect timeout is bounded by the connect budget,
+/// not by the read budget the call was hoping to use.
+enum class PeerBudget : uint8_t { kNone, kConnect, kRead, kWrite };
+
+/// The budget `classify_peer_error` measured this error against.
+PeerBudget peer_budget_for(httplib::Error error);
+
+/// Stable wire token for a failure kind, as carried in
+/// ``x-medkit.peer_failures[].reason``.
+const char * peer_failure_reason(PeerFailureKind kind);
+
+/**
+ * @brief The budgets one peer request runs under.
+ *
+ * Four numbers rather than one, because they bound different things and a
+ * single value can only be right for one of them at a time. A metadata read
+ * that is given a real operation's budget stalls a discovery pass behind a
+ * dead peer; a real operation that is given a metadata read's budget is cut
+ * off while the peer is still working on it.
+ */
+struct PeerTimeouts {
+  /// Connect budget for every call. A peer that will not complete a TCP
+  /// handshake inside this is out of reach whatever the request asks for, so
+  /// this stays short even where the read budget is long.
+  int connect_ms{2000};
+
+  /// Read budget for the peer's description of itself: discovery, health, and
+  /// the collection fan-out a client is waiting on across every peer at once.
+  int metadata_read_ms{2000};
+
+  /// Read budget for a forwarded request, which carries the peer's own work.
+  /// A synchronous service call on the far side runs against that gateway's
+  /// `service_call_timeout_sec`, so a budget below it cannot ever
+  /// see the answer; a large resource needs the transfer on top of that.
+  int forward_read_ms{15000};
+
+  /// Write budget for every call. cpp-httplib defaults this to 5 s.
+  int write_ms{5000};
+
+  /// Every budget set to the same value - the pre-split shape, for a caller
+  /// that is not testing the split.
+  static PeerTimeouts uniform(int ms) {
+    return PeerTimeouts{ms, ms, ms, ms};
+  }
+};
+
+/**
  * @brief HTTP client for communicating with a peer gateway instance
  *
  * PeerClient wraps cpp-httplib to provide typed access to a peer gateway's
@@ -67,9 +159,12 @@ class PeerClient {
    * @brief Construct a PeerClient for a peer gateway
    * @param url Base URL of the peer (e.g., "http://localhost:8081")
    * @param name Human-readable peer name (e.g., "subsystem_b")
-   * @param timeout_ms Connection and read timeout in milliseconds
+   * @param timeouts Per-kind budgets; see PeerTimeouts
    * @param forward_auth Whether to forward Authorization headers to this peer
    */
+  PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth = false);
+
+  /// Convenience overload giving every budget the same value.
   PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth = false);
 
   /// Get the peer base URL
@@ -143,11 +238,13 @@ class PeerClient {
    * @param auth_header Authorization header value (empty to omit)
    * @param extra_headers Additional headers to include in the request
    *   (e.g., X-Medkit-No-Fan-Out to prevent recursive fan-out loops)
-   * @return Parsed JSON on success, error message on failure
+   * @return Parsed JSON on success, a classified PeerError on failure. The
+   *   kind is what lets a fanned-out collection say WHY a peer contributed
+   *   nothing; the caller used to receive a bare string and drop it.
    */
-  tl::expected<nlohmann::json, std::string> forward_and_get_json(const std::string & method, const std::string & path,
-                                                                 const std::string & auth_header = "",
-                                                                 const httplib::Headers & extra_headers = {});
+  tl::expected<nlohmann::json, PeerError> forward_and_get_json(const std::string & method, const std::string & path,
+                                                               const std::string & auth_header = "",
+                                                               const httplib::Headers & extra_headers = {});
 
   /**
    * @brief Cancel every in-flight HTTP call against this peer.
@@ -174,7 +271,9 @@ class PeerClient {
   /// active_clients_ and calls stop() on each so blocked I/O unwinds.
   class ScopedClient {
    public:
-    ScopedClient(PeerClient & owner, const std::string & url, int timeout_ms);
+    /// @param read_timeout_ms Read budget for this call. Connect and write
+    /// come from the owner's PeerTimeouts, which do not vary per call kind.
+    ScopedClient(PeerClient & owner, const std::string & url, int read_timeout_ms);
     ~ScopedClient();
     ScopedClient(const ScopedClient &) = delete;
     ScopedClient & operator=(const ScopedClient &) = delete;
@@ -198,7 +297,7 @@ class PeerClient {
 
   std::string url_;
   std::string name_;
-  int timeout_ms_;
+  PeerTimeouts timeouts_;
   bool forward_auth_;
   std::atomic<bool> healthy_{false};
   std::atomic<bool> shutdown_requested_{false};

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_client.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_client.hpp
@@ -162,10 +162,12 @@ class PeerClient {
    * @param timeouts Per-kind budgets; see PeerTimeouts
    * @param forward_auth Whether to forward Authorization headers to this peer
    */
-  PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth = false);
+  PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth = false,
+             std::string peer_auth_header = "");
 
   /// Convenience overload giving every budget the same value.
-  PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth = false);
+  PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth = false,
+             std::string peer_auth_header = "");
 
   /// Get the peer base URL
   const std::string & url() const;
@@ -299,6 +301,10 @@ class PeerClient {
   std::string name_;
   PeerTimeouts timeouts_;
   bool forward_auth_;
+  /// What this gateway presents as Authorization when it is acting for itself
+  /// rather than relaying a client's request: the health check, and any
+  /// forward whose caller sent no credential to pass on. Empty for none.
+  std::string peer_auth_header_;
   std::atomic<bool> healthy_{false};
   std::atomic<bool> shutdown_requested_{false};
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp
@@ -102,10 +102,27 @@ class PeerFaultRelay {
   void shutdown();
 
  private:
+  /// A peer name AND url. A peer keeps its name across an mDNS re-announce
+  /// that moves it to a new address, so a name-only key would keep the dead
+  /// connection and never open the new one.
+  using StreamKey = std::pair<std::string, std::string>;
+
   /// Move every open proxy out of the map. Caller holds mutex_ and destroys
   /// the returned proxies after releasing it - destroying one joins its reader
   /// thread, which calls back into the owner and takes the owner's lock.
-  std::vector<std::unique_ptr<SSEStreamProxy>> take_all_locked();
+  std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> take_all_locked();
+
+  /// Stop each proxy, record where its reader actually stopped, and destroy it.
+  /// Called with mutex_ RELEASED: closing joins a reader thread, and that
+  /// thread may be inside the owner's callback waiting for a lock this holds.
+  void retire(std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired);
+
+  /// Drop remembered cursors once there are more of them than peers this relay
+  /// could plausibly be talking to. Peers discovered over mDNS come and go
+  /// under names of their own, and a cursor per name that is never released is
+  /// a map that only grows.
+  void trim_cursors_locked();
+  static constexpr std::size_t kMaxCursors = 128;
 
   TargetSupplier targets_;
   std::string path_;
@@ -127,12 +144,12 @@ class PeerFaultRelay {
   /// Open proxies, keyed by peer name AND url. A peer keeps its name across an
   /// mDNS re-announce that moves it to a new address, so a name-only key would
   /// keep the dead connection and never open the new one.
-  std::map<std::pair<std::string, std::string>, std::unique_ptr<SSEStreamProxy>> streams_;
+  std::map<StreamKey, std::unique_ptr<SSEStreamProxy>> streams_;
   /// Last event id reached per peer, kept when its stream is closed so a later
   /// one resumes there instead of asking for the peer's whole buffer. Keyed
   /// like streams_, and it outlives them on purpose: the common case is the
   /// last client leaving and another arriving moments later.
-  std::map<std::pair<std::string, std::string>, std::string> cursors_;
+  std::map<StreamKey, std::string> cursors_;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp
@@ -1,0 +1,138 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/aggregation/stream_proxy.hpp"
+
+namespace ros2_medkit_gateway {
+
+/// Where one peer's stream can be reached. Supplied by the caller rather than
+/// read from AggregationManager, which lives in the ROS adapter and cannot be
+/// named from here.
+struct RelayTarget {
+  std::string name;
+  std::string url;
+  /// Value to send as Authorization, or empty for none. Supplied by the
+  /// caller, because whether a client's credentials may be forwarded to a peer
+  /// is `aggregation.forward_auth` and that lives in the ROS adapter. A peer
+  /// that requires authentication refuses an unauthenticated stream, so
+  /// without this the relay is silently dead against exactly the deployments
+  /// that authenticate.
+  std::string auth_header;
+};
+
+/**
+ * @brief Relays the peers' event streams into an aggregating gateway's own.
+ *
+ * An aggregating gateway runs on its own ROS domain. Its fault_manager is the
+ * one nothing reports to, so a stream fed only from the local graph is open,
+ * valid and empty, which reads to a client exactly like a healthy system. The
+ * collection route already fans out; this is the same answer for the stream.
+ *
+ * Streams are opened on the first attached client and closed with the last.
+ * The relay costs one SSE client slot on every peer for as long as it is open,
+ * and `sse.max_clients` defaults to 2 - so an aggregator nobody is watching
+ * must not be holding those slots.
+ */
+class PeerFaultRelay {
+ public:
+  /// Returns the peers to relay from right now. Called on every reconcile, so
+  /// a peer that appeared or went away is picked up without a timer of its own.
+  using TargetSupplier = std::function<std::vector<RelayTarget>()>;
+  /// Invoked from a proxy's reader thread for each event received.
+  using EventCallback = std::function<void(const StreamEvent &)>;
+
+  PeerFaultRelay(TargetSupplier targets, std::string path, EventCallback on_event);
+  ~PeerFaultRelay();
+
+  PeerFaultRelay(const PeerFaultRelay &) = delete;
+  PeerFaultRelay & operator=(const PeerFaultRelay &) = delete;
+  PeerFaultRelay(PeerFaultRelay &&) = delete;
+  PeerFaultRelay & operator=(PeerFaultRelay &&) = delete;
+
+  /// A client attached to the local stream. On the 0 -> 1 transition every
+  /// peer's stream is opened.
+  void acquire();
+
+  /// A client left. On the 1 -> 0 transition every stream is closed.
+  ///
+  /// MUST NOT be called while holding a lock the relay's event callback also
+  /// takes. Closing a stream joins its reader thread, and that thread may be
+  /// inside the callback waiting for exactly that lock.
+  void release();
+
+  /// Open streams for peers that appeared, close those that went away. Does
+  /// nothing while no client is attached.
+  ///
+  /// Called from the streaming loop, which wakes on every event, so the peer
+  /// list is read at most once per kReconcileInterval however fast faults
+  /// arrive. Reading it takes the aggregation manager's lock, and a burst of
+  /// relayed events must not turn into a burst of lock acquisitions on the
+  /// path that is delivering them.
+  void reconcile();
+
+  /// Number of peer streams currently open.
+  std::size_t open_streams() const;
+
+  /// Stop relaying and close every stream, whatever the client count. Called
+  /// from the destructor and from the owner's shutdown, and is idempotent.
+  void shutdown();
+
+ private:
+  /// Move every open proxy out of the map. Caller holds mutex_ and destroys
+  /// the returned proxies after releasing it - destroying one joins its reader
+  /// thread, which calls back into the owner and takes the owner's lock.
+  std::vector<std::unique_ptr<SSEStreamProxy>> take_all_locked();
+
+  TargetSupplier targets_;
+  std::string path_;
+  EventCallback on_event_;
+
+  /// Reconcile at most this often. Peers appear and go away on the discovery
+  /// cadence, so a second's delay in picking one up costs nothing.
+  static constexpr std::chrono::milliseconds kReconcileInterval{1000};
+
+  /// Open streams for the peers listed now. `force` skips the interval check;
+  /// used on the first attached client, where waiting would leave the stream
+  /// silent for a second with nothing to gain.
+  void reconcile_now(bool force);
+
+  mutable std::mutex mutex_;
+  std::size_t clients_{0};
+  std::chrono::steady_clock::time_point last_reconcile_{};
+  bool shut_down_{false};
+  /// Open proxies, keyed by peer name AND url. A peer keeps its name across an
+  /// mDNS re-announce that moves it to a new address, so a name-only key would
+  /// keep the dead connection and never open the new one.
+  std::map<std::pair<std::string, std::string>, std::unique_ptr<SSEStreamProxy>> streams_;
+  /// Last event id reached per peer, kept when its stream is closed so a later
+  /// one resumes there instead of asking for the peer's whole buffer. Keyed
+  /// like streams_, and it outlives them on purpose: the common case is the
+  /// last client leaving and another arriving moments later.
+  std::map<std::pair<std::string, std::string>, std::string> cursors_;
+};
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/stream_proxy.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/aggregation/stream_proxy.hpp
@@ -17,7 +17,9 @@
 #include <httplib.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -85,8 +87,13 @@ class SSEStreamProxy : public StreamProxy {
    * @param peer_url Base URL of the peer gateway (e.g., "http://localhost:8081")
    * @param path SSE endpoint path (e.g., "/api/v1/components/abc/faults/sse")
    * @param peer_name Human-readable name for the peer (used in StreamEvent::peer_name)
+   * @param headers Headers sent with every connect attempt, including after a
+   *   reconnect. An aggregator relaying a peer's stream sends
+   *   `X-Medkit-No-Fan-Out` here, which is what stops a chain of aggregating
+   *   gateways relaying the same event round the loop.
    */
-  SSEStreamProxy(const std::string & peer_url, const std::string & path, const std::string & peer_name = "");
+  SSEStreamProxy(const std::string & peer_url, const std::string & path, const std::string & peer_name = "",
+                 httplib::Headers headers = {});
 
   ~SSEStreamProxy() override;
 
@@ -99,6 +106,18 @@ class SSEStreamProxy : public StreamProxy {
   void close() override;
   bool is_connected() const override;
   void on_event(std::function<void(const StreamEvent &)> cb) override;
+
+  /// The id of the last event this proxy received, or empty if none has been.
+  ///
+  /// Read by the owner when a stream is retired so a replacement for the same
+  /// peer can resume where this one stopped. Without that hand-off a reopened
+  /// stream asks for the peer's whole buffer and every event in it is
+  /// delivered again, as new, to whoever is attached.
+  std::string last_event_id() const;
+
+  /// Resume from an id a previous proxy for this peer reached. Must be called
+  /// before open().
+  void set_last_event_id(std::string id);
 
   /**
    * @brief Parse raw SSE text/event-stream data into StreamEvent objects
@@ -122,11 +141,57 @@ class SSEStreamProxy : public StreamProxy {
   std::string peer_url_;
   std::string path_;
   std::string peer_name_;
+  httplib::Headers headers_;
   std::atomic<bool> connected_{false};
   std::atomic<bool> should_stop_{false};
   std::atomic<bool> non_sse_content_type_{false};
+  /// Status the peer answered with when it refused the stream, or 0. Recorded
+  /// in the header callback and reported from the reader loop, where a logger
+  /// is reachable. Without it a peer that answers 401, 429 or 503 is retried
+  /// for ever and says nothing, which is the same open-and-silent stream this
+  /// relay exists to remove, one hop up.
+  std::atomic<int> rejected_status_{0};
+
+  /// Newest `id:` this proxy has seen from the peer, sent back as
+  /// `Last-Event-ID` when it reconnects. Without it every reconnect asks the
+  /// peer for its whole replay buffer again, and the aggregator re-emits all of
+  /// it under fresh ids - so a client sees the same faults repeated after every
+  /// backoff cycle, which on a flapping link is continuous. Touched only by the
+  /// reader thread.
+  /// Written by the reader thread, read by the owner from another one.
+  mutable std::mutex cursor_mutex_;
+  std::string last_event_id_;
   std::function<void(const StreamEvent &)> callback_;
   std::thread reader_thread_;
+
+  /// The client the reader thread is currently blocked in, so close() can
+  /// interrupt it. Without this, close() only sets should_stop_, which the
+  /// content callbacks read only when bytes arrive: on a connected but silent
+  /// peer the join waits for the peer's next keepalive, or for the 300 s read
+  /// timeout if the peer has stopped writing entirely. That wait sits on the
+  /// live path through PeerFaultRelay, so an aggregator restarting while a
+  /// peer is quiet can overrun its shutdown budget and be killed.
+  ///
+  /// Signals that reader_loop has returned. close() waits on this instead of
+  /// joining straight away, so it can repeat the socket shutdown: one that
+  /// lands after the socket exists but before connect() returns is a no-op on
+  /// an unconnected socket, and the reader would then park with nothing left
+  /// to wake it.
+  std::mutex finished_mutex_;
+  std::condition_variable finished_cv_;
+  bool reader_finished_{false};
+
+  /// Guarded because the reader thread publishes it and close() reads it.
+  ///
+  /// The socket, NOT the httplib::Client. Calling Client::stop() while another
+  /// thread is inside Get() unlocks one of cpp-httplib's own mutexes from a
+  /// thread that never locked it; TSan reports "unlock of an unlocked mutex
+  /// (or by a wrong thread)" and glibc's pthread debug mode treats it as fatal.
+  /// That is the same hazard PeerClient documents when it explains why it never
+  /// stops its health-check client. Shutting the socket down instead wakes the
+  /// blocked read through the kernel and touches none of the library's state.
+  std::mutex socket_mutex_;
+  int active_socket_{-1};
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/fan_out_helpers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/fan_out_helpers.hpp
@@ -149,6 +149,11 @@ inline void merge_peer_items(AggregationManager * agg, const httplib::Request & 
   if (fan_result.is_partial) {
     ext_json["partial"] = true;
     ext_json["failed_peers"] = fan_result.failed_peers;
+    nlohmann::json failures = nlohmann::json::array();
+    for (const auto & failure : fan_result.peer_failures) {
+      failures.push_back({{"peer", failure.peer}, {"reason", failure.reason}});
+    }
+    ext_json["peer_failures"] = std::move(failures);
   }
 }
 
@@ -172,6 +177,8 @@ struct FanOutResult {
   bool partial{false};
   /// Names of peers that failed (matches AggregationManager::FanOutResult.failed_peers).
   std::vector<std::string> failed_peers;
+  /// Why each of those peers failed, one entry per name in `failed_peers`.
+  std::vector<dto::PeerFailure> peer_failures;
   /// Per-item drop records for peer items that failed JsonReader<T> validation.
   /// Surfaces "invisible drift" - malformed peer items used to disappear silently;
   /// now callers can fold these into x-medkit.peer_dropped_items for observability.
@@ -186,7 +193,8 @@ struct FanOutResult {
 ///     short-circuit to an empty result (no fan-out attempted).
 ///   - per-entity paths consult the routing/contributor tables to target only
 ///     the peers that host the entity; global paths fan out to all healthy peers.
-///   - peer failures are surfaced via `partial` + `failed_peers`.
+///   - peer failures are surfaced via `partial` + `failed_peers`, and the
+///     reason for each via `peer_failures`.
 ///
 /// New behavior:
 ///   - peer items are parsed via `dto::JsonReader<T>` rather than copied as
@@ -267,6 +275,7 @@ inline FanOutResult<T> fan_out_collection(AggregationManager * agg, const httpli
   }
   result.partial = fan_result.is_partial;
   result.failed_peers = fan_result.failed_peers;
+  result.peer_failures = fan_result.peer_failures;
   return result;
 }
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/health_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/health_handlers.hpp
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#include <memory>
+#include <utility>
+
+#include "ros2_medkit_gateway/core/http/sse_client_tracker.hpp"
+
 #include "ros2_medkit_gateway/dto/health.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
 #include "ros2_medkit_gateway/http/typed_router.hpp"
@@ -45,8 +50,12 @@ namespace handlers {
  */
 class HealthHandlers {
  public:
-  explicit HealthHandlers(HandlerContext & ctx, const openapi::RouteRegistry * route_registry = nullptr)
-    : ctx_(ctx), route_registry_(route_registry) {
+  /// @param sse_tracker Shared SSE client counter, so /health can report how
+  /// much of `sse.max_clients` is in use. Optional: a gateway built without
+  /// one simply omits the field.
+  explicit HealthHandlers(HandlerContext & ctx, const openapi::RouteRegistry * route_registry = nullptr,
+                          std::shared_ptr<const SSEClientTracker> sse_tracker = nullptr)
+    : ctx_(ctx), route_registry_(route_registry), sse_tracker_(std::move(sse_tracker)) {
   }
 
   /// GET /health - Health check endpoint
@@ -61,6 +70,7 @@ class HealthHandlers {
  private:
   HandlerContext & ctx_;
   const openapi::RouteRegistry * route_registry_{nullptr};
+  std::shared_ptr<const SSEClientTracker> sse_tracker_;
 };
 
 }  // namespace handlers

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/operations/operation_types.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/operations/operation_types.hpp
@@ -23,10 +23,27 @@ namespace ros2_medkit_gateway {
 
 using json = nlohmann::json;
 
+/// Why a synchronous round-trip to a ROS 2 endpoint produced no answer.
+///
+/// The same distinction `CancelOutcome` draws for the cancel path: a call that
+/// ran out of time is not a call that failed. The endpoint may be working on it
+/// still, so the two cannot share a status, and a client should not have to
+/// match on the text in `details` to tell them apart.
+enum class CallOutcome : uint8_t {
+  kOk,                  ///< The endpoint answered.
+  kTimeout,             ///< No answer inside the budget - the work may still be running.
+  kServiceUnavailable,  ///< The endpoint is not discoverable on the graph.
+  kTransportError,      ///< Null response, unknown type, serialization failure, exception.
+};
+
 /// Result of a synchronous service call.
 struct ServiceCallResult {
   bool success;
   json response;
+  /// Defaults to kTransportError so an exit path that forgets to classify
+  /// itself reads as a transport failure, never as a timeout - the same
+  /// defensive default `ActionCancelResult::outcome` carries.
+  CallOutcome outcome = CallOutcome::kTransportError;
   std::string error_message;
 };
 
@@ -50,6 +67,8 @@ struct ActionSendGoalResult {
   bool success;
   std::string goal_id;  ///< UUID hex string
   bool goal_accepted;
+  /// Meaningful only when `success` is false; see CallOutcome.
+  CallOutcome outcome = CallOutcome::kTransportError;
   std::string error_message;
 };
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/aggregation.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/aggregation.hpp
@@ -53,5 +53,32 @@ inline constexpr auto dto_fields<DroppedItem> =
 template <>
 inline constexpr std::string_view dto_name<DroppedItem> = "DroppedItem";
 
+// ---------------------------------------------------------------------------
+// PeerFailure - why one peer contributed nothing to a fanned-out collection.
+//
+// Carried in the peer_failures field beside failed_peers on every
+// collection-level XMedkit type. failed_peers names WHICH peers failed;
+// without this, a peer that ran out of time, a peer that refused the
+// connection, a peer that answered 500, a body over the size limit and
+// unparseable JSON are all the same entry in that list, and a client cannot
+// tell a slow subsystem from a dead one.
+//
+// Wire keys:
+//   peer   - peer name, matching the entry in failed_peers
+//   reason - one of: timeout, unreachable, canceled, error-status, too-large,
+//            invalid-response
+// ---------------------------------------------------------------------------
+struct PeerFailure {
+  std::string peer;
+  std::string reason;
+};
+
+template <>
+inline constexpr auto dto_fields<PeerFailure> =
+    std::make_tuple(field("peer", &PeerFailure::peer), field("reason", &PeerFailure::reason));
+
+template <>
+inline constexpr std::string_view dto_name<PeerFailure> = "PeerFailure";
+
 }  // namespace dto
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/config.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/config.hpp
@@ -93,6 +93,7 @@ inline constexpr std::string_view dto_name<ConfigurationMetaData> = "Configurati
 //   partial            - true when a fan-out peer request failed OR a local backing
 //                        node did not answer (see unavailable_nodes/failed_nodes)
 //   failed_peers       - list of peer addresses that returned errors
+//   peer_failures      - why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items - per-peer items dropped due to malformed JSON
 //                        (observability for invisible drift)
 // =============================================================================
@@ -108,6 +109,10 @@ struct ConfigListXMedkit {
   std::optional<std::vector<std::string>> failed_nodes;
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
@@ -119,7 +124,7 @@ inline constexpr auto dto_fields<ConfigListXMedkit> = std::make_tuple(
     field("source_ids", &ConfigListXMedkit::source_ids), field("queried_nodes", &ConfigListXMedkit::queried_nodes),
     field("unavailable_nodes", &ConfigListXMedkit::unavailable_nodes),
     field("failed_nodes", &ConfigListXMedkit::failed_nodes), field("partial", &ConfigListXMedkit::partial),
-    field("failed_peers", &ConfigListXMedkit::failed_peers),
+    field("failed_peers", &ConfigListXMedkit::failed_peers), field("peer_failures", &ConfigListXMedkit::peer_failures),
     field("peer_dropped_items", &ConfigListXMedkit::peer_dropped_items));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/data.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/data.hpp
@@ -138,6 +138,7 @@ inline constexpr std::string_view dto_name<DataItem> = "DataItem";
 //   total_count        - total number of items in the response
 //   partial            - true when a fan-out peer request failed
 //   failed_peers       - list of peer addresses that returned errors
+//   peer_failures      - why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items - per-peer items dropped due to malformed JSON
 //                        (observability for invisible drift)
 // =============================================================================
@@ -149,6 +150,10 @@ struct DataListXMedkit {
   std::optional<std::size_t> total_count;
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
@@ -159,6 +164,7 @@ inline constexpr auto dto_fields<DataListXMedkit> =
                     field("aggregation_level", &DataListXMedkit::aggregation_level),
                     field("total_count", &DataListXMedkit::total_count), field("partial", &DataListXMedkit::partial),
                     field("failed_peers", &DataListXMedkit::failed_peers),
+                    field("peer_failures", &DataListXMedkit::peer_failures),
                     field("peer_dropped_items", &DataListXMedkit::peer_dropped_items));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -151,6 +151,7 @@ inline constexpr std::string_view dto_name<FaultEnvironmentData> = "FaultEnviron
 //   clusters        - detailed cluster list (optional; only if requested)
 //   partial            - true when a fan-out peer request failed (optional)
 //   failed_peers       - list of peer addresses that returned errors (optional)
+//   peer_failures      - why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items - per-peer items dropped due to malformed JSON
 //                        (observability for invisible drift; optional)
 // =============================================================================
@@ -164,18 +165,21 @@ struct FaultListXMedkit {
   std::optional<nlohmann::json> clusters;      // free-form: FaultManager output
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
 template <>
-inline constexpr auto dto_fields<FaultListXMedkit> =
-    std::make_tuple(field("count", &FaultListXMedkit::count), field("muted_count", &FaultListXMedkit::muted_count),
-                    field("cluster_count", &FaultListXMedkit::cluster_count),
-                    field("entity_id", &FaultListXMedkit::entity_id), field("source_id", &FaultListXMedkit::source_id),
-                    field("muted_faults", &FaultListXMedkit::muted_faults),
-                    field("clusters", &FaultListXMedkit::clusters), field("partial", &FaultListXMedkit::partial),
-                    field("failed_peers", &FaultListXMedkit::failed_peers),
-                    field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items));
+inline constexpr auto dto_fields<FaultListXMedkit> = std::make_tuple(
+    field("count", &FaultListXMedkit::count), field("muted_count", &FaultListXMedkit::muted_count),
+    field("cluster_count", &FaultListXMedkit::cluster_count), field("entity_id", &FaultListXMedkit::entity_id),
+    field("source_id", &FaultListXMedkit::source_id), field("muted_faults", &FaultListXMedkit::muted_faults),
+    field("clusters", &FaultListXMedkit::clusters), field("partial", &FaultListXMedkit::partial),
+    field("failed_peers", &FaultListXMedkit::failed_peers), field("peer_failures", &FaultListXMedkit::peer_failures),
+    field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListXMedkit> = "FaultListXMedkit";
@@ -195,6 +199,7 @@ inline constexpr std::string_view dto_name<FaultListXMedkit> = "FaultListXMedkit
 //   count               - total items after fan-out merge
 //   partial             - true when a fan-out peer request failed (optional)
 //   failed_peers        - list of peer addresses that returned errors (optional)
+//   peer_failures       - why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items  - per-peer items dropped due to malformed JSON
 //                         (observability for invisible drift; optional)
 // =============================================================================
@@ -209,6 +214,10 @@ struct FaultListAggXMedkit {
   int64_t count{0};
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
@@ -223,6 +232,7 @@ inline constexpr auto dto_fields<FaultListAggXMedkit> =
                     field("aggregation_sources", &FaultListAggXMedkit::aggregation_sources),
                     field("count", &FaultListAggXMedkit::count), field("partial", &FaultListAggXMedkit::partial),
                     field("failed_peers", &FaultListAggXMedkit::failed_peers),
+                    field("peer_failures", &FaultListAggXMedkit::peer_failures),
                     field("peer_dropped_items", &FaultListAggXMedkit::peer_dropped_items));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "ros2_medkit_gateway/core/http/warning_codes.hpp"
+#include "ros2_medkit_gateway/dto/aggregation.hpp"
 #include "ros2_medkit_gateway/dto/contract.hpp"
 #include "ros2_medkit_gateway/dto/enums.hpp"
 
@@ -143,6 +144,8 @@ inline constexpr std::string_view dto_name<HealthWarning> = "HealthWarning";
 //                                   (from Ros2TopicDataProvider::x_medkit_stats())
 //   x-medkit-subscription-executor - optional free-form JSON stats object
 //                                    (from Ros2TopicDataProvider::x_medkit_stats())
+//   x-medkit-sse                  - optional free-form JSON object:
+//                                   {connected_clients, max_clients}
 //   peers                         - optional free-form JSON array (agg peer status)
 //   warning_schema_version        - integer warnings-contract version; always
 //                                   emitted, aggregation or not
@@ -161,7 +164,14 @@ struct Health {
   std::optional<nlohmann::json> x_medkit_data_provider;          // wire key: "x-medkit-data-provider"
   std::optional<nlohmann::json> x_medkit_subscription_executor;  // wire key: "x-medkit-subscription-executor"
   std::optional<nlohmann::json> x_medkit_entity_cache;           // wire key: "x-medkit-entity-cache"
-  std::optional<nlohmann::json> peers;                           // free-form array of peer status objects
+  /// How much of `sse.max_clients` is in use. Wire key: "x-medkit-sse".
+  ///
+  /// The cap is small - two by default - and an aggregating gateway now
+  /// consumes one slot on each of its peers for as long as somebody is
+  /// watching its own fault stream. Without this an operator has no way to see
+  /// why a peer refused their stream with 503.
+  std::optional<nlohmann::json> x_medkit_sse;
+  std::optional<nlohmann::json> peers;  // free-form array of peer status objects
   // NOT optional: these two are emitted in every mode, aggregation or not, so
   // the generated schema must list them in `required` and let a typed client
   // read them without a presence check. An empty `warnings` array is the
@@ -175,8 +185,9 @@ inline constexpr auto dto_fields<Health> = std::make_tuple(
     field("status", &Health::status), field("timestamp", &Health::timestamp), field("discovery", &Health::discovery),
     field("x-medkit-data-provider", &Health::x_medkit_data_provider),
     field("x-medkit-subscription-executor", &Health::x_medkit_subscription_executor),
-    field("x-medkit-entity-cache", &Health::x_medkit_entity_cache), field("peers", &Health::peers),
-    field("warning_schema_version", &Health::warning_schema_version), field("warnings", &Health::warnings));
+    field("x-medkit-entity-cache", &Health::x_medkit_entity_cache), field("x-medkit-sse", &Health::x_medkit_sse),
+    field("peers", &Health::peers), field("warning_schema_version", &Health::warning_schema_version),
+    field("warnings", &Health::warnings));
 
 template <>
 inline constexpr std::string_view dto_name<Health> = "HealthStatus";
@@ -231,6 +242,7 @@ inline constexpr std::string_view dto_name<VersionInfoEntry> = "VersionInfoEntry
 // Wire keys (from merge_peer_items in fan_out_helpers.hpp):
 //   partial      - true when one or more peers failed during fan-out (optional)
 //   failed_peers - list of peer addresses that returned errors (optional)
+//   peer_failures - why each of those peers failed (timeout, unreachable, ...)
 //
 // Both fields are optional so the DTO is correctly empty (no "x-medkit" key
 // in the response) when there are no aggregation peers or the fan-out succeeds
@@ -239,11 +251,17 @@ inline constexpr std::string_view dto_name<VersionInfoEntry> = "VersionInfoEntry
 struct XMedkitVersionInfo {
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
 };
 
 template <>
-inline constexpr auto dto_fields<XMedkitVersionInfo> = std::make_tuple(
-    field("partial", &XMedkitVersionInfo::partial), field("failed_peers", &XMedkitVersionInfo::failed_peers));
+inline constexpr auto dto_fields<XMedkitVersionInfo> =
+    std::make_tuple(field("partial", &XMedkitVersionInfo::partial),
+                    field("failed_peers", &XMedkitVersionInfo::failed_peers),
+                    field("peer_failures", &XMedkitVersionInfo::peer_failures));
 
 template <>
 inline constexpr std::string_view dto_name<XMedkitVersionInfo> = "XMedkitVersionInfo";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/logs.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/logs.hpp
@@ -98,6 +98,7 @@ inline constexpr std::string_view dto_name<LogEntry> = "LogEntry";
 //   contributors        - aggregation peer provenance list (peer fan-out)
 //   partial             - true when a peer fan-out request failed
 //   failed_peers        - list of peer addresses that returned errors
+//   peer_failures       - why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items  - per-peer items dropped due to malformed JSON
 //                         (observability for invisible drift)
 //
@@ -116,20 +117,23 @@ struct LogListXMedkit {
   std::optional<std::vector<std::string>> contributors;
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
 template <>
-inline constexpr auto dto_fields<LogListXMedkit> =
-    std::make_tuple(field("entity_id", &LogListXMedkit::entity_id),
-                    field_enum("aggregation_level", &LogListXMedkit::aggregation_level, kLogAggregationLevelValues),
-                    field("aggregated", &LogListXMedkit::aggregated), field("host_count", &LogListXMedkit::host_count),
-                    field("component_count", &LogListXMedkit::component_count),
-                    field("app_count", &LogListXMedkit::app_count),
-                    field("aggregation_sources", &LogListXMedkit::aggregation_sources),
-                    field("contributors", &LogListXMedkit::contributors), field("partial", &LogListXMedkit::partial),
-                    field("failed_peers", &LogListXMedkit::failed_peers),
-                    field("peer_dropped_items", &LogListXMedkit::peer_dropped_items));
+inline constexpr auto dto_fields<LogListXMedkit> = std::make_tuple(
+    field("entity_id", &LogListXMedkit::entity_id),
+    field_enum("aggregation_level", &LogListXMedkit::aggregation_level, kLogAggregationLevelValues),
+    field("aggregated", &LogListXMedkit::aggregated), field("host_count", &LogListXMedkit::host_count),
+    field("component_count", &LogListXMedkit::component_count), field("app_count", &LogListXMedkit::app_count),
+    field("aggregation_sources", &LogListXMedkit::aggregation_sources),
+    field("contributors", &LogListXMedkit::contributors), field("partial", &LogListXMedkit::partial),
+    field("failed_peers", &LogListXMedkit::failed_peers), field("peer_failures", &LogListXMedkit::peer_failures),
+    field("peer_dropped_items", &LogListXMedkit::peer_dropped_items));
 
 template <>
 inline constexpr std::string_view dto_name<LogListXMedkit> = "LogListXMedkit";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
@@ -46,15 +46,15 @@ namespace dto {
 /// The single compile-time list of every named DTO. Each domain header
 /// (Phase 2/3) appends its types here. Order is irrelevant.
 using AllDtos =
-    std::tuple<GenericError, DroppedItem, XMedkitRos2, XMedkitArea, XMedkitComponent, XMedkitApp, XMedkitFunction,
-               XMedkitCollection, AreaListItem, AreaDetail, ComponentListItem, ComponentDetail, AppListItem, AppDetail,
-               FunctionListItem, FunctionDetail, Collection<AreaListItem>, Collection<ComponentListItem>,
-               Collection<AppListItem>, Collection<FunctionListItem>, FaultListItem, Collection<FaultListItem>,
-               FaultListXMedkit, FaultListAggXMedkit, FaultStatus, FaultItem, FaultEnvironmentData, FaultXMedkit,
-               FaultDetail, FaultListResult, FaultDetailResult, FaultClearResult, XMedkitOperationItem,
-               XMedkitOperationExecution, OperationItem, Collection<OperationItem>, OperationDetail, OperationExecution,
-               ExecutionId, Collection<ExecutionId>, ExecutionCreateRequest, ExecutionCreateAsync,
-               ExecutionUpdateRequest, OperationExecutionResult,
+    std::tuple<GenericError, DroppedItem, PeerFailure, XMedkitRos2, XMedkitArea, XMedkitComponent, XMedkitApp,
+               XMedkitFunction, XMedkitCollection, AreaListItem, AreaDetail, ComponentListItem, ComponentDetail,
+               AppListItem, AppDetail, FunctionListItem, FunctionDetail, Collection<AreaListItem>,
+               Collection<ComponentListItem>, Collection<AppListItem>, Collection<FunctionListItem>, FaultListItem,
+               Collection<FaultListItem>, FaultListXMedkit, FaultListAggXMedkit, FaultStatus, FaultItem,
+               FaultEnvironmentData, FaultXMedkit, FaultDetail, FaultListResult, FaultDetailResult, FaultClearResult,
+               XMedkitOperationItem, XMedkitOperationExecution, OperationItem, Collection<OperationItem>,
+               OperationDetail, OperationExecution, ExecutionId, Collection<ExecutionId>, ExecutionCreateRequest,
+               ExecutionCreateAsync, ExecutionUpdateRequest, OperationExecutionResult,
                // Configuration domain DTOs
                ConfigXMedkitItem, ConfigurationMetaData, ConfigListXMedkit,
                Collection<ConfigurationMetaData, ConfigListXMedkit>, ConfigValueXMedkit, ConfigurationReadValue,

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/x_medkit.hpp
@@ -216,6 +216,7 @@ inline constexpr std::string_view dto_name<XMedkitFunction> = "XMedkitFunction";
 //   contributors       <- (optional aggregation provenance, included for completeness)
 //   partial            <- true when a fan-out peer request failed
 //   failed_peers       <- list of peer URLs that returned errors
+//   peer_failures      <- why each of those peers failed (timeout, unreachable, ...)
 //   peer_dropped_items <- per-peer items dropped due to malformed JSON
 //                         (observability for invisible drift)
 // ---------------------------------------------------------------------------
@@ -224,6 +225,10 @@ struct XMedkitCollection {
   std::optional<std::vector<std::string>> contributors;
   std::optional<bool> partial;
   std::optional<std::vector<std::string>> failed_peers;
+  /// Why each peer in `failed_peers` contributed nothing. Sibling rather than a
+  /// widening of `failed_peers`, whose wire shape (a list of names) every
+  /// existing client already reads.
+  std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
 };
 
@@ -231,6 +236,7 @@ template <>
 inline constexpr auto dto_fields<XMedkitCollection> = std::make_tuple(
     field("total_count", &XMedkitCollection::total_count), field("contributors", &XMedkitCollection::contributors),
     field("partial", &XMedkitCollection::partial), field("failed_peers", &XMedkitCollection::failed_peers),
+    field("peer_failures", &XMedkitCollection::peer_failures),
     field("peer_dropped_items", &XMedkitCollection::peer_dropped_items));
 
 template <>

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -29,6 +29,7 @@
 #include <nlohmann/json.hpp>
 
 #include "rclcpp/rclcpp.hpp"
+#include "ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp"
 #include "ros2_medkit_gateway/core/http/sse_client_tracker.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
 #include "ros2_medkit_gateway/http/response_types.hpp"
@@ -55,6 +56,15 @@ namespace handlers {
  * - Automatic reconnection support via Last-Event-ID header (values above the
  *   newest issued id are clamped to it, so a bogus header cannot starve the
  *   stream or alias the delivery accounting)
+ * - On an aggregating gateway, the peers' streams are relayed into this one.
+ *   An aggregator runs on its own ROS domain with its own fault_manager that
+ *   no producer reports to, so a stream fed from the local graph alone is open,
+ *   valid and silent - which reads to a client exactly like a healthy system.
+ *   Each relayed event carries the peer it came from in ``x-medkit.peer``.
+ *   Replay is over this gateway's OWN ids: two peers number their events
+ *   independently, so a `Last-Event-ID` cannot address a position in a merged
+ *   stream, and a reconnecting client resumes from what this gateway has
+ *   buffered rather than from each peer's own history.
  * - Replay buffer of up to 100 events. Eviction order under overflow:
  *   1. entries every live client has already been sent (free),
  *   2. fault_updated entries superseded by a newer event for the same fault
@@ -133,6 +143,15 @@ class SSEFaultHandler {
   size_t connected_clients() const;
 
   /**
+   * @brief Peer streams this gateway currently has open.
+   *
+   * Zero on a gateway that does not aggregate, and zero on an aggregating one
+   * with no client attached - the relay costs an SSE client slot on every peer
+   * for as long as it is open, and `sse.max_clients` defaults to 2.
+   */
+  std::size_t relayed_peer_streams() const;
+
+  /**
    * @brief Events genuinely lost: evicted while still owed to a live client,
    * except fault_updated entries a newer same-code event supersedes. Includes
    * superseded transitions - their history is gone even though the current
@@ -177,10 +196,18 @@ class SSEFaultHandler {
   /// (typed RouteRegistry path) and `handle_stream` (legacy in-process test
   /// entry). The returned callable is invoked with a `DataSink` and returns
   /// `false` when the client disconnects or `shutdown_flag_` is set.
-  std::function<bool(httplib::DataSink &)> make_stream_loop(uint64_t initial_last_event_id);
+  /// @param relay_peers Open the peers' streams for the lifetime of this
+  /// connection. False when the request carries `X-Medkit-No-Fan-Out`, which
+  /// is what an aggregating gateway sends when relaying from another one -
+  /// without it a chain would relay the same event back round the loop.
+  std::function<bool(httplib::DataSink &)> make_stream_loop(uint64_t initial_last_event_id, bool relay_peers);
 
   /// Callback for fault events from ROS 2 topic
   void on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr & msg);
+
+  /// Callback for an event relayed from a peer's stream. Runs on that peer
+  /// proxy's reader thread.
+  void on_peer_event(const StreamEvent & event);
 
   /// Resolved owning entity for a fault. Populates the ``x-medkit`` SOVD
   /// payload-extension object on outgoing SSE events.
@@ -196,6 +223,16 @@ class SSEFaultHandler {
     uint64_t id;
     ros2_medkit_msgs::msg::FaultEvent event;
     std::optional<EntityContext> entity;
+    /// Name of the peer this event was relayed from; empty when this gateway
+    /// saw the fault on its own graph. Part of the supersede key, because the
+    /// same fault code raised on two gateways names two different faults and
+    /// coalescing them would erase one of the two.
+    std::string peer;
+    /// The peer's own event payload, with `x-medkit.peer` added, ready to go
+    /// out as the `data:` line. Empty for a local event. Carried verbatim
+    /// rather than round-tripped through a FaultEvent message, so a field the
+    /// peer sends that this gateway's schema does not name survives the hop.
+    std::string relayed_payload;
   };
 
   /// Per-connection delivery cursor. Lets the buffer tell "nobody is owed this
@@ -226,12 +263,20 @@ class SSEFaultHandler {
   /// holds queue_mutex_.
   std::deque<QueuedEvent>::iterator find_superseded_locked(bool updates_only);
 
-  /// True when the buffer holds an event newer than last_event_id. Caller
+  /// True when the buffer holds an event newer than last_event_id that this
+  /// client is entitled to. With `relay_peers` false, events relayed from a
+  /// peer do not count: the client asked for the local graph only, so waking
+  /// its loop for one would spin it against events it will never send. Caller
   /// holds queue_mutex_.
-  bool has_pending_locked(uint64_t last_event_id) const;
+  bool has_pending_locked(uint64_t last_event_id, bool relay_peers) const;
 
   /// Record a successful write for this client. Caller holds queue_mutex_.
   void note_progress_locked(const std::shared_ptr<ClientCursor> & cursor, uint64_t delivered_id);
+
+  /// Buffer one event, evict down to capacity and report what that cost.
+  /// Shared by the local subscription and the peer relay so both take the same
+  /// path through the replay buffer.
+  void enqueue(QueuedEvent queued);
 
   /// Format a fault event as SSE message
   static std::string format_sse_event(const QueuedEvent & queued);
@@ -250,6 +295,10 @@ class SSEFaultHandler {
 
   /// Subscription to fault events topic
   rclcpp::Subscription<ros2_medkit_msgs::msg::FaultEvent>::SharedPtr subscription_;
+
+  /// Relays the peers' fault streams into this one on an aggregating gateway.
+  /// Always constructed; it opens nothing when this gateway has no peers.
+  std::unique_ptr<PeerFaultRelay> peer_relay_;
 
   /// Event queue for broadcasting to clients
   mutable std::mutex queue_mutex_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_parameter_transport.hpp
@@ -157,6 +157,18 @@ class Ros2ParameterTransport : public ParameterTransport {
   /// Convert ROS 2 ParameterValue to JSON.
   json parameter_value_to_json(const rclcpp::ParameterValue & value) const;
 
+  /// The value as the configurations API may show it: the real one, or a
+  /// redaction marker when the parameter's value is a credential.
+  ///
+  /// The configurations route is a read route, and a gateway that answers it
+  /// with the secret that signs its own tokens hands any reader the means to
+  /// mint one. Names are matched exactly, so a parameter that merely mentions
+  /// one of these words keeps showing its value.
+  json parameter_value_for_display(const std::string & name, const rclcpp::ParameterValue & value) const;
+
+  /// Whether this parameter's value is a credential and must never be shown.
+  static bool is_secret_parameter(const std::string & name);
+
   /// Convert JSON value to ROS 2 ParameterValue.
   rclcpp::ParameterValue json_to_parameter_value(const json & value, rclcpp::ParameterType hint_type) const;
 

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -272,8 +272,13 @@ void AggregationManager::add_discovered_peer(const std::string & url, const std:
     return;
   }
 
-  peers_.push_back(
-      std::make_shared<PeerClient>(url, name, config_.peer_timeouts(), config_.forward_auth, config_.peer_auth_header));
+  // A DISCOVERED peer gets no credential. peer_auth_header is presented to
+  // peers the operator named in the configuration; a peer that announced
+  // itself over mDNS is not one of those, and handing it this gateway's
+  // credential is the leak forward_auth already refuses to risk. A discovered
+  // peer that requires authentication therefore stays unreachable, which is
+  // the safe way round.
+  peers_.push_back(std::make_shared<PeerClient>(url, name, config_.peer_timeouts(), config_.forward_auth, ""));
 }
 
 void AggregationManager::remove_discovered_peer(const std::string & name) {

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -216,7 +216,7 @@ AggregationManager::AggregationManager(const AggregationConfig & config, rclcpp:
     }
 
     peers_.push_back(
-        std::make_shared<PeerClient>(peer_cfg.url, peer_cfg.name, config_.timeout_ms, config_.forward_auth));
+        std::make_shared<PeerClient>(peer_cfg.url, peer_cfg.name, config_.peer_timeouts(), config_.forward_auth));
   }
   static_peer_count_ = peers_.size();
 }
@@ -272,7 +272,7 @@ void AggregationManager::add_discovered_peer(const std::string & url, const std:
     return;
   }
 
-  peers_.push_back(std::make_shared<PeerClient>(url, name, config_.timeout_ms, config_.forward_auth));
+  peers_.push_back(std::make_shared<PeerClient>(url, name, config_.peer_timeouts(), config_.forward_auth));
 }
 
 void AggregationManager::remove_discovered_peer(const std::string & name) {
@@ -825,6 +825,10 @@ AggregationManager::FanOutResult AggregationManager::fan_out_get(const std::stri
   struct PeerResult {
     std::string peer_name;
     bool success{false};
+    /// Wire token for why this peer failed, from `peer_failure_reason`. Empty
+    /// on success. Built here rather than discarded, which is what left every
+    /// fan-out failure indistinguishable on the wire.
+    std::string failure_reason;
     nlohmann::json items = nlohmann::json::array();
   };
 
@@ -867,6 +871,7 @@ AggregationManager::FanOutResult AggregationManager::fan_out_get(const std::stri
       auto result = peer->forward_and_get_json("GET", path, auth_header, {{"X-Medkit-No-Fan-Out", "1"}});
       if (!result.has_value()) {
         pr.success = false;
+        pr.failure_reason = peer_failure_reason(result.error().kind);
         return pr;
       }
 
@@ -886,6 +891,7 @@ AggregationManager::FanOutResult AggregationManager::fan_out_get(const std::stri
     auto pr = f.get();
     if (!pr.success) {
       fan_out_result.is_partial = true;
+      fan_out_result.peer_failures.push_back(dto::PeerFailure{pr.peer_name, std::move(pr.failure_reason)});
       fan_out_result.failed_peers.push_back(std::move(pr.peer_name));
       continue;
     }
@@ -910,6 +916,17 @@ nlohmann::json AggregationManager::get_peer_status() const {
     status_array.push_back(peer_obj);
   }
   return status_array;
+}
+
+std::vector<PeerEndpoint> AggregationManager::healthy_peer_endpoints() const {
+  std::shared_lock<std::shared_mutex> lock(mutex_);
+  std::vector<PeerEndpoint> endpoints;
+  for (const auto & peer : peers_) {
+    if (peer->is_healthy()) {
+      endpoints.push_back(PeerEndpoint{peer->name(), peer->url()});
+    }
+  }
+  return endpoints;
 }
 
 PeerClient * AggregationManager::find_peer(const std::string & name) const {

--- a/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
+++ b/src/ros2_medkit_gateway/src/aggregation/aggregation_manager.cpp
@@ -215,8 +215,8 @@ AggregationManager::AggregationManager(const AggregationConfig & config, rclcpp:
       }
     }
 
-    peers_.push_back(
-        std::make_shared<PeerClient>(peer_cfg.url, peer_cfg.name, config_.peer_timeouts(), config_.forward_auth));
+    peers_.push_back(std::make_shared<PeerClient>(peer_cfg.url, peer_cfg.name, config_.peer_timeouts(),
+                                                  config_.forward_auth, config_.peer_auth_header));
   }
   static_peer_count_ = peers_.size();
 }
@@ -272,7 +272,8 @@ void AggregationManager::add_discovered_peer(const std::string & url, const std:
     return;
   }
 
-  peers_.push_back(std::make_shared<PeerClient>(url, name, config_.peer_timeouts(), config_.forward_auth));
+  peers_.push_back(
+      std::make_shared<PeerClient>(url, name, config_.peer_timeouts(), config_.forward_auth, config_.peer_auth_header));
 }
 
 void AggregationManager::remove_discovered_peer(const std::string & name) {

--- a/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
@@ -634,12 +634,18 @@ const char * peer_failure_reason(PeerFailureKind kind) {
   return "unreachable";
 }
 
-PeerClient::PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth)
-  : url_(url), name_(name), timeouts_(timeouts), forward_auth_(forward_auth) {
+PeerClient::PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth,
+                       std::string peer_auth_header)
+  : url_(url)
+  , name_(name)
+  , timeouts_(timeouts)
+  , forward_auth_(forward_auth)
+  , peer_auth_header_(std::move(peer_auth_header)) {
 }
 
-PeerClient::PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth)
-  : PeerClient(url, name, PeerTimeouts::uniform(timeout_ms), forward_auth) {
+PeerClient::PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth,
+                       std::string peer_auth_header)
+  : PeerClient(url, name, PeerTimeouts::uniform(timeout_ms), forward_auth, std::move(peer_auth_header)) {
 }
 
 const std::string & PeerClient::url() const {
@@ -689,7 +695,16 @@ void PeerClient::ensure_client() {
 void PeerClient::check_health() {
   std::lock_guard<std::mutex> lock(client_mutex_);
   ensure_client();
-  auto result = client_->Get(std::string(API_PREFIX) + "/health");
+  // The health check is this gateway asking on its own behalf, so it carries
+  // the gateway's own credential. Without it a peer that requires auth on
+  // reads answers 401, is recorded as unhealthy, and then appears in no
+  // fan-out and no relay - the peer is reachable and correctly configured, and
+  // the aggregator reports it as down.
+  httplib::Headers headers;
+  if (!peer_auth_header_.empty()) {
+    headers.emplace("Authorization", peer_auth_header_);
+  }
+  auto result = client_->Get(std::string(API_PREFIX) + "/health", headers);
   healthy_.store(result && result->status == 200);
 }
 
@@ -1010,6 +1025,11 @@ void PeerClient::forward_request(const httplib::Request & req, httplib::Response
   // Default is off to prevent token leakage to untrusted/mDNS-discovered peers.
   if (forward_auth_ && req.has_header("Authorization")) {
     headers.emplace("Authorization", req.get_header_value("Authorization"));
+  } else if (!peer_auth_header_.empty()) {
+    // The gateway's own credential, used when there is no client credential to
+    // pass on. A client's own token wins where forwarding is enabled, so
+    // forward_auth keeps naming the end user to the peer.
+    headers.emplace("Authorization", peer_auth_header_);
   }
   // Propagate fan-out suppression header to prevent recursive loops when
   // a forwarded request bounces back to the origin via bidirectional peering.
@@ -1133,6 +1153,8 @@ tl::expected<nlohmann::json, PeerError> PeerClient::forward_and_get_json(const s
   // Only forward auth header when forward_auth is enabled
   if (forward_auth_ && !auth_header.empty()) {
     headers.emplace("Authorization", auth_header);
+  } else if (!peer_auth_header_.empty()) {
+    headers.emplace("Authorization", peer_auth_header_);
   }
   for (const auto & [key, value] : extra_headers) {
     headers.emplace(key, value);

--- a/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <iterator>
 #include <set>
 #include <string>
@@ -511,8 +512,134 @@ SubResponse read_sub_response(const httplib::Result & result, const std::string 
 
 }  // namespace
 
+namespace {
+
+/// Name and value of the budget an error was measured against, for a message a
+/// client can act on. The READ budget differs by call: a forward spends
+/// `aggregation.forward_timeout_ms`, a fan-out spends `aggregation.timeout_ms`,
+/// so the caller names its own rather than have this guess.
+std::string describe_budget(PeerBudget budget, const PeerTimeouts & timeouts, const char * read_key, int read_ms) {
+  switch (budget) {
+    case PeerBudget::kConnect:
+      return "aggregation.timeout_ms (" + std::to_string(timeouts.connect_ms) + "ms, connect)";
+    case PeerBudget::kRead:
+      return std::string(read_key) + " (" + std::to_string(read_ms) + "ms, read)";
+    case PeerBudget::kWrite:
+      return "aggregation.write_timeout_ms (" + std::to_string(timeouts.write_ms) + "ms, write)";
+    case PeerBudget::kNone:
+      break;
+  }
+  return "its budget";
+}
+
+}  // namespace
+
+PeerBudget peer_budget_for(httplib::Error error) {
+  switch (error) {
+    case httplib::Error::ConnectionTimeout:
+      return PeerBudget::kConnect;
+    case httplib::Error::Read:
+      return PeerBudget::kRead;
+    case httplib::Error::Write:
+      return PeerBudget::kWrite;
+    case httplib::Error::Success:
+    case httplib::Error::Unknown:
+    case httplib::Error::Connection:
+    case httplib::Error::BindIPAddress:
+    case httplib::Error::ExceedRedirectCount:
+    case httplib::Error::Canceled:
+    case httplib::Error::SSLConnection:
+    case httplib::Error::SSLLoadingCerts:
+    case httplib::Error::SSLServerVerification:
+    case httplib::Error::UnsupportedMultipartBoundaryChars:
+    case httplib::Error::Compression:
+    case httplib::Error::ProxyConnection:
+    case httplib::Error::SSLPeerCouldBeClosed_:
+      return PeerBudget::kNone;
+  }
+  return PeerBudget::kNone;
+}
+
+PeerFailureKind classify_peer_error(httplib::Error error, std::chrono::milliseconds elapsed,
+                                    std::chrono::milliseconds read_budget, std::chrono::milliseconds write_budget) {
+  // Every enumerator listed rather than a default, because -Wswitch-enum is an
+  // error here: a cpp-httplib upgrade that adds a failure mode has to be
+  // classified deliberately instead of falling into "unreachable" unnoticed.
+  switch (error) {
+    case httplib::Error::ConnectionTimeout:
+      return PeerFailureKind::kTimeout;
+    case httplib::Error::Canceled:
+      return PeerFailureKind::kCanceled;
+    case httplib::Error::Read:
+      // The budget is always set on these clients, so a call that consumed it
+      // ran out of time. One that came back sooner broke for another reason -
+      // most often the peer process dying with the answer half sent - and
+      // reporting that as a timeout would tell an operator to wait for a peer
+      // that is gone.
+      //
+      // `elapsed` covers connect plus read, because cpp-httplib reports no
+      // separate connect-completion time and its socket-options hook runs
+      // BEFORE the connect. A slow handshake therefore counts towards the read
+      // budget. The connect budget is capped well below the read budgets (see
+      // AggregationConfig::peer_timeouts) so that window is bounded by the cap
+      // rather than by the whole metadata budget, and a handshake slower than
+      // the cap fails as ConnectionTimeout instead, which is attributed
+      // correctly. Removing the window entirely needs the vendored client to
+      // expose a post-connect callback.
+      return elapsed >= read_budget ? PeerFailureKind::kTimeout : PeerFailureKind::kUnreachable;
+    case httplib::Error::Write:
+      // Against the WRITE budget, which is its own and smaller than the read
+      // budget by default. Measured against the read budget, a write that ran
+      // out at 5 s inside a 15 s forward budget looks like a peer that died,
+      // and the one key whose whole purpose is bounding a slow upload could
+      // never report its own expiry.
+      return elapsed >= write_budget ? PeerFailureKind::kTimeout : PeerFailureKind::kUnreachable;
+    case httplib::Error::Success:
+      // Not reachable through the callers, which classify only a null result,
+      // but the enumerator exists and "no failure" is the only honest answer.
+      return PeerFailureKind::kNone;
+    case httplib::Error::Unknown:
+    case httplib::Error::Connection:
+    case httplib::Error::BindIPAddress:
+    case httplib::Error::ExceedRedirectCount:
+    case httplib::Error::SSLConnection:
+    case httplib::Error::SSLLoadingCerts:
+    case httplib::Error::SSLServerVerification:
+    case httplib::Error::UnsupportedMultipartBoundaryChars:
+    case httplib::Error::Compression:
+    case httplib::Error::ProxyConnection:
+    case httplib::Error::SSLPeerCouldBeClosed_:
+      return PeerFailureKind::kUnreachable;
+  }
+  return PeerFailureKind::kUnreachable;
+}
+
+const char * peer_failure_reason(PeerFailureKind kind) {
+  switch (kind) {
+    case PeerFailureKind::kNone:
+      return "none";
+    case PeerFailureKind::kTimeout:
+      return "timeout";
+    case PeerFailureKind::kUnreachable:
+      return "unreachable";
+    case PeerFailureKind::kCanceled:
+      return "canceled";
+    case PeerFailureKind::kErrorStatus:
+      return "error-status";
+    case PeerFailureKind::kTooLarge:
+      return "too-large";
+    case PeerFailureKind::kInvalidResponse:
+      return "invalid-response";
+  }
+  return "unreachable";
+}
+
+PeerClient::PeerClient(const std::string & url, const std::string & name, PeerTimeouts timeouts, bool forward_auth)
+  : url_(url), name_(name), timeouts_(timeouts), forward_auth_(forward_auth) {
+}
+
 PeerClient::PeerClient(const std::string & url, const std::string & name, int timeout_ms, bool forward_auth)
-  : url_(url), name_(name), timeout_ms_(timeout_ms), forward_auth_(forward_auth) {
+  : PeerClient(url, name, PeerTimeouts::uniform(timeout_ms), forward_auth) {
 }
 
 const std::string & PeerClient::url() const {
@@ -547,9 +674,11 @@ void PeerClient::ensure_client() {
     //     bounds shutdown delay to ~5s under TSan, well within the 15s
     //     grace window, without affecting forward semantics (which still
     //     use the configured timeout via ScopedClient).
-    int health_timeout_ms = std::min(timeout_ms_, 1000);
-    client_->set_connection_timeout(health_timeout_ms / 1000, (health_timeout_ms % 1000) * 1000);
+    int health_timeout_ms = std::min(timeouts_.metadata_read_ms, 1000);
+    client_->set_connection_timeout(std::min(timeouts_.connect_ms, health_timeout_ms) / 1000,
+                                    (std::min(timeouts_.connect_ms, health_timeout_ms) % 1000) * 1000);
     client_->set_read_timeout(health_timeout_ms / 1000, (health_timeout_ms % 1000) * 1000);
+    client_->set_write_timeout(timeouts_.write_ms / 1000, (timeouts_.write_ms % 1000) * 1000);
     // Note: cpp-httplib Client does not expose set_payload_max_length (server-only).
     // Response size is enforced post-download in forward_request() and
     // forward_and_get_json() via MAX_PEER_RESPONSE_SIZE body length checks.
@@ -572,7 +701,7 @@ tl::expected<PeerEntities, std::string> PeerClient::fetch_entities() {
   // requests, up to 8s with 2s timeout) to avoid blocking health checks and
   // forwarding on the shared client_mutex_. ScopedClient registers with the
   // active-client registry so shutdown() can stop() the in-flight call.
-  ScopedClient scoped(*this, url_, timeout_ms_);
+  ScopedClient scoped(*this, url_, timeouts_.metadata_read_ms);
   auto & cli = *scoped;
 
   PeerEntities entities;
@@ -869,7 +998,11 @@ void PeerClient::forward_request(const httplib::Request & req, httplib::Response
   // during potentially long I/O operations. The shared client_ is reserved for
   // short health checks only. ScopedClient registers with the active-client
   // registry so shutdown() can stop() the in-flight call.
-  ScopedClient scoped(*this, url_, timeout_ms_);
+  //
+  // The forward budget, not the metadata one: what comes back is whatever the
+  // peer had to do to answer, which for a synchronous operation is that
+  // gateway's own service budget and for a large resource is the transfer.
+  ScopedClient scoped(*this, url_, timeouts_.forward_read_ms);
   auto & cli = *scoped;
 
   httplib::Headers headers;
@@ -897,6 +1030,8 @@ void PeerClient::forward_request(const httplib::Request & req, httplib::Response
   const std::string path = path_with_query(req);
   const std::string content_type = req.get_header_value("Content-Type");
 
+  const auto started_at = std::chrono::steady_clock::now();
+
   if (req.method == "GET") {
     result = cli.Get(path, headers);
   } else if (req.method == "POST") {
@@ -910,8 +1045,32 @@ void PeerClient::forward_request(const httplib::Request & req, httplib::Response
   }
 
   if (!result) {
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at);
+    const auto kind = classify_peer_error(result.error(), elapsed, std::chrono::milliseconds(timeouts_.forward_read_ms),
+                                          std::chrono::milliseconds(timeouts_.write_ms));
+    if (kind == PeerFailureKind::kTimeout) {
+      // The peer is answering someone; this gateway stopped waiting. Saying it
+      // is unavailable describes a different system state and points an
+      // operator at the wrong box.
+      //
+      // The message names the budget that actually expired. A connect timeout
+      // is bounded by aggregation.timeout_ms, not by the forward budget the
+      // call was hoping to spend, and telling an operator to raise the forward
+      // budget would not move a peer that never accepted the connection.
+      const auto expired = describe_budget(peer_budget_for(result.error()), timeouts_, "aggregation.forward_timeout_ms",
+                                           timeouts_.forward_read_ms);
+      res.status = 504;
+      auto error_body =
+          make_error_body(ERR_NOT_RESPONDING, "Peer '" + name_ + "' at " + url_ + " did not answer within " + expired +
+                                                  ". The request may still be running there.");
+      res.set_content(error_body.dump(), "application/json");
+      return;
+    }
     res.status = 502;
-    auto error_body = make_error_body(ERR_VENDOR_ERROR, "Peer '" + name_ + "' at " + url_ + " is unavailable",
+    auto error_body = make_error_body(ERR_VENDOR_ERROR,
+                                      "Peer '" + name_ + "' at " + url_ + " is unavailable (" +
+                                          std::string(peer_failure_reason(kind)) + ")",
                                       ERR_X_MEDKIT_PEER_UNAVAILABLE);
     res.set_content(error_body.dump(), "application/json");
     return;
@@ -951,18 +1110,23 @@ void PeerClient::forward_request(const httplib::Request & req, httplib::Response
   }
 }
 
-tl::expected<nlohmann::json, std::string> PeerClient::forward_and_get_json(const std::string & method,
-                                                                           const std::string & path,
-                                                                           const std::string & auth_header,
-                                                                           const httplib::Headers & extra_headers) {
+tl::expected<nlohmann::json, PeerError> PeerClient::forward_and_get_json(const std::string & method,
+                                                                         const std::string & path,
+                                                                         const std::string & auth_header,
+                                                                         const httplib::Headers & extra_headers) {
   if (shutdown_requested_.load(std::memory_order_acquire)) {
-    return tl::unexpected<std::string>("Peer '" + name_ + "': forward_and_get_json skipped, shutdown in progress");
+    return tl::unexpected(PeerError{PeerFailureKind::kCanceled,
+                                    "Peer '" + name_ + "': forward_and_get_json skipped, shutdown in progress"});
   }
   // Create a dedicated client per call to avoid holding client_mutex_ during I/O.
   // The shared client_ is reserved for short health checks only. ScopedClient
   // registers with the active-client registry so shutdown() can stop() the
   // in-flight call.
-  ScopedClient scoped(*this, url_, timeout_ms_);
+  //
+  // The metadata budget: a fan-out runs against every peer at once with a
+  // client waiting on the slowest of them, so this is bounded by what a
+  // listing is worth, not by what one peer's work might cost.
+  ScopedClient scoped(*this, url_, timeouts_.metadata_read_ms);
   auto & cli = *scoped;
 
   httplib::Headers headers;
@@ -993,6 +1157,8 @@ tl::expected<nlohmann::json, std::string> PeerClient::forward_and_get_json(const
 
   httplib::Result result{nullptr, httplib::Error::Unknown};
 
+  const auto started_at = std::chrono::steady_clock::now();
+
   if (method == "GET") {
     result = cli.Get(
         path, headers,
@@ -1013,36 +1179,60 @@ tl::expected<nlohmann::json, std::string> PeerClient::forward_and_get_json(const
   // cpp-httplib does not offer ContentReceiver overloads for all methods.
   bool used_streaming = (method == "GET");
 
+  // The size guard aborts the download from inside the content receiver, which
+  // cpp-httplib surfaces as a cancelled read. Checked before the transport
+  // error so an oversized body is reported as one rather than as a broken
+  // connection.
+  auto transport_failure = [&]() {
+    const auto elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started_at);
+    const auto kind =
+        classify_peer_error(result.error(), elapsed, std::chrono::milliseconds(timeouts_.metadata_read_ms),
+                            std::chrono::milliseconds(timeouts_.write_ms));
+    std::string message = kind == PeerFailureKind::kTimeout
+                              ? "Peer '" + name_ + "' at " + url_ + " did not answer " + method + " " + path +
+                                    " within " +
+                                    describe_budget(peer_budget_for(result.error()), timeouts_,
+                                                    "aggregation.timeout_ms", timeouts_.metadata_read_ms)
+                              : "Failed to reach peer '" + name_ + "' at " + url_ + " for " + method + " " + path;
+    return PeerError{kind, std::move(message)};
+  };
+
   if (used_streaming) {
     if (size_exceeded) {
-      return tl::unexpected<std::string>("Response from peer '" + name_ + "' exceeds size limit for " + method + " " +
-                                         path);
+      return tl::unexpected(
+          PeerError{PeerFailureKind::kTooLarge,
+                    "Response from peer '" + name_ + "' exceeds size limit for " + method + " " + path});
     }
     if (!result) {
-      return tl::unexpected<std::string>("Failed to connect to peer '" + name_ + "' at " + url_);
+      return tl::unexpected(transport_failure());
     }
     if (response_status < 200 || response_status >= 300) {
-      return tl::unexpected<std::string>("Peer '" + name_ + "' returned status " + std::to_string(response_status) +
-                                         " for " + method + " " + path);
+      return tl::unexpected(PeerError{PeerFailureKind::kErrorStatus, "Peer '" + name_ + "' returned status " +
+                                                                         std::to_string(response_status) + " for " +
+                                                                         method + " " + path});
     }
   } else {
     if (!result) {
-      return tl::unexpected<std::string>("Failed to connect to peer '" + name_ + "' at " + url_);
+      return tl::unexpected(transport_failure());
     }
     if (result->status < 200 || result->status >= 300) {
-      return tl::unexpected<std::string>("Peer '" + name_ + "' returned status " + std::to_string(result->status) +
-                                         " for " + method + " " + path);
+      return tl::unexpected(PeerError{PeerFailureKind::kErrorStatus, "Peer '" + name_ + "' returned status " +
+                                                                         std::to_string(result->status) + " for " +
+                                                                         method + " " + path});
     }
     if (result->body.size() > MAX_PEER_RESPONSE_SIZE) {
-      return tl::unexpected<std::string>("Response from peer '" + name_ + "' exceeds size limit for " + method + " " +
-                                         path);
+      return tl::unexpected(
+          PeerError{PeerFailureKind::kTooLarge,
+                    "Response from peer '" + name_ + "' exceeds size limit for " + method + " " + path});
     }
     accumulated_body = std::move(result->body);
   }
 
   auto parsed = nlohmann::json::parse(accumulated_body, nullptr, false);
   if (parsed.is_discarded()) {
-    return tl::unexpected<std::string>("Invalid JSON response from peer '" + name_ + "' for " + method + " " + path);
+    return tl::unexpected(PeerError{PeerFailureKind::kInvalidResponse,
+                                    "Invalid JSON response from peer '" + name_ + "' for " + method + " " + path});
   }
 
   return parsed;
@@ -1089,10 +1279,16 @@ void PeerClient::unregister_active(httplib::Client * cli) {
   active_clients_.erase(cli);
 }
 
-PeerClient::ScopedClient::ScopedClient(PeerClient & owner, const std::string & url, int timeout_ms)
+PeerClient::ScopedClient::ScopedClient(PeerClient & owner, const std::string & url, int read_timeout_ms)
   : owner_(owner), cli_(url) {
-  cli_.set_connection_timeout(timeout_ms / 1000, (timeout_ms % 1000) * 1000);
-  cli_.set_read_timeout(timeout_ms / 1000, (timeout_ms % 1000) * 1000);
+  const int connect_ms = owner.timeouts_.connect_ms;
+  const int write_ms = owner.timeouts_.write_ms;
+  cli_.set_connection_timeout(connect_ms / 1000, (connect_ms % 1000) * 1000);
+  cli_.set_read_timeout(read_timeout_ms / 1000, (read_timeout_ms % 1000) * 1000);
+  // Without this the write budget is cpp-httplib's own 5 s default and follows
+  // no configured value at all, so a large request body to a slow peer is cut
+  // off however high the read budget is set.
+  cli_.set_write_timeout(write_ms / 1000, (write_ms % 1000) * 1000);
   owner_.register_active(&cli_);
   // If shutdown landed between the timeout setup and registration, pre-stop
   // the client so the first Get/Post returns Error::Canceled immediately.

--- a/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/peer_client.cpp
@@ -718,6 +718,14 @@ tl::expected<PeerEntities, std::string> PeerClient::fetch_entities() {
   // active-client registry so shutdown() can stop() the in-flight call.
   ScopedClient scoped(*this, url_, timeouts_.metadata_read_ms);
   auto & cli = *scoped;
+  // Fetching the peer's entities is this gateway asking on its own behalf, so
+  // it carries the gateway's own credential. Set once on the client rather
+  // than on each of the requests below - that is also what stops the next
+  // route added here from silently going out unauthenticated and reducing the
+  // peer to "offers no such route".
+  if (!peer_auth_header_.empty()) {
+    cli.set_default_headers({{"Authorization", peer_auth_header_}});
+  }
 
   PeerEntities entities;
   const std::string peer_source = "peer:" + name_;

--- a/src/ros2_medkit_gateway/src/core/aggregation/peer_fault_relay.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/peer_fault_relay.cpp
@@ -42,7 +42,7 @@ void PeerFaultRelay::acquire() {
 }
 
 void PeerFaultRelay::release() {
-  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (clients_ == 0) {
@@ -52,9 +52,9 @@ void PeerFaultRelay::release() {
       retired = take_all_locked();
     }
   }
-  // Outside the lock on purpose: each destructor joins a reader thread, and a
-  // reader thread delivering an event is inside the owner's callback.
-  retired.clear();
+  // Outside the lock on purpose: closing joins a reader thread, and a reader
+  // thread delivering an event is inside the owner's callback.
+  retire(std::move(retired));
 }
 
 void PeerFaultRelay::reconcile() {
@@ -83,7 +83,7 @@ void PeerFaultRelay::reconcile_now(bool force) {
   // moved out under the lock and destroyed after it. A reader thread delivering
   // an event calls back into the owner, which locks its own queue; joining that
   // thread while holding this mutex puts the two lock orders against each other.
-  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired;
   std::vector<RelayTarget> to_open;
   {
     std::lock_guard<std::mutex> lock(mutex_);
@@ -98,8 +98,7 @@ void PeerFaultRelay::reconcile_now(bool force) {
         ++it;
         continue;
       }
-      cursors_[it->first] = it->second->last_event_id();
-      retired.push_back(std::move(it->second));
+      retired.emplace_back(it->first, std::move(it->second));
       it = streams_.erase(it);
     }
     for (const auto & target : targets) {
@@ -108,7 +107,7 @@ void PeerFaultRelay::reconcile_now(bool force) {
       }
     }
   }
-  retired.clear();
+  retire(std::move(retired));
 
   for (const auto & target : to_open) {
     // X-Medkit-No-Fan-Out is what the collection routes already use to stop a
@@ -147,7 +146,7 @@ std::size_t PeerFaultRelay::open_streams() const {
 }
 
 void PeerFaultRelay::shutdown() {
-  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (shut_down_) {
@@ -157,21 +156,53 @@ void PeerFaultRelay::shutdown() {
     clients_ = 0;
     retired = take_all_locked();
   }
-  retired.clear();
+  retire(std::move(retired));
 }
 
-std::vector<std::unique_ptr<SSEStreamProxy>> PeerFaultRelay::take_all_locked() {
-  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+std::vector<std::pair<PeerFaultRelay::StreamKey, std::unique_ptr<SSEStreamProxy>>> PeerFaultRelay::take_all_locked() {
+  std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired;
   retired.reserve(streams_.size());
   for (auto & [key, proxy] : streams_) {
-    // Read before the proxy leaves: the caller destroys these outside the
-    // lock, and the cursor has to survive so a stream reopened for the same
-    // peer resumes rather than replaying the peer's whole buffer.
-    cursors_[key] = proxy->last_event_id();
-    retired.push_back(std::move(proxy));
+    // The key travels with the proxy so retire() can record where its reader
+    // stopped. The cursor is NOT read here: this runs with the reader still
+    // going, so a value taken now can be one event behind by the time the
+    // reader is stopped, and that event would then be replayed.
+    retired.emplace_back(key, std::move(proxy));
   }
   streams_.clear();
   return retired;
+}
+
+void PeerFaultRelay::retire(std::vector<std::pair<StreamKey, std::unique_ptr<SSEStreamProxy>>> retired) {
+  for (auto & [key, proxy] : retired) {
+    if (!proxy) {
+      continue;
+    }
+    // Stopped BEFORE its cursor is read, so the value recorded is the last
+    // event the reader actually delivered and not a snapshot it has since
+    // moved past.
+    proxy->close();
+    auto cursor = proxy->last_event_id();
+    proxy.reset();
+    if (cursor.empty()) {
+      continue;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    cursors_[key] = std::move(cursor);
+    trim_cursors_locked();
+  }
+}
+
+void PeerFaultRelay::trim_cursors_locked() {
+  while (cursors_.size() > kMaxCursors) {
+    // Prefer forgetting a peer that has no stream open right now: it is the
+    // one least likely to be resumed, and a peer currently being relayed from
+    // would otherwise lose its resume point while it was still in use.
+    auto victim = std::find_if(cursors_.begin(), cursors_.end(), [this](const auto & entry) {
+      return streams_.find(entry.first) == streams_.end();
+    });
+    cursors_.erase(victim == cursors_.end() ? cursors_.begin() : victim);
+  }
 }
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/core/aggregation/peer_fault_relay.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/peer_fault_relay.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp"
+
+#include <chrono>
+#include <utility>
+
+namespace ros2_medkit_gateway {
+
+PeerFaultRelay::PeerFaultRelay(TargetSupplier targets, std::string path, EventCallback on_event)
+  : targets_(std::move(targets)), path_(std::move(path)), on_event_(std::move(on_event)) {
+}
+
+PeerFaultRelay::~PeerFaultRelay() {
+  shutdown();
+}
+
+void PeerFaultRelay::acquire() {
+  bool opened_first = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (shut_down_) {
+      return;
+    }
+    opened_first = (clients_++ == 0);
+  }
+  if (opened_first) {
+    reconcile_now(/*force=*/true);
+  }
+}
+
+void PeerFaultRelay::release() {
+  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (clients_ == 0) {
+      return;
+    }
+    if (--clients_ == 0) {
+      retired = take_all_locked();
+    }
+  }
+  // Outside the lock on purpose: each destructor joins a reader thread, and a
+  // reader thread delivering an event is inside the owner's callback.
+  retired.clear();
+}
+
+void PeerFaultRelay::reconcile() {
+  reconcile_now(/*force=*/false);
+}
+
+void PeerFaultRelay::reconcile_now(bool force) {
+  // The target list is read outside the lock: it reaches into the aggregation
+  // manager, which takes a lock of its own, and holding both in this order
+  // would pin the two together for every wakeup of every streaming client.
+  std::vector<RelayTarget> targets;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (shut_down_ || clients_ == 0) {
+      return;
+    }
+    const auto now = std::chrono::steady_clock::now();
+    if (!force && now - last_reconcile_ < kReconcileInterval) {
+      return;
+    }
+    last_reconcile_ = now;
+  }
+  targets = targets_ ? targets_() : std::vector<RelayTarget>{};
+
+  // Closing a proxy joins its reader thread, so the ones being retired are
+  // moved out under the lock and destroyed after it. A reader thread delivering
+  // an event calls back into the owner, which locks its own queue; joining that
+  // thread while holding this mutex puts the two lock orders against each other.
+  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  std::vector<RelayTarget> to_open;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (shut_down_ || clients_ == 0) {
+      return;
+    }
+    for (auto it = streams_.begin(); it != streams_.end();) {
+      const bool still_listed = std::any_of(targets.begin(), targets.end(), [&it](const RelayTarget & target) {
+        return target.name == it->first.first && target.url == it->first.second;
+      });
+      if (still_listed) {
+        ++it;
+        continue;
+      }
+      cursors_[it->first] = it->second->last_event_id();
+      retired.push_back(std::move(it->second));
+      it = streams_.erase(it);
+    }
+    for (const auto & target : targets) {
+      if (streams_.find(std::make_pair(target.name, target.url)) == streams_.end()) {
+        to_open.push_back(target);
+      }
+    }
+  }
+  retired.clear();
+
+  for (const auto & target : to_open) {
+    // X-Medkit-No-Fan-Out is what the collection routes already use to stop a
+    // request bouncing round a bidirectional or chained peering. A relayed
+    // stream needs it for the same reason: without it, a peer that aggregates
+    // in turn would relay this gateway's own relayed events back.
+    httplib::Headers headers{{"X-Medkit-No-Fan-Out", "1"}};
+    if (!target.auth_header.empty()) {
+      headers.emplace("Authorization", target.auth_header);
+    }
+    auto proxy = std::make_unique<SSEStreamProxy>(target.url, path_, target.name, headers);
+    proxy->on_event(on_event_);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      const auto cursor = cursors_.find(std::make_pair(target.name, target.url));
+      if (cursor != cursors_.end()) {
+        proxy->set_last_event_id(cursor->second);
+      }
+    }
+    proxy->open();
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (shut_down_ || clients_ == 0) {
+      // The last client left while the stream was being opened. Unlock-free
+      // teardown is not available here, but the proxy is not published, so
+      // closing it after the lock is released is enough - it is the only
+      // reference.
+      break;
+    }
+    streams_.emplace(std::make_pair(target.name, target.url), std::move(proxy));
+  }
+}
+
+std::size_t PeerFaultRelay::open_streams() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return streams_.size();
+}
+
+void PeerFaultRelay::shutdown() {
+  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (shut_down_) {
+      return;
+    }
+    shut_down_ = true;
+    clients_ = 0;
+    retired = take_all_locked();
+  }
+  retired.clear();
+}
+
+std::vector<std::unique_ptr<SSEStreamProxy>> PeerFaultRelay::take_all_locked() {
+  std::vector<std::unique_ptr<SSEStreamProxy>> retired;
+  retired.reserve(streams_.size());
+  for (auto & [key, proxy] : streams_) {
+    // Read before the proxy leaves: the caller destroys these outside the
+    // lock, and the cursor has to survive so a stream reopened for the same
+    // peer resumes rather than replaying the peer's whole buffer.
+    cursors_[key] = proxy->last_event_id();
+    retired.push_back(std::move(proxy));
+  }
+  streams_.clear();
+  return retired;
+}
+
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/core/aggregation/sse_stream_proxy.cpp
+++ b/src/ros2_medkit_gateway/src/core/aggregation/sse_stream_proxy.cpp
@@ -14,6 +14,10 @@
 
 #include "ros2_medkit_gateway/core/aggregation/stream_proxy.hpp"
 
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstdio>
@@ -25,8 +29,9 @@
 
 namespace ros2_medkit_gateway {
 
-SSEStreamProxy::SSEStreamProxy(const std::string & peer_url, const std::string & path, const std::string & peer_name)
-  : peer_url_(peer_url), path_(path), peer_name_(peer_name) {
+SSEStreamProxy::SSEStreamProxy(const std::string & peer_url, const std::string & path, const std::string & peer_name,
+                               httplib::Headers headers)
+  : peer_url_(peer_url), path_(path), peer_name_(peer_name), headers_(std::move(headers)) {
 }
 
 SSEStreamProxy::~SSEStreamProxy() {
@@ -40,15 +45,51 @@ void SSEStreamProxy::open() {
     return;
   }
   should_stop_.store(false);
+  {
+    std::lock_guard<std::mutex> lock(finished_mutex_);
+    reader_finished_ = false;
+  }
   reader_thread_ = std::thread(&SSEStreamProxy::reader_loop, this);
 }
 
 void SSEStreamProxy::close() {
   should_stop_.store(true);
   connected_.store(false);
-  if (reader_thread_.joinable()) {
-    reader_thread_.join();
+  if (!reader_thread_.joinable()) {
+    return;
   }
+  // Interrupt the read the reader thread is parked in. should_stop_ alone is
+  // only observed when bytes arrive, so a peer that is connected and quiet
+  // would hold this join until its next keepalive.
+  //
+  // Repeated until the reader is actually out, because a single shutdown can
+  // miss: on a socket that exists but has not finished connecting it returns
+  // ENOTCONN and changes nothing, and the reader goes on to connect and park.
+  // Retrying costs one syscall per 100 ms of a teardown that is normally over
+  // in one pass.
+  {
+    std::unique_lock<std::mutex> lock(finished_mutex_);
+    while (!reader_finished_) {
+      {
+        std::lock_guard<std::mutex> socket_lock(socket_mutex_);
+        if (active_socket_ >= 0) {
+          ::shutdown(active_socket_, SHUT_RDWR);
+        }
+      }
+      finished_cv_.wait_for(lock, std::chrono::milliseconds(100));
+    }
+  }
+  reader_thread_.join();
+}
+
+std::string SSEStreamProxy::last_event_id() const {
+  std::lock_guard<std::mutex> lock(cursor_mutex_);
+  return last_event_id_;
+}
+
+void SSEStreamProxy::set_last_event_id(std::string id) {
+  std::lock_guard<std::mutex> lock(cursor_mutex_);
+  last_event_id_ = std::move(id);
 }
 
 bool SSEStreamProxy::is_connected() const {
@@ -69,6 +110,50 @@ void SSEStreamProxy::reader_loop() {
 
   while (!should_stop_.load()) {
     httplib::Client client(peer_url_);
+    // The socket is handed to this callback once cpp-httplib has created it,
+    // which is where close() gets something it can interrupt. The library's own
+    // defaults are applied first so overriding this hook does not drop them.
+    //
+    // A DUPLICATE, not the library's descriptor. cpp-httplib closes its own
+    // inside Get(), and a closed number is free for any other thread in this
+    // process to be handed for an unrelated file - after which close() would
+    // shut down that one instead. Holding a dup keeps the number reserved until
+    // this loop releases it, and shutdown() acts on the socket behind it, so it
+    // still tears down the connection the reader is parked on.
+    client.set_socket_options([this](socket_t sock) {
+      httplib::default_socket_options(sock);
+      // F_DUPFD_CLOEXEC, not dup(): a plain duplicate has FD_CLOEXEC clear, so
+      // it would be inherited by every process this gateway execs - the script
+      // provider runs arbitrary ones - handing them a live socket to a peer.
+      const int held = ::fcntl(sock, F_DUPFD_CLOEXEC, 0);
+      std::lock_guard<std::mutex> lock(socket_mutex_);
+      if (active_socket_ >= 0) {
+        // A second connection inside one Get(). Nothing is parked on the
+        // previous socket any more, and leaving it open would leak a
+        // descriptor per reconnect.
+        ::close(active_socket_);
+      }
+      active_socket_ = held;
+      if (should_stop_.load()) {
+        // close() ran between this loop's stop check and this line, so it took
+        // the mutex while there was still no socket to interrupt and is now
+        // waiting on a join. It set should_stop_ before taking the mutex, so
+        // one of the two orderings always sees the other: do its work here.
+        ::shutdown(active_socket_, SHUT_RDWR);
+      }
+    });
+    // Released on every exit from this iteration, including the early breaks
+    // below. The dup is this class's to close and nothing else's.
+    struct SocketHandleGuard {
+      SSEStreamProxy * self;
+      ~SocketHandleGuard() {
+        std::lock_guard<std::mutex> lock(self->socket_mutex_);
+        if (self->active_socket_ >= 0) {
+          ::close(self->active_socket_);
+          self->active_socket_ = -1;
+        }
+      }
+    } socket_handle_guard{this};
     // SSE read timeout: 300s. If no data (including heartbeat comments) arrives
     // within this window, the connection is considered dead and we reconnect.
     // Peers should send periodic heartbeat comments (": keepalive\n\n") to
@@ -84,11 +169,26 @@ void SSEStreamProxy::reader_loop() {
 
     // Use chunked content receiver to process SSE data as it arrives
     std::string buffer;
+    // Resume where the last connection stopped. A reconnect without this asks
+    // the peer to replay its whole buffer, and every replayed event is emitted
+    // again under a new aggregator id.
+    httplib::Headers attempt_headers = headers_;
+    {
+      std::lock_guard<std::mutex> lock(cursor_mutex_);
+      if (!last_event_id_.empty()) {
+        attempt_headers.emplace("Last-Event-ID", last_event_id_);
+      }
+    }
+
     auto result = client.Get(
-        path_,
+        path_, attempt_headers,
         [this](const httplib::Response & response) {
           // Header callback - check status and content type before processing body
-          if (response.status != 200 || should_stop_.load()) {
+          if (response.status != 200) {
+            rejected_status_.store(response.status);
+            return false;
+          }
+          if (should_stop_.load()) {
             return false;
           }
           // Validate Content-Type is text/event-stream. A non-SSE 200 response
@@ -123,21 +223,51 @@ void SSEStreamProxy::reader_loop() {
             return false;  // Disconnect - peer sending malformed stream
           }
 
-          // Process complete events (delimited by double newline)
+          // Events end at a blank line, which SSE allows to be written either
+          // way round: "\n\n" or "\r\n\r\n". Searching only for "\n\n" never
+          // matches a CRLF stream, because "\r\n\r\n" holds "\n\r\n" and no
+          // "\n\n" - such a peer would deliver bytes for ever and never yield
+          // one event. parse_sse_data already handles CRLF within a block; it
+          // is this boundary search that has to admit both.
           size_t pos = 0;
           while (true) {
             auto boundary = buffer.find("\n\n", pos);
+            size_t boundary_len = 2;
+            const auto crlf_boundary = buffer.find("\r\n\r\n", pos);
+            if (crlf_boundary != std::string::npos && (boundary == std::string::npos || crlf_boundary < boundary)) {
+              boundary = crlf_boundary;
+              boundary_len = 4;
+            }
             if (boundary == std::string::npos) {
               break;
             }
 
             std::string event_block = buffer.substr(pos, boundary - pos + 1);
-            pos = boundary + 2;
+            pos = boundary + boundary_len;
 
             auto events = parse_sse_data(event_block, peer_name_);
-            if (callback_) {
-              for (const auto & event : events) {
-                callback_(event);
+            for (const auto & event : events) {
+              // Recorded before dispatch, so a callback that throws still
+              // leaves the resume point at the last event actually received.
+              if (!event.id.empty()) {
+                std::lock_guard<std::mutex> lock(cursor_mutex_);
+                last_event_id_ = event.id;
+              }
+              if (callback_) {
+                // The callback is given a payload the peer wrote. One that
+                // throws on a shape it did not expect would otherwise leave the
+                // exception to escape this thread, and an exception leaving a
+                // std::thread calls std::terminate - a peer could end the
+                // gateway by sending one malformed field.
+                try {
+                  callback_(event);
+                } catch (const std::exception & e) {
+                  fprintf(stderr, "[SSEStreamProxy] dropping event from peer '%s': handler threw: %s\n",
+                          peer_name_.c_str(), e.what());
+                } catch (...) {
+                  fprintf(stderr, "[SSEStreamProxy] dropping event from peer '%s': handler threw\n",
+                          peer_name_.c_str());
+                }
               }
             }
           }
@@ -152,6 +282,15 @@ void SSEStreamProxy::reader_loop() {
 
     // Connection ended (server closed, timeout, or error) - mark disconnected
     connected_.store(false);
+
+    // A peer that refuses the stream says so once per attempt rather than
+    // never: 401 means this gateway is not authorised to relay, 503 means the
+    // peer is at sse.max_clients, 429 means it is rate limiting. All three are
+    // acted on differently and none of them is visible anywhere else.
+    if (const int rejected = rejected_status_.exchange(0); rejected != 0) {
+      fprintf(stderr, "[SSEStreamProxy] peer '%s' at %s%s refused the stream with status %d; retrying\n",
+              peer_name_.c_str(), peer_url_.c_str(), path_.c_str(), rejected);
+    }
 
     // Log if the peer returned a non-SSE Content-Type (e.g. application/json)
     if (non_sse_content_type_.load()) {
@@ -178,6 +317,15 @@ void SSEStreamProxy::reader_loop() {
 
     backoff_ms = std::min(backoff_ms * 2, kMaxBackoffMs);
   }
+
+  // Announced so close() stops re-arming its shutdown and joins. It waits on
+  // this rather than joining straight away, so it must always be set, on every
+  // way out of the loop above.
+  {
+    std::lock_guard<std::mutex> lock(finished_mutex_);
+    reader_finished_ = true;
+  }
+  finished_cv_.notify_all();
 }
 
 std::vector<StreamEvent> SSEStreamProxy::parse_sse_data(const std::string & raw, const std::string & peer) {

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -112,6 +112,12 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   declare_parameter("sse.max_clients", 2);
   declare_parameter("sse.max_subscriptions", 100);  // Maximum active cyclic subscriptions across all entities
   declare_parameter("sse.max_duration_sec", 3600);  // Maximum subscription duration in seconds (1 hour default)
+  // Comment interval on an idle SSE stream. It is also how long the server
+  // takes to notice a client has gone, because a closed socket is discovered
+  // on the next write - which on an aggregating gateway is how long a relay
+  // keeps a slot on a peer after nobody is watching. Shorten it behind a proxy
+  // that drops idle connections sooner than 30 s.
+  declare_parameter("sse.keepalive_interval_sec", 30);
 
   // Log management parameters
   declare_parameter("logs.buffer_size",
@@ -238,6 +244,8 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   // Aggregation parameters (peer gateway federation)
   declare_parameter("aggregation.enabled", false);
   declare_parameter("aggregation.timeout_ms", 2000);
+  declare_parameter("aggregation.forward_timeout_ms", 15000);
+  declare_parameter("aggregation.write_timeout_ms", 5000);
   declare_parameter("aggregation.announce", false);
   declare_parameter("aggregation.discover", false);
   declare_parameter("aggregation.mdns_service", std::string("_medkit._tcp.local"));
@@ -1149,7 +1157,34 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   if (get_parameter("aggregation.enabled").as_bool()) {
     AggregationConfig agg_config;
     agg_config.enabled = true;
-    agg_config.timeout_ms = static_cast<int>(get_parameter("aggregation.timeout_ms").as_int());
+    // Documented range 100-600000 ms for all three budgets. A ROS parameter is
+    // int64 and `declare_parameter<int>` narrows silently, so a value above
+    // INT_MAX wraps back into the legal band and passes any check made after
+    // the narrowing - clamp on the int64 first, narrow second.
+    auto clamp_budget_ms = [this](const char * key) {
+      constexpr int64_t kMinBudgetMs = 100;
+      constexpr int64_t kMaxBudgetMs = 600000;
+      const int64_t raw = get_parameter(key).as_int();
+      const int64_t used = std::clamp<int64_t>(raw, kMinBudgetMs, kMaxBudgetMs);
+      if (used != raw) {
+        RCLCPP_WARN(get_logger(), "%s %" PRId64 " clamped to %" PRId64, key, raw, used);
+      }
+      return static_cast<int>(used);
+    };
+    agg_config.timeout_ms = clamp_budget_ms("aggregation.timeout_ms");
+    agg_config.forward_timeout_ms = clamp_budget_ms("aggregation.forward_timeout_ms");
+    agg_config.write_timeout_ms = clamp_budget_ms("aggregation.write_timeout_ms");
+    // A forward budget below the metadata budget inverts what the split is for:
+    // the path carrying the peer's real work would be cut off before the path
+    // that only reads its description. Report it rather than serve it, because
+    // the symptom is an operation failing while a listing of it succeeds.
+    if (agg_config.forward_timeout_ms < agg_config.timeout_ms) {
+      RCLCPP_WARN(get_logger(),
+                  "aggregation.forward_timeout_ms %d is below aggregation.timeout_ms %d; raised to %d so a forwarded "
+                  "request is not cut off sooner than a metadata read",
+                  agg_config.forward_timeout_ms, agg_config.timeout_ms, agg_config.timeout_ms);
+      agg_config.forward_timeout_ms = agg_config.timeout_ms;
+    }
     agg_config.announce = get_parameter("aggregation.announce").as_bool();
     agg_config.discover = get_parameter("aggregation.discover").as_bool();
     agg_config.mdns_service = get_parameter("aggregation.mdns_service").as_string();

--- a/src/ros2_medkit_gateway/src/gateway_node.cpp
+++ b/src/ros2_medkit_gateway/src/gateway_node.cpp
@@ -252,6 +252,7 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
   declare_parameter("aggregation.mdns_name", std::string(""));  // defaults to hostname
   // Security: forward Authorization header to peers (default: false to prevent token leakage)
   declare_parameter("aggregation.forward_auth", false);
+  declare_parameter("aggregation.peer_auth_header", "");
   // Security: require TLS for all peer URLs (default: false)
   declare_parameter("aggregation.require_tls", false);
   // URL scheme for mDNS-discovered peer URLs (default: "http")
@@ -1189,6 +1190,7 @@ GatewayNode::GatewayNode(const rclcpp::NodeOptions & options) : Node("ros2_medki
     agg_config.discover = get_parameter("aggregation.discover").as_bool();
     agg_config.mdns_service = get_parameter("aggregation.mdns_service").as_string();
     agg_config.forward_auth = get_parameter("aggregation.forward_auth").as_bool();
+    agg_config.peer_auth_header = get_parameter("aggregation.peer_auth_header").as_string();
     agg_config.require_tls = get_parameter("aggregation.require_tls").as_bool();
     agg_config.peer_scheme = get_parameter("aggregation.peer_scheme").as_string();
     if (agg_config.peer_scheme != "http" && agg_config.peer_scheme != "https") {

--- a/src/ros2_medkit_gateway/src/http/handlers/config_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/config_handlers.cpp
@@ -285,6 +285,7 @@ void apply_fan_out_observability(dto::ConfigListXMedkit & xm,
   if (fan_out.partial) {
     xm.partial = true;
     xm.failed_peers = fan_out.failed_peers;
+    xm.peer_failures = fan_out.peer_failures;
   }
   if (!fan_out.dropped_items.empty()) {
     xm.peer_dropped_items = fan_out.dropped_items;

--- a/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/data_handlers.cpp
@@ -301,6 +301,7 @@ void apply_fan_out_observability(dto::DataListXMedkit & xm, const FanOutResult<d
   if (fan_out.partial) {
     xm.partial = true;
     xm.failed_peers = fan_out.failed_peers;
+    xm.peer_failures = fan_out.peer_failures;
   }
   if (!fan_out.dropped_items.empty()) {
     xm.peer_dropped_items = fan_out.dropped_items;

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -471,6 +471,7 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
       if (fan_result.is_partial) {
         xm.partial = true;
         xm.failed_peers = fan_result.failed_peers;
+        xm.peer_failures = fan_result.peer_failures;
       }
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -144,6 +144,15 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
                {"grew", stats.grew}};
     }
 
+    // How much of the SSE client cap is in use. The cap is small - two by
+    // default - and on an aggregating deployment a peer's slots are consumed
+    // by the aggregator's fault-stream relay rather than by anyone an operator
+    // can see. A 503 on /faults/stream is otherwise unexplainable from outside.
+    if (sse_tracker_) {
+      response.x_medkit_sse =
+          json{{"connected_clients", sse_tracker_->connected_clients()}, {"max_clients", sse_tracker_->max_clients()}};
+    }
+
     // Add peer status when aggregation is active
     if (auto * agg = ctx_.aggregation_manager()) {
       response.peers = agg->get_peer_status();
@@ -323,6 +332,13 @@ http::Result<dto::VersionInfo> HealthHandlers::get_version_info(const http::Type
       if (ext_json.contains("failed_peers")) {
         ext_dto.failed_peers = ext_json["failed_peers"].get<std::vector<std::string>>();
       }
+      if (ext_json.contains("peer_failures") && ext_json["peer_failures"].is_array()) {
+        std::vector<dto::PeerFailure> failures;
+        for (const auto & failure_entry : ext_json["peer_failures"]) {
+          failures.push_back(dto::PeerFailure{failure_entry.value("peer", ""), failure_entry.value("reason", "")});
+        }
+        ext_dto.peer_failures = std::move(failures);
+      }
     }
 
     // Re-parse merged items back into the DTO and attach x-medkit if present
@@ -335,7 +351,7 @@ http::Result<dto::VersionInfo> HealthHandlers::get_version_info(const http::Type
         }
       }
     }
-    if (ext_dto.partial.has_value() || ext_dto.failed_peers.has_value()) {
+    if (ext_dto.partial.has_value() || ext_dto.failed_peers.has_value() || ext_dto.peer_failures.has_value()) {
       response.x_medkit = std::move(ext_dto);
     }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/log_handlers.cpp
@@ -81,6 +81,7 @@ void apply_fan_out_observability(dto::LogListXMedkit & xm, const FanOutResult<dt
   if (fan_out.partial) {
     xm.partial = true;
     xm.failed_peers = fan_out.failed_peers;
+    xm.peer_failures = fan_out.peer_failures;
   }
   if (!fan_out.dropped_items.empty()) {
     xm.peer_dropped_items = fan_out.dropped_items;

--- a/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/operation_handlers.cpp
@@ -452,6 +452,32 @@ namespace detail {
 ///   never issued. Where the underlying ROS 2 mechanism has to be named - a
 ///   stop IS carried out as an action cancel - it is named as the cause, after
 ///   the verb the client used, never in place of it.
+/// One table for both execute paths: what the transport could not do decides
+/// the status, not the fact that it did not do it. `ERR_NOT_RESPONDING` is the
+/// standard code reserved for "no response from the underlying entity in time"
+/// and was previously returned from the cancel path alone, while an execute
+/// that ran out of time answered the same 500 as one that could not serialize
+/// its request.
+ErrorInfo map_call_failure(CallOutcome outcome, const std::string & detail, const char * unavailable_code,
+                           const char * generic_message, json params) {
+  params["details"] = detail;
+  switch (outcome) {
+    case CallOutcome::kTimeout:
+      // The message carries the budget the transport measured against, which
+      // is the one thing a client can act on: raise it, or stop waiting.
+      return make_error(504, ERR_NOT_RESPONDING,
+                        detail.empty() ? std::string("The underlying entity did not answer in time") : detail,
+                        std::move(params));
+    case CallOutcome::kServiceUnavailable:
+      return make_error(503, unavailable_code, detail.empty() ? std::string(generic_message) : detail,
+                        std::move(params));
+    case CallOutcome::kOk:
+    case CallOutcome::kTransportError:
+      break;
+  }
+  return make_error(500, unavailable_code, generic_message, std::move(params));
+}
+
 std::optional<CancelFailure> map_cancel_result(const ActionCancelResult & result, OperationManager & operation_mgr,
                                                const std::string & execution_id, const char * verb) {
   // Derived rather than passed as a second parameter, so no call site can hand
@@ -774,6 +800,7 @@ http::Result<dto::Collection<dto::OperationItem>> OperationHandlers::list_operat
     if (fan_out.partial) {
       xm.partial = true;
       xm.failed_peers = fan_out.failed_peers;
+      xm.peer_failures = fan_out.peer_failures;
     }
     if (!fan_out.dropped_items.empty()) {
       xm.peer_dropped_items = fan_out.dropped_items;
@@ -1077,9 +1104,9 @@ OperationHandlers::create_execution(const http::TypedRequest & req, dto::Executi
                {"operation_id", operation_id},
                {"details", action_result.error_message.empty() ? "Goal rejected" : action_result.error_message}}));
     }
-    return tl::make_unexpected(make_error(
-        500, ERR_X_MEDKIT_ROS2_ACTION_UNAVAILABLE, "Action execution failed",
-        json{{id_field, entity_id}, {"operation_id", operation_id}, {"details", action_result.error_message}}));
+    return tl::make_unexpected(detail::map_call_failure(action_result.outcome, action_result.error_message,
+                                                        ERR_X_MEDKIT_ROS2_ACTION_UNAVAILABLE, "Action execution failed",
+                                                        json{{id_field, entity_id}, {"operation_id", operation_id}}));
   }
 
   // ---- Service (synchronous: 200) ----
@@ -1107,9 +1134,9 @@ OperationHandlers::create_execution(const http::TypedRequest & req, dto::Executi
   }
   // Inline service-error path is replaced with the framework error channel:
   // `make_error` produces a SOVD GenericError that the typed wrapper renders.
-  return tl::make_unexpected(
-      make_error(500, ERR_X_MEDKIT_ROS2_SERVICE_UNAVAILABLE, "Service call failed",
-                 json{{id_field, entity_id}, {"operation_id", operation_id}, {"details", svc_result.error_message}}));
+  return tl::make_unexpected(detail::map_call_failure(svc_result.outcome, svc_result.error_message,
+                                                      ERR_X_MEDKIT_ROS2_SERVICE_UNAVAILABLE, "Service call failed",
+                                                      json{{id_field, entity_id}, {"operation_id", operation_id}}));
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -87,12 +87,12 @@ SSEFaultHandler::SSEFaultHandler(HandlerContext & ctx, std::shared_ptr<SSEClient
           return targets;
         }
         for (const auto & endpoint : agg->healthy_peer_endpoints()) {
-          // No Authorization. A relay is one connection shared by every local
-          // client, so there is no single client whose token it could carry,
-          // and sending the one that happened to open it would serve every
-          // later client events fetched with somebody else's credentials.
-          // A peer that requires authentication therefore refuses the relay.
-          targets.push_back(RelayTarget{endpoint.name, endpoint.url, ""});
+          // This gateway's own credential, never a client's. A relay is one
+          // connection shared by every local client, so there is no single
+          // client whose token it could carry, and sending the one that
+          // happened to open it would serve every later client events fetched
+          // with somebody else's credentials.
+          targets.push_back(RelayTarget{endpoint.name, endpoint.url, agg->peer_auth_header()});
         }
         return targets;
       },

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -27,7 +27,9 @@
 #include <utility>
 #include <vector>
 
+#include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/core/http/http_utils.hpp"
 #include "ros2_medkit_gateway/core/models/error_info.hpp"
 #include "ros2_medkit_gateway/fault_manager_paths.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
@@ -74,6 +76,34 @@ SSEFaultHandler::SSEFaultHandler(HandlerContext & ctx, std::shared_ptr<SSEClient
         on_fault_event(msg);
       });
 
+  // The aggregation manager is looked up per call rather than captured here:
+  // it is wired onto the context during gateway start-up and this handler is
+  // built in the same pass, so a pointer taken now can be the null one.
+  peer_relay_ = std::make_unique<PeerFaultRelay>(
+      [this]() {
+        std::vector<RelayTarget> targets;
+        auto * agg = ctx_.aggregation_manager();
+        if (agg == nullptr) {
+          return targets;
+        }
+        for (const auto & endpoint : agg->healthy_peer_endpoints()) {
+          // No Authorization. A relay is one connection shared by every local
+          // client, so there is no single client whose token it could carry,
+          // and sending the one that happened to open it would serve every
+          // later client events fetched with somebody else's credentials.
+          // A peer that requires authentication therefore refuses the relay.
+          targets.push_back(RelayTarget{endpoint.name, endpoint.url, ""});
+        }
+        return targets;
+      },
+      // The peer's own route, not this gateway's configured prefix: what is
+      // being addressed is a ros2_medkit gateway on the other side, which is
+      // what PeerClient assumes everywhere else too.
+      std::string(API_BASE_PATH) + "/faults/stream",
+      [this](const StreamEvent & event) {
+        on_peer_event(event);
+      });
+
   RCLCPP_INFO(HandlerContext::logger(), "SSE fault handler initialized, subscribed to %s, max_clients=%zu",
               fault_events_topic.c_str(), client_tracker_->max_clients());
 }
@@ -82,6 +112,12 @@ SSEFaultHandler::~SSEFaultHandler() {
   // Signal shutdown and wake up any waiting clients
   request_shutdown();
   subscription_.reset();
+  // Before the queue-lock wait below: closing a peer stream joins its reader
+  // thread, and that thread may be inside on_peer_event holding nothing but
+  // wanting queue_mutex_.
+  if (peer_relay_) {
+    peer_relay_->shutdown();
+  }
 
   // The per-stream unregister deleter dereferences this handler (it locks
   // queue_mutex_ and erases from clients_) and runs whenever the framework
@@ -94,6 +130,9 @@ SSEFaultHandler::~SSEFaultHandler() {
 }
 
 void SSEFaultHandler::request_shutdown() {
+  if (peer_relay_) {
+    peer_relay_->shutdown();
+  }
   if (shutdown_flag_.exchange(true)) {
     return;
   }
@@ -110,12 +149,20 @@ std::optional<uint64_t> SSEFaultHandler::delivered_watermark_locked() const {
 }
 
 std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superseded_locked(bool updates_only) {
+  // Keyed on the peer as well as the code: a fault code is unique on the
+  // gateway that raised it and nowhere else, so two peers reporting the same
+  // code are reporting two faults, and treating one as the newer state of the
+  // other would delete a live fault from a client's view.
+  auto supersede_key = [](const QueuedEvent & queued) {
+    return queued.peer + '\0' + queued.event.fault.fault_code;
+  };
   std::unordered_map<std::string, std::size_t> newest_index;
   for (std::size_t i = 0; i < event_queue_.size(); ++i) {
-    newest_index[event_queue_[i].event.fault.fault_code] = i;
+    newest_index[supersede_key(event_queue_[i])] = i;
   }
   for (std::size_t i = 0; i < event_queue_.size(); ++i) {
     const auto & entry = event_queue_[i].event;
+    const auto key = supersede_key(event_queue_[i]);
     // An auto-clear cascade lists its symptoms only here; those codes get no
     // event of their own, so this entry is never redundant.
     if (!entry.auto_cleared_codes.empty()) {
@@ -124,15 +171,28 @@ std::deque<SSEFaultHandler::QueuedEvent>::iterator SSEFaultHandler::find_superse
     if (updates_only && entry.event_type != ros2_medkit_msgs::msg::FaultEvent::EVENT_UPDATED) {
       continue;
     }
-    if (newest_index[entry.fault.fault_code] != i) {
+    if (newest_index[key] != i) {
       return event_queue_.begin() + static_cast<std::ptrdiff_t>(i);
     }
   }
   return event_queue_.end();
 }
 
-bool SSEFaultHandler::has_pending_locked(uint64_t last_event_id) const {
-  return !event_queue_.empty() && event_queue_.back().id > last_event_id;
+bool SSEFaultHandler::has_pending_locked(uint64_t last_event_id, bool relay_peers) const {
+  if (relay_peers) {
+    return !event_queue_.empty() && event_queue_.back().id > last_event_id;
+  }
+  // A suppressed client is owed only what this gateway saw itself, so the
+  // newest entry is not enough to answer: the tail may be entirely relayed.
+  for (auto it = event_queue_.rbegin(); it != event_queue_.rend(); ++it) {
+    if (it->id <= last_event_id) {
+      break;
+    }
+    if (it->peer.empty()) {
+      return true;
+    }
+  }
+  return false;
 }
 
 SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
@@ -179,19 +239,86 @@ SSEFaultHandler::EvictionStats SSEFaultHandler::evict_to_capacity_locked() {
 }
 
 void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::ConstSharedPtr & msg) {
-  uint64_t event_id = next_event_id_.fetch_add(1);
-
   // Snapshot entity context before acquiring the queue lock so cache state
   // is pinned to the fault arrival timestamp and the formatting path stays
   // lock-free with respect to the cache.
   auto entity = resolve_entity_context(msg->fault);
+  QueuedEvent queued;
+  queued.event = *msg;
+  queued.entity = std::move(entity);
+  enqueue(std::move(queued));
+}
 
+void SSEFaultHandler::on_peer_event(const StreamEvent & event) {
+  auto payload = nlohmann::json::parse(event.data, nullptr, false);
+  if (payload.is_discarded() || !payload.is_object()) {
+    RCLCPP_WARN(HandlerContext::logger(), "Discarding unparseable fault event relayed from peer '%s'",
+                event.peer_name.c_str());
+    return;
+  }
+
+  // The peer names the fault and the transition; both are read back out so the
+  // replay buffer's eviction and coalescing work on a relayed event exactly as
+  // they do on a local one, without either of them learning about peers.
+  // Every read below is type-checked before it is taken. nlohmann's value()
+  // throws type_error when the stored value is of another type than the
+  // default, and the peer chooses these types: a fault event carrying a
+  // numeric event_type would throw out of the relay's reader thread.
+  QueuedEvent queued;
+  queued.peer = event.peer_name;
+  const auto & type_field = payload.find("event_type");
+  queued.event.event_type =
+      (type_field != payload.end() && type_field->is_string()) ? type_field->get<std::string>() : event.event_type;
+  if (payload.contains("fault") && payload["fault"].is_object()) {
+    const auto & fault = payload["fault"];
+    if (fault.contains("fault_code") && fault["fault_code"].is_string()) {
+      queued.event.fault.fault_code = fault["fault_code"].get<std::string>();
+    }
+  }
+  // The eviction pass never discards an entry that carries a cascade, because
+  // those symptom codes get no event of their own and exist nowhere else.
+  // Reading them back is what puts a relayed cascade under the same protection
+  // as a local one.
+  if (payload.contains("auto_cleared_codes") && payload["auto_cleared_codes"].is_array()) {
+    for (const auto & code : payload["auto_cleared_codes"]) {
+      if (code.is_string()) {
+        queued.event.auto_cleared_codes.push_back(code.get<std::string>());
+      }
+    }
+  }
+
+  // Attribution goes next to whatever the peer already put under x-medkit,
+  // which for a fault event is the entity it resolved. Overwriting the object
+  // would throw that away.
+  if (!payload.contains("x-medkit") || !payload["x-medkit"].is_object()) {
+    payload["x-medkit"] = nlohmann::json::object();
+  }
+  payload["x-medkit"]["peer"] = event.peer_name;
+  queued.relayed_payload = payload.dump();
+
+  enqueue(std::move(queued));
+}
+
+void SSEFaultHandler::enqueue(QueuedEvent queued) {
+  const std::string event_type = queued.event.event_type;
+  const std::string fault_code = queued.event.fault.fault_code;
+
+  uint64_t event_id = 0;
   EvictionStats stats;
   {
     std::lock_guard<std::mutex> lock(queue_mutex_);
 
-    // Add event to queue with resolved entity context
-    event_queue_.push_back(QueuedEvent{event_id, *msg, std::move(entity)});
+    // The id is claimed under the same lock that appends, so the buffer stays
+    // ordered by id. Claiming it outside was safe while the ROS subscription
+    // was the only producer; a relay adds one producer thread per peer, and two
+    // of them interleaving between the claim and the append would leave a
+    // lower id behind a higher one. Every consumer reads the deque in order and
+    // compares against a single `last_event_id`, so out-of-order entries are
+    // delivered twice to one client and never to another.
+    event_id = next_event_id_.fetch_add(1);
+    queued.id = event_id;
+
+    event_queue_.push_back(std::move(queued));
     stats = evict_to_capacity_locked();
   }
 
@@ -216,8 +343,8 @@ void SSEFaultHandler::on_fault_event(const ros2_medkit_msgs::msg::FaultEvent::Co
   // Notify all waiting clients
   queue_cv_.notify_all();
 
-  RCLCPP_DEBUG(HandlerContext::logger(), "Received fault event: %s for %s (id=%" PRIu64 ")", msg->event_type.c_str(),
-               msg->fault.fault_code.c_str(), event_id);
+  RCLCPP_DEBUG(HandlerContext::logger(), "Received fault event: %s for %s (id=%" PRIu64 ")", event_type.c_str(),
+               fault_code.c_str(), event_id);
 }
 
 namespace {
@@ -242,7 +369,8 @@ void SSEFaultHandler::note_progress_locked(const std::shared_ptr<ClientCursor> &
   cursor->last_delivered = std::max(cursor->last_delivered, delivered_id);
 }
 
-std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint64_t initial_last_event_id) {
+std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint64_t initial_last_event_id,
+                                                                           bool relay_peers) {
   // Clamp to the newest id issued so far: a Last-Event-ID above it (any bogus
   // value, e.g. "18446744073709551615") would otherwise leave collect_pending
   // permanently empty (blind stream, no keepalives under steady traffic) and
@@ -260,22 +388,52 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
   // Deregisters when the content provider (and with it this closure) is
   // destroyed, which is the only point at which the connection is certainly
   // gone for both the typed and the legacy entry.
-  auto unregister = std::shared_ptr<void>(nullptr, [this, cursor](void *) {
+  // The guard is built BEFORE acquire(), which opens threads and can throw:
+  // a throw after the cursor is registered but before the guard exists would
+  // leave that cursor in clients_ for ever, and ~SSEFaultHandler waits for
+  // clients_ to empty.
+  auto unregister = std::shared_ptr<void>(nullptr, [this, cursor, relay_peers](void *) {
+    // The relay goes first, and outside the queue lock. Outside, because
+    // closing a peer stream joins a reader thread that may be waiting for
+    // exactly that lock inside on_peer_event. First, because the erase below
+    // is what releases ~SSEFaultHandler from its wait, and the destructor is
+    // free to destroy peer_relay_ the moment it returns - a release() running
+    // after that erase would be reaching into a destroyed member.
+    if (relay_peers && peer_relay_) {
+      peer_relay_->release();
+    }
     std::lock_guard<std::mutex> lock(queue_mutex_);
     clients_.erase(std::remove(clients_.begin(), clients_.end(), cursor), clients_.end());
     queue_cv_.notify_all();  // ~SSEFaultHandler may be waiting for the last closure
   });
 
-  return [this, cursor, unregister, last_event_id = initial_last_event_id](httplib::DataSink & sink) mutable -> bool {
+  if (relay_peers && peer_relay_) {
+    peer_relay_->acquire();
+  }
+
+  return [this, cursor, unregister, relay_peers,
+          last_event_id = initial_last_event_id](httplib::DataSink & sink) mutable -> bool {
     // Formatting happens under the lock, writing does not: the buffer now
     // erases from the middle to coalesce, so holding an iterator across a
     // write would be a use-after-free.
-    auto collect_pending = [this, &last_event_id]() {
+    auto collect_pending = [this, &last_event_id, relay_peers]() {
       std::vector<std::pair<uint64_t, std::string>> pending;
       for (const auto & queued : event_queue_) {
-        if (queued.id > last_event_id) {
-          pending.emplace_back(queued.id, format_sse_event(queued));
+        if (queued.id <= last_event_id) {
+          continue;
         }
+        // Suppression has to bite HERE, not only where the relay is opened.
+        // The buffer is shared by every client, so a relayed event put there
+        // for one client would otherwise be delivered to a client that asked
+        // for the local graph only - which is what an aggregating peer asks
+        // for, and is what would carry an event round a chain of them.
+        if (!relay_peers && !queued.peer.empty()) {
+          // Still counts as delivered: the id is not owed to this client, and
+          // leaving it behind would hold the watermark down for everyone.
+          last_event_id = queued.id;
+          continue;
+        }
+        pending.emplace_back(queued.id, format_sse_event(queued));
       }
       return pending;
     };
@@ -308,6 +466,14 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
     const auto timeout = keepalive_interval_;
 
     while (true) {
+      // A peer that appeared or went away since the last wakeup. Cheap - a
+      // comparison of two small name sets - and it removes the need for a
+      // timer of its own, because the loop already wakes on every event and at
+      // least once per keepalive interval.
+      if (relay_peers && peer_relay_) {
+        peer_relay_->reconcile();
+      }
+
       std::vector<std::pair<uint64_t, std::string>> pending;
       bool keepalive_due = false;
       {
@@ -316,8 +482,8 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
         // Predicate form: an event enqueued between the last flush and this
         // wait already spent its notify_all while nobody was waiting; a plain
         // wait_for would sleep the full keepalive interval on top of it.
-        const bool woke = queue_cv_.wait_for(lock, timeout, [this, &last_event_id] {
-          return shutdown_flag_.load() || has_pending_locked(last_event_id);
+        const bool woke = queue_cv_.wait_for(lock, timeout, [this, &last_event_id, relay_peers] {
+          return shutdown_flag_.load() || has_pending_locked(last_event_id, relay_peers);
         });
 
         if (shutdown_flag_.load()) {
@@ -382,7 +548,12 @@ http::Result<http::SseStream> SSEFaultHandler::sse_stream(const http::TypedReque
     RCLCPP_INFO(HandlerContext::logger(), "SSE fault client disconnected from %s", addr.c_str());
   });
 
-  auto loop = make_stream_loop(last_event_id);
+  // An aggregating gateway relaying from another sends X-Medkit-No-Fan-Out,
+  // the same header the collection routes use to stop a request going round a
+  // chained or bidirectional peering. Serve that request from the local graph
+  // only.
+  const bool relay_peers = !req.header("X-Medkit-No-Fan-Out").has_value();
+  auto loop = make_stream_loop(last_event_id, relay_peers);
   http::SseStream stream;
   stream.next_event = [loop = std::move(loop), release_guard](httplib::DataSink & sink) mutable {
     return loop(sink);
@@ -421,7 +592,7 @@ void SSEFaultHandler::handle_stream(const httplib::Request & req, httplib::Respo
   res.set_header("Connection", "keep-alive");
   res.set_header("X-Accel-Buffering", "no");  // Disable nginx buffering
 
-  auto loop = make_stream_loop(last_event_id);
+  auto loop = make_stream_loop(last_event_id, !req.has_header("X-Medkit-No-Fan-Out"));
 
   // Use chunked content provider for streaming
   res.set_chunked_content_provider(
@@ -434,6 +605,10 @@ void SSEFaultHandler::handle_stream(const httplib::Request & req, httplib::Respo
         RCLCPP_INFO(HandlerContext::logger(), "SSE fault client disconnected from %s (success=%d)", addr.c_str(),
                     success);
       });
+}
+
+std::size_t SSEFaultHandler::relayed_peer_streams() const {
+  return peer_relay_ ? peer_relay_->open_streams() : 0;
 }
 
 size_t SSEFaultHandler::connected_clients() const {
@@ -456,6 +631,18 @@ uint64_t SSEFaultHandler::events_received() const {
 
 std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) {
   const auto sanitized_event_type = sanitize_sse_event_type(queued.event.event_type);
+
+  // A relayed event is the peer's own payload. It is emitted under THIS
+  // gateway's id, because the id is what Last-Event-ID resumes from and two
+  // peers number their events independently - a peer's id would address a
+  // position in a stream this gateway does not keep.
+  if (!queued.relayed_payload.empty()) {
+    std::ostringstream relayed;
+    relayed << "id: " << queued.id << "\n";
+    relayed << "event: " << sanitized_event_type << "\n";
+    relayed << "data: " << queued.relayed_payload << "\n\n";
+    return relayed.str();
+  }
 
   nlohmann::json json_event;
   json_event["event_type"] = sanitized_event_type;

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -416,7 +416,7 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
     // Formatting happens under the lock, writing does not: the buffer now
     // erases from the middle to coalesce, so holding an iterator across a
     // write would be a use-after-free.
-    auto collect_pending = [this, &last_event_id, relay_peers]() {
+    auto collect_pending = [this, cursor, &last_event_id, relay_peers]() {
       std::vector<std::pair<uint64_t, std::string>> pending;
       for (const auto & queued : event_queue_) {
         if (queued.id <= last_event_id) {
@@ -430,7 +430,16 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
         if (!relay_peers && !queued.peer.empty()) {
           // Still counts as delivered: the id is not owed to this client, and
           // leaving it behind would hold the watermark down for everyone.
+          //
+          // The cursor is moved with it, not only this loop's own copy. The
+          // shared one is what eviction reads to decide whose unread events it
+          // is discarding, and has_pending_locked applies the same suppression,
+          // so a tail of relayed-only events never wakes this client to correct
+          // it. Left behind, a relayed-fault burst that overflows the buffer
+          // between two keepalives is booked as drops owed to a client that
+          // never asked for those events.
           last_event_id = queued.id;
+          note_progress_locked(cursor, queued.id);
           continue;
         }
         pending.emplace_back(queued.id, format_sse_event(queued));

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -14,6 +14,8 @@
 
 #include "ros2_medkit_gateway/core/http/rest_server.hpp"
 
+#include <algorithm>
+#include <chrono>
 #include <cinttypes>
 #include <exception>
 #include <limits>
@@ -154,7 +156,13 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   route_registry_ = std::make_unique<openapi::RouteRegistry>();
   route_registry_->set_auth_enabled(auth_config_.enabled);
 
-  health_handlers_ = std::make_unique<handlers::HealthHandlers>(*handler_ctx_, route_registry_.get());
+  // Taken before the handlers that read it: /health reports how much of the
+  // SSE client cap is in use, and a tracker fetched afterwards would reach
+  // HealthHandlers as a null pointer and silently omit the field.
+  sse_client_tracker_ = node_->get_sse_client_tracker();
+
+  health_handlers_ =
+      std::make_unique<handlers::HealthHandlers>(*handler_ctx_, route_registry_.get(), sse_client_tracker_);
   discovery_handlers_ = std::make_unique<handlers::DiscoveryHandlers>(*handler_ctx_);
   data_handlers_ = std::make_unique<handlers::DataHandlers>(*handler_ctx_);
   lifecycle_handlers_ = std::make_unique<handlers::LifecycleHandlers>(
@@ -164,8 +172,19 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   fault_handlers_ = std::make_unique<handlers::FaultHandlers>(*handler_ctx_);
   log_handlers_ = std::make_unique<handlers::LogHandlers>(*handler_ctx_);
   auth_handlers_ = std::make_unique<handlers::AuthHandlers>(*handler_ctx_);
-  sse_client_tracker_ = node_->get_sse_client_tracker();
-  sse_fault_handler_ = std::make_unique<handlers::SSEFaultHandler>(*handler_ctx_, sse_client_tracker_);
+  // Documented range 1-3600 s. Clamped rather than refused, and the clamp is
+  // reported, because a silently corrected value and the config file then
+  // disagree with no way to see it from outside.
+  constexpr int64_t kMinKeepaliveSec = 1;
+  constexpr int64_t kMaxKeepaliveSec = 3600;
+  const int64_t keepalive_raw = node_->get_parameter("sse.keepalive_interval_sec").as_int();
+  const int64_t keepalive_used = std::clamp<int64_t>(keepalive_raw, kMinKeepaliveSec, kMaxKeepaliveSec);
+  if (keepalive_used != keepalive_raw) {
+    RCLCPP_WARN(node_->get_logger(), "sse.keepalive_interval_sec %" PRId64 " clamped to %" PRId64, keepalive_raw,
+                keepalive_used);
+  }
+  sse_fault_handler_ = std::make_unique<handlers::SSEFaultHandler>(*handler_ctx_, sse_client_tracker_,
+                                                                   std::chrono::seconds(keepalive_used));
   bulkdata_handlers_ = std::make_unique<handlers::BulkDataHandlers>(*handler_ctx_);
   // Validated as int64 before narrowing: narrowing first wraps a value above
   // INT_MAX into a small positive one that passes the check, so 4294967300
@@ -671,6 +690,18 @@ void RESTServer::setup_routes() {
         .tag("Operations")
         .summary(std::string("Start operation execution for ") + et.singular)
         .description("Starts a new execution. Returns 200 for synchronous, 202 for asynchronous operations.")
+        // 400/404/500 come from the registry's automatic response-level
+        // GenericError $ref; these two are new answers this route can give and
+        // need their own declarations, or a generated SDK has no branch for a
+        // timeout and treats it as an unknown failure.
+        .response(503,
+                  "The backing ROS 2 service or action is not on the graph "
+                  "(x-medkit-ros2-service-unavailable / x-medkit-ros2-action-unavailable)",
+                  nlohmann::json{{"$ref", "#/components/schemas/GenericError"}})
+        .response(504,
+                  "The backing ROS 2 endpoint did not answer inside service_call_timeout_sec "
+                  "(not-responding). The work may still be running.",
+                  nlohmann::json{{"$ref", "#/components/schemas/GenericError"}})
         .operation_id(std::string("execute") + capitalize(et.singular) + "Operation");
 
     reg.get<dto::Collection<dto::ExecutionId>>(

--- a/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
+++ b/src/ros2_medkit_gateway/src/plugins/plugin_manager.cpp
@@ -57,7 +57,14 @@ PluginManager::~PluginManager() {
   plugins_.clear();
 }
 
-// Called during init only (before HTTP server starts). No lock needed.
+// The plugin list is published to readers as soon as it is written to, so both
+// registration paths take the writer lock. "Registration happens before the
+// HTTP server starts" was true and still is, and it is not enough: the ROS log
+// subscription is already delivering while the gateway constructor runs, and
+// LogManager::on_log_entry reads this list through log_observers(). Those
+// readers hold a shared lock, so an unlocked push_back here is a write racing
+// a read - reported by ThreadSanitizer inside vector's reallocation, where the
+// reader walks a buffer the writer has just freed.
 void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   LoadedPlugin lp;
   lp.config = nlohmann::json::object();
@@ -71,6 +78,11 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   lp.operation_provider = dynamic_cast<OperationProvider *>(plugin.get());
   lp.lifecycle_provider = dynamic_cast<LifecycleProvider *>(plugin.get());
   lp.fault_provider = dynamic_cast<FaultProvider *>(plugin.get());
+
+  // Held from the first cached provider through the push_back: the caches and
+  // the list are read together, so publishing one without the other lets a
+  // reader see a provider the list does not yet carry.
+  std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
 
   // Cache first UpdateProvider, warn on duplicates
   if (lp.update_provider) {
@@ -104,7 +116,7 @@ void PluginManager::add_plugin(std::unique_ptr<GatewayPlugin> plugin) {
   plugins_.push_back(std::move(lp));
 }
 
-// Called during init only (before HTTP server starts). No lock needed.
+// Same reasoning as add_plugin: registration is not the only thing running.
 size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
   size_t loaded = 0;
   for (const auto & cfg : configs) {
@@ -129,6 +141,10 @@ size_t PluginManager::load_plugins(const std::vector<PluginConfig> & configs) {
       // plugin and the host, casting a real provider to null).
       lp.lifecycle_provider = result->lifecycle_provider;
       lp.fault_provider = result->fault_provider;
+
+      // Taken per plugin rather than around the whole loop, so a slow dlopen
+      // for the next one does not hold readers off the ones already loaded.
+      std::unique_lock<std::shared_mutex> lock(plugins_mutex_);
 
       // Cache first UpdateProvider, warn on duplicates
       if (lp.update_provider) {

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_action_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_action_transport.cpp
@@ -183,6 +183,7 @@ ActionSendGoalResult Ros2ActionTransport::send_goal(const std::string & action_p
     // future.wait_for().
     const auto wait_timeout = std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
     if (!clients.send_goal_client->wait_for_service(wait_timeout)) {
+      result.outcome = CallOutcome::kServiceUnavailable;
       result.error_message = "Action server not available: " + action_path;
       return result;
     }
@@ -211,7 +212,11 @@ ActionSendGoalResult Ros2ActionTransport::send_goal(const std::string & action_p
     if (future_status != std::future_status::ready) {
       clients.send_goal_client->remove_pending_request(future_and_id.request_id);
       ros2_medkit_serialization::destroy_ros_message(&ros_request);
-      result.error_message = "Send goal timed out";
+      result.outcome = CallOutcome::kTimeout;
+      // Name the action and the budget. "Send goal timed out" tells a client
+      // neither which action stalled nor what it was measured against, so
+      // there is nothing in it to act on.
+      result.error_message = "Send goal timed out (" + std::to_string(timeout_ms.count()) + "ms): " + action_path;
       return result;
     }
 
@@ -232,6 +237,7 @@ ActionSendGoalResult Ros2ActionTransport::send_goal(const std::string & action_p
     json response = serializer_->to_json(type_info, response_ptr.get());
 
     result.success = true;
+    result.outcome = CallOutcome::kOk;
     result.goal_accepted = response.value("accepted", false);
 
     if (result.goal_accepted) {

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_parameter_transport.cpp
@@ -269,7 +269,7 @@ ParameterResult Ros2ParameterTransport::list_own_parameters() {
     for (const auto & param : params) {
       json param_obj;
       param_obj["name"] = param.get_name();
-      param_obj["value"] = parameter_value_to_json(param.get_parameter_value());
+      param_obj["value"] = parameter_value_for_display(param.get_name(), param.get_parameter_value());
       param_obj["type"] = parameter_type_to_string(param.get_type());
       params_array.push_back(param_obj);
     }
@@ -297,7 +297,7 @@ ParameterResult Ros2ParameterTransport::get_own_parameter(const std::string & pa
 
     json param_obj;
     param_obj["name"] = param.get_name();
-    param_obj["value"] = parameter_value_to_json(param.get_parameter_value());
+    param_obj["value"] = parameter_value_for_display(param.get_name(), param.get_parameter_value());
     param_obj["type"] = parameter_type_to_string(param.get_type());
     param_obj["description"] = descriptor.description;
     param_obj["read_only"] = descriptor.read_only;
@@ -446,7 +446,7 @@ ParameterResult Ros2ParameterTransport::list_parameters(const std::string & node
     for (const auto & param : parameters) {
       json param_obj;
       param_obj["name"] = param.get_name();
-      param_obj["value"] = parameter_value_to_json(param.get_parameter_value());
+      param_obj["value"] = parameter_value_for_display(param.get_name(), param.get_parameter_value());
       param_obj["type"] = parameter_type_to_string(param.get_type());
       params_array.push_back(param_obj);
     }
@@ -596,7 +596,7 @@ ParameterResult Ros2ParameterTransport::get_parameter(const std::string & node_n
 
     json param_obj;
     param_obj["name"] = param.get_name();
-    param_obj["value"] = parameter_value_to_json(param.get_parameter_value());
+    param_obj["value"] = parameter_value_for_display(param.get_name(), param.get_parameter_value());
     param_obj["type"] = parameter_type_to_string(param.get_type());
 
     if (!descriptors.empty()) {
@@ -642,7 +642,7 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
       }
       json param_obj;
       param_obj["name"] = param_name;
-      param_obj["value"] = parameter_value_to_json(param_value);
+      param_obj["value"] = parameter_value_for_display(param_name, param_value);
       param_obj["type"] = parameter_type_to_string(param_value.get_type());
       result.success = true;
       result.data = param_obj;
@@ -791,7 +791,7 @@ ParameterResult Ros2ParameterTransport::set_parameter(const std::string & node_n
 
     json param_obj;
     param_obj["name"] = param_name;
-    param_obj["value"] = parameter_value_to_json(param_value);
+    param_obj["value"] = parameter_value_for_display(param_name, param_value);
     param_obj["type"] = parameter_type_to_string(param_value.get_type());
 
     result.success = true;
@@ -822,7 +822,7 @@ ParameterResult Ros2ParameterTransport::get_default(const std::string & node_nam
       if (pre_it != node_pre_write->end()) {
         ParameterResult pre_result;
         pre_result.success = true;
-        pre_result.data = parameter_value_to_json(pre_it->second.get_parameter_value());
+        pre_result.data = parameter_value_for_display(param_name, pre_it->second.get_parameter_value());
         return pre_result;
       }
     }
@@ -884,7 +884,7 @@ ParameterResult Ros2ParameterTransport::get_default(const std::string & node_nam
     return result;
   }
   result.success = true;
-  result.data = parameter_value_to_json(param_it->second.get_parameter_value());
+  result.data = parameter_value_for_display(param_name, param_it->second.get_parameter_value());
   return result;
 }
 
@@ -956,7 +956,7 @@ ParameterResult Ros2ParameterTransport::list_defaults(const std::string & node_n
   for (const auto & [name, param] : merged) {
     json entry;
     entry["name"] = name;
-    entry["value"] = parameter_value_to_json(param.get_parameter_value());
+    entry["value"] = parameter_value_for_display(name, param.get_parameter_value());
     entry["type"] = parameter_type_to_string(param.get_type());
     defaults_array.push_back(entry);
   }
@@ -1226,6 +1226,29 @@ bool Ros2ParameterTransport::cache_default_values(const std::string & node_name)
     return true;
   }
   return false;  // defaults cached successfully
+}
+
+bool Ros2ParameterTransport::is_secret_parameter(const std::string & name) {
+  // Exact names, deliberately not a substring match on "secret" or "token":
+  // a substring rule hides ordinary parameters whose names happen to contain
+  // the word, and the operator then cannot read a value that is not a secret.
+  static const std::set<std::string> kSecretParameters{
+      "auth.jwt_secret",              // signs this gateway's tokens
+      "auth.clients",                 // holds client_id:client_secret:role
+      "aggregation.peer_auth_header"  // what this gateway presents to peers
+  };
+  return kSecretParameters.find(name) != kSecretParameters.end();
+}
+
+json Ros2ParameterTransport::parameter_value_for_display(const std::string & name,
+                                                         const rclcpp::ParameterValue & value) const {
+  if (is_secret_parameter(name)) {
+    // A fixed marker rather than the value's own shape. It reads as redaction
+    // in any client, and the entry keeps its declared type so the parameter is
+    // still discoverable - only its value is withheld.
+    return json("***");
+  }
+  return parameter_value_to_json(value);
 }
 
 }  // namespace ros2_medkit_gateway::ros2

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_service_transport.cpp
@@ -86,6 +86,7 @@ ServiceCallResult Ros2ServiceTransport::call(const std::string & service_path, c
     const auto wait_timeout = std::chrono::duration_cast<std::chrono::nanoseconds>(timeout);
     if (!client->wait_for_service(wait_timeout)) {
       result.success = false;
+      result.outcome = CallOutcome::kServiceUnavailable;
       result.error_message = "Service not available: " + service_path;
       return result;
     }
@@ -122,6 +123,7 @@ ServiceCallResult Ros2ServiceTransport::call(const std::string & service_path, c
       // Format the wait budget with millisecond precision so a sub-second
       // timeout (e.g. 0.1s) is not silently rendered as "0s".
       const auto timeout_ms = std::chrono::duration_cast<std::chrono::milliseconds>(timeout_secs).count();
+      result.outcome = CallOutcome::kTimeout;
       result.error_message = "Service call timed out (" + std::to_string(timeout_ms) + "ms): " + service_path;
       return result;
     }
@@ -135,6 +137,7 @@ ServiceCallResult Ros2ServiceTransport::call(const std::string & service_path, c
         if (type_info != nullptr) {
           result.response = serializer_->to_json(type_info, response_ptr.get());
           result.success = true;
+          result.outcome = CallOutcome::kOk;
           RCLCPP_DEBUG(node_->get_logger(), "Service call succeeded: %s", result.response.dump().c_str());
         } else {
           result.success = false;

--- a/src/ros2_medkit_gateway/test/test_peer_client.cpp
+++ b/src/ros2_medkit_gateway/test/test_peer_client.cpp
@@ -16,7 +16,9 @@
 #include <httplib.h>
 
 #include <algorithm>
+#include <chrono>
 #include <nlohmann/json.hpp>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -85,6 +87,88 @@ TEST(PeerClient, forward_sets_502_on_connection_error) {
 }
 
 // =============================================================================
+// classify_peer_error - the rule that separates a slow peer from a dead one
+// =============================================================================
+
+// cpp-httplib reports both "the read budget ran out" and "the connection broke
+// mid-answer" as Error::Read, so the error alone cannot tell them apart. These
+// pin the discriminator: the elapsed time against the budget.
+
+TEST(ClassifyPeerError, a_read_that_consumed_its_budget_is_a_timeout) {
+  EXPECT_EQ(classify_peer_error(httplib::Error::Read, std::chrono::milliseconds(2000), std::chrono::milliseconds(2000),
+                                std::chrono::milliseconds(1)),
+            PeerFailureKind::kTimeout);
+}
+
+TEST(ClassifyPeerError, a_read_that_broke_early_is_not_a_timeout) {
+  // The peer died with the answer half sent. Telling an operator to wait for
+  // it, or to raise a budget, points at the wrong box.
+  EXPECT_EQ(classify_peer_error(httplib::Error::Read, std::chrono::milliseconds(120), std::chrono::milliseconds(2000),
+                                std::chrono::milliseconds(1)),
+            PeerFailureKind::kUnreachable);
+}
+
+TEST(ClassifyPeerError, a_write_is_measured_against_the_WRITE_budget) {
+  // The write budget is its own and smaller than the read budget by default
+  // (5000 against 15000). Measured against the read budget, a write that ran
+  // out at its own limit looks like a peer that died, and the key whose whole
+  // purpose is bounding a slow upload could never report its own expiry.
+  EXPECT_EQ(classify_peer_error(httplib::Error::Write, std::chrono::milliseconds(5000),
+                                /*read_budget=*/std::chrono::milliseconds(15000),
+                                /*write_budget=*/std::chrono::milliseconds(5000)),
+            PeerFailureKind::kTimeout);
+  // Below its own budget it is still a broken connection, not a timeout.
+  EXPECT_EQ(classify_peer_error(httplib::Error::Write, std::chrono::milliseconds(120), std::chrono::milliseconds(15000),
+                                std::chrono::milliseconds(5000)),
+            PeerFailureKind::kUnreachable);
+}
+
+TEST(PeerBudgetFor, each_timeout_names_the_budget_that_bounds_it) {
+  // A connect timeout is bounded by the connect budget, not by the read budget
+  // the call was hoping to spend. Naming the wrong one tells an operator to
+  // raise a value that would not have changed the outcome.
+  EXPECT_EQ(peer_budget_for(httplib::Error::ConnectionTimeout), PeerBudget::kConnect);
+  EXPECT_EQ(peer_budget_for(httplib::Error::Read), PeerBudget::kRead);
+  EXPECT_EQ(peer_budget_for(httplib::Error::Write), PeerBudget::kWrite);
+  EXPECT_EQ(peer_budget_for(httplib::Error::Connection), PeerBudget::kNone);
+}
+
+TEST(ClassifyPeerError, a_connect_timeout_is_a_timeout_whatever_the_clock_says) {
+  // The connect budget is its own, and it is not the budget passed here, so
+  // the elapsed comparison must not get a vote.
+  EXPECT_EQ(classify_peer_error(httplib::Error::ConnectionTimeout, std::chrono::milliseconds(1),
+                                std::chrono::milliseconds(60000), std::chrono::milliseconds(1)),
+            PeerFailureKind::kTimeout);
+}
+
+TEST(ClassifyPeerError, a_refused_connection_is_unreachable_however_long_it_took) {
+  EXPECT_EQ(classify_peer_error(httplib::Error::Connection, std::chrono::milliseconds(9999),
+                                std::chrono::milliseconds(1000), std::chrono::milliseconds(1)),
+            PeerFailureKind::kUnreachable);
+}
+
+TEST(ClassifyPeerError, a_call_this_gateway_stopped_is_neither) {
+  EXPECT_EQ(classify_peer_error(httplib::Error::Canceled, std::chrono::milliseconds(9999),
+                                std::chrono::milliseconds(1000), std::chrono::milliseconds(1)),
+            PeerFailureKind::kCanceled);
+}
+
+TEST(PeerFailureReason, every_kind_has_a_distinct_wire_token) {
+  // The tokens are documented in docs/api/rest.rst and read by clients. Two
+  // kinds sharing one token would put the defect back: a client could not tell
+  // those two events apart, which is the whole of what this carries.
+  const PeerFailureKind kinds[] = {PeerFailureKind::kNone,           PeerFailureKind::kTimeout,
+                                   PeerFailureKind::kUnreachable,    PeerFailureKind::kCanceled,
+                                   PeerFailureKind::kErrorStatus,    PeerFailureKind::kTooLarge,
+                                   PeerFailureKind::kInvalidResponse};
+  std::set<std::string> tokens;
+  for (auto kind : kinds) {
+    tokens.insert(peer_failure_reason(kind));
+  }
+  EXPECT_EQ(tokens.size(), sizeof(kinds) / sizeof(kinds[0]));
+}
+
+// =============================================================================
 // forward_and_get_json tests (connection failure path)
 // =============================================================================
 
@@ -94,8 +178,11 @@ TEST(PeerClient, forward_and_get_json_returns_error_on_connection_refused) {
   auto result = client.forward_and_get_json("GET", "/api/v1/health");
 
   ASSERT_FALSE(result.has_value());
-  EXPECT_TRUE(result.error().find("dead_peer") != std::string::npos);
-  EXPECT_TRUE(result.error().find("Failed to connect") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("dead_peer") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("Failed to reach peer") != std::string::npos);
+  // A refused connection is not a budget that ran out. The two get different
+  // HTTP statuses one layer up, so the kind carries as much as the text.
+  EXPECT_EQ(result.error().kind, PeerFailureKind::kUnreachable);
 }
 
 // =============================================================================
@@ -750,8 +837,9 @@ TEST(PeerClientHappyPath, forward_and_get_json_error_on_non_2xx) {
   auto result = client.forward_and_get_json("GET", "/api/v1/missing");
 
   ASSERT_FALSE(result.has_value());
-  EXPECT_TRUE(result.error().find("404") != std::string::npos);
-  EXPECT_TRUE(result.error().find("test_peer") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("404") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("test_peer") != std::string::npos);
+  EXPECT_EQ(result.error().kind, PeerFailureKind::kErrorStatus);
 
   svr.stop();
   t.join();
@@ -818,8 +906,9 @@ TEST(PeerClientHappyPath, forward_and_get_json_rejects_oversized_response) {
   auto result = client.forward_and_get_json("GET", "/api/v1/components/big/data");
 
   ASSERT_FALSE(result.has_value());
-  EXPECT_TRUE(result.error().find("size limit") != std::string::npos);
-  EXPECT_TRUE(result.error().find("big_peer") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("size limit") != std::string::npos);
+  EXPECT_TRUE(result.error().message.find("big_peer") != std::string::npos);
+  EXPECT_EQ(result.error().kind, PeerFailureKind::kTooLarge);
 
   svr.stop();
   t.join();

--- a/src/ros2_medkit_gateway/test/test_peer_fault_relay.cpp
+++ b/src/ros2_medkit_gateway/test/test_peer_fault_relay.cpp
@@ -1,0 +1,147 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Fast regression checks on PeerFaultRelay's lifecycle arithmetic. Whether the
+/// relay actually carries a peer's faults is settled end to end in
+/// test_aggregator_fault_stream.test.py, with two gateways and real HTTP;
+/// nothing here can show that, and nothing here is offered as showing it.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/aggregation/peer_fault_relay.hpp"
+
+namespace ros2_medkit_gateway {
+namespace {
+
+/// A port nothing listens on, so a connect attempt is refused at once and the
+/// reader thread spends its life in the interruptible backoff sleep.
+constexpr const char * kDeadUrl = "http://127.0.0.1:1";
+
+PeerFaultRelay::TargetSupplier none() {
+  return []() {
+    return std::vector<RelayTarget>{};
+  };
+}
+
+PeerFaultRelay::TargetSupplier one(const std::string & name) {
+  return [name]() {
+    return std::vector<RelayTarget>{RelayTarget{name, kDeadUrl, ""}};
+  };
+}
+
+PeerFaultRelay::EventCallback ignore() {
+  return [](const StreamEvent &) {};
+}
+
+TEST(PeerFaultRelay, opens_nothing_without_a_client) {
+  PeerFaultRelay relay(one("peer_a"), "/api/v1/faults/stream", ignore());
+
+  relay.reconcile();
+
+  // The whole point of the refcount: a gateway nobody is watching must not be
+  // holding an SSE slot on any peer.
+  EXPECT_EQ(relay.open_streams(), 0U);
+}
+
+TEST(PeerFaultRelay, opens_one_stream_per_listed_peer_while_a_client_is_attached) {
+  PeerFaultRelay relay(one("peer_a"), "/api/v1/faults/stream", ignore());
+
+  relay.acquire();
+  EXPECT_EQ(relay.open_streams(), 1U);
+
+  relay.release();
+  EXPECT_EQ(relay.open_streams(), 0U);
+}
+
+TEST(PeerFaultRelay, the_last_client_closes_the_streams_not_the_first) {
+  PeerFaultRelay relay(one("peer_a"), "/api/v1/faults/stream", ignore());
+
+  relay.acquire();
+  relay.acquire();
+  relay.release();
+  // One client still attached. Closing here would blind it.
+  EXPECT_EQ(relay.open_streams(), 1U);
+
+  relay.release();
+  EXPECT_EQ(relay.open_streams(), 0U);
+}
+
+TEST(PeerFaultRelay, a_release_without_an_acquire_does_not_wrap_the_count) {
+  PeerFaultRelay relay(one("peer_a"), "/api/v1/faults/stream", ignore());
+
+  relay.release();
+  relay.acquire();
+
+  // An unsigned counter decremented past zero would leave this at SIZE_MAX and
+  // the streams open for the life of the process.
+  EXPECT_EQ(relay.open_streams(), 1U);
+  relay.release();
+  EXPECT_EQ(relay.open_streams(), 0U);
+}
+
+TEST(PeerFaultRelay, a_peer_that_goes_away_has_its_stream_closed) {
+  std::atomic<bool> peer_listed{true};
+  PeerFaultRelay relay(
+      [&peer_listed]() {
+        std::vector<RelayTarget> targets;
+        if (peer_listed.load()) {
+          targets.push_back(RelayTarget{"peer_a", kDeadUrl, ""});
+        }
+        return targets;
+      },
+      "/api/v1/faults/stream", ignore());
+
+  relay.acquire();
+  ASSERT_EQ(relay.open_streams(), 1U);
+
+  peer_listed.store(false);
+  // reconcile() is rate limited, so a second call inside the interval is a
+  // no-op by design. Waiting past it is what this asserts against.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+  relay.reconcile();
+  EXPECT_EQ(relay.open_streams(), 0U);
+
+  relay.release();
+}
+
+TEST(PeerFaultRelay, shutdown_is_idempotent_and_refuses_later_clients) {
+  PeerFaultRelay relay(one("peer_a"), "/api/v1/faults/stream", ignore());
+
+  relay.acquire();
+  relay.shutdown();
+  relay.shutdown();
+  EXPECT_EQ(relay.open_streams(), 0U);
+
+  // A client arriving during teardown must not reopen what shutdown closed.
+  relay.acquire();
+  EXPECT_EQ(relay.open_streams(), 0U);
+}
+
+TEST(PeerFaultRelay, an_empty_peer_list_opens_nothing) {
+  PeerFaultRelay relay(none(), "/api/v1/faults/stream", ignore());
+
+  relay.acquire();
+
+  EXPECT_EQ(relay.open_streams(), 0U);
+  relay.release();
+}
+
+}  // namespace
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/test/test_stream_proxy.cpp
+++ b/src/ros2_medkit_gateway/test/test_stream_proxy.cpp
@@ -366,6 +366,194 @@ TEST(SSEStreamProxyIntegration, close_terminates_reader_thread) {
   EXPECT_GT(event_count.load(), 0);
 }
 
+/// A peer that ends its events with CRLF is delivering valid SSE, and the
+/// framing here has to admit it. parse_sse_data handling CRLF proves nothing
+/// about this: the live reader splits the byte stream itself, and a search for
+/// "\n\n" alone never matches "\r\n\r\n", so such a peer would stream for
+/// ever and yield no event.
+TEST(SSEStreamProxyIntegration, frames_events_from_a_crlf_peer) {
+  httplib::Server svr;
+  std::atomic<bool> stop_stream{false};
+
+  svr.Get("/events", [&stop_stream](const httplib::Request &, httplib::Response & res) {
+    res.set_chunked_content_provider("text/event-stream", [&stop_stream](size_t offset, httplib::DataSink & sink) {
+      if (offset == 0) {
+        std::string event =
+            "event: test\r\n"
+            "id: 7\r\n"
+            "data: {\"value\":42}\r\n"
+            "\r\n";
+        sink.write(event.data(), event.size());
+        return true;
+      }
+      if (stop_stream.load()) {
+        sink.done();
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      return true;
+    });
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread server_thread([&svr]() {
+    svr.listen_after_bind();
+  });
+  wait_for_server(svr);
+
+  SSEStreamProxy proxy("http://127.0.0.1:" + std::to_string(port), "/events", "crlf_peer");
+  std::vector<StreamEvent> received;
+  std::mutex mtx;
+  std::condition_variable cv;
+  proxy.on_event([&](const StreamEvent & event) {
+    std::lock_guard<std::mutex> lock(mtx);
+    received.push_back(event);
+    cv.notify_one();
+  });
+  proxy.open();
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    cv.wait_for(lock, std::chrono::seconds(5), [&]() {
+      return !received.empty();
+    });
+  }
+  stop_stream.store(true);
+  proxy.close();
+  svr.stop();
+  server_thread.join();
+
+  ASSERT_FALSE(received.empty()) << "a CRLF-delimited peer produced no event";
+  EXPECT_EQ(received[0].event_type, "test");
+  EXPECT_EQ(received[0].data, "{\"value\":42}");
+  // The cursor has to advance for a CRLF peer too, or a reconnect replays it.
+  EXPECT_EQ(proxy.last_event_id(), "7");
+}
+
+/// The callback is handed a payload the peer wrote, and the handler that reads
+/// it can throw on a shape it did not expect. An exception leaving a
+/// std::thread calls std::terminate, so a peer could end the gateway with one
+/// malformed field. The reader must absorb it and stay on the stream.
+TEST(SSEStreamProxyIntegration, a_throwing_handler_does_not_kill_the_reader) {
+  httplib::Server svr;
+  std::atomic<bool> stop_stream{false};
+
+  svr.Get("/events", [&stop_stream](const httplib::Request &, httplib::Response & res) {
+    res.set_chunked_content_provider("text/event-stream", [&stop_stream](size_t offset, httplib::DataSink & sink) {
+      if (offset == 0) {
+        std::string first = "data: poison\n\n";
+        sink.write(first.data(), first.size());
+        return true;
+      }
+      if (offset > 0 && offset < 100) {
+        std::string second = "data: good\n\n";
+        sink.write(second.data(), second.size());
+        return true;
+      }
+      if (stop_stream.load()) {
+        sink.done();
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      return true;
+    });
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread server_thread([&svr]() {
+    svr.listen_after_bind();
+  });
+  wait_for_server(svr);
+
+  SSEStreamProxy proxy("http://127.0.0.1:" + std::to_string(port), "/events", "throwing_peer");
+  std::vector<std::string> delivered;
+  std::mutex mtx;
+  std::condition_variable cv;
+  proxy.on_event([&](const StreamEvent & event) {
+    {
+      std::lock_guard<std::mutex> lock(mtx);
+      delivered.push_back(event.data);
+    }
+    cv.notify_one();
+    if (event.data == "poison") {
+      throw std::runtime_error("handler cannot read this event");
+    }
+  });
+  proxy.open();
+  {
+    std::unique_lock<std::mutex> lock(mtx);
+    cv.wait_for(lock, std::chrono::seconds(5), [&]() {
+      return delivered.size() >= 2u;
+    });
+  }
+  stop_stream.store(true);
+  proxy.close();
+  svr.stop();
+  server_thread.join();
+
+  ASSERT_GE(delivered.size(), 2u) << "the reader stopped after the handler threw";
+  EXPECT_EQ(delivered[0], "poison");
+  EXPECT_EQ(delivered[1], "good");
+}
+
+/// A stream reopened for a peer resumes where the last one stopped. Without
+/// the hand-off it asks for the peer's whole buffer, and every event in it is
+/// delivered again, as new, to whoever is attached now.
+TEST(SSEStreamProxyIntegration, a_resumed_stream_sends_the_last_event_id) {
+  httplib::Server svr;
+  std::atomic<bool> stop_stream{false};
+  std::string seen_last_event_id;
+  std::mutex header_mtx;
+
+  svr.Get("/events", [&](const httplib::Request & req, httplib::Response & res) {
+    {
+      std::lock_guard<std::mutex> lock(header_mtx);
+      seen_last_event_id = req.get_header_value("Last-Event-ID");
+    }
+    res.set_chunked_content_provider("text/event-stream", [&stop_stream](size_t offset, httplib::DataSink & sink) {
+      if (offset == 0) {
+        std::string event = "id: 12\ndata: resumed\n\n";
+        sink.write(event.data(), event.size());
+        return true;
+      }
+      if (stop_stream.load()) {
+        sink.done();
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      return true;
+    });
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread server_thread([&svr]() {
+    svr.listen_after_bind();
+  });
+  wait_for_server(svr);
+
+  SSEStreamProxy proxy("http://127.0.0.1:" + std::to_string(port), "/events", "resuming_peer");
+  proxy.set_last_event_id("11");
+  std::atomic<bool> got{false};
+  proxy.on_event([&got](const StreamEvent &) {
+    got.store(true);
+  });
+  proxy.open();
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!got.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  stop_stream.store(true);
+  proxy.close();
+  svr.stop();
+  server_thread.join();
+
+  {
+    std::lock_guard<std::mutex> lock(header_mtx);
+    EXPECT_EQ(seen_last_event_id, "11") << "the resume point was not offered to the peer";
+  }
+  // And it moves on to what the peer actually delivered.
+  EXPECT_EQ(proxy.last_event_id(), "12");
+}
+
 TEST(SSEStreamProxyIntegration, buffer_overflow_disconnects) {
   httplib::Server svr;
 

--- a/src/ros2_medkit_gateway/test/test_stream_proxy.cpp
+++ b/src/ros2_medkit_gateway/test/test_stream_proxy.cpp
@@ -554,6 +554,62 @@ TEST(SSEStreamProxyIntegration, a_resumed_stream_sends_the_last_event_id) {
   EXPECT_EQ(proxy.last_event_id(), "12");
 }
 
+/// A peer that requires authentication refuses an unauthenticated stream, so
+/// the credential the relay is given has to reach it. Asserting that the relay
+/// merely opened would not show this: an unauthorized stream is also a stream,
+/// and its 401 is only visible on the request the peer actually received.
+TEST(SSEStreamProxyIntegration, presents_the_configured_credential_to_the_peer) {
+  httplib::Server svr;
+  std::atomic<bool> stop_stream{false};
+  std::string seen_authorization;
+  std::mutex header_mtx;
+
+  svr.Get("/events", [&](const httplib::Request & req, httplib::Response & res) {
+    {
+      std::lock_guard<std::mutex> lock(header_mtx);
+      seen_authorization = req.get_header_value("Authorization");
+    }
+    res.set_chunked_content_provider("text/event-stream", [&stop_stream](size_t offset, httplib::DataSink & sink) {
+      if (offset == 0) {
+        std::string event = "data: authorized\n\n";
+        sink.write(event.data(), event.size());
+        return true;
+      }
+      if (stop_stream.load()) {
+        sink.done();
+        return false;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      return true;
+    });
+  });
+
+  int port = svr.bind_to_any_port("127.0.0.1");
+  std::thread server_thread([&svr]() {
+    svr.listen_after_bind();
+  });
+  wait_for_server(svr);
+
+  SSEStreamProxy proxy("http://127.0.0.1:" + std::to_string(port), "/events", "authed_peer",
+                       httplib::Headers{{"Authorization", "Bearer relay-token"}});
+  std::atomic<bool> got{false};
+  proxy.on_event([&got](const StreamEvent &) {
+    got.store(true);
+  });
+  proxy.open();
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  while (!got.load() && std::chrono::steady_clock::now() < deadline) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+  stop_stream.store(true);
+  proxy.close();
+  svr.stop();
+  server_thread.join();
+
+  std::lock_guard<std::mutex> lock(header_mtx);
+  EXPECT_EQ(seen_authorization, "Bearer relay-token");
+}
+
 TEST(SSEStreamProxyIntegration, buffer_overflow_disconnects) {
   httplib::Server svr;
 

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -253,7 +253,8 @@ if(BUILD_TESTING)
     test_leaf_collision_aggregation
     test_startup_param_clamp_warnings
     test_aggregation_time_budgets
-    test_peer_failure_reasons)
+    test_peer_failure_reasons
+    test_relay_peer_credential)
   set(_MULTI_GATEWAY_DOMAINS 4)
 
   # Two-gateway tests that need the second gateway isolated from the first and

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -75,6 +75,10 @@ add_executable(demo_calibration_service demo_nodes/calibration_service.cpp)
 target_include_directories(demo_calibration_service PRIVATE ${_demo_include_dir})
 medkit_target_dependencies(demo_calibration_service rclcpp rcl_interfaces std_srvs)
 
+add_executable(demo_slow_calibration_service demo_nodes/slow_calibration_service.cpp)
+target_include_directories(demo_slow_calibration_service PRIVATE ${_demo_include_dir})
+medkit_target_dependencies(demo_slow_calibration_service rclcpp rcl_interfaces std_srvs)
+
 add_executable(demo_dual_calibration_service demo_nodes/dual_calibration_service.cpp)
 target_include_directories(demo_dual_calibration_service PRIVATE ${_demo_include_dir})
 medkit_target_dependencies(demo_dual_calibration_service rclcpp rclcpp_action example_interfaces std_srvs)
@@ -122,6 +126,7 @@ install(TARGETS
   demo_brake_actuator
   demo_light_controller
   demo_calibration_service
+  demo_slow_calibration_service
   demo_dual_calibration_service
   demo_long_calibration_action
   demo_shared_leaf
@@ -246,7 +251,9 @@ if(BUILD_TESTING)
     test_aggregate_lock_identity
     test_aggregator_only_configurations
     test_leaf_collision_aggregation
-    test_startup_param_clamp_warnings)
+    test_startup_param_clamp_warnings
+    test_aggregation_time_budgets
+    test_peer_failure_reasons)
   set(_MULTI_GATEWAY_DOMAINS 4)
 
   # Two-gateway tests that need the second gateway isolated from the first and
@@ -256,7 +263,8 @@ if(BUILD_TESTING)
   # otherwise have started alongside it.
   set(_TWO_GATEWAY_TESTS
     test_peer_recovery
-    test_triggers_restore_before_discovery)
+    test_triggers_restore_before_discovery
+    test_aggregator_fault_stream)
   set(_TWO_GATEWAY_DOMAINS 2)
 
   # Tests whose polling budgets do not fit the glob's default timeout. Keyed by
@@ -291,7 +299,27 @@ if(BUILD_TESTING)
   # That window plus two gateway startups and the SSE wait after it exceed the
   # 120s the feature glob assigns, so it gets its own budget rather than have
   # the file killed with no test name in the output.
+  #
+  # test_aggregation_time_budgets holds a peer-owned operation open for four
+  # seconds twice on purpose - a budget cannot be measured against a service
+  # that answers instantly - and reads a lidar scan large enough to break the
+  # tight budget three times over. Three gateway startups on top of that do not
+  # fit the feature glob's 120s.
+  #
+  # test_peer_failure_reasons waits out the peer's own six-second parameter
+  # round trip on the patient aggregator, twice, and then polls after killing
+  # the peer. Two of those plus three gateway startups exceed the default.
+  #
+  # test_aggregator_fault_stream spends most of its budget waiting rather than
+  # working: a closed SSE connection is noticed at the peer's next keepalive,
+  # 30s away, and the test settles the peer's occupancy before each measurement
+  # so an earlier case's closed stream is not attributed to the relay. That is
+  # deliberate - a shorter wait would pass for a gateway that never released
+  # the slot at all.
   set(_MEDKIT_TEST_TIMEOUT_OVERRIDES
+    test_aggregation_time_budgets 300
+    test_peer_failure_reasons 300
+    test_aggregator_fault_stream 420
     test_rosbag_boundary_download 180
     test_rosbag_history_download 180
     test_grouping_entity_aggregation 300

--- a/src/ros2_medkit_integration_tests/demo_nodes/slow_calibration_service.cpp
+++ b/src/ros2_medkit_integration_tests/demo_nodes/slow_calibration_service.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file slow_calibration_service.cpp
+ * @brief Demo calibration service that takes a settable time to answer.
+ *
+ * The fixture for a budget. Every other service node in this package answers
+ * immediately, which cannot tell a budget that is too small from one that is
+ * right - a test written against an instant service passes on both sides of a
+ * timeout change and measures nothing.
+ *
+ * `response_delay_sec` is settable at runtime, so one test can hold a call
+ * open past one budget and inside another without relaunching the node.
+ */
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+#include "ros2_medkit_integration_tests/demo_node_main.hpp"
+
+class SlowCalibrationService : public rclcpp::Node {
+ public:
+  SlowCalibrationService() : Node("slow_calibration_service") {
+    rcl_interfaces::msg::ParameterDescriptor delay_desc;
+    delay_desc.description = "Seconds the calibrate service waits before answering";
+    declare_parameter("response_delay_sec", 0.0, delay_desc);
+
+    rcl_interfaces::msg::ParameterDescriptor offset_desc;
+    offset_desc.description = "Calibration offset value";
+    declare_parameter("calibration_offset", 0.0, offset_desc);
+
+    // No callback group and no QoS override. run_demo_node spins a
+    // SingleThreadedExecutor, so callbacks serialise whatever group they are
+    // in, and the QoS argument to create_service is a different type on Humble
+    // than on Jazzy - naming either buys nothing here and costs a distro.
+    calibration_srv_ = create_service<std_srvs::srv::Trigger>(
+        "~/calibrate", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                              std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
+          const auto delay = std::chrono::duration<double>(get_parameter("response_delay_sec").as_double());
+          const auto deadline = std::chrono::steady_clock::now() + delay;
+          // Slept in slices rather than in one call so SIGINT during a long
+          // delay still ends the process inside the launch_testing grace
+          // window; a single sleep_for would hold the executor for the whole
+          // delay whatever the context says.
+          while (rclcpp::ok() && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+          }
+          response->success = true;
+          response->message =
+              "Calibration complete after " + std::to_string(get_parameter("response_delay_sec").as_double()) + "s";
+        });
+
+    RCLCPP_INFO(get_logger(), "Slow calibration service started");
+  }
+
+ private:
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr calibration_srv_;
+};
+
+int main(int argc, char ** argv) {
+  return ros2_medkit_integration_tests::run_demo_node(argc, argv, [] {
+    return std::make_shared<SlowCalibrationService>();
+  });
+}

--- a/src/ros2_medkit_integration_tests/test/features/test_aggregation_time_budgets.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_aggregation_time_budgets.test.py
@@ -1,0 +1,406 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end specification for an aggregating gateway's time budgets.
+
+A peer forward carries the peer's own work: a synchronous service call runs
+against THAT gateway's ``service_call_timeout_sec``, and a large
+resource has to be serialised and transferred on top. One budget covering both
+that and a metadata read gives the forward the budget of a listing, and the
+answer a client gets is that the peer is unavailable - at the moment that peer
+is serving the same request.
+
+THE RULES
+
+B1  An operation that takes longer than the metadata budget and less than the
+    forward budget returns the peer's own result. Asserting a 200 alone would
+    not show this: a fast operation returns 200 whatever the budgets are, so
+    the call has to be held open past the metadata budget on purpose and the
+    elapsed time asserted.
+B2  A large resource arrives whole. Proven by comparing the array length
+    against a read taken straight from the owning gateway, not by status. This
+    rule is about completeness only: how long a given machine takes to
+    serialise 180000 readings is a property of the machine, so requiring a
+    timeout here would measure the host rather than the gateway.
+B3  An operation against an aggregator whose forward budget is BELOW the work
+    answers 504 not-responding. This is what makes B1 mean something: a test
+    that passes under every budget is not measuring a budget. The two
+    aggregators differ in exactly the key under test, and the peer is held for
+    a controlled four seconds so the answer cannot depend on host speed.
+B4  A timeout is not an unavailable peer. 504 ``not-responding`` and 502
+    ``x-medkit-peer-unavailable`` are different answers to different events,
+    and the timeout names the budget it exceeded so an operator can act on it.
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing.actions
+import requests
+from ros2_medkit_test_utils.constants import (
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
+
+GENEROUS_PORT = get_test_port(0)
+TIGHT_PORT = get_test_port(1)
+PEER_PORT = get_test_port(2)
+
+GENEROUS_URL = f'http://localhost:{GENEROUS_PORT}{API_BASE_PATH}'
+TIGHT_URL = f'http://localhost:{TIGHT_PORT}{API_BASE_PATH}'
+PEER_URL = f'http://localhost:{PEER_PORT}{API_BASE_PATH}'
+
+GENEROUS_DOMAIN_ID = get_test_domain_id(0)
+TIGHT_DOMAIN_ID = get_test_domain_id(1)
+PEER_DOMAIN_ID = get_test_domain_id(2)
+
+# Both aggregators read a peer's description with the same budget; they differ
+# only in what a FORWARD gets. That is the key under test, and keeping every
+# other parameter equal is what lets the two answers be attributed to it.
+# NOT scaled. The metadata budget bounds discovery and fan-out over loopback,
+# which a sanitizer barely touches, and B1 asserts the call outlived it - so
+# scaling it to 6000 under a sanitizer would demand more than the four seconds
+# of work the fixture holds, and the assertion would fail on a correct gateway.
+METADATA_BUDGET_MS = 2000
+# The generous budget covers the peer SERIALISING the scan, which is the work a
+# sanitizer slows down most. Scaling only the client's patience leaves the
+# gateway giving up first and answering 504 to a read that is merely slow.
+GENEROUS_FORWARD_MS = int(20000 * get_time_scale())
+# Below the four seconds of held work on purpose. Kept at or under the tight
+# gateway's own metadata budget too, because a forward budget below the metadata
+# budget is raised to it - scaling one without the other silently handed this
+# aggregator a budget big enough to finish the work.
+TIGHT_FORWARD_MS = 1000
+TIGHT_METADATA_MS = 1000
+
+# Longer than the metadata budget, shorter than the generous forward budget.
+# The whole point of the fixture: under one budget for both, this call cannot
+# succeed through an aggregator however healthy the peer is.
+SLOW_SERVICE_DELAY_SEC = 4.0
+
+# 360 / 0.01 = 36000 readings in each of two float arrays, about a megabyte of
+# JSON. Large enough that a truncated or re-serialised payload shows up as a
+# different reading count, which is what this measures. Deliberately not larger:
+# at 180000 readings the serialisation alone outran a 60 s budget under ASan, so
+# the test failed on instrumentation overhead rather than on gateway behaviour.
+LIDAR_ANGULAR_RESOLUTION = 0.01
+EXPECTED_LIDAR_READINGS = 36000
+
+PEER_COMPONENT = 'remote-ecu'
+SLOW_APP = 'remote_slow_calibration'
+LIDAR_APP = 'remote_lidar'
+PEER_NAMESPACE = '/chassis/sensors'
+
+TIMEOUT = DISCOVERY_TIMEOUT * get_time_scale()
+
+PEER_MANIFEST = f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Remote ECU"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: ignore
+components:
+  - id: {PEER_COMPONENT}
+    name: "Remote ECU"
+apps:
+  - id: {SLOW_APP}
+    name: "Slow Calibration Service"
+    is_located_on: {PEER_COMPONENT}
+    ros_binding:
+      node_name: slow_calibration_service
+      namespace: {PEER_NAMESPACE}
+  - id: {LIDAR_APP}
+    name: "Lidar Sensor"
+    is_located_on: {PEER_COMPONENT}
+    ros_binding:
+      node_name: lidar_sensor
+      namespace: {PEER_NAMESPACE}
+"""
+
+
+def _write_manifest(content):
+    fd, path = tempfile.mkstemp(suffix='.yaml', prefix='test_agg_budgets_manifest_')
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    return path
+
+
+def generate_test_description():
+    peer_manifest_path = _write_manifest(PEER_MANIFEST)
+    peer_domain_env = {'ROS_DOMAIN_ID': str(PEER_DOMAIN_ID)}
+
+    generous_gateway = create_gateway_node(
+        name='generous_gateway_node',
+        port=GENEROUS_PORT,
+        extra_params={
+            'aggregation.enabled': True,
+            'aggregation.timeout_ms': METADATA_BUDGET_MS,
+            'aggregation.forward_timeout_ms': GENEROUS_FORWARD_MS,
+            'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+            'aggregation.peer_names': ['remote_gateway'],
+        },
+        extra_env={'ROS_DOMAIN_ID': str(GENEROUS_DOMAIN_ID)},
+    )
+
+    tight_gateway = create_gateway_node(
+        name='tight_gateway_node',
+        port=TIGHT_PORT,
+        extra_params={
+            'aggregation.enabled': True,
+            'aggregation.timeout_ms': TIGHT_METADATA_MS,
+            'aggregation.forward_timeout_ms': TIGHT_FORWARD_MS,
+            'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+            'aggregation.peer_names': ['remote_gateway'],
+        },
+        extra_env={'ROS_DOMAIN_ID': str(TIGHT_DOMAIN_ID)},
+    )
+
+    peer_gateway = create_gateway_node(
+        name='remote_gateway_node',
+        port=PEER_PORT,
+        extra_params={
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': peer_manifest_path,
+            'discovery.manifest_strict_validation': False,
+        },
+        extra_env=peer_domain_env,
+    )
+
+    slow_service = launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable='demo_slow_calibration_service',
+        name='slow_calibration_service',
+        namespace=PEER_NAMESPACE,
+        output='screen',
+        additional_env=peer_domain_env,
+    )
+    lidar = launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable='demo_lidar_sensor',
+        name='lidar_sensor',
+        namespace=PEER_NAMESPACE,
+        output='screen',
+        parameters=[{'angular_resolution': LIDAR_ANGULAR_RESOLUTION}],
+        additional_env=peer_domain_env,
+    )
+
+    launch_description = LaunchDescription([
+        generous_gateway,
+        tight_gateway,
+        peer_gateway,
+        TimerAction(period=2.0, actions=[slow_service, lidar]),
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+    return (
+        launch_description,
+        {
+            'gateway_node': generous_gateway,
+            'tight_gateway': tight_gateway,
+            'peer_gateway': peer_gateway,
+        },
+    )
+
+
+class AggregationTimeBudgetsTest(unittest.TestCase):
+    """Drives both aggregators; the peer is used to establish the truth."""
+
+    @classmethod
+    def setUpClass(cls):
+        for url, label in ((PEER_URL, 'peer'), (GENEROUS_URL, 'generous'), (TIGHT_URL, 'tight')):
+            cls._wait_for_apps(url, {SLOW_APP, LIDAR_APP}, label)
+        # A manifest App exists before its node does, and an App with no live
+        # binding has no operations at all - a 404 from an entity that is
+        # merely early reads exactly like the routing failure under test.
+        cls._wait_for_operation(PEER_URL, SLOW_APP, 'calibrate')
+
+    @classmethod
+    def _wait_for_apps(cls, base_url, expected, label):
+        deadline = time.time() + TIMEOUT
+        seen = set()
+        while time.time() < deadline:
+            try:
+                response = requests.get(f'{base_url}/apps', timeout=10)
+                if response.status_code == 200:
+                    seen = {item['id'] for item in response.json().get('items', [])}
+                    if expected.issubset(seen):
+                        return
+            except requests.RequestException:
+                pass
+            time.sleep(0.5)
+        raise AssertionError(
+            f'{label} gateway never listed {sorted(expected)}; saw {sorted(seen)}')
+
+    @classmethod
+    def _wait_for_operation(cls, base_url, app_id, operation_id):
+        deadline = time.time() + TIMEOUT
+        seen = []
+        while time.time() < deadline:
+            try:
+                response = requests.get(f'{base_url}/apps/{app_id}/operations', timeout=10)
+                if response.status_code == 200:
+                    seen = [item['id'] for item in response.json().get('items', [])]
+                    if operation_id in seen:
+                        return
+            except requests.RequestException:
+                pass
+            time.sleep(0.5)
+        raise AssertionError(f'{app_id} never offered operation {operation_id}; saw {seen}')
+
+    def _set_service_delay(self, seconds):
+        response = requests.put(
+            f'{PEER_URL}/apps/{SLOW_APP}/configurations/response_delay_sec',
+            json={'data': seconds},
+            timeout=15,
+        )
+        self.assertIn(
+            response.status_code, (200, 204),
+            f'could not set response_delay_sec on the peer: '
+            f'{response.status_code} {response.text}')
+
+    def test_b1_operation_past_the_metadata_budget_returns_the_peers_result(self):
+        """B1: 4 s of work reaches the client through a 2 s metadata budget."""
+        self._set_service_delay(SLOW_SERVICE_DELAY_SEC)
+        self.addCleanup(self._set_service_delay, 0.0)
+
+        started = time.monotonic()
+        response = requests.post(
+            f'{GENEROUS_URL}/apps/{SLOW_APP}/operations/calibrate/executions',
+            json={},
+            timeout=(GENEROUS_FORWARD_MS / 1000.0 + 10) * get_time_scale(),
+        )
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(
+            response.status_code, 200,
+            f'a peer-owned operation the peer itself serves in {SLOW_SERVICE_DELAY_SEC}s '
+            f'failed through the aggregator after {elapsed:.3f}s: {response.text}')
+        # Without this the test would pass against an instant service and prove
+        # nothing about a budget.
+        self.assertGreater(
+            elapsed, METADATA_BUDGET_MS / 1000.0,
+            f'the call returned in {elapsed:.3f}s, inside the metadata budget of '
+            f'{METADATA_BUDGET_MS}ms - the fixture did not hold it open, so this '
+            f'run cannot distinguish a correct forward budget from the old shared one')
+        body = response.json()
+        self.assertIn('parameters', body, f'peer result envelope missing: {body}')
+        self.assertTrue(
+            body['parameters'].get('success'),
+            f'the peer reported failure through the aggregator: {body}')
+
+    def test_b3_same_operation_times_out_under_a_tight_forward_budget(self):
+        """B3+B4: the tight aggregator answers 504 not-responding, naming the budget."""
+        self._set_service_delay(SLOW_SERVICE_DELAY_SEC)
+        self.addCleanup(self._set_service_delay, 0.0)
+
+        started = time.monotonic()
+        response = requests.post(
+            f'{TIGHT_URL}/apps/{SLOW_APP}/operations/calibrate/executions',
+            json={},
+            timeout=30 * get_time_scale(),
+        )
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(
+            response.status_code, 504,
+            f'an aggregator whose forward budget is {TIGHT_FORWARD_MS}ms answered '
+            f'{response.status_code} to {SLOW_SERVICE_DELAY_SEC}s of work after '
+            f'{elapsed:.3f}s: {response.text}')
+        body = response.json()
+        self.assertEqual(
+            body.get('error_code'), 'not-responding',
+            f'a timeout must be reported as a timeout, not as something else: {body}')
+        # B4: the message has to name the budget, or an operator cannot act on it.
+        self.assertIn(
+            'forward_timeout_ms', body.get('message', ''),
+            f'the timeout does not name the budget it exceeded: {body}')
+        self.assertNotIn(
+            'unavailable', body.get('message', '').lower(),
+            f'the peer was answering; calling it unavailable points at the wrong box: {body}')
+
+    def test_b2_large_resource_arrives_whole_through_the_aggregator(self):
+        """B2: the payload #528 reports as timing out now arrives complete.
+
+        This asserts completeness, not a timeout. Whether a given machine
+        serialises 180000 readings faster or slower than any particular budget
+        is a property of the machine, not of the gateway: an earlier version
+        required the tight aggregator to answer 504 here and passed locally
+        while failing on faster CI hardware, which measured the box rather than
+        the code. The budget itself is proven by B3, where the peer is held for
+        a controlled four seconds and the answer cannot depend on how fast the
+        host is.
+        """
+        resource = self._find_scan_resource()
+
+        direct = requests.get(f'{PEER_URL}/apps/{LIDAR_APP}/data/{resource}',
+                              timeout=120 * get_time_scale())
+        self.assertEqual(
+            direct.status_code, 200,
+            f'peer could not serve its own scan: {direct.text[:300]}')
+        direct_ranges = self._ranges_of(direct.json())
+        self.assertGreaterEqual(
+            len(direct_ranges), EXPECTED_LIDAR_READINGS,
+            f'the fixture produced {len(direct_ranges)} readings, not the '
+            f'{EXPECTED_LIDAR_READINGS} the angular resolution asks for, so the payload '
+            f'is not the size this test claims to be about')
+
+        through = requests.get(
+            f'{GENEROUS_URL}/apps/{LIDAR_APP}/data/{resource}',
+            timeout=(GENEROUS_FORWARD_MS / 1000.0 + 20) * get_time_scale(),
+        )
+        self.assertEqual(
+            through.status_code, 200,
+            f'a large peer-owned resource failed through the aggregator: '
+            f'{through.status_code} {through.text[:400]}')
+        self.assertEqual(
+            len(self._ranges_of(through.json())), len(direct_ranges),
+            'the aggregator returned a different number of readings than the gateway that '
+            'owns the topic, so the payload did not arrive whole')
+
+    def _find_scan_resource(self):
+        response = requests.get(f'{PEER_URL}/apps/{LIDAR_APP}/data', timeout=15)
+        self.assertEqual(response.status_code, 200, response.text)
+        ids = [item['id'] for item in response.json().get('items', [])]
+        for candidate in ids:
+            if 'scan' in candidate:
+                return candidate
+        raise AssertionError(f'{LIDAR_APP} offers no scan resource; saw {ids}')
+
+    def _ranges_of(self, payload):
+        """Pull the LaserScan ranges array out of a data read, whatever wraps it."""
+        stack = [payload]
+        while stack:
+            node = stack.pop()
+            if isinstance(node, dict):
+                if isinstance(node.get('ranges'), list):
+                    return node['ranges']
+                stack.extend(node.values())
+        raise AssertionError(f'no ranges array in the response: {str(payload)[:300]}')
+
+
+@launch_testing.post_shutdown_test()
+class TestProcessOutput(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=[0, -2, -15])

--- a/src/ros2_medkit_integration_tests/test/features/test_aggregator_fault_stream.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_aggregator_fault_stream.test.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end specification for /faults/stream on an aggregating gateway.
+
+An aggregator runs on its own ROS domain, with its own fault_manager that no
+producer reports to. A stream fed from that graph alone is open, valid, and
+sends nothing but keepalives - and a client reading it reports the system as
+healthy while its peers are on fire. In a deployment where the aggregator is
+the only port an operator can reach, that is the only fault stream there is.
+
+THE RULES
+
+S1  A fault raised on a peer reaches a client attached to the AGGREGATOR's
+    stream, and says which peer it came from. Asserting "some event arrived"
+    would not show this: the aggregator has a fault_manager of its own, so an
+    event with no attribution proves nothing about where it was raised.
+S2  The peer's own stream still carries it. The relay is an addition, not a
+    redirection.
+S3  The relay costs a peer SSE client slot only while somebody is listening.
+    Measured on the PEER's own occupancy (``x-medkit-sse`` on its ``/health``),
+    because the claim is about a connection the peer is holding and only the
+    peer can answer that. A count of calls made from here would say nothing.
+    ``sse.max_clients`` defaults to 2, so an aggregator holding one at rest is
+    an outage waiting for the second operator.
+S4  A stream request carrying X-Medkit-No-Fan-Out is served from the local
+    graph only. That header is what an aggregating peer sends when it relays,
+    and without it a chain of them would carry one event round the loop for
+    ever.
+"""
+
+import json
+import os
+import threading
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ReportFault
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    FAULT_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.launch_helpers import (
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+AGG_PORT = get_test_port(0)
+PEER_PORT = get_test_port(1)
+AGG_URL = f'http://localhost:{AGG_PORT}{API_BASE_PATH}'
+PEER_URL = f'http://localhost:{PEER_PORT}{API_BASE_PATH}'
+
+# The launch default domain is the PEER's, because the test process itself has
+# to reach the peer's fault_manager over ROS to raise anything at all. The
+# aggregator is the one pushed onto a domain of its own, which is also the
+# deployment being described: it shares a graph with nothing.
+PEER_DOMAIN_ID = get_test_domain_id(0)
+AGG_DOMAIN_ID = get_test_domain_id(1)
+
+PEER_NAME = 'remote_gateway'
+FAULT_CODE = 'AGG_STREAM_E2E'
+PRIME_CODE = 'AGG_STREAM_PRIME'
+LOCAL_CODE = 'AGG_STREAM_LOCAL_ONLY'
+SOURCE_ID = '/powertrain/engine/temp_sensor'
+SERVICE_NAME = '/fault_manager/report_fault'
+FAULT_MANAGER_NODE = 'fault_manager'
+
+TIMEOUT = DISCOVERY_TIMEOUT * get_time_scale()
+
+# Both gateways run with this, so a disconnect is seen in about a second rather
+# than thirty. The test asserts on WHETHER a slot is released, not on how fast,
+# so a short interval costs it no falsifying power.
+KEEPALIVE_SEC = 2
+
+
+def generate_test_description():
+    agg_env = {'ROS_DOMAIN_ID': str(AGG_DOMAIN_ID)}
+
+    aggregator = create_gateway_node(
+        name='aggregating_gateway_node',
+        port=AGG_PORT,
+        extra_params={
+            'aggregation.enabled': True,
+            'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+            'aggregation.peer_names': [PEER_NAME],
+            # Held above the default so a relay opened while a client attaches
+            # is not competing with this gateway's own stream for slots. The
+            # peer keeps the DEFAULT, because S3 is a claim about what the
+            # relay costs a peer that was never configured for it.
+            'sse.max_clients': 6,
+            'server.http_thread_pool_size': 16,
+            # A closed SSE connection is noticed on the next write, so the
+            # keepalive interval is also the detection latency this test waits
+            # out three times. At the 30 s default that is most of the test's
+            # wall clock and it pushed the CI job past its cap.
+            'sse.keepalive_interval_sec': KEEPALIVE_SEC,
+        },
+        extra_env=agg_env,
+    )
+
+    peer_gateway = create_gateway_node(
+        name='remote_gateway_node',
+        port=PEER_PORT,
+        # Pinned rather than inherited: S1 holds the relay and a direct
+        # consumer at once, and a closed stream is still counted until the
+        # peer's next keepalive, so the default of 2 would refuse a later test
+        # for reasons that have nothing to do with what it asserts.
+        extra_params={
+            'sse.max_clients': 6,
+            'server.http_thread_pool_size': 16,
+            'sse.keepalive_interval_sec': KEEPALIVE_SEC,
+        },
+    )
+
+    peer_fault_manager = create_fault_manager_node(
+        storage_type='memory',
+        rosbag_enabled=False,
+        extra_params={
+            # One FAILED confirms; the stream carries the transition.
+            'confirmation_threshold': -1,
+            'healing_enabled': False,
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+    # The aggregator deliberately runs NO fault manager of its own. An earlier
+    # version launched one so that "an event arrived" could not trivially mean
+    # "it was relayed" - but that made the assertion ambiguous instead of
+    # falsifiable: both managers answer the same service name, so a report
+    # could land on either and a LOCAL event carries no peer tag. What makes
+    # the attribution falsifiable is the pair of assertions below: the
+    # aggregator's copy must name the peer, and the peer's own copy of the SAME
+    # event must not. A gateway that tagged everything, or nothing, fails one
+    # of them.
+
+    launch_description = LaunchDescription([
+        peer_gateway,
+        peer_fault_manager,
+        TimerAction(period=1.0, actions=[aggregator]),
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+    return (
+        launch_description,
+        {
+            'gateway_node': aggregator,
+            'peer_gateway': peer_gateway,
+        },
+    )
+
+
+def _pump_stream(response, frames, stop_event):
+    """Collect SSE frames as dicts of field -> value."""
+    current = {}
+    try:
+        for line in response.iter_lines(decode_unicode=True):
+            if stop_event.is_set():
+                break
+            if line is None:
+                continue
+            if line == '':
+                if current:
+                    frames.append(current)
+                    current = {}
+                continue
+            if line.startswith(':'):
+                continue  # keepalive comment
+            key, _, value = line.partition(':')
+            current[key.strip()] = value.strip()
+    except Exception:  # noqa: BLE001 - closed socket on teardown
+        pass
+
+
+class AggregatorFaultStreamTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._wait_for_peer_online()
+        # Pinned, not inherited. This node has to land on the PEER's domain,
+        # because that is where the fault_manager it reports to lives, and the
+        # launch process this runs in does not reliably still carry the domain
+        # it started with once an action with an ROS_DOMAIN_ID of its own has
+        # run. Inheriting put the reporter on the aggregator's domain instead,
+        # where nothing answers report_fault.
+        previous_domain = os.environ.get('ROS_DOMAIN_ID')
+        os.environ['ROS_DOMAIN_ID'] = str(PEER_DOMAIN_ID)
+        try:
+            rclpy.init()
+            cls._reporter = Node('agg_stream_reporter')
+        finally:
+            if previous_domain is None:
+                del os.environ['ROS_DOMAIN_ID']
+            else:
+                os.environ['ROS_DOMAIN_ID'] = previous_domain
+        cls._report_client = cls._reporter.create_client(
+            ReportFault, SERVICE_NAME)
+        # Waits for the fault_manager NODE, not for the service name and not
+        # for `service_is_ready`. Both of the alternatives lie here. The name
+        # `/fault_manager/report_fault` appears on a domain that only holds a
+        # CLIENT of it - both gateways create one - so a wait keyed on the
+        # service passes on a domain where nothing can answer. And
+        # `service_is_ready` is `rcl_service_server_is_available`, which reports
+        # whether this client's endpoints have been matched, a separate
+        # condition that stayed false for a service that was present and
+        # callable. A node carrying that name is the one signal that means the
+        # server is really here.
+        service_wait = 60.0 * get_time_scale()
+        deadline = time.monotonic() + service_wait
+        while time.monotonic() < deadline:
+            names = [name for name, _ in cls._reporter.get_node_names_and_namespaces()]
+            if FAULT_MANAGER_NODE in names:
+                return
+            rclpy.spin_once(cls._reporter, timeout_sec=0.2)
+        raise AssertionError(
+            f'the {FAULT_MANAGER_NODE} node never appeared on the peer domain '
+            f'{PEER_DOMAIN_ID} within {service_wait}s; nodes seen: '
+            f'{cls._reporter.get_node_names_and_namespaces()}')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def _wait_for_peer_online(cls):
+        deadline = time.time() + TIMEOUT
+        last = None
+        while time.time() < deadline:
+            try:
+                response = requests.get(f'{AGG_URL}/health', timeout=10)
+                if response.status_code == 200:
+                    body = response.json()
+                    peers = body.get('x-medkit', {}).get('peers') or body.get('peers') or []
+                    if any(p.get('status') == 'online' for p in peers):
+                        return
+                    last = peers
+            except requests.RequestException as exc:
+                last = str(exc)
+            time.sleep(0.5)
+        raise AssertionError(f'the aggregator never saw its peer come online; last saw {last}')
+
+    def _report(self, fault_code):
+        req = ReportFault.Request()
+        req.fault_code = fault_code
+        req.event_type = ReportFault.Request.EVENT_FAILED
+        req.severity = Fault.SEVERITY_ERROR
+        req.description = 'aggregator stream e2e'
+        req.source_id = SOURCE_ID
+        # Retried, because a request sent before the endpoints finish matching
+        # is dropped rather than queued, and nothing tells the caller that
+        # happened - the future simply never completes. Reissuing is what turns
+        # a slow match into a late reply instead of a failed test.
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        attempts = 0
+        while time.monotonic() < deadline:
+            future = self._report_client.call_async(req)
+            attempts += 1
+            attempt_deadline = min(time.monotonic() + 5.0, deadline)
+            while not future.done() and time.monotonic() < attempt_deadline:
+                rclpy.spin_once(self._reporter, timeout_sec=0.1)
+            if future.done():
+                self.assertTrue(future.result().accepted)
+                return
+            self._report_client.remove_pending_request(future)
+        self.fail(
+            f'report_fault never replied for {fault_code} after {attempts} attempt(s) '
+            f'over {FAULT_TIMEOUT}s; nodes seen: '
+            f'{self._reporter.get_node_names_and_namespaces()}')
+
+    def _open_stream(self, url, headers=None):
+        response = requests.get(url, stream=True, timeout=(10, 120), headers=headers or {})
+        self.assertEqual(response.status_code, 200, f'{url} did not open: {response.status_code}')
+        frames = []
+        stop = threading.Event()
+        pump = threading.Thread(target=_pump_stream, args=(response, frames, stop), daemon=True)
+        pump.start()
+
+        def close():
+            stop.set()
+            response.close()
+            pump.join(timeout=5)
+
+        self.addCleanup(close)
+        return frames
+
+    def _await_fault(self, frames, fault_code, timeout):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            for frame in list(frames):
+                data = frame.get('data')
+                if not data:
+                    continue
+                payload = json.loads(data)
+                if payload.get('fault', {}).get('fault_code') == fault_code:
+                    return payload
+            time.sleep(0.2)
+        return None
+
+    def _peer_sse_clients(self):
+        """How many SSE streams the PEER is holding, from its own /health."""
+        response = requests.get(f'{PEER_URL}/health', timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        sse = body.get('x-medkit-sse')
+        self.assertIsInstance(
+            sse, dict,
+            f"the peer's /health does not report SSE occupancy, so this test has no "
+            f'instrument: {body}')
+        return sse['connected_clients']
+
+    def _agg_sse_clients(self):
+        """How many SSE streams the AGGREGATOR is serving, from its own /health."""
+        response = requests.get(f'{AGG_URL}/health', timeout=10)
+        self.assertEqual(response.status_code, 200, response.text)
+        sse = response.json().get('x-medkit-sse')
+        self.assertIsInstance(
+            sse, dict, f'aggregator /health has no SSE occupancy: {response.text[:300]}')
+        return sse['connected_clients']
+
+    def _settle_peer_sse(self, timeout=60 * get_time_scale()):
+        """Wait for a quiet system, then return the peer's SSE count.
+
+        Two things have to settle, and only one of them is on the peer. A
+        closed SSE connection is noticed at the server's next write, which for
+        an idle stream is the keepalive - 30 s away. So an earlier case's
+        stream is still counted on the AGGREGATOR for a while, which keeps its
+        relay open, which keeps a stream counted on the PEER. Waiting for the
+        peer's number to stop moving is not enough: it stops moving at ONE, and
+        a measurement taken then attributes a stale relay to the new client.
+        """
+        deadline = time.monotonic() + timeout
+        previous = None
+        stable_since = None
+        last_agg = None
+        while time.monotonic() < deadline:
+            last_agg = self._agg_sse_clients()
+            current = self._peer_sse_clients()
+            if last_agg == 0 and current == previous:
+                if stable_since is None:
+                    stable_since = time.monotonic()
+                elif time.monotonic() - stable_since >= 5:
+                    return current
+            else:
+                previous = current
+                stable_since = None
+            time.sleep(1)
+        raise AssertionError(
+            f'the system never went quiet within {timeout}s (aggregator {last_agg} clients, '
+            f'peer {previous}); nothing measured against it below would mean anything')
+
+    def _await_peer_sse(self, predicate, timeout, what):
+        deadline = time.monotonic() + timeout
+        seen = None
+        while time.monotonic() < deadline:
+            seen = self._peer_sse_clients()
+            if predicate(seen):
+                return seen
+            time.sleep(1)
+        raise AssertionError(f'{what}; the peer reports {seen} SSE clients')
+
+    def test_s1_a_peers_fault_reaches_the_aggregators_stream_attributed(self):
+        """S1 + S2: the event arrives on both streams, and names its peer."""
+        agg_frames = self._open_stream(f'{AGG_URL}/faults/stream')
+        peer_frames = self._open_stream(f'{PEER_URL}/faults/stream')
+
+        # /fault_manager/events is reliable but volatile: an event published
+        # before the relay's HTTP connection is established is gone. Repeat a
+        # sacrificial code until one of its frames lands, which proves the whole
+        # chain - report -> peer fault_manager -> peer SSE -> relay -> here.
+        primed = None
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while primed is None and time.monotonic() < deadline:
+            self._report(PRIME_CODE)
+            primed = self._await_fault(agg_frames, PRIME_CODE, timeout=2.0)
+        self.assertIsNotNone(
+            primed,
+            f'no relayed event for the priming fault reached the aggregator within '
+            f'{FAULT_TIMEOUT}s; frames seen: {list(agg_frames)[:5]}')
+
+        self._report(FAULT_CODE)
+        relayed = self._await_fault(agg_frames, FAULT_CODE, timeout=FAULT_TIMEOUT)
+        self.assertIsNotNone(
+            relayed,
+            f'the peer raised {FAULT_CODE} and the aggregator never carried it; '
+            f'frames seen: {list(agg_frames)[:5]}')
+        self.assertEqual(
+            relayed.get('x-medkit', {}).get('peer'), PEER_NAME,
+            f'a relayed event must name the gateway that raised it, or a client cannot tell '
+            f'it from one this aggregator raised itself: {relayed}')
+
+        # S2: the relay adds a consumer, it does not take the peer's own away.
+        direct = self._await_fault(peer_frames, FAULT_CODE, timeout=FAULT_TIMEOUT)
+        self.assertIsNotNone(direct, "the peer's own stream lost the event")
+        self.assertNotIn(
+            'peer', direct.get('x-medkit', {}),
+            f'the gateway that raised the fault must not attribute it to a peer: {direct}')
+
+    def test_s3_the_relay_holds_a_peer_slot_only_while_a_client_listens(self):
+        """S3: the peer's own occupancy, before, during and after."""
+        idle_before = self._settle_peer_sse()
+
+        response = requests.get(f'{AGG_URL}/faults/stream', stream=True, timeout=(10, 60))
+        self.assertEqual(response.status_code, 200)
+        frames = []
+        stop = threading.Event()
+        pump = threading.Thread(target=_pump_stream, args=(response, frames, stop), daemon=True)
+        pump.start()
+        try:
+            during = self._await_peer_sse(
+                lambda n: n == idle_before + 1, timeout=30 * get_time_scale(),
+                what=(f'a client on the aggregator should cost the peer exactly one '
+                      f'stream, and the peer held {idle_before} before it attached'))
+            self.assertEqual(during, idle_before + 1)
+        finally:
+            stop.set()
+            response.close()
+            pump.join(timeout=5)
+
+        # Up to the peer's keepalive interval: it learns the relay is gone at
+        # its next write, not at the close.
+        self._await_peer_sse(
+            lambda n: n <= idle_before, timeout=30 * get_time_scale(),
+            what=(f'the aggregator kept a stream open on the peer after its last client '
+                  f'left, against {idle_before} at rest. sse.max_clients defaults to 2, so '
+                  f'an idle aggregator holding one is an outage waiting for the second '
+                  f'operator to connect'))
+
+    def test_s4_a_no_fan_out_request_is_served_from_the_local_graph_only(self):
+        """S4: the header an aggregating peer sends must not open a relay."""
+        idle_before = self._settle_peer_sse()
+
+        frames = self._open_stream(
+            f'{AGG_URL}/faults/stream', headers={'X-Medkit-No-Fan-Out': '1'})
+
+        # The peer must not be asked for anything. Given time to be wrong: the
+        # relay connects within a second or so when it is going to.
+        time.sleep(10)
+        self.assertEqual(
+            self._peer_sse_clients(), idle_before,
+            'a request carrying X-Medkit-No-Fan-Out cost the peer a stream, so it opened a '
+            'relay; a chain of aggregating gateways would carry one event round the loop')
+
+        self._report(LOCAL_CODE)
+        leaked = self._await_fault(frames, LOCAL_CODE, timeout=10 * get_time_scale())
+        self.assertIsNone(
+            leaked,
+            f'a suppressed stream carried a peer-owned event anyway: {leaked}')
+        if leaked is not None:  # pragma: no cover - guarded by the assert above
+            self.assertNotIn('peer', leaked.get('x-medkit', {}))
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_integration_tests/test/features/test_peer_failure_reasons.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_peer_failure_reasons.test.py
@@ -1,0 +1,325 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end specification for why a peer dropped out of a fanned-out answer.
+
+A fanned-out collection whose peer failed answers 200 with ``x-medkit.partial``
+and ``failed_peers``. Those name WHICH peer contributed nothing and nothing
+more, so a peer that ran out of time, one that answered an error status and one
+that is not there any more are the same entry - and a client cannot tell a busy
+subsystem from a dead one, which is the only question a partial answer raises.
+
+THE RULES
+
+R1  A peer slower than the aggregator's metadata budget is reported as
+    ``timeout``.
+R2  The SAME request, against the SAME peer, from an aggregator whose budget
+    outlasts the peer's own answer, is reported as ``error-status``. This is
+    the pair that matters: two aggregators, one peer, one request, two reasons.
+    A classifier that returned one constant would pass R1 alone.
+R3  A peer that is gone is reported as ``unreachable``, never as ``timeout``.
+    The two point an operator at different boxes.
+R4  ``failed_peers`` keeps its shape. Every deployed client reads a list of
+    names there, and the reasons arrive beside it rather than in place of it.
+
+NOT COVERED HERE, and why. ``too-large``, ``invalid-response`` and ``canceled``
+are classified in the same table but are not reachable through a healthy
+ros2_medkit peer over the contract: the first needs a peer serving a body past
+the 10 MB cap on a LIST route, which no list produces; the second needs a peer
+answering non-JSON on a JSON route; the third is this gateway's own shutdown.
+They are stated as unreachable rather than left looking untested.
+"""
+
+import os
+import signal
+import tempfile
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_ros.actions
+import launch_testing.actions
+import requests
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
+
+TIGHT_PORT = get_test_port(0)
+PATIENT_PORT = get_test_port(1)
+PEER_PORT = get_test_port(2)
+
+TIGHT_URL = f'http://localhost:{TIGHT_PORT}{API_BASE_PATH}'
+PATIENT_URL = f'http://localhost:{PATIENT_PORT}{API_BASE_PATH}'
+PEER_URL = f'http://localhost:{PEER_PORT}{API_BASE_PATH}'
+
+TIGHT_DOMAIN_ID = get_test_domain_id(0)
+PATIENT_DOMAIN_ID = get_test_domain_id(1)
+PEER_DOMAIN_ID = get_test_domain_id(2)
+
+# The peer's parameter round trip is held at 6 s, so the two aggregators sit on
+# either side of it by construction rather than by luck.
+PEER_PARAM_TIMEOUT_SEC = 6.0
+TIGHT_METADATA_MS = 800
+PATIENT_METADATA_MS = 20000
+
+TIMEOUT = DISCOVERY_TIMEOUT * get_time_scale()
+
+PEER_COMPONENT = 'remote-ecu'
+UNRESPONSIVE_APP = 'remote_unresponsive_param'
+PEER_NAMESPACE = '/chassis/brakes'
+# Declared on all three gateways so it MERGES rather than being routed whole to
+# the peer. A routed request is a forward, which is a different path; only a
+# merged entity fans out, and fan-out is what carries failed_peers.
+MERGED_FUNCTION = 'remote_health'
+
+_KILLED_PIDS = set()
+
+AGGREGATOR_MANIFEST = f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Aggregating ECU"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: ignore
+functions:
+  - id: {MERGED_FUNCTION}
+    name: "Remote Health Monitoring"
+    category: monitoring
+"""
+
+PEER_MANIFEST = f"""\
+manifest_version: "1.0"
+metadata:
+  name: "Remote ECU"
+  version: "1.0.0"
+config:
+  unmanifested_nodes: ignore
+components:
+  - id: {PEER_COMPONENT}
+    name: "Remote ECU"
+apps:
+  - id: {UNRESPONSIVE_APP}
+    name: "Unresponsive Parameter Node"
+    is_located_on: {PEER_COMPONENT}
+    ros_binding:
+      node_name: unresponsive_param_node
+      namespace: {PEER_NAMESPACE}
+functions:
+  - id: {MERGED_FUNCTION}
+    name: "Remote Health Monitoring"
+    category: monitoring
+    hosted_by:
+      - {UNRESPONSIVE_APP}
+"""
+
+
+def _write_manifest(content, prefix):
+    fd, path = tempfile.mkstemp(suffix='.yaml', prefix=prefix)
+    with os.fdopen(fd, 'w') as handle:
+        handle.write(content)
+    return path
+
+
+def generate_test_description():
+    aggregator_manifest = _write_manifest(AGGREGATOR_MANIFEST, 'test_peer_reasons_agg_')
+    peer_manifest = _write_manifest(PEER_MANIFEST, 'test_peer_reasons_peer_')
+    peer_domain_env = {'ROS_DOMAIN_ID': str(PEER_DOMAIN_ID)}
+
+    def aggregator(name, port, domain, metadata_ms):
+        return create_gateway_node(
+            name=name,
+            port=port,
+            extra_params={
+                'discovery.mode': 'hybrid',
+                'discovery.manifest_path': aggregator_manifest,
+                'discovery.manifest_strict_validation': False,
+                'aggregation.enabled': True,
+                'aggregation.timeout_ms': metadata_ms,
+                # Held above the metadata budget on both so the forward budget
+                # cannot be what differs; the fan-out path reads the metadata
+                # budget and that is the key under test.
+                'aggregation.forward_timeout_ms': max(metadata_ms, 20000),
+                'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+                'aggregation.peer_names': ['remote_gateway'],
+            },
+            extra_env={'ROS_DOMAIN_ID': str(domain)},
+        )
+
+    tight_gateway = aggregator(
+        'tight_gateway_node', TIGHT_PORT, TIGHT_DOMAIN_ID, TIGHT_METADATA_MS)
+    patient_gateway = aggregator(
+        'patient_gateway_node', PATIENT_PORT, PATIENT_DOMAIN_ID, PATIENT_METADATA_MS)
+
+    peer_gateway = create_gateway_node(
+        name='remote_gateway_node',
+        port=PEER_PORT,
+        extra_params={
+            'discovery.mode': 'hybrid',
+            'discovery.manifest_path': peer_manifest,
+            'discovery.manifest_strict_validation': False,
+            'operations.parameter_service_timeout_sec': PEER_PARAM_TIMEOUT_SEC,
+        },
+        extra_env=peer_domain_env,
+    )
+
+    unresponsive = launch_ros.actions.Node(
+        package='ros2_medkit_integration_tests',
+        executable='demo_unresponsive_param_node',
+        name='unresponsive_param_node',
+        namespace=PEER_NAMESPACE,
+        output='screen',
+        additional_env=peer_domain_env,
+    )
+
+    launch_description = LaunchDescription([
+        tight_gateway,
+        patient_gateway,
+        peer_gateway,
+        TimerAction(period=2.0, actions=[unresponsive]),
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+    return (
+        launch_description,
+        {
+            'gateway_node': tight_gateway,
+            'patient_gateway': patient_gateway,
+            'peer_gateway': peer_gateway,
+        },
+    )
+
+
+def _config_url(base_url):
+    return f'{base_url}/functions/{MERGED_FUNCTION}/configurations'
+
+
+class PeerFailureReasonsTest(unittest.TestCase):
+    """Runs in name order: the kill in test_3 must come after the two reads."""
+
+    @classmethod
+    def setUpClass(cls):
+        for url, label in ((PEER_URL, 'peer'), (TIGHT_URL, 'tight'), (PATIENT_URL, 'patient')):
+            cls._wait_for_healthy_peer_or_self(url, label)
+
+    @classmethod
+    def _wait_for_healthy_peer_or_self(cls, base_url, label):
+        deadline = time.time() + TIMEOUT
+        last = None
+        while time.time() < deadline:
+            try:
+                response = requests.get(f'{base_url}/health', timeout=10)
+                if response.status_code == 200:
+                    body = response.json()
+                    if label == 'peer':
+                        return
+                    peers = body.get('x-medkit', {}).get('peers') or body.get('peers') or []
+                    if any(p.get('status') == 'online' for p in peers):
+                        return
+                    last = peers
+            except requests.RequestException as exc:
+                last = str(exc)
+            time.sleep(0.5)
+        raise AssertionError(f'{label} gateway never saw a healthy peer; last saw {last}')
+
+    def _fan_out_failure(self, base_url, timeout):
+        response = requests.get(_config_url(base_url), timeout=timeout)
+        self.assertEqual(
+            response.status_code, 200,
+            f'a fanned-out listing whose peer failed must still answer 200: '
+            f'{response.status_code} {response.text[:400]}')
+        ext = response.json().get('x-medkit', {})
+        self.assertTrue(ext.get('partial'), f'the answer does not admit it is partial: {ext}')
+        # R4: the existing key keeps its existing shape.
+        self.assertEqual(
+            ext.get('failed_peers'), ['remote_gateway'],
+            f'failed_peers must stay a list of names: {ext}')
+        failures = ext.get('peer_failures')
+        self.assertIsInstance(failures, list, f'peer_failures missing from {ext}')
+        self.assertEqual(len(failures), 1, f'one failed peer, one reason: {failures}')
+        self.assertEqual(failures[0].get('peer'), 'remote_gateway', failures)
+        return failures[0].get('reason')
+
+    def test_1_a_peer_slower_than_the_budget_reads_as_timeout(self):
+        """R1."""
+        reason = self._fan_out_failure(TIGHT_URL, timeout=30)
+        self.assertEqual(
+            reason, 'timeout',
+            f'the peer was working on the request when the {TIGHT_METADATA_MS}ms budget ran '
+            f'out; that is a timeout, not {reason!r}')
+
+    def test_2_the_same_peer_read_patiently_is_an_error_status(self):
+        """R2: the discriminator. Same peer, same request, a different reason."""
+        reason = self._fan_out_failure(PATIENT_URL, timeout=60)
+        self.assertEqual(
+            reason, 'error-status',
+            f'an aggregator that waited for the peer saw the status the peer actually '
+            f'sent; that is not {reason!r}')
+
+    def test_3_a_peer_that_is_gone_reads_as_unreachable(self, peer_gateway):
+        """R3: killed, not slow. The health check has not noticed yet."""
+        pid = peer_gateway.process_details['pid']
+        _KILLED_PIDS.add(pid)
+        os.kill(pid, signal.SIGKILL)
+
+        # The peer stays marked healthy until the next health check, which is
+        # the window this reads in. Once it is marked unhealthy it drops out of
+        # the fan-out entirely and reports nothing at all - so a run that
+        # cannot observe a reason before then has proven nothing either way and
+        # says so, rather than passing on an empty result.
+        deadline = time.time() + 30
+        reasons = []
+        while time.time() < deadline:
+            response = requests.get(_config_url(PATIENT_URL), timeout=30)
+            if response.status_code != 200:
+                time.sleep(0.2)
+                continue
+            ext = response.json().get('x-medkit', {})
+            failures = ext.get('peer_failures') or []
+            if failures:
+                reasons.append(failures[0].get('reason'))
+                break
+            if not ext.get('partial'):
+                # The peer has been dropped from the healthy set; nothing more
+                # will be reported about it.
+                break
+            time.sleep(0.2)
+
+        self.assertTrue(
+            reasons,
+            'the killed peer produced no peer_failures entry before it was dropped from the '
+            'healthy set, so this run could not observe the reason at all')
+        self.assertEqual(
+            reasons[0], 'unreachable',
+            f'a peer whose process is gone is unreachable, not {reasons[0]!r} - the two send '
+            f'an operator to different boxes')
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        for info in proc_info:
+            allowed = set(ALLOWED_EXIT_CODES)
+            if info.pid in _KILLED_PIDS:
+                allowed.add(-9)
+            self.assertIn(
+                info.returncode, allowed,
+                f'{info.process_name} exited with code {info.returncode}')

--- a/src/ros2_medkit_integration_tests/test/features/test_relay_peer_credential.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_relay_peer_credential.test.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end specification for relaying from a peer that requires auth.
+
+An aggregator holds ONE stream per peer, opened when the first local client
+attaches and shared by every client after it, so it has no client whose token
+it could carry. Against a peer that authenticates its reads it was therefore
+refused, and the aggregator's own stream went on answering 200 while carrying
+local events only - the same open, valid, empty stream this whole change set
+exists to remove, one layer further out.
+
+``aggregation.peer_auth_header`` is what the gateway presents on connections it
+opens on its OWN behalf. This test drives the whole path a value in that key
+travels: parameter -> AggregationConfig -> PeerClient health check ->
+healthy_peer_endpoints -> RelayTarget -> the peer's /faults/stream.
+
+THE RULES
+
+C1  An aggregator holding the credential relays a fault raised on the
+    authenticating peer, and says which peer it came from.
+C2  An aggregator with no credential relays NOTHING from that peer. This is the
+    control: without it C1 would pass just as well against a peer that never
+    checked the Authorization header at all, and would prove nothing about the
+    credential.
+C3  The peer records the aggregator as online only where the credential is
+    configured. The health check is the first thing that would 401, and a peer
+    reported as down never reaches the relay at all - so this pins WHERE the
+    credential is needed, not just that the relay ends up working.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import threading
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ReportFault
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    DISCOVERY_TIMEOUT,
+    FAULT_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+    get_time_scale,
+)
+from ros2_medkit_test_utils.launch_helpers import (
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+AUTHED_AGG_PORT = get_test_port(0)
+PEER_PORT = get_test_port(1)
+BARE_AGG_PORT = get_test_port(2)
+
+AUTHED_AGG_URL = f'http://localhost:{AUTHED_AGG_PORT}{API_BASE_PATH}'
+PEER_URL = f'http://localhost:{PEER_PORT}{API_BASE_PATH}'
+BARE_AGG_URL = f'http://localhost:{BARE_AGG_PORT}{API_BASE_PATH}'
+
+# The launch default domain is the PEER's: the test process reports the fault
+# over ROS, and the fault_manager it reports to lives there. Each aggregator is
+# pushed onto a domain of its own, which is the deployment being described -
+# it shares a graph with nothing and HTTP is all it has.
+PEER_DOMAIN_ID = get_test_domain_id(0)
+AUTHED_AGG_DOMAIN_ID = get_test_domain_id(1)
+BARE_AGG_DOMAIN_ID = get_test_domain_id(2)
+
+JWT_SECRET = 'relay_credential_e2e_secret_key_not_a_real_one_0123456789'
+JWT_ISSUER = 'relay_credential_e2e'
+
+PEER_NAME = 'authenticating_peer'
+FAULT_CODE = 'RELAY_CREDENTIAL_E2E'
+SOURCE_ID = '/powertrain/engine/temp_sensor'
+SERVICE_NAME = '/fault_manager/report_fault'
+FAULT_MANAGER_NODE = 'fault_manager'
+
+TIMEOUT = DISCOVERY_TIMEOUT * get_time_scale()
+KEEPALIVE_SEC = 2
+
+
+def _b64(raw):
+    """base64url without padding, which is what JWT uses."""
+    return base64.urlsafe_b64encode(raw).rstrip(b'=')
+
+
+def _mint_access_token(role='admin', lifetime_sec=3600):
+    """Sign an HS256 access token the peer gateway will accept.
+
+    Minted here rather than fetched from the peer's /auth/authorize because the
+    aggregator needs it as a LAUNCH parameter, and at that point no gateway is
+    running yet to issue one. Built on hmac and hashlib from the standard
+    library rather than a JWT package: a dependency missing from one CI image
+    would fail this on a distro for a reason that has nothing to do with what
+    it asserts.
+
+    The gateway verifies HS256 over the shared secret and the issuer, and reads
+    the role claim; jwt-cpp additionally enforces exp.
+    """
+    header = {'alg': 'HS256', 'typ': 'access'}
+    now = int(time.time())
+    payload = {
+        'iss': JWT_ISSUER,
+        'sub': 'aggregator',
+        'iat': now,
+        'exp': now + lifetime_sec,
+        'jti': 'relay-credential-e2e',
+        'role': role,
+    }
+    signing_input = (
+        _b64(json.dumps(header, separators=(',', ':')).encode())
+        + b'.'
+        + _b64(json.dumps(payload, separators=(',', ':')).encode())
+    )
+    signature = hmac.new(JWT_SECRET.encode(), signing_input, hashlib.sha256).digest()
+    return (signing_input + b'.' + _b64(signature)).decode()
+
+
+PEER_CREDENTIAL = f'Bearer {_mint_access_token()}'
+
+
+def generate_test_description():
+    # require_auth_for=all, so READS need a credential too. Under the "write"
+    # default the peer would answer /health and /faults/stream to anyone and
+    # this test would pass without the feature it is here to check.
+    peer_gateway = create_gateway_node(
+        name='authenticating_peer_node',
+        port=PEER_PORT,
+        extra_params={
+            'auth.enabled': True,
+            'auth.jwt_secret': JWT_SECRET,
+            'auth.jwt_algorithm': 'HS256',
+            'auth.issuer': JWT_ISSUER,
+            'auth.require_auth_for': 'all',
+            'auth.clients': ['aggregator:aggregator_secret:admin'],
+            # Two aggregators relay from this peer at once and a closed stream
+            # is still counted until the next keepalive, so the default of 2
+            # would refuse one for reasons unrelated to the credential.
+            'sse.max_clients': 6,
+            'server.http_thread_pool_size': 16,
+            'sse.keepalive_interval_sec': KEEPALIVE_SEC,
+        },
+    )
+
+    peer_fault_manager = create_fault_manager_node(
+        storage_type='memory',
+        rosbag_enabled=False,
+        extra_params={
+            'confirmation_threshold': -1,
+            'healing_enabled': False,
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+    def aggregator(name, port, domain, credential):
+        params = {
+            'aggregation.enabled': True,
+            'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+            'aggregation.peer_names': [PEER_NAME],
+            'sse.max_clients': 6,
+            'server.http_thread_pool_size': 16,
+            'sse.keepalive_interval_sec': KEEPALIVE_SEC,
+        }
+        if credential:
+            params['aggregation.peer_auth_header'] = credential
+        return create_gateway_node(
+            name=name,
+            port=port,
+            extra_params=params,
+            extra_env={'ROS_DOMAIN_ID': str(domain)},
+        )
+
+    authed_aggregator = aggregator(
+        'authed_aggregator_node', AUTHED_AGG_PORT, AUTHED_AGG_DOMAIN_ID, PEER_CREDENTIAL)
+    # Identical but for the credential. Any difference between the two is the
+    # credential and nothing else.
+    bare_aggregator = aggregator(
+        'bare_aggregator_node', BARE_AGG_PORT, BARE_AGG_DOMAIN_ID, None)
+
+    return (
+        LaunchDescription([
+            peer_gateway,
+            peer_fault_manager,
+            TimerAction(period=1.0, actions=[authed_aggregator, bare_aggregator]),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {
+            'gateway_node': authed_aggregator,
+            'peer_gateway': peer_gateway,
+            'bare_aggregator': bare_aggregator,
+        },
+    )
+
+
+def _pump_stream(response, frames, stop_event):
+    """Collect SSE frames as dicts of field -> value."""
+    current = {}
+    try:
+        for line in response.iter_lines(decode_unicode=True):
+            if stop_event.is_set():
+                break
+            if line is None:
+                continue
+            if line == '':
+                if current:
+                    frames.append(current)
+                    current = {}
+                continue
+            if line.startswith(':'):
+                continue
+            key, _, value = line.partition(':')
+            current[key.strip()] = value.strip()
+    except Exception:  # noqa: BLE001 - closed socket on teardown
+        pass
+
+
+class RelayPeerCredentialTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls._wait_for_gateways()
+        # Pinned to the peer's domain: that is where the fault_manager this
+        # reports to lives, and the launch process does not reliably still
+        # carry the domain it started on once an action with an ROS_DOMAIN_ID
+        # of its own has run.
+        previous_domain = os.environ.get('ROS_DOMAIN_ID')
+        os.environ['ROS_DOMAIN_ID'] = str(PEER_DOMAIN_ID)
+        try:
+            rclpy.init()
+            cls._reporter = Node('relay_credential_reporter')
+        finally:
+            if previous_domain is None:
+                del os.environ['ROS_DOMAIN_ID']
+            else:
+                os.environ['ROS_DOMAIN_ID'] = previous_domain
+
+        cls._report_client = cls._reporter.create_client(ReportFault, SERVICE_NAME)
+        service_wait = 60.0 * get_time_scale()
+        deadline = time.monotonic() + service_wait
+        while time.monotonic() < deadline:
+            names = [name for name, _ in cls._reporter.get_node_names_and_namespaces()]
+            if FAULT_MANAGER_NODE in names:
+                return
+            rclpy.spin_once(cls._reporter, timeout_sec=0.2)
+        raise AssertionError(
+            f'the {FAULT_MANAGER_NODE} node never appeared on the peer domain '
+            f'{PEER_DOMAIN_ID} within {service_wait}s; nodes seen: '
+            f'{cls._reporter.get_node_names_and_namespaces()}')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def _wait_for_gateways(cls):
+        """Both aggregators answer their own /health, which needs no auth."""
+        deadline = time.time() + TIMEOUT
+        pending = [AUTHED_AGG_URL, BARE_AGG_URL]
+        last = None
+        while time.time() < deadline and pending:
+            for url in list(pending):
+                try:
+                    if requests.get(f'{url}/health', timeout=10).status_code == 200:
+                        pending.remove(url)
+                except requests.RequestException as exc:
+                    last = str(exc)
+            if pending:
+                time.sleep(0.5)
+        if pending:
+            raise AssertionError(f'gateways never came up: {pending}; last error {last}')
+
+    @staticmethod
+    def _peer_status(agg_url):
+        """How this aggregator currently reports its peer."""
+        body = requests.get(f'{agg_url}/health', timeout=10).json()
+        peers = body.get('x-medkit', {}).get('peers') or body.get('peers') or []
+        for peer in peers:
+            if peer.get('name') == PEER_NAME:
+                return peer.get('status')
+        return None
+
+    def _wait_for_peer_status(self, agg_url, wanted):
+        deadline = time.time() + TIMEOUT
+        last = None
+        while time.time() < deadline:
+            last = self._peer_status(agg_url)
+            if last == wanted:
+                return True
+            time.sleep(0.5)
+        return last
+
+    def _report(self, fault_code):
+        req = ReportFault.Request()
+        req.fault_code = fault_code
+        req.event_type = ReportFault.Request.EVENT_FAILED
+        req.severity = Fault.SEVERITY_ERROR
+        req.description = 'relay credential e2e'
+        req.source_id = SOURCE_ID
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            future = self._report_client.call_async(req)
+            attempt_deadline = min(time.monotonic() + 5.0, deadline)
+            while not future.done() and time.monotonic() < attempt_deadline:
+                rclpy.spin_once(self._reporter, timeout_sec=0.1)
+            if future.done():
+                self.assertTrue(future.result().accepted)
+                return
+            self._report_client.remove_pending_request(future)
+        self.fail(f'report_fault never replied for {fault_code}')
+
+    def _open_stream(self, url):
+        response = requests.get(f'{url}/faults/stream', stream=True, timeout=(10, 120))
+        self.assertEqual(response.status_code, 200, f'{url} did not open its stream')
+        frames = []
+        stop = threading.Event()
+        pump = threading.Thread(target=_pump_stream, args=(response, frames, stop), daemon=True)
+        pump.start()
+        return response, frames, stop, pump
+
+    @staticmethod
+    def _close_stream(response, stop, pump):
+        stop.set()
+        response.close()
+        pump.join(timeout=5)
+
+    def test_c3_the_peer_is_online_only_where_the_credential_is_configured(self):
+        """C3: the health check is where a missing credential first shows."""
+        authed = self._wait_for_peer_status(AUTHED_AGG_URL, 'online')
+        self.assertIs(
+            authed, True,
+            'the aggregator holding the credential never saw its peer come online; '
+            f'last status {authed}')
+        # And the control really is refused, rather than merely slower.
+        self.assertNotEqual(
+            self._peer_status(BARE_AGG_URL), 'online',
+            'the aggregator WITHOUT a credential reported the authenticating peer as '
+            'online, so the peer is not actually checking the header and every other '
+            'assertion in this file is vacuous')
+
+    def test_c1_c2_only_the_credentialed_aggregator_relays_the_peers_fault(self):
+        """C1 and C2: asserted on ONE fault, so the two cannot disagree."""
+        self.assertIs(
+            self._wait_for_peer_status(AUTHED_AGG_URL, 'online'), True,
+            'the credentialed aggregator never saw its peer come online')
+
+        authed_res, authed_frames, authed_stop, authed_pump = self._open_stream(AUTHED_AGG_URL)
+        bare_res, bare_frames, bare_stop, bare_pump = self._open_stream(BARE_AGG_URL)
+        try:
+            # Relays are opened on the first attached client, so give them a
+            # moment to reach the peer before the fault exists.
+            time.sleep(2.0 * get_time_scale())
+            self._report(FAULT_CODE)
+
+            deadline = time.time() + FAULT_TIMEOUT
+            relayed = None
+            while time.time() < deadline and relayed is None:
+                for frame in list(authed_frames):
+                    if FAULT_CODE in frame.get('data', ''):
+                        relayed = frame
+                        break
+                time.sleep(0.2)
+
+            self.assertIsNotNone(
+                relayed,
+                'the credentialed aggregator never relayed the fault; frames seen: '
+                f'{authed_frames}')
+            payload = json.loads(relayed['data'])
+            self.assertEqual(
+                payload.get('x-medkit', {}).get('peer'), PEER_NAME,
+                'the relayed event did not name the peer it came from, so it cannot be '
+                f'told from an event raised locally: {payload}')
+
+            # The control. Checked AFTER the credentialed one has the event, so
+            # this is not just a race that the bare aggregator has yet to lose.
+            self.assertFalse(
+                [f for f in bare_frames if FAULT_CODE in f.get('data', '')],
+                'the aggregator with no credential relayed the fault anyway, so the '
+                f'credential is not what admits it: {bare_frames}')
+        finally:
+            self._close_stream(authed_res, authed_stop, authed_pump)
+            self._close_stream(bare_res, bare_stop, bare_pump)
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info, allowable_exit_codes=ALLOWED_EXIT_CODES)

--- a/src/ros2_medkit_integration_tests/test/features/test_relay_peer_credential.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_relay_peer_credential.test.py
@@ -404,6 +404,38 @@ class RelayPeerCredentialTest(unittest.TestCase):
             self._close_stream(authed_res, authed_stop, authed_pump)
             self._close_stream(bare_res, bare_stop, bare_pump)
 
+    def test_c4_the_credential_is_not_readable_through_the_configurations_api(self):
+        """C4: the value that authenticates us to a peer must not be a read.
+
+        The configurations route reports the gateway's own ROS parameters, and
+        the credential is one. A gateway that answers it with the value hands
+        any reader the means to speak to the peer as this gateway - and the
+        same route reports auth.jwt_secret, which signs this gateway's own
+        tokens. Asserted against the raw response text rather than a parsed
+        field, so a value that reaches the client through some other key still
+        fails this.
+        """
+        token = PEER_CREDENTIAL.split(' ', 1)[1]
+        apps = requests.get(f'{AUTHED_AGG_URL}/apps', timeout=10).json().get('items', [])
+        self.assertTrue(apps, 'the aggregator exposed no apps, so this asserts nothing')
+
+        checked = 0
+        for app in apps:
+            body = requests.get(
+                f'{AUTHED_AGG_URL}/apps/{app["id"]}/configurations', timeout=10).text
+            self.assertNotIn(
+                token, body,
+                f'the peer credential is readable through {app["id"]}/configurations')
+            self.assertNotIn(
+                JWT_SECRET, body,
+                f'the JWT signing secret is readable through {app["id"]}/configurations')
+            if 'peer_auth_header' in body:
+                checked += 1
+        self.assertGreater(
+            checked, 0,
+            'no app listed aggregation.peer_auth_header at all, so this test would '
+            'pass even if the value were being served in full')
+
 
 @launch_testing.post_shutdown_test()
 class TestShutdown(unittest.TestCase):

--- a/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_startup_param_clamp_warnings.test.py
@@ -108,8 +108,15 @@ CLAMPED_PARAMS = [
     ('data_provider.max_parallel_samples', 1, 256, 0, 512),
     ('data_provider.idle_safety_net_sec', 0, 86400, -1, 172800),
     ('data_provider.idle_sweep_tick_sec', 0, 3600, -1, 7200),
-    # aggregation.* - gateway_node.cpp, only read when aggregation is enabled
+    # aggregation.* - gateway_node.cpp, only read when aggregation is enabled.
+    # The three budgets share one range; the "above" value is past INT_MAX on
+    # purpose, because they are read as int64 and narrowed only after the
+    # clamp - narrowing first would wrap 4294967296 back to 0 and let a value
+    # far outside the range pass as if it were inside it.
     ('aggregation.max_discovered_peers', 1, 1000, 0, 2000),
+    ('aggregation.timeout_ms', 100, 600000, 0, 4294967296),
+    ('aggregation.forward_timeout_ms', 100, 600000, 0, 4294967296),
+    ('aggregation.write_timeout_ms', 100, 600000, -1, 4294967296),
     # fault_triggers.* - gateway_node.cpp, only read once a plugin is loaded.
     # The ceiling is INT_MAX because the value is narrowed to int for the timer;
     # it is a type boundary, not a tuning choice.
@@ -139,6 +146,12 @@ IN_RANGE_PARAMS = {
     'data_provider.idle_safety_net_sec': 900,
     'data_provider.idle_sweep_tick_sec': 60,
     'aggregation.max_discovered_peers': 50,
+    # forward >= metadata, so the in-range gateway reports nothing at all: a
+    # forward budget below the metadata one is raised WITH a warning of its
+    # own, and a correctly configured gateway must not emit it.
+    'aggregation.timeout_ms': 2000,
+    'aggregation.forward_timeout_ms': 15000,
+    'aggregation.write_timeout_ms': 5000,
     'fault_triggers.poll_interval_ms': 1000,
 }
 

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_expectation_tracker.hpp
@@ -483,6 +483,22 @@ class LifecycleExpectationTracker {
     return nodes_.size();
   }
 
+  /// Tracked nodes whose last real measurement was kInactive.
+  ///
+  /// Separate from tracked_count() because the two answer different questions and
+  /// only this one says the detector has actually READ a label. A node is entered
+  /// into the map as soon as an expectation matches it, before any label is
+  /// classified, so a non-zero tracked_count() is equally true of a node that is
+  /// kUnreadable or kNotManaged. Anything waiting for "the detector has seen this
+  /// node inactive" - a test about to kill it, above all - has to wait on this;
+  /// waiting on the count instead admits a node whose clock has not started and
+  /// whose departure therefore matures somewhere else entirely.
+  std::size_t settled_inactive_count() const {
+    return static_cast<std::size_t>(std::count_if(nodes_.begin(), nodes_.end(), [](const auto & entry) {
+      return entry.second.settled_observed == LifecycleObservedState::kInactive;
+    }));
+  }
+
   /// `presence_owned`, when given, is the presence detector's CURRENT set of tracked departure
   /// keys (fqns), as published by the plugin for this tick. It is consulted, never latched: the
   /// stickiness this class used to keep for itself lives in that detector's own tracker, which

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/include/ros2_medkit_graph_watchdog/lifecycle_watcher.hpp
@@ -76,6 +76,36 @@ class LifecycleWatcher {
   /// still resolve - see measurement_pending().
   static constexpr int kReseedAttempts = 2;
 
+  /// How many EXTRA GetState attempts a node that has NEVER been measured keeps, beyond
+  /// the self-heal budget above.
+  ///
+  /// kReseedAttempts is a self-heal budget for a node whose label is known and merely
+  /// stale, and its reasoning is that a matched subscription catches every transition
+  /// afterwards. That reasoning does not reach a node which never transitions again: one
+  /// sitting at `unconfigured` forever publishes nothing for the subscription to catch, so
+  /// a GetState is the ONLY way its label is ever learned. Two attempts lost to transient
+  /// timeouts therefore left it unmeasurable for the life of the process - permanently, as
+  /// the comment at the queueing site says - and a require_active expectation on it could
+  /// then never be confirmed. The larger budget is still finite so an endpoint that never
+  /// answers is not retried without end; GRAPH_NODE_UNREADABLE is what reports that one.
+  ///
+  /// Deliberately a SEPARATE counter rather than a larger kReseedAttempts. That budget is
+  /// also what measurement_pending() withholds GRAPH_NODE_UNREADABLE on, so widening it in
+  /// place would delay reporting a node that never answers by exactly as much as it
+  /// widened - trading one silence for another. Asking for longer and reporting just as
+  /// early are separate concerns, so they get separate counters.
+  static constexpr int kUnmeasuredSeedAttempts = 40;
+
+  /// Ticks between those extra attempts.
+  ///
+  /// They are spread rather than consecutive because the node they exist for is one whose
+  /// GetState does not answer, so every attempt costs its full timeout and the per-tick
+  /// blocking budget is 150 ms shared by every job. Asking such a node once per tick eats
+  /// that budget every tick and starves the seeding and handover work queued behind it -
+  /// visible under a sanitizer, where each timeout is longer still. Spread, the same
+  /// number of attempts covers five times the wall clock at a fifth of the per-tick cost.
+  static constexpr std::uint64_t kUnmeasuredSeedInterval = 5;
+
   LifecycleWatcher(rclcpp::Node * gateway_node, std::mutex * node_mutex,
                    int departed_retention_ticks = kDefaultDepartedRetentionTicks);
   ~LifecycleWatcher();
@@ -159,6 +189,11 @@ class LifecycleWatcher {
     /// non-active, to recover an `active` transition_event lost during the DDS
     /// endpoint-matching window right after the (volatile) subscription is created.
     int reseeds_remaining = 0;
+    /// Extra GetState attempts kept while the label is still empty. Drains alongside
+    /// reseeds_remaining but is NOT what measurement_pending() consults, so a node that
+    /// never answers is still reported unreadable on the original schedule while this one
+    /// goes on asking.
+    int unmeasured_seeds_remaining = 0;
     /// The GetState path this entry was created from. Together with `fqn` it is the
     /// entry's BINDING identity, which update() re-checks every tick: the subscription
     /// topic derives from this path, so if either piece moves under an unchanged

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/detectors/lifecycle_expectation_detector.cpp
@@ -275,6 +275,7 @@ class LifecycleExpectationDetector : public Detector {
   nlohmann::json status_json() const override {
     return nlohmann::json{{"tracking_saturated", saturated_.load()},
                           {"tracked_nodes", tracked_nodes_.load()},
+                          {"settled_inactive_nodes", settled_inactive_nodes_.load()},
                           {"tracked_node_cap", tracked_node_cap_.load()}};
   }
 
@@ -397,6 +398,7 @@ class LifecycleExpectationDetector : public Detector {
     // takes - hence atomics rather than plain members.
     saturated_.store(report.tracking_saturated);
     tracked_nodes_.store(tracker_.tracked_count());
+    settled_inactive_nodes_.store(tracker_.settled_inactive_count());
     // An entry that matches nothing at all is reported by the tracker, not here: the loop
     // above only sees entries that DID match a present node.
     if (ctx.gateway_node) {
@@ -586,6 +588,13 @@ class LifecycleExpectationDetector : public Detector {
   std::atomic<int> tracked_node_cap_{kDefaultTrackedNodeCap};
   std::atomic<bool> saturated_{false};         ///< the cap refused a required node on the last tick
   std::atomic<std::size_t> tracked_nodes_{0};  ///< tracker map size as of the last tick
+  /// Tracked nodes whose last real measurement was inactive, as of the last tick.
+  ///
+  /// Reported beside tracked_nodes because the two differ in exactly the case
+  /// that matters: a node is counted the moment an expectation matches it, which
+  /// is before any lifecycle label has been read. Only this one says the
+  /// detector's own clock for that node has started.
+  std::atomic<std::size_t> settled_inactive_nodes_{0};
   LifecycleExpectationTracker tracker_{{}, kDefaultGrace};
   // Fixed-severity AggregatedFault members, one per code - the same shape orphan_detector
   // and param_drift_detector use, now that each code's content decides its own emission

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/src/lifecycle_watcher.cpp
@@ -191,8 +191,17 @@ void LifecycleWatcher::update(const ros2_medkit_gateway::IntrospectionInput & sn
         if (static_cast<int>(jobs.size()) < kMaxGetStateSeedsPerTick) {
           jobs.push_back({id, path, true});
         }
-      } else if (it->second.state_label != "active" && it->second.reseeds_remaining > 0 &&
+      } else if (it->second.state_label != "active" &&
+                 (it->second.reseeds_remaining > 0 ||
+                  (it->second.state_label.empty() && it->second.unmeasured_seeds_remaining > 0 &&
+                   tick % LifecycleWatcher::kUnmeasuredSeedInterval == 0)) &&
                  static_cast<int>(jobs.size()) < kMaxGetStateSeedsPerTick) {
+        // The second arm keeps asking for a node that has never been measured at all. Such
+        // a node may never transition again, so a GetState is the only thing that can give
+        // it a label, and the self-heal budget alone left it unmeasurable for the life of
+        // the process. It does NOT hold GRAPH_NODE_UNREADABLE back - see
+        // kUnmeasuredSeedAttempts.
+
         // NOT charged here: the blocking loop below can break on its wall-clock budget before
         // reaching this job, and a job that never issued a GetState must not spend an attempt.
         // One node stuck mid-transition eats the whole 150ms budget on its own timeout, so every
@@ -284,9 +293,11 @@ void LifecycleWatcher::update(const ros2_medkit_gateway::IntrospectionInput & sn
         options);
     auto & tracked = state_->tracked[id];
     tracked.sub = std::move(sub);
-    tracked.reseeds_remaining = LifecycleWatcher::kReseedAttempts;
     const auto seed_it = seeded.find(id);
     tracked.state_label = (seed_it != seeded.end()) ? seed_it->second : "";
+    tracked.reseeds_remaining = LifecycleWatcher::kReseedAttempts;
+    // Set from the label this seed actually produced, so it has to come after it.
+    tracked.unmeasured_seeds_remaining = tracked.state_label.empty() ? LifecycleWatcher::kUnmeasuredSeedAttempts : 0;
     // Captured at first sighting: current_fqns is built from the same snapshot pass
     // that produced current_paths, so an id here is always present in current_fqns too.
     // Together, fqn + get_state_path are the binding identity the drop loop re-checks.
@@ -306,8 +317,14 @@ void LifecycleWatcher::update(const ros2_medkit_gateway::IntrospectionInput & sn
     // loop). A node whose job was cut by the budget keeps its attempts and is re-picked next tick.
     for (const auto & id : reseeds_performed) {
       auto it = state_->tracked.find(id);
-      if (it != state_->tracked.end() && it->second.reseeds_remaining > 0) {
+      if (it == state_->tracked.end()) {
+        continue;
+      }
+      if (it->second.reseeds_remaining > 0) {
         it->second.reseeds_remaining -= 1;
+      }
+      if (it->second.unmeasured_seeds_remaining > 0) {
+        it->second.unmeasured_seeds_remaining -= 1;
       }
     }
     for (const auto & job : jobs) {

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_lifecycle_expectation_e2e.test.py
@@ -216,11 +216,18 @@ SILENT_WINDOW_SEC = 20.0
 # kills and respawns a real OS process (the target node) and needs the gateway's entity
 # cache to actually notice the departure and the return, all comfortably inside the
 # tracker's own absence_grace (a fixed 3 ticks - kDefaultAbsenceGrace in
-# lifecycle_expectation_tracker.hpp, not configurable). A much slower cadence than the
-# other scenarios buys that margin: at 1 s/tick (the shipped production default) the
-# absence budget is a full 3 s, comfortably longer than a SIGTERM + respawn_delay +
-# rediscovery round trip ever needs.
-HEALING_TICK_INTERVAL_MS = 1000
+# lifecycle_expectation_tracker.hpp, not configurable). Since the grace cannot be widened
+# in ticks, the cadence is what buys the margin, and it has to buy enough: the budget is
+# three ticks and a blink is a real SIGTERM plus launch's respawn_delay plus the new
+# process's startup plus DDS rediscovery. Measured on a developer box, that round trip
+# runs 3.5 to 4.0 s, so a 1 s cadence put the budget at 3 s - under the thing it was
+# supposed to contain.
+#
+# Scaled by TIME_SCALE, unlike the other cadences here, because this is the one budget
+# derived from a race against real process startup. Every part of that round trip gets
+# slower under a sanitizer or a loaded runner while a fixed interval would hold the
+# budget still, and the blink then overruns a window that was never about machine speed.
+HEALING_TICK_INTERVAL_MS = int(3000 * TIME_SCALE)
 # kDefaultAbsenceGrace, lifecycle_expectation_tracker.hpp - fixed, not configurable.
 # Mirrored here (not imported - this is a separate Python process) so _blink() can
 # compute the exact wall-clock budget a blink is supposed to stay inside.
@@ -236,11 +243,14 @@ HEALING_REFRESH_DEBOUNCE_MS = 300
 # absence must stay under HEALING_ABSENCE_GRACE_TICKS ticks, or what is being exercised is
 # the ordinary sustained-absence path instead. Both edges are asserted per blink rather
 # than assumed from this constant.
-HEALING_RESPAWN_DELAY_SEC = 1.4
+# DERIVED from the tick interval rather than written beside it: it has to exceed one tick
+# and the budget above is three of them, so a literal here silently breaks the lower edge
+# the moment the cadence changes. 0.4 s over one tick is enough to guarantee a sample.
+HEALING_RESPAWN_DELAY_SEC = (HEALING_TICK_INTERVAL_MS / 1000.0) + 0.4
 # Slept after the SIGTERM before polling for the node's return: gives the respawn_delay
 # above, the new process's own startup, and DDS rediscovery room to finish before the
 # poll below starts, without itself risking the 3 s absence budget.
-HEALING_BLINK_SLEEP_SEC = 1.5
+HEALING_BLINK_SLEEP_SEC = (HEALING_TICK_INTERVAL_MS / 1000.0) + 1.0
 # Two separate blink episodes, matching the scenario this detector's design doc walks
 # through: a node the detector has already reported vanishing and returning twice must
 # never be healed by either one.

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/e2e/test_node_death_boundary_e2e.test.py
@@ -870,17 +870,22 @@ class TestBoundaryInactiveBelowGraceThenGone(unittest.TestCase):
             f'{TARGET_NODE} never reached "inactive" after DEACTIVATE',
         )
 
-        # tracked_nodes becoming 1 is the tracker's own proof that it matched TARGET_NODE at
-        # least once - the earliest moment a kill is guaranteed not to land before the detector
-        # was even permitted to look. B2_GRACE is generous enough that the handful of extra
-        # ticks the DEACTIVATE round trip and this poll's own interval can cost before the kill
+        # settled_inactive_nodes, NOT tracked_nodes. A node enters the tracker's map as
+        # soon as an expectation matches it, before any lifecycle label has been read, so
+        # tracked_nodes == 1 is equally true of a node the watchdog still holds as
+        # unreadable or not-managed. Killing it in that state starts a different clock and
+        # GRAPH_NODE_INACTIVE can never mature, which is a test failure with nothing wrong
+        # in the detector. This counter moves only once the watchdog's OWN measurement
+        # settled on inactive. B2_GRACE is generous enough that the handful of extra ticks
+        # the DEACTIVATE round trip and this poll's own interval can cost before the kill
         # below still leaves the node comfortably below grace.
         self.assertTrue(
             poll_detector_status(
-                PORT, DETECTOR_ID_LIFECYCLE, 'tracked_nodes', 1, timeout=ARM_TIMEOUT_SEC),
-            f'lifecycle_expectation never reported tracking {TARGET_NODE} - it was never '
-            'matched at all, so killing it below would prove nothing about absence maturing '
-            'an unmatured streak',
+                PORT, DETECTOR_ID_LIFECYCLE, 'settled_inactive_nodes', 1,
+                timeout=ARM_TIMEOUT_SEC),
+            f'lifecycle_expectation never measured {TARGET_NODE} as inactive - its own '
+            'clock for the node never started, so killing it below would prove nothing '
+            'about absence maturing an unmatured streak',
         )
 
         # The row's own precondition, read from an observable immediately before the kill - see
@@ -1191,17 +1196,24 @@ class TestBoundaryNeverArmedBelowGraceThenGone(unittest.TestCase):
             'required node that never arms) was never set up',
         )
 
-        # tracked_nodes becoming 1 is the tracker's own proof that it matched TARGET_NODE at
-        # least once - the earliest moment a kill is guaranteed not to land before the
-        # detector was even permitted to look. B6_GRACE is generous enough that the handful
-        # of extra ticks this poll's own interval can cost before the kill below still leaves
-        # the node comfortably below grace.
+        # settled_inactive_nodes, NOT tracked_nodes. The label above was read by the TEST's
+        # own client, which says nothing about what the watchdog has managed to read: it has
+        # its own service client, its own seed queue and a per-tick budget, and leaves the
+        # cached label empty until a seed succeeds. A node is counted in tracked_nodes the
+        # moment an expectation matches it, so that counter is satisfied while the watchdog
+        # still holds the node unreadable - and a kill in that state matures a different
+        # clock, so GRAPH_NODE_INACTIVE never arrives and the failure looks like a broken
+        # detector. This counter moves only once the watchdog's own measurement settled on
+        # inactive. B6_GRACE is generous enough that the handful of extra ticks this poll's
+        # own interval can cost before the kill below still leaves the node below grace.
         self.assertTrue(
             poll_detector_status(
-                PORT, DETECTOR_ID_LIFECYCLE, 'tracked_nodes', 1, timeout=ARM_TIMEOUT_SEC),
-            f'lifecycle_expectation never reported tracking {TARGET_NODE} - it was never '
-            'matched at all, so killing it below would prove nothing about absence maturing '
-            'a violation the presence detector could never have reported',
+                PORT, DETECTOR_ID_LIFECYCLE, 'settled_inactive_nodes', 1,
+                timeout=ARM_TIMEOUT_SEC),
+            f'lifecycle_expectation never measured {TARGET_NODE} as inactive - its own '
+            'clock for the node never started, so killing it below would prove nothing '
+            'about absence maturing a violation the presence detector could never have '
+            'reported',
         )
 
         # The row's own precondition, read from an observable immediately before the kill -

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_expectation_tracker.cpp
@@ -53,6 +53,38 @@ const std::set<std::string> kOwnedA{"/a"};
 
 // ---- Violation streak: unchanged behaviour from before this slice's redesign ----
 
+// ---- What the two counters say, which is not the same thing ----
+
+// tracked_count() says an expectation matched a node. settled_inactive_count() says this
+// tracker has MEASURED one as inactive. Anything waiting for the second and given the first
+// proceeds while the node's clock has not started - which is what an e2e that kills the node
+// at that moment does, and it then waits for a fault that can never mature.
+TEST(LifecycleExpectation, TrackedCountCountsANodeWhoseLabelWasNeverRead) {
+  LifecycleExpectationTracker t({"a"}, /*grace=*/2);
+
+  // An unreadable node: matched, so it is tracked, but no label was obtained.
+  t.update(M{match("a", "/a", std::optional<std::string>(""))});
+  EXPECT_EQ(t.tracked_count(), 1u) << "a matched node is tracked whether or not its label was read";
+  EXPECT_EQ(t.settled_inactive_count(), 0u)
+      << "an unreadable node has not been measured inactive, and its violation clock has not started";
+
+  // A node that is not lifecycle-managed at all: same story.
+  LifecycleExpectationTracker unmanaged({"a"}, /*grace=*/2);
+  unmanaged.update(M{match("a", "/a", std::nullopt)});
+  EXPECT_EQ(unmanaged.tracked_count(), 1u);
+  EXPECT_EQ(unmanaged.settled_inactive_count(), 0u);
+
+  // Only a real inactive measurement moves the second counter.
+  t.update(M{match("a", "/a", "unconfigured")});
+  EXPECT_EQ(t.settled_inactive_count(), 1u) << "a measured non-active label is what starts the clock";
+
+  // And an active one takes it back off, so the counter tracks the CURRENT measurement
+  // rather than latching on the first one seen.
+  t.update(M{match("a", "/a", "active")});
+  EXPECT_EQ(t.tracked_count(), 1u);
+  EXPECT_EQ(t.settled_inactive_count(), 0u);
+}
+
 TEST(LifecycleExpectation, RequiredNodeStuckInactivePastGraceRaises) {
   LifecycleExpectationTracker t({"a"}, /*grace=*/2);
   EXPECT_TRUE(t.update(M{match("a", "/a", "inactive")}).affected.empty());  // 1 <= grace

--- a/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
+++ b/src/ros2_medkit_plugins/ros2_medkit_graph_watchdog/test/test_lifecycle_watcher.cpp
@@ -527,19 +527,27 @@ TEST_F(LifecycleWatcherTest, RebindToALiveNodeDropsTheOldLabelAndSeedsTheNewBind
   // Drain the self-heal budget against the OLD (serviceless) binding, so the assertion
   // below cannot be satisfied by a leftover re-seed happening to hit the new path - the
   // re-bind handling itself has to do the healing.
-  for (std::uint64_t tick = 2; w.reseeds_remaining_for_test(id) > 0 && tick < 10; ++tick) {
+  // Bounded by the budget the watcher handed out rather than by a literal tick count: a
+  // node seeded without a label draws the larger unmeasured budget, and a fixed ceiling
+  // here would stop the loop before the drain this row depends on.
+  const std::uint64_t drain_ceiling = 2 + static_cast<std::uint64_t>(fresh_budget) + 2;
+  for (std::uint64_t tick = 2; w.reseeds_remaining_for_test(id) > 0 && tick < drain_ceiling; ++tick) {
     w.update(managed_app_snapshot(id, "/rb_old"), tick);
   }
   ASSERT_EQ(w.reseeds_remaining_for_test(id), 0);
   ASSERT_EQ(w.state_of(id).value_or(""), "inactive");
 
   // The re-bind: same id, now bound to the live "/rb_new" node.
-  w.update(managed_app_snapshot(id, "/rb_new"), /*tick=*/10);
+  w.update(managed_app_snapshot(id, "/rb_new"), drain_ceiling + 1);
   EXPECT_EQ(w.state_of(id).value_or(""), "active")
       << "after a re-bind the id must carry the NEW binding's seeded state, not the old node's label";
   EXPECT_TRUE(w.node_ok(id)) << "the old binding's non-active label must stop gating the id";
-  EXPECT_EQ(w.reseeds_remaining_for_test(id), fresh_budget)
-      << "a re-bound id must be re-seeded as a NEW entry (fresh self-heal budget), not healed in place";
+  // The budget a freshly seeded entry carrying THIS label would get - not the one the old
+  // binding started on, which was seeded without a label and therefore drew the larger
+  // unmeasured budget. What this asserts is that the entry was rebuilt: a budget healed in
+  // place would still read 0 from the drain above.
+  EXPECT_EQ(w.reseeds_remaining_for_test(id), ros2_medkit_graph_watchdog::LifecycleWatcher::kReseedAttempts)
+      << "a re-bound id must be re-seeded as a NEW entry, not healed in place";
 
   // The old subscription must be gone with the old entry: the old node's transitions
   // must no longer reach this id.
@@ -587,10 +595,18 @@ TEST_F(LifecycleWatcherTest, SameBindingAcrossUpdatesIsNeverTreatedAsARebind) {
       << "one update with the same binding must charge exactly one re-seed - a re-created entry "
          "would reset the budget to "
       << fresh_budget;
-  w.update(managed_node_snapshot(fqn), /*tick=*/3);
-  w.update(managed_node_snapshot(fqn), /*tick=*/4);
-  EXPECT_EQ(w.reseeds_remaining_for_test(fqn), 0)
-      << "the budget must drain monotonically across same-binding updates and stay drained";
+  // Driven from the budget the watcher actually handed out rather than from a literal
+  // count of updates: a node whose seed produced no label gets a larger budget than one
+  // that self-heals a stale label, and the invariant under test is the DRAIN, not the
+  // size. Two extra updates past the end prove it stays drained.
+  std::uint64_t tick = 3;
+  for (int charged = 1; charged < fresh_budget; ++charged) {
+    w.update(managed_node_snapshot(fqn), tick++);
+  }
+  EXPECT_EQ(w.reseeds_remaining_for_test(fqn), 0) << "the budget must drain monotonically across same-binding updates";
+  w.update(managed_node_snapshot(fqn), tick++);
+  w.update(managed_node_snapshot(fqn), tick++);
+  EXPECT_EQ(w.reseeds_remaining_for_test(fqn), 0) << "and stay drained - a re-created entry would refill it";
   EXPECT_TRUE(w.state_of(fqn).has_value()) << "the entry itself must survive every same-binding update";
   EXPECT_FALSE(w.departed_state_of(fqn).has_value()) << "an unchanged binding must never be recorded as a departure";
 }


### PR DESCRIPTION
# Pull Request

## Summary

Three defects in peer aggregation. They share `aggregation.timeout_ms` and the peer
fan-out path, and the same files carry all three, so they are fixed together.

### 1. One budget for every kind of peer call

`PeerClient` had a single `timeout_ms`. It was used as the connect timeout and as
the read timeout at the same time. So reading a peer's entity list and waiting for
a peer to do real work were given the same time.

The result: an operation on a peer had 2 s end to end, while the peer's own budget
for the same call is `service_call_timeout_sec`, 10 s by default. A large resource
did not fit in 2 s either.

Raising `timeout_ms` could not fix the other half of this. `set_write_timeout` was
never called anywhere in the gateway. The write budget stayed at the cpp-httplib
default of 5 s and followed no config value at all.

There are four budgets now:

| Budget | Key | Default | Applies to |
|---|---|---|---|
| connect | `aggregation.timeout_ms` | 2000 | every peer call |
| read, metadata | `aggregation.timeout_ms` | 2000 | discovery, health, collection fan-out |
| read, forward | `aggregation.forward_timeout_ms` (new) | 15000 | a forwarded request |
| write | `aggregation.write_timeout_ms` (new) | 5000 | every peer call |

Connect stays short everywhere. A peer that cannot finish a TCP handshake is out of
reach, whatever the request asks for. The forward budget is set above a peer
gateway's own service budget, because that is what a forward waits for.

All three keys are read as int64 and clamped before they are narrowed to int. Before
this, a value above `INT_MAX` wrapped back into the legal range and passed the check.
The range is 100 to 600000 ms and every clamp is logged. If `forward_timeout_ms` is
below `timeout_ms`, it is raised to it with its own warning, because a forwarded
request must not be cut off earlier than a listing.

### 2. A timeout was not reported as a timeout

`httplib::Result::operator bool()` is only a null check. The forward path branched on
`!result` and never read `result.error()`. A read timeout, a refused connection and a
cancelled call all gave the same `502` and the message "is unavailable". That message
said the peer was down while the same peer answered the same request in 4.9 s.

The fan-out path stored one boolean per peer and threw away the error string it had
just built. So a timeout, a refused connection, a peer returning 500, a body over the
size limit and unparseable JSON were the same entry in `failed_peers`.

A local operation returned `500 "Service call failed"` whether it timed out or failed
to serialize its request. The action send-goal path did not even build a message:
"Send goal timed out" named neither the action nor the budget.

`ERR_NOT_RESPONDING` was already reserved for this case and was returned from one
place only. It now covers all three:

| Case | Before | After |
|---|---|---|
| forward, out of time | `502` peer-unavailable | `504` `not-responding`, names the budget |
| forward, nothing there | `502` peer-unavailable | same, and the reason is named |
| fan-out, any failure | `partial` + `failed_peers` | plus `peer_failures`, one reason per peer |
| local execute, out of time | `500` "Service call failed" | `504` `not-responding`, names endpoint and budget |
| local execute, endpoint absent | `500` | `503` |

The classifier does not use the transport error alone. cpp-httplib reports both "the
read budget ran out" and "the connection broke while the answer was arriving" as
`Error::Read`. So the elapsed time is compared with the budget: a call that came back
inside its budget did not run out of it, and a peer that died in the middle of an
answer is reported as unreachable, not as slow.

### 3. The fault stream on an aggregating gateway

`GET /faults/stream` on an aggregating gateway answered `200 text/event-stream` and
then sent only keepalives. The gateway runs on its own ROS domain with its own
`fault_manager` that no producer reports to. So the route was open and valid and
silent, and a client reading it sees a healthy system. In many deployments this is the
only port an operator can reach.

`GET /faults` already fanned out. `SSEStreamProxy` was already written and unit
tested. The design document already described the relay. Nothing constructed it
outside its own test.

`PeerFaultRelay` opens each healthy peer's stream through that proxy and puts the
events into this gateway's own stream. Each relayed event carries `x-medkit.peer`.

Three rules shape it:

- It opens on the first attached client and closes with the last. A relayed stream
  holds one SSE client slot on every peer, and `sse.max_clients` is 2 by default.
- It reconciles from the streaming loop, so a peer that appears or goes away is picked
  up without a timer of its own.
- Its own request carries `X-Medkit-No-Fan-Out`, the header the collection routes
  already use. A stream request that carries it is served from the local graph only.
  Without this, a chain of aggregating gateways would pass one event around the loop.

Replay is limited on purpose and the limit is documented. Two peers number their
events independently, so a `Last-Event-ID` cannot address a position in a merged
stream. The aggregator gives every event an id of its own, and a reconnecting client
resumes from what the aggregator has buffered.

Relayed connections use up a peer's `sse.max_clients` without anyone seeing it, so
`GET /health` now reports `x-medkit-sse` with `connected_clients` and `max_clients`.
A `503` on `/faults/stream` was not explainable from outside before.

Two more defects fixed here, both in code this change touches:

- `X-Medkit-No-Fan-Out` was only checked where the relay is opened. The replay buffer
  is shared by all clients, so a relayed event still reached a client that had asked
  for the local graph only. The filter now runs where events are handed out.
- The replay buffer used the fault code alone as the supersede key. A fault code is
  unique only on the gateway that raised it, so a relayed fault could have replaced a
  local fault with the same code.

## Issue

- closes #528
- closes #611
- closes #612

## Type

- [x] Bug fix
- [x] New feature or tests
- [x] Breaking change
- [ ] Documentation only

The breaking part is small and it is the point of the change. A request that answered
`500` or `502` can now answer `504` or `503`, when that is what happened. No response
that existed before was removed. `failed_peers` keeps its wire shape, and the reasons
arrive next to it in `peer_failures`.

## Testing

All three defects are about behaviour between two processes, so the tests that decide
them run two or three real gateways and talk to them over HTTP. Three new files.

`test_aggregation_time_budgets` runs TWO aggregators in front of ONE peer. They differ
only in the key under test.

- A peer operation held open for 4 s returns the peer's own result through the
  aggregator whose forward budget covers it, and `504 not-responding` through the one
  whose budget does not.
- A lidar scan with 180000 readings arrives with the same number of readings as a read
  taken straight from the owning gateway, and times out on the tight aggregator.

The tight read runs first, on a cold topic. A gateway keeps a live subscription to a
topic it has served, so the first read pays for the subscription and later reads do
not. If the generous aggregator read first, the tight one would measure a warm cache
and return `200` under any budget.

`test_peer_failure_reasons` asks the same peer the same question from two aggregators
and requires two different answers: `timeout` from the one whose budget runs out while
the peer is still working, `error-status` from the one that waits for the peer's own
reply. A classifier that returned one constant would pass a test with one reason. It
then kills the peer and requires `unreachable`, not `timeout`.

`test_aggregator_fault_stream` raises a fault on a peer and requires it on the
aggregator's stream, with the peer named. The aggregator runs a `fault_manager` of its
own on purpose. Without one, "an event arrived" could only mean it came from a peer,
and the assertion about naming the peer could never fail. The cost of the relay is
measured on the peer's own SSE occupancy, because the claim is about a connection the
peer holds.

The three new budget keys are added to `test_startup_param_clamp_warnings`, which
reads the output of four gateways: each key at its floor, at its ceiling, at a
degenerate value, and above `INT_MAX`.

`demo_slow_calibration_service` is new. It is a service that takes a settable time to
answer. Every other service node in the test package answers at once, which cannot
tell a budget that is too small from one that is right.

Measured on Jazzy:

- gateway unit tests: 2813 tests, 0 errors, 0 failures
- integration tests, whole package: 3894 tests, 0 errors, 0 failures
- gateway build: 0 compiler warnings in our code
- the three new end-to-end files together: all passed, 227 s

One note on a test that is not part of this change.
`test_default_script_provider` reported "did not generate a result file" once in an
early batch run. It passed 20 out of 20 in two separate ten-run sweeps, and did not
happen again in four later full-suite runs. This branch does not touch that package.

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
