### PR TITLE
fault_manager, gateway: declare a planned stop, so a weekend is not a wave of faults

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2793,7 +2793,15 @@ drops a window that is still running.
 What makes a fault expected
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A fault is expected when its ``first_occurred`` lies in ``[from, to]``, inclusive at both ends.
+A fault is expected when its ``first_occurred`` lies in ``[from, to]``, inclusive at both ends and
+compared at **millisecond** resolution: both sides are floored to the millisecond before the
+comparison, so a fault reported anywhere inside the millisecond a window opens or closes is inside
+the window. That is the resolution of the whole API - the parser rounds an ISO 8601 fraction down
+to it, a ``GET`` returns exactly what the ``POST`` sent - because an operator declares a stop at
+minute or second precision while ``first_occurred`` crosses the wire as a double resolving to about
+a quarter of a microsecond, and a boundary defined more finely than the data can express is one
+nobody can rely on.
+
 ``first_occurred`` is the start of the fault's **current cycle**, not its first report ever: it
 is reset when a FAILED event raises a CLEARED fault again. A code that failed during a
 changeover and failed again after it was acknowledged is therefore expected for the first cycle
@@ -2826,8 +2834,8 @@ window logic.
      - One window
    * - ``DELETE /api/v1/x-medkit-planned-stops/{planned_stop_id}``
      - operator
-     - End a window early. ``200`` with the ended window, not ``204``: the caller has to be told
-       where ``to`` landed
+     - End a window early, or cancel one that has not started. ``200`` with the window, not
+       ``204``: the caller has to be told where ``to`` landed, or that the window is gone
 
 Declaring a window
 ~~~~~~~~~~~~~~~~~~
@@ -2847,34 +2855,54 @@ Declaring a window
      "reason": "line changeover",
      "declared_by": "shift_lead",
      "declared_at": "2026-09-06T17:58:12.004Z",
-     "ended_early": false
+     "ended_early": false,
+     "cancelled": false
    }
 
 Request fields:
 
 - ``from`` (optional) - ISO 8601 in UTC (``Z`` or ``+00:00``). Omit it for a stop that starts
-  now. A window wholly in the past is accepted and marks the faults it covers: a stop is a fact
-  about the plant, not about when someone typed it in.
+  now: the gateway fills in its own clock, and an explicit instant always reaches the fault
+  manager. A window wholly in the past is accepted and marks the faults it covers: a stop is a
+  fact about the plant, not about when someone typed it in.
 - ``to`` (required) - ISO 8601 in UTC, strictly after ``from``. There is no maximum duration.
-- ``reason`` (required) - carried verbatim on every fault the window marks.
+- ``reason`` (required) - why the plant is stopping. It is **not** carried on the faults the
+  window marks: a marked fault carries ``planned_stop_id``, and that id resolves to this window
+  and its reason through ``GET /api/v1/x-medkit-planned-stops/{id}``.
 - ``declared_by`` (optional) - defaults to the authenticated client id, or ``anonymous`` when
   authentication is off.
 
-Windows may overlap. Refusals are all ``400``: ``to`` at or before ``from``, a time that is not
+Windows may overlap. Refusals are ``400`` for: ``to`` at or before ``from``, a time that is not
 ISO 8601 in UTC (a real offset such as ``+02:00`` is refused rather than converted), and an
-instant outside ``1970-01-01T00:00:00Z`` to ``2038-01-19T03:14:07Z``, which is the range a
-``builtin_interfaces/Time`` can carry.
+instant outside the representable range. That range is **after** ``1970-01-01T00:00:00Z`` and no
+later than ``2038-01-19T03:14:07Z``, the upper bound being what a ``builtin_interfaces/Time``
+carries. The epoch itself is excluded on purpose: zero is what an unset time reads as, and a
+sentinel that is also a legal value cannot tell a caller who meant the epoch from one who filled
+in nothing.
 
-Ending a window early
-~~~~~~~~~~~~~~~~~~~~~
+A ``409`` means the request was well formed and the store could not take it - the configured
+``planned_stop.max_windows`` had no room. Raise the bound, or end a window, and retry.
+
+Ending or cancelling a window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
    curl -X DELETE http://localhost:8080/api/v1/x-medkit-planned-stops/1788716982473405798-1
 
-``to`` moves to the moment of the request and ``ended_early`` becomes true. Faults whose cycle
-started before that instant stay expected; faults raised after it do not. A window whose end
-has already passed answers ``400`` with vendor code ``x-medkit-planned-stop-ended`` - when a
+One route, two things, and the answer says which happened.
+
+A window that is **running** is cut short: ``to`` moves to the moment of the request and
+``ended_early`` becomes true. Faults whose cycle started before that instant stay expected; faults
+raised after it do not.
+
+A window that has **not started** is cancelled: it is removed, and the ``200`` carries the window
+as it was with ``cancelled: true`` and ``ended_early`` still false. It marked nothing, and storing
+a ``to`` before its own ``from`` would contradict what the window claims to be. A ``GET`` on that
+id afterwards answers ``404``.
+
+A window that has **already ended**, early or on its own, answers ``400`` with vendor code
+``x-medkit-planned-stop-ended``. A backdated request cannot walk its end backwards either: when a
 stop actually finished is not something a later request gets to rewrite. An unknown id answers
 ``404``.
 
@@ -2898,16 +2926,23 @@ tally beside them:
      "x-medkit": {"count": 1, "expected_count": 1}
    }
 
-``planned_stop_id`` is present only when ``expected`` is true. ``expected_count`` counts the
-items this gateway derived a flag for; items merged from an aggregated peer carry the peer's
-own flag and are not recounted.
+``planned_stop_id`` is present only when ``expected`` is true, and the window's ``reason`` is not
+carried beside it - resolve the id. ``expected_count`` counts the list that was actually served:
+items this gateway flagged plus items an aggregated peer flagged, after filtering.
 
 Both fault lists take ``?expected=true|false|all``. Omitting it means ``all``: the flag is extra
-information about a fault, never a reason to hide it by default.
+information about a fault, never a reason to hide it by default. On an aggregating gateway the
+query goes to the peers with the request, and their items are filtered again on the way in using
+the flag the **peer** derived from its own windows - never re-derived here. An item from a peer
+that sent no flag satisfies neither ``true`` nor ``false``, because this gateway cannot claim
+either.
 
 The ``/faults/stream`` frames carry the same pair inside their ``x-medkit`` object, alongside
-the ``entity_type`` / ``entity_id`` hint. ``expected`` is sent as an explicit ``false`` rather
-than omitted, so a consumer can tell "not expected" from "this gateway could not say".
+the ``entity_type`` / ``entity_id`` hint. ``expected`` is sent as an explicit ``false`` for a
+fault no window covers - but only once the gateway has actually read the declared windows. While
+it never has (no fault manager, or none reachable since start) the frame carries **no**
+``expected`` key at all: a consumer must not read an outage of the fault manager as "nothing is
+expected", which is exactly what an operator watching a stop would act on.
 
 Fault Triggers (threshold rules)
 --------------------------------

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2787,20 +2787,31 @@ fault manager consults a window. The flag is there so a reader can tell an expec
 a surprise, and the evidence chain still describes the plant that existed.
 
 The windows live in the fault manager, next to the faults they describe, and survive a
-restart. Retention is bounded by count (``planned_stop.max_windows``), never by age, and never
-drops a window that is still running.
+restart. Retention is bounded by count (``planned_stop.max_windows``), never by age. The bound is
+hard: ended windows are pruned oldest-first to make room, and when every retained window has yet
+to end a new declaration is refused with ``409`` rather than the table growing. A window that has
+not ended is never dropped to make room for anything.
 
 What makes a fault expected
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A fault is expected when its ``first_occurred`` lies in ``[from, to]``, inclusive at both ends and
-compared at **millisecond** resolution: both sides are floored to the millisecond before the
-comparison, so a fault reported anywhere inside the millisecond a window opens or closes is inside
-the window. That is the resolution of the whole API - the parser rounds an ISO 8601 fraction down
-to it, a ``GET`` returns exactly what the ``POST`` sent - because an operator declares a stop at
-minute or second precision while ``first_occurred`` crosses the wire as a double resolving to about
-a quarter of a microsecond, and a boundary defined more finely than the data can express is one
-nobody can rely on.
+A fault is expected when its ``first_occurred`` lies in ``[from, to]`` at **millisecond**
+resolution. That qualifier is the whole of it, so exactly what it means:
+
+- The window's bounds are floored to their millisecond. A window declared through the REST route
+  has millisecond bounds already (the parser rounds an ISO 8601 fraction down, and a ``GET``
+  returns what the ``POST`` sent). One declared through the ROS service with finer bounds opens at
+  the START of ``from``'s millisecond - up to 999999 ns before the instant asked for - and closes
+  at the start of ``to``'s.
+- The fault's own instant is rounded to the NEAREST millisecond. A fault within half a millisecond
+  of a bound therefore lands on that bound: one 400 us after ``to`` is still expected, one 600 us
+  after it is not.
+
+"Closed at both ends" is exact at that resolution and only at that resolution. The resolution is a
+millisecond because an operator declares a stop at minute or second precision, while
+``first_occurred`` crosses the wire as a double whose resolution at today's epoch is about a
+quarter of a microsecond - a boundary defined more finely than the data can express is one nobody
+can rely on.
 
 ``first_occurred`` is the start of the fault's **current cycle**, not its first report ever: it
 is reset when a FAILED event raises a CLEARED fault again. A code that failed during a
@@ -2827,8 +2838,9 @@ window logic.
      - Declare a window. ``201`` with the stored window and a ``Location`` header
    * - ``GET /api/v1/x-medkit-planned-stops``
      - viewer
-     - List windows, newest declaration first. ``?active=true`` keeps only the ones containing
-       now
+     - List windows, newest declaration first. ``?active=true`` keeps the ones that have NOT
+       ENDED - running and not-yet-started alike, which is the same notion retention uses, so it
+       lists exactly the windows holding the bound
    * - ``GET /api/v1/x-medkit-planned-stops/{planned_stop_id}``
      - viewer
      - One window
@@ -2880,8 +2892,10 @@ carries. The epoch itself is excluded on purpose: zero is what an unset time rea
 sentinel that is also a legal value cannot tell a caller who meant the epoch from one who filled
 in nothing.
 
-A ``409`` means the request was well formed and the store could not take it - the configured
-``planned_stop.max_windows`` had no room. Raise the bound, or end a window, and retry.
+A ``409`` means the request was well formed and the store could not take it: every retained window
+has yet to end, so ``planned_stop.max_windows`` has no room. Ended windows are pruned to make
+space automatically - a window that is still running, or has yet to start, never is. End one, or
+raise the bound, and retry.
 
 Ending or cancelling a window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2930,8 +2944,20 @@ tally beside them:
    }
 
 ``planned_stop_id`` is present only when ``expected`` is true, and the window's ``reason`` is not
-carried beside it - resolve the id. ``expected_count`` counts the list that was actually served:
-items this gateway flagged plus items an aggregated peer flagged, after filtering.
+carried beside it - resolve the id.
+
+``expected_count`` counts **distinct fault codes** in the served list that were flagged expected -
+after the peer merge and after the filter. Distinct, because an aggregating gateway serves a code
+raised on two gateways as two items, and counting both would report two stops' worth of expected
+faults where the plant had one. An item that carries no ``expected`` key at all - one relayed from
+a peer running a gateway that predates this flag - is counted by neither side: its flag is unknown,
+and unknown is not false. Such an item is served only under ``expected=all``.
+
+``count`` beside it is the length of ``items`` in THIS response: after the merge and after the
+``status`` and ``expected`` filters. It is not the fault manager's own total, and it changed
+meaning in the release that added planned stops - it was the fault manager's count before. The
+``muted_count`` and ``cluster_count`` next to it are still the local unfiltered numbers, so a
+filtered request can answer ``count: 1`` beside ``muted_count: 7``.
 
 Both fault lists take ``?expected=true|false|all``. Omitting it means ``all``: the flag is extra
 information about a fault, never a reason to hide it by default. On an aggregating gateway the
@@ -2941,11 +2967,23 @@ that sent no flag satisfies neither ``true`` nor ``false``, because this gateway
 either.
 
 The ``/faults/stream`` frames carry the same pair inside their ``x-medkit`` object, alongside
-the ``entity_type`` / ``entity_id`` hint. ``expected`` is sent as an explicit ``false`` for a
-fault no window covers - but only once the gateway has actually read the declared windows. While
-it never has (no fault manager, or none reachable since start) the frame carries **no**
-``expected`` key at all: a consumer must not read an outage of the fault manager as "nothing is
-expected", which is exactly what an operator watching a stop would act on.
+the ``entity_type`` / ``entity_id`` hint.
+
+``expected`` is sent as an explicit ``false`` for a fault no window covers - but only while the
+gateway can actually read the declared windows. When it cannot, **no surface says anything**: the
+frames carry no ``expected`` key, the fault-list items carry none either, and the list omits
+``expected_count`` altogether. A consumer must not read an outage of the fault manager as "nothing
+is expected", which is exactly what an operator watching a stop would act on.
+
+Two states produce that silence. One is a fault manager that is unreachable, or one from a release
+that has no planned-stop service - the gateway checks that service's readiness before calling it,
+so this costs no timeout on the fault list. The other is knowledge that has gone stale: a window
+set the gateway read successfully is reported for a few seconds past its last successful re-read
+and no longer, so replacing the fault manager under a running gateway makes the flag go quiet
+rather than leaving it naming a window that no longer exists.
+
+A request that filters on a flag the gateway cannot derive - ``?expected=true`` or
+``?expected=false`` in that state - returns no items rather than half a set nobody knows.
 
 Fault Triggers (threshold rules)
 --------------------------------

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -3470,6 +3470,11 @@ Vendor-specific ``x-medkit-*`` codes are enveloped: the response carries
    * - ``x-medkit-unsupported-protocol``
      - 400
      - The requested subscription ``protocol`` has no registered transport
+   * - ``x-medkit-planned-stop-ended``
+     - 400
+     - The planned-stop window has already ended and cannot be ended again. Distinct from a 404 on an
+       unknown id: the window is there, and when the stop actually finished is not something a later
+       request gets to rewrite
 
 The table is kept complete by a check rather than by review:
 ``scripts/check_error_codes_documented.py`` (ctest

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2901,10 +2901,13 @@ as it was with ``cancelled: true`` and ``ended_early`` still false. It marked no
 a ``to`` before its own ``from`` would contradict what the window claims to be. A ``GET`` on that
 id afterwards answers ``404``.
 
-A window that has **already ended**, early or on its own, answers ``400`` with vendor code
-``x-medkit-planned-stop-ended``. A backdated request cannot walk its end backwards either: when a
-stop actually finished is not something a later request gets to rewrite. An unknown id answers
-``404``.
+A window that has **already finished**, early or on its own, answers ``400`` with vendor code
+``x-medkit-planned-stop-ended``. An unknown id answers ``404``.
+
+Which of the three situations a window is in is decided against the fault manager's own wall
+clock, never against an instant the caller supplies: a backdated request cannot walk a finished
+window's end backwards, and it cannot cancel one either. When a stop actually finished is not
+something a later request gets to rewrite.
 
 Reading the flag
 ~~~~~~~~~~~~~~~~

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -2772,6 +2772,143 @@ silent. Once the entity has been discovered, the budget applies as usual and a
 resource path that still cannot be resolved to a topic is given up on with a
 warning naming the trigger.
 
+Planned Stops
+-------------
+
+A **planned stop** is a window of wall-clock time during which faults are expected: a
+changeover, a maintenance weekend, a line move. An operator declares one at runtime and the
+gateway then reports every fault whose current cycle started inside it with
+``x-medkit.expected`` - on ``GET /faults``, on the per-entity fault lists, on a fault's detail
+document and on the ``/faults/stream`` frames.
+
+Declaring a window changes **nothing** about how faults are handled. An expected fault is
+confirmed, healed, cleared, captured and audited exactly as any other; no code path in the
+fault manager consults a window. The flag is there so a reader can tell an expected fault from
+a surprise, and the evidence chain still describes the plant that existed.
+
+The windows live in the fault manager, next to the faults they describe, and survive a
+restart. Retention is bounded by count (``planned_stop.max_windows``), never by age, and never
+drops a window that is still running.
+
+What makes a fault expected
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A fault is expected when its ``first_occurred`` lies in ``[from, to]``, inclusive at both ends.
+``first_occurred`` is the start of the fault's **current cycle**, not its first report ever: it
+is reset when a FAILED event raises a CLEARED fault again. A code that failed during a
+changeover and failed again after it was acknowledged is therefore expected for the first cycle
+and a surprise for the second - which is what an operator asking "did anything break outside
+the stop" means.
+
+When several windows cover a fault, ``planned_stop_id`` names the **earliest-starting** one, so
+the fault list and the event stream never disagree about which window applies.
+
+In an aggregated deployment the windows are per fault manager. Each peer's gateway derives the
+flag for its own faults and the aggregator relays what the peer said; there is no cross-peer
+window logic.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 12 54
+
+   * - Endpoint
+     - Role
+     - Description
+   * - ``POST /api/v1/x-medkit-planned-stops``
+     - operator
+     - Declare a window. ``201`` with the stored window and a ``Location`` header
+   * - ``GET /api/v1/x-medkit-planned-stops``
+     - viewer
+     - List windows, newest declaration first. ``?active=true`` keeps only the ones containing
+       now
+   * - ``GET /api/v1/x-medkit-planned-stops/{planned_stop_id}``
+     - viewer
+     - One window
+   * - ``DELETE /api/v1/x-medkit-planned-stops/{planned_stop_id}``
+     - operator
+     - End a window early. ``200`` with the ended window, not ``204``: the caller has to be told
+       where ``to`` landed
+
+Declaring a window
+~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   curl -X POST http://localhost:8080/api/v1/x-medkit-planned-stops \
+     -H 'Content-Type: application/json' \
+     -d '{"from": "2026-09-06T18:00:00Z", "to": "2026-09-06T22:00:00Z", "reason": "line changeover"}'
+
+.. code-block:: json
+
+   {
+     "id": "1788716982473405798-1",
+     "from": "2026-09-06T18:00:00.000Z",
+     "to": "2026-09-06T22:00:00.000Z",
+     "reason": "line changeover",
+     "declared_by": "shift_lead",
+     "declared_at": "2026-09-06T17:58:12.004Z",
+     "ended_early": false
+   }
+
+Request fields:
+
+- ``from`` (optional) - ISO 8601 in UTC (``Z`` or ``+00:00``). Omit it for a stop that starts
+  now. A window wholly in the past is accepted and marks the faults it covers: a stop is a fact
+  about the plant, not about when someone typed it in.
+- ``to`` (required) - ISO 8601 in UTC, strictly after ``from``. There is no maximum duration.
+- ``reason`` (required) - carried verbatim on every fault the window marks.
+- ``declared_by`` (optional) - defaults to the authenticated client id, or ``anonymous`` when
+  authentication is off.
+
+Windows may overlap. Refusals are all ``400``: ``to`` at or before ``from``, a time that is not
+ISO 8601 in UTC (a real offset such as ``+02:00`` is refused rather than converted), and an
+instant outside ``1970-01-01T00:00:00Z`` to ``2038-01-19T03:14:07Z``, which is the range a
+``builtin_interfaces/Time`` can carry.
+
+Ending a window early
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   curl -X DELETE http://localhost:8080/api/v1/x-medkit-planned-stops/1788716982473405798-1
+
+``to`` moves to the moment of the request and ``ended_early`` becomes true. Faults whose cycle
+started before that instant stay expected; faults raised after it do not. A window whose end
+has already passed answers ``400`` with vendor code ``x-medkit-planned-stop-ended`` - when a
+stop actually finished is not something a later request gets to rewrite. An unknown id answers
+``404``.
+
+Reading the flag
+~~~~~~~~~~~~~~~~
+
+``GET /api/v1/faults`` (and every per-entity fault list) carries the flag on each item and the
+tally beside them:
+
+.. code-block:: json
+
+   {
+     "items": [
+       {
+         "fault_code": "MOTOR_STALL",
+         "status": "CONFIRMED",
+         "first_occurred": 1788716990.12,
+         "x-medkit": {"expected": true, "planned_stop_id": "1788716982473405798-1"}
+       }
+     ],
+     "x-medkit": {"count": 1, "expected_count": 1}
+   }
+
+``planned_stop_id`` is present only when ``expected`` is true. ``expected_count`` counts the
+items this gateway derived a flag for; items merged from an aggregated peer carry the peer's
+own flag and are not recounted.
+
+Both fault lists take ``?expected=true|false|all``. Omitting it means ``all``: the flag is extra
+information about a fault, never a reason to hide it by default.
+
+The ``/faults/stream`` frames carry the same pair inside their ``x-medkit`` object, alongside
+the ``entity_type`` / ``entity_id`` hint. ``expected`` is sent as an explicit ``false`` rather
+than omitted, so a consumer can tell "not expected" from "this gateway could not say".
+
 Fault Triggers (threshold rules)
 --------------------------------
 

--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -122,6 +122,45 @@ fault cycle must not erase how often that code approached confirmation across cy
    storage API (``FaultStorage::get_near_misses``). A database written by an earlier build gains
    the table on first open. There is no service or REST surface for it yet.
 
+Planned Stops
+~~~~~~~~~~~~~
+
+A **planned stop** is a window of wall-clock time during which faults are expected: a changeover, a
+maintenance weekend, a line move. An operator declares one at runtime through the fault manager's
+``~/declare_planned_stop`` service or through the gateway's ``/x-medkit-planned-stops`` routes.
+
+Declaring a window changes nothing about how faults are handled. A fault whose cycle starts inside
+one is confirmed, healed, cleared, captured and audited exactly as any other fault - the window only
+lets a reader tell an expected fault from a surprise, which the gateway serves as
+``x-medkit.expected`` on the fault list and on the event stream.
+
+Windows may overlap, may be declared after the stop they describe, and have no maximum duration.
+They are stored in the ``planned_stops`` table of the fault database and survive a restart; a
+database written by an earlier build gains the table on first open.
+
+.. code-block:: yaml
+
+   fault_manager:
+     ros__parameters:
+       planned_stop:
+         max_windows: 100                  # Declared windows retained (clamped to [1, 10000])
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 12 58
+
+   * - Parameter
+     - Default
+     - Description
+   * - ``planned_stop.max_windows``
+     - ``100``
+     - Declared windows retained. Bounded by **count**, not by age: a window that has ended is
+       still the reason a fault from last month reads as expected. When the bound is reached the
+       **oldest ended** windows are dropped first; a window that is still running is never dropped,
+       so the stored count can exceed the bound while more than that many windows are live. Values
+       outside ``[1, 10000]`` are clamped and the clamp is logged at startup. Lowering the bound
+       deletes stored declarations on the next start, which is also logged.
+
 Per-Entity Thresholds
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -154,12 +154,13 @@ database written by an earlier build gains the table on first open.
      - Description
    * - ``planned_stop.max_windows``
      - ``100``
-     - Declared windows retained. Bounded by **count**, not by age: a window that has ended is
-       still the reason a fault from last month reads as expected. When the bound is reached the
-       **oldest ended** windows are dropped first; a window that is still running is never dropped,
-       so the stored count can exceed the bound while more than that many windows are live. Values
-       outside ``[1, 10000]`` are clamped and the clamp is logged at startup. Lowering the bound
-       deletes stored declarations on the next start, which is also logged.
+     - Bound on the retained windows that are **no longer active**. Bounded by count, not by age:
+       a window that has ended is still the reason a fault from last month reads as expected. When
+       the bound is reached the **oldest ended** windows are dropped first. An active window is
+       always kept and is never dropped to make room - not even for the declaration that triggered
+       the prune - so the stored count is at most this value **plus the number of windows still
+       running**. Values outside ``[1, 10000]`` are clamped and the clamp is logged at startup.
+       Lowering the bound deletes stored declarations on the next start, which is also logged.
 
 Per-Entity Thresholds
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/config/fault-manager.rst
+++ b/docs/config/fault-manager.rst
@@ -186,13 +186,15 @@ database written by an earlier build gains the table on first open.
      - Description
    * - ``planned_stop.max_windows``
      - ``100``
-     - Bound on the retained windows that are **no longer active**. Bounded by count, not by age:
-       a window that has ended is still the reason a fault from last month reads as expected. When
-       the bound is reached the **oldest ended** windows are dropped first. An active window is
-       always kept and is never dropped to make room - not even for the declaration that triggered
-       the prune - so the stored count is at most this value **plus the number of windows still
-       running**. Values outside ``[1, 10000]`` are clamped and the clamp is logged at startup.
-       Lowering the bound deletes stored declarations on the next start, which is also logged.
+     - **Hard** bound on stored windows. Bounded by count, not by age: a window that has ended is
+       still the reason a fault from last month reads as expected. A declaration prunes the
+       **oldest ended** windows to make room for itself; when every stored window has yet to end
+       there is no room to make, and the declaration is refused (``409`` over REST) rather than the
+       table growing. A window that has not ended is never dropped to make room, which is why the
+       refusal exists at all. ``ListPlannedStops`` with ``active_only`` lists exactly those
+       unprunable windows. Values outside ``[1, 10000]`` are clamped and the clamp is logged at
+       startup. Lowering the bound deletes stored declarations on the next start, which is also
+       logged; a table loaded above a lowered bound stays above it until those windows end.
 
 Per-Entity Thresholds
 ~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros2_medkit_fault_manager/CMakeLists.txt
+++ b/src/ros2_medkit_fault_manager/CMakeLists.txt
@@ -136,6 +136,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_sqlite_storage fault_manager_lib)
   medkit_target_dependencies(test_sqlite_storage rclcpp ros2_medkit_msgs)
 
+  # Planned-stop windows: every behavioural assertion runs against both storage
+  # backends, plus the SQLite-only reopen and schema cases.
+  medkit_add_gtest(test_planned_stops test/test_planned_stops.cpp)
+  target_link_libraries(test_planned_stops fault_manager_lib)
+  medkit_target_dependencies(test_planned_stops rclcpp ros2_medkit_msgs)
+
   # Rosbag retention parity: every assertion runs against both storage backends.
   medkit_add_gtest(test_rosbag_storage_parity test/test_rosbag_storage_parity.cpp)
   target_link_libraries(test_rosbag_storage_parity fault_manager_lib)
@@ -191,6 +197,11 @@ if(BUILD_TESTING)
 
   medkit_add_launch_test(test_entity_thresholds_integration test/integration/test_entity_thresholds_integration.test.py
     TIMEOUT 60 LABELS "integration")
+
+  # Planned-stop windows over SQLite: each case spawns its own fault_manager so it
+  # can pick a retention bound, and one of them kills the node and brings it back.
+  medkit_add_launch_test(test_planned_stops_integration test/integration/test_planned_stops.test.py
+    TIMEOUT 240 LABELS "integration")
 
   medkit_add_launch_test(test_rosbag_entity_scope test/integration/test_rosbag_entity_scope.test.py TIMEOUT 120
     LABELS "integration")

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -74,7 +74,7 @@ ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault \
 | `auto_confirm_after_sec` | double | `0.0` | Auto-confirm PREFAILED faults after timeout (0 = disabled) |
 | `entity_thresholds.config_file` | string | `""` | Path to YAML file with per-entity debounce threshold overrides |
 | `near_miss.max_per_fault` | int | `200` | Near-miss entries retained per fault code, oldest evicted first (0 = unlimited) |
-| `planned_stop.max_windows` | int | `100` | Bound on the retained planned-stop windows that are **no longer active**, oldest declaration dropped first. An active window is always kept and never dropped to make room, so the table holds at most this many plus the number of running windows. Clamped to `[1, 10000]` |
+| `planned_stop.max_windows` | int | `100` | **Hard** bound on stored planned-stop windows. A declaration prunes the oldest **ended** windows to make room; when every stored window has yet to end the declaration is refused instead. Clamped to `[1, 10000]` |
 
 ### Snapshot Parameters
 
@@ -211,7 +211,8 @@ NOW=$(date +%s)
 ros2 service call /fault_manager/declare_planned_stop ros2_medkit_msgs/srv/DeclarePlannedStop \
   "{starts_at: {sec: $NOW, nanosec: 0}, ends_at: {sec: $((NOW + 14400)), nanosec: 0}, reason: 'line changeover', declared_by: 'shift_lead'}"
 
-# List the windows that contain this instant. `now: 0` here means "the fault
+# List the windows that have NOT ENDED - running and not-yet-started alike, the
+# same notion retention uses. `now: 0` here means "the fault
 # manager's own wall clock", which is a request-time reference rather than a
 # window bound - the clock the fault timestamps come from is the one to compare
 # against.
@@ -237,9 +238,9 @@ Behaviour worth knowing before relying on it:
 - A fault belongs to a window when its `first_occurred` lies in `[starts_at, ends_at]`, inclusive at both ends and compared at millisecond resolution. `first_occurred` is the start of the current **cycle**, so a code that fails inside a window and fails again after it was cleared is expected for the first cycle and unexpected for the second.
 - Windows may overlap, and may be declared **after** the stop they describe: a stop is a fact about the plant, not about when someone typed it in.
 - Both bounds must be after the Unix epoch. Zero is what an unset `builtin_interfaces/Time` reads as, so it cannot also mean "now" - a caller who wants the current instant sends it.
-- Whether a window is **finished**, **not started** or **running** is decided against the fault manager's own wall clock, never against the `at` a caller supplies. A running window is cut short at `at`, which may only fall in `[starts_at, now]`; a window that has not started is **cancelled** (removed, with `cancelled` set on the answer); a window that has already finished, early or on its own, cannot be touched again, backdated instants included.
+- Whether a window is **finished**, **not started** or **running** is decided against the fault manager's own wall clock, never against the `at` a caller supplies. A running window is cut short at `at`, which must fall in `(starts_at, now]` - strictly after the start, because ending at the start would store a zero-length window; a window that has not started is **cancelled** (removed, with `cancelled` set on the answer); a window that has already finished, early or on its own, cannot be touched again, backdated instants included.
 - Windows are stored in the `planned_stops` table and survive a restart. A database written by an earlier build gains the table on first open.
-- Retention is by count (`planned_stop.max_windows`), never by age. The bound counts windows that are **no longer active**: an active window is always kept and is never dropped to make room, so the table holds at most `max_windows` plus however many windows are currently running.
+- Retention is by count (`planned_stop.max_windows`), never by age, and the bound is **hard**. A declaration prunes the oldest **ended** windows to make room for itself; when every stored window has yet to end there is no room to make and the declaration is refused (`OUTCOME_NOT_RETAINED`, `409` over REST). A window that has not ended is never dropped to make room. `~/list_planned_stops` with `active_only` lists exactly those unprunable windows.
 
 ## Advanced: Tamper-Evident Audit Log
 

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -43,6 +43,9 @@ ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault \
 | `~/list_faults` | `ros2_medkit_msgs/srv/ListFaults` | Query faults with filtering |
 | `~/clear_fault` | `ros2_medkit_msgs/srv/ClearFault` | Clear/acknowledge a fault |
 | `~/get_snapshots` | `ros2_medkit_msgs/srv/GetSnapshots` | Get topic snapshots for a fault |
+| `~/declare_planned_stop` | `ros2_medkit_msgs/srv/DeclarePlannedStop` | Declare a window during which faults are expected |
+| `~/end_planned_stop` | `ros2_medkit_msgs/srv/EndPlannedStop` | Cut a planned-stop window short |
+| `~/list_planned_stops` | `ros2_medkit_msgs/srv/ListPlannedStops` | List declared windows, optionally only the active ones |
 
 ## Features
 
@@ -54,6 +57,7 @@ ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault \
 - **Snapshot capture**: Captures topic data when faults are confirmed for debugging (snapshots are deleted when fault is cleared)
 - **Near-miss series**: Appends one entry per FAILED report that moved the debounce counter without confirming, bounded per fault code and retained when the fault is cleared
 - **Freeze-frame retention**: One compact JSON freeze-frame per fault code, retained across `clear_fault` (see below)
+- **Planned stops**: Windows of wall-clock time during which faults are expected. Marked, never suppressed - an expected fault takes exactly the same path through storage, debounce, capture and the audit log
 - **Fault correlation** (optional): Root cause analysis with symptom muting and auto-clear
 - **Tamper-evident audit log** (optional): Append-only, hash-chained record of fault state transitions for verifiable history
 
@@ -69,6 +73,7 @@ ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault \
 | `auto_confirm_after_sec` | double | `0.0` | Auto-confirm PREFAILED faults after timeout (0 = disabled) |
 | `entity_thresholds.config_file` | string | `""` | Path to YAML file with per-entity debounce threshold overrides |
 | `near_miss.max_per_fault` | int | `200` | Near-miss entries retained per fault code, oldest evicted first (0 = unlimited) |
+| `planned_stop.max_windows` | int | `100` | Declared planned-stop windows retained, oldest **ended** one dropped first; a running window is never dropped. Clamped to `[1, 10000]` |
 
 ### Snapshot Parameters
 
@@ -189,6 +194,34 @@ The series lives in the `near_misses` table of the fault database and is read th
 API (`FaultStorage::get_near_misses`). A database written by an earlier build gains the table on
 first open. **There is no service or REST surface for it yet** - reading it means going through the
 storage API or the database file.
+
+## Planned Stops
+
+A **planned stop** is a window of wall-clock time during which faults are expected: a changeover, a maintenance weekend, a line move. An operator declares one at runtime; the fault manager stores it and serves it.
+
+Declaring a window changes nothing about how faults are handled. A fault whose cycle starts inside one is confirmed, healed, cleared, captured and audited exactly as any other fault. The window only lets a reader tell an expected fault from a surprise - the gateway derives that flag and serves it as `x-medkit.expected` on the fault list and the event stream.
+
+```bash
+# Declare a four-hour changeover starting now (a zero start means "now")
+ros2 service call /fault_manager/declare_planned_stop ros2_medkit_msgs/srv/DeclarePlannedStop \
+  "{starts_at: {sec: 0, nanosec: 0}, ends_at: {sec: 1788800000, nanosec: 0}, reason: 'line changeover', declared_by: 'shift_lead'}"
+
+# List the windows that contain this instant
+ros2 service call /fault_manager/list_planned_stops ros2_medkit_msgs/srv/ListPlannedStops \
+  "{active_only: true, now: {sec: 0, nanosec: 0}}"
+
+# Cut a window short
+ros2 service call /fault_manager/end_planned_stop ros2_medkit_msgs/srv/EndPlannedStop \
+  "{id: '1788716982473405798-1', at: {sec: 0, nanosec: 0}}"
+```
+
+Behaviour worth knowing before relying on it:
+
+- A fault belongs to a window when its `first_occurred` lies in `[starts_at, ends_at]`, inclusive at both ends. `first_occurred` is the start of the current **cycle**, so a code that fails inside a window and fails again after it was cleared is expected for the first cycle and unexpected for the second.
+- Windows may overlap, and may be declared **after** the stop they describe: a stop is a fact about the plant, not about when someone typed it in.
+- Ending a window early moves `ends_at` to that instant. Faults raised before it stay expected; faults raised after it do not. A window whose end has already passed cannot be ended again.
+- Windows are stored in the `planned_stops` table and survive a restart. A database written by an earlier build gains the table on first open.
+- Retention is by count (`planned_stop.max_windows`), never by age, and never drops a running window.
 
 ## Advanced: Tamper-Evident Audit Log
 

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -217,9 +217,10 @@ ros2 service call /fault_manager/end_planned_stop ros2_medkit_msgs/srv/EndPlanne
 
 Behaviour worth knowing before relying on it:
 
-- A fault belongs to a window when its `first_occurred` lies in `[starts_at, ends_at]`, inclusive at both ends. `first_occurred` is the start of the current **cycle**, so a code that fails inside a window and fails again after it was cleared is expected for the first cycle and unexpected for the second.
+- A fault belongs to a window when its `first_occurred` lies in `[starts_at, ends_at]`, inclusive at both ends and compared at millisecond resolution. `first_occurred` is the start of the current **cycle**, so a code that fails inside a window and fails again after it was cleared is expected for the first cycle and unexpected for the second.
 - Windows may overlap, and may be declared **after** the stop they describe: a stop is a fact about the plant, not about when someone typed it in.
-- Ending a window early moves `ends_at` to that instant. Faults raised before it stay expected; faults raised after it do not. A window whose end has already passed cannot be ended again.
+- Both bounds must be after the Unix epoch. Zero is what an unset `builtin_interfaces/Time` reads as, so it cannot also mean "now" - a caller who wants the current instant sends it.
+- Ending a window that is running moves `ends_at` to that instant. Faults raised before it stay expected; faults raised after it do not. A window that has not started yet is **cancelled** instead: removed, with `cancelled` set on the answer. A window that has already ended cannot be ended again, and a backdated `at` cannot move its end earlier.
 - Windows are stored in the `planned_stops` table and survive a restart. A database written by an earlier build gains the table on first open.
 - Retention is by count (`planned_stop.max_windows`), never by age, and never drops a running window.
 

--- a/src/ros2_medkit_fault_manager/README.md
+++ b/src/ros2_medkit_fault_manager/README.md
@@ -73,7 +73,7 @@ ros2 service call /fault_manager/clear_fault ros2_medkit_msgs/srv/ClearFault \
 | `auto_confirm_after_sec` | double | `0.0` | Auto-confirm PREFAILED faults after timeout (0 = disabled) |
 | `entity_thresholds.config_file` | string | `""` | Path to YAML file with per-entity debounce threshold overrides |
 | `near_miss.max_per_fault` | int | `200` | Near-miss entries retained per fault code, oldest evicted first (0 = unlimited) |
-| `planned_stop.max_windows` | int | `100` | Declared planned-stop windows retained, oldest **ended** one dropped first; a running window is never dropped. Clamped to `[1, 10000]` |
+| `planned_stop.max_windows` | int | `100` | Bound on the retained planned-stop windows that are **no longer active**, oldest declaration dropped first. An active window is always kept and never dropped to make room, so the table holds at most this many plus the number of running windows. Clamped to `[1, 10000]` |
 
 ### Snapshot Parameters
 
@@ -201,18 +201,34 @@ A **planned stop** is a window of wall-clock time during which faults are expect
 
 Declaring a window changes nothing about how faults are handled. A fault whose cycle starts inside one is confirmed, healed, cleared, captured and audited exactly as any other fault. The window only lets a reader tell an expected fault from a surprise - the gateway derives that flag and serves it as `x-medkit.expected` on the fault list and the event stream.
 
-```bash
-# Declare a four-hour changeover starting now (a zero start means "now")
-ros2 service call /fault_manager/declare_planned_stop ros2_medkit_msgs/srv/DeclarePlannedStop \
-  "{starts_at: {sec: 0, nanosec: 0}, ends_at: {sec: 1788800000, nanosec: 0}, reason: 'line changeover', declared_by: 'shift_lead'}"
+The service takes explicit instants. Zero is what an **unset** `builtin_interfaces/Time` reads as, so it is not a stand-in for "now" on either bound - a caller who wants the current instant sends it:
 
-# List the windows that contain this instant
+```bash
+# Declare a four-hour changeover. Both bounds are explicit; `date +%s` is the
+# shortest way to say "now" from a shell.
+NOW=$(date +%s)
+ros2 service call /fault_manager/declare_planned_stop ros2_medkit_msgs/srv/DeclarePlannedStop \
+  "{starts_at: {sec: $NOW, nanosec: 0}, ends_at: {sec: $((NOW + 14400)), nanosec: 0}, reason: 'line changeover', declared_by: 'shift_lead'}"
+
+# List the windows that contain this instant. `now: 0` here means "the fault
+# manager's own wall clock", which is a request-time reference rather than a
+# window bound - the clock the fault timestamps come from is the one to compare
+# against.
 ros2 service call /fault_manager/list_planned_stops ros2_medkit_msgs/srv/ListPlannedStops \
   "{active_only: true, now: {sec: 0, nanosec: 0}}"
 
-# Cut a window short
+# Cut a window short. `at: 0` means the fault manager's clock, for the same
+# reason; an explicit instant may only refine where a RUNNING window ends.
 ros2 service call /fault_manager/end_planned_stop ros2_medkit_msgs/srv/EndPlannedStop \
   "{id: '1788716982473405798-1', at: {sec: 0, nanosec: 0}}"
+```
+
+Over REST the same window is one call, and there **omitting** `from` is how you say "now" - the gateway fills in its own clock and always sends an explicit instant:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/x-medkit-planned-stops \
+  -H 'Content-Type: application/json' \
+  -d '{"to": "2026-09-06T22:00:00Z", "reason": "line changeover"}'
 ```
 
 Behaviour worth knowing before relying on it:
@@ -220,9 +236,9 @@ Behaviour worth knowing before relying on it:
 - A fault belongs to a window when its `first_occurred` lies in `[starts_at, ends_at]`, inclusive at both ends and compared at millisecond resolution. `first_occurred` is the start of the current **cycle**, so a code that fails inside a window and fails again after it was cleared is expected for the first cycle and unexpected for the second.
 - Windows may overlap, and may be declared **after** the stop they describe: a stop is a fact about the plant, not about when someone typed it in.
 - Both bounds must be after the Unix epoch. Zero is what an unset `builtin_interfaces/Time` reads as, so it cannot also mean "now" - a caller who wants the current instant sends it.
-- Ending a window that is running moves `ends_at` to that instant. Faults raised before it stay expected; faults raised after it do not. A window that has not started yet is **cancelled** instead: removed, with `cancelled` set on the answer. A window that has already ended cannot be ended again, and a backdated `at` cannot move its end earlier.
+- Whether a window is **finished**, **not started** or **running** is decided against the fault manager's own wall clock, never against the `at` a caller supplies. A running window is cut short at `at`, which may only fall in `[starts_at, now]`; a window that has not started is **cancelled** (removed, with `cancelled` set on the answer); a window that has already finished, early or on its own, cannot be touched again, backdated instants included.
 - Windows are stored in the `planned_stops` table and survive a restart. A database written by an earlier build gains the table on first open.
-- Retention is by count (`planned_stop.max_windows`), never by age, and never drops a running window.
+- Retention is by count (`planned_stop.max_windows`), never by age. The bound counts windows that are **no longer active**: an active window is always kept and is never dropped to make room, so the table holds at most `max_windows` plus however many windows are currently running.
 
 ## Advanced: Tamper-Evident Audit Log
 

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -191,11 +191,17 @@ Clears (acknowledges) a fault by setting its status to CLEARED.
 
 Declare, cut short and list the windows of wall-clock time during which faults are expected.
 
-- **Declare**: refuses a window that is not an interval (``ends_at <= starts_at``); a zero
-  ``starts_at`` means "now". Windows may overlap and may lie wholly in the past.
-- **End**: moves ``ends_at`` to the given instant (zero means "now") and sets ``ended_early``.
-  Refused for an unknown id and for a window whose end has already passed, and the message
-  distinguishes the two so a caller can map them onto different answers.
+- **Declare**: refuses a window that is not an interval (``ends_at <= starts_at``) and one whose
+  bounds are at or before the Unix epoch - zero is what an unset time reads as, not a request for
+  "now". Windows may overlap and may lie wholly in the past. The stored row is read back before
+  success is reported, and the declaration is exempt from the retention pruning its own arrival
+  triggers, so a window answered as stored is there afterwards.
+- **End**: for a window still RUNNING at the given instant (zero means the fault manager's own
+  wall clock), moves ``ends_at`` there and sets ``ended_early``. A window that has not STARTED by
+  then is cancelled instead - removed, with ``cancelled`` set on the copy returned - because it
+  marked nothing and an inverted interval would contradict the message. Refused for an unknown id
+  and for a window that has already ended, backdated instants included. The structured ``outcome``
+  distinguishes the four cases so a caller maps them onto answers without reading prose.
 - **List**: newest declaration first; ``active_only`` keeps the windows containing ``now``.
 - **Returns**: the stored ``PlannedStop`` in every success case.
 

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -196,12 +196,16 @@ Declare, cut short and list the windows of wall-clock time during which faults a
   "now". Windows may overlap and may lie wholly in the past. The stored row is read back before
   success is reported, and the declaration is exempt from the retention pruning its own arrival
   triggers, so a window answered as stored is there afterwards.
-- **End**: for a window still RUNNING at the given instant (zero means the fault manager's own
-  wall clock), moves ``ends_at`` there and sets ``ended_early``. A window that has not STARTED by
-  then is cancelled instead - removed, with ``cancelled`` set on the copy returned - because it
-  marked nothing and an inverted interval would contradict the message. Refused for an unknown id
-  and for a window that has already ended, backdated instants included. The structured ``outcome``
-  distinguishes the four cases so a caller maps them onto answers without reading prose.
+- **End**: whether a window is FINISHED, NOT STARTED or RUNNING is decided against the fault
+  manager's own wall clock, never against the ``at`` the caller sends. A running window is cut
+  short at ``at`` - which may only fall in ``[starts_at, now]``, and is refused outside it rather
+  than clamped - moving ``ends_at`` there and setting ``ended_early``. A window that has not
+  started is cancelled instead: removed, with ``cancelled`` set on the copy returned, because it
+  marked nothing and an inverted interval would contradict the message. A finished window is
+  immutable. Judging on ``at`` let the caller pick the answer: a backdated instant inside the
+  original span re-ended a window that had run out, and one before the start deleted it. The
+  structured ``outcome`` distinguishes the five cases so a caller maps them onto answers without
+  reading prose.
 - **List**: newest declaration first; ``active_only`` keeps the windows containing ``now``.
 - **Returns**: the stored ``PlannedStop`` in every success case.
 
@@ -287,9 +291,12 @@ is expected for the first cycle and unexpected for the second, which is what an 
 
 Windows are bounded by count rather than by age (``planned_stop.max_windows``). A window that has
 ended is still the reason a fault from last month reads as expected, so it cannot be dropped for
-being old - only for being one of too many. Retention prunes ended windows, oldest declaration
-first, and **never** a window that is still running: a live window vanishing under the operator who
-declared it would be the one failure mode with no recovery.
+being old - only for being one of too many. The bound counts windows that are no longer ACTIVE:
+retention prunes those, oldest declaration first, and **never** a window that is still running, not
+even to make room for the declaration that triggered the prune. The stored count is therefore at
+most the bound plus the number of active windows. A live window vanishing under the operator who
+declared it would be the one failure mode with no recovery, and a table a few rows over its nominal
+bound is the price.
 
 Rosbag Black-Box Recording
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -186,6 +186,19 @@ Clears (acknowledges) a fault by setting its status to CLEARED.
 - **Idempotent**: Clearing an already-cleared fault succeeds
 - **Returns**: ``success=true`` if fault existed, ``success=false`` if not found
 
+~/declare_planned_stop, ~/end_planned_stop, ~/list_planned_stops
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Declare, cut short and list the windows of wall-clock time during which faults are expected.
+
+- **Declare**: refuses a window that is not an interval (``ends_at <= starts_at``); a zero
+  ``starts_at`` means "now". Windows may overlap and may lie wholly in the past.
+- **End**: moves ``ends_at`` to the given instant (zero means "now") and sets ``ended_early``.
+  Refused for an unknown id and for a window whose end has already passed, and the message
+  distinguishes the two so a caller can map them onto different answers.
+- **List**: newest declaration first; ``active_only`` keeps the windows containing ``now``.
+- **Returns**: the stored ``PlannedStop`` in every success case.
+
 Design Decisions
 ----------------
 
@@ -245,6 +258,32 @@ means heal on a single PASSED event); the node validates the
 merged per-entity config at startup, logs a warning, and falls back to safe defaults if not. When
 healing is disabled, any HEALED row left by a previous (healing-enabled) run is reclassified to
 CLEARED once at startup so it does not behave inconsistently under the latch.
+
+Planned Stops Are Marked, Never Suppressed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A planned-stop window records that an operator expected faults during an interval. **No code on
+the report, confirm, heal, clear, capture or audit path reads a window.** A fault whose cycle
+starts inside one takes exactly the same journey as any other fault: the same debounce, the same
+rows, the same rosbag, the same audit transitions, the same ``occurrence_count``. The three
+services above are the only place in the package that touches the ``planned_stops`` table.
+
+That is deliberate rather than incidental. The evidence chain has to describe the plant that
+existed, and a window is a statement about intent, not about what the machines did. A reader that
+wants to separate the two derives the flag from the window and the fault's ``first_occurred``; the
+gateway does exactly this and serves it as ``x-medkit.expected`` on the fault list and the event
+stream.
+
+The cycle boundary is ``first_occurred``, which is set on a new fault and reset when a FAILED event
+raises a CLEARED fault again - so a fault code that fails inside a window and fails again outside it
+is expected for the first cycle and unexpected for the second, which is what an operator asking
+"did anything break outside the stop" means.
+
+Windows are bounded by count rather than by age (``planned_stop.max_windows``). A window that has
+ended is still the reason a fault from last month reads as expected, so it cannot be dropped for
+being old - only for being one of too many. Retention prunes ended windows, oldest declaration
+first, and **never** a window that is still running: a live window vanishing under the operator who
+declared it would be the one failure mode with no recovery.
 
 Rosbag Black-Box Recording
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ros2_medkit_fault_manager/design/index.rst
+++ b/src/ros2_medkit_fault_manager/design/index.rst
@@ -187,7 +187,7 @@ Clears (acknowledges) a fault by setting its status to CLEARED.
 - **Returns**: ``success=true`` if fault existed, ``success=false`` if not found
 
 ~/declare_planned_stop, ~/end_planned_stop, ~/list_planned_stops
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Declare, cut short and list the windows of wall-clock time during which faults are expected.
 
@@ -260,7 +260,7 @@ healing is disabled, any HEALED row left by a previous (healing-enabled) run is 
 CLEARED once at startup so it does not behave inconsistently under the latch.
 
 Planned Stops Are Marked, Never Suppressed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A planned-stop window records that an operator expected faults during an interval. **No code on
 the report, confirm, heal, clear, capture or audit path reads a window.** A fault whose cycle

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_manager_node.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_manager_node.hpp
@@ -31,11 +31,14 @@
 #include "ros2_medkit_fault_manager/snapshot_capture.hpp"
 #include "ros2_medkit_msgs/msg/fault_event.hpp"
 #include "ros2_medkit_msgs/srv/clear_fault.hpp"
+#include "ros2_medkit_msgs/srv/declare_planned_stop.hpp"
+#include "ros2_medkit_msgs/srv/end_planned_stop.hpp"
 #include "ros2_medkit_msgs/srv/get_fault.hpp"
 #include "ros2_medkit_msgs/srv/get_rosbag.hpp"
 #include "ros2_medkit_msgs/srv/get_snapshots.hpp"
 #include "ros2_medkit_msgs/srv/list_faults.hpp"
 #include "ros2_medkit_msgs/srv/list_faults_for_entity.hpp"
+#include "ros2_medkit_msgs/srv/list_planned_stops.hpp"
 #include "ros2_medkit_msgs/srv/list_rosbags.hpp"
 #include "ros2_medkit_msgs/srv/report_fault.hpp"
 
@@ -156,6 +159,19 @@ class FaultManagerNode : public rclcpp::Node {
   handle_list_faults_for_entity(const std::shared_ptr<ros2_medkit_msgs::srv::ListFaultsForEntity::Request> & request,
                                 const std::shared_ptr<ros2_medkit_msgs::srv::ListFaultsForEntity::Response> & response);
 
+  /// Handle DeclarePlannedStop service request
+  void
+  handle_declare_planned_stop(const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Request> & request,
+                              const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Response> & response);
+
+  /// Handle EndPlannedStop service request
+  void handle_end_planned_stop(const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Request> & request,
+                               const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Response> & response);
+
+  /// Handle ListPlannedStops service request
+  void handle_list_planned_stops(const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Request> & request,
+                                 const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Response> & response);
+
   /// Create snapshot configuration from parameters
   SnapshotConfig create_snapshot_config();
 
@@ -231,6 +247,14 @@ class FaultManagerNode : public rclcpp::Node {
   rclcpp::Service<ros2_medkit_msgs::srv::GetRosbag>::SharedPtr get_rosbag_srv_;
   rclcpp::Service<ros2_medkit_msgs::srv::ListRosbags>::SharedPtr list_rosbags_srv_;
   rclcpp::Service<ros2_medkit_msgs::srv::ListFaultsForEntity>::SharedPtr list_faults_for_entity_srv_;
+  rclcpp::Service<ros2_medkit_msgs::srv::DeclarePlannedStop>::SharedPtr declare_planned_stop_srv_;
+  rclcpp::Service<ros2_medkit_msgs::srv::EndPlannedStop>::SharedPtr end_planned_stop_srv_;
+  rclcpp::Service<ros2_medkit_msgs::srv::ListPlannedStops>::SharedPtr list_planned_stops_srv_;
+
+  /// Serial number behind the id of each declared window. Ids are
+  /// "<declared_at_ns>-<counter>", which is unique within a fault manager and
+  /// sorts by declaration without a UUID dependency.
+  std::atomic<uint64_t> planned_stop_seq_{0};
   rclcpp::TimerBase::SharedPtr auto_confirm_timer_;
 
   /// Timer for periodic cleanup of expired correlation data

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -218,6 +218,11 @@ struct PlannedStopWindow {
   /// moment of that request.
   bool ended_early{false};
 
+  /// True on the window returned by a cancellation - a window removed before it
+  /// ever started. Never stored: a cancelled window is gone, and the field is
+  /// how the answer says which of the two things happened to it.
+  bool cancelled{false};
+
   /// Whether @p when_ns falls inside the window. The interval is CLOSED at both
   /// ends, and the gateway derives its `expected` flag from the same rule, so a
   /// fault reported at the instant a window opens or closes is inside it in both
@@ -238,8 +243,9 @@ struct PlannedStopWindow {
 /// structurally rather than by inspecting a message string.
 enum class EndPlannedStopOutcome : uint8_t {
   Ended,        ///< The window was running and now ends at the requested instant
+  Cancelled,    ///< The window had not started yet, so it was removed instead
   NotFound,     ///< No window with that id
-  AlreadyEnded  ///< The window's end had already passed; it is not moved again
+  AlreadyEnded  ///< The window had already ended, early or on its own; it is not moved again
 };
 
 /// Result of an end-early request. `window` is the window as stored afterwards
@@ -531,12 +537,23 @@ class FaultStorage {
   /// @return fault codes of the reclassified faults, so the caller can audit each transition
   /// Store a planned-stop window. Returns false when a window with that id
   /// already exists; the stored one is left untouched. Applies the retention
-  /// bound afterwards using the new window's declared_at_ns as "now".
+  /// bound afterwards using the new window's declared_at_ns as "now", with the
+  /// window just declared EXEMPT: a declaration that is reported as stored has
+  /// to still be there afterwards, and without the exemption a cap already
+  /// filled by an unprunable (running) window made the new row the only
+  /// candidate for its own eviction.
   virtual bool declare_planned_stop(const PlannedStopWindow & window) = 0;
 
-  /// Cut a window short at @p at_ns: ends_at_ns moves there and ended_early is
-  /// set. Refused when the window's end has already passed, so that the record
-  /// of when a stop actually finished cannot be rewritten after the fact.
+  /// Stop a window at @p at_ns.
+  ///
+  /// Three answers, because there are three situations. A window still running
+  /// at that instant is CUT SHORT: ends_at_ns moves there and ended_early is
+  /// set. A window that has not STARTED by then is CANCELLED - removed, with
+  /// `cancelled` set on the returned copy - because it marked nothing and
+  /// storing ends_at <= starts_at would contradict the message's own promise.
+  /// A window that has already ended, early or on its own, is refused: when a
+  /// stop actually finished is not something a later request gets to rewrite,
+  /// backdated `at` included.
   virtual EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) = 0;
 
   /// One window by id, or nothing when no window carries that id.
@@ -648,8 +665,9 @@ class InMemoryFaultStorage : public FaultStorage {
   bool path_referenced(const std::string & file_path) const;
 
   /// Drop ended windows, oldest declaration first, until at most
-  /// max_planned_stops_ remain. Returns how many went. Caller holds mutex_.
-  size_t prune_planned_stops_locked(int64_t now_ns);
+  /// max_planned_stops_ remain. Returns how many went. @p exempt_id is never
+  /// dropped. Caller holds mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id = {});
 
   mutable std::mutex mutex_;
   std::map<std::string, FaultState> faults_;

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -195,6 +195,85 @@ struct RosbagFileInfo {
   int64_t created_at_ns{0};  ///< Timestamp when bag was created
 };
 
+/// One declared planned-stop window: an interval of wall-clock time during which
+/// faults are expected.
+///
+/// Nothing in the fault pipeline reads a window. A fault whose cycle starts
+/// inside one confirms, heals, clears, is captured and is audited exactly as any
+/// other fault; the window only lets a reader tell an expected fault from a
+/// surprise. Keeping the two apart in storage rather than in the transition
+/// logic is what makes the evidence chain describe the plant that existed.
+struct PlannedStopWindow {
+  std::string id;
+  int64_t starts_at_ns{0};
+  int64_t ends_at_ns{0};
+  std::string reason;
+  std::string declared_by;
+
+  /// When the declaration was recorded. Retention orders by this and not by
+  /// starts_at_ns: a window may be declared after the stop it describes.
+  int64_t declared_at_ns{0};
+
+  /// True when an operator cut the window short, which moved ends_at_ns to the
+  /// moment of that request.
+  bool ended_early{false};
+
+  /// Whether @p when_ns falls inside the window. The interval is CLOSED at both
+  /// ends, and the gateway derives its `expected` flag from the same rule, so a
+  /// fault reported at the instant a window opens or closes is inside it in both
+  /// places.
+  bool covers(int64_t when_ns) const {
+    return when_ns >= starts_at_ns && when_ns <= ends_at_ns;
+  }
+
+  /// Whether the window is still running at @p now_ns. Retention never prunes a
+  /// window for which this is true.
+  bool active_at(int64_t now_ns) const {
+    return now_ns < ends_at_ns;
+  }
+};
+
+/// Why an end-early request did or did not change a window. The three cases carry
+/// different HTTP answers (200 / 404 / 400), so they are distinguished
+/// structurally rather than by inspecting a message string.
+enum class EndPlannedStopOutcome : uint8_t {
+  Ended,        ///< The window was running and now ends at the requested instant
+  NotFound,     ///< No window with that id
+  AlreadyEnded  ///< The window's end had already passed; it is not moved again
+};
+
+/// Result of an end-early request. `window` is the window as stored afterwards
+/// and is meaningful only when `outcome` is Ended.
+struct EndPlannedStopResult {
+  EndPlannedStopOutcome outcome{EndPlannedStopOutcome::NotFound};
+  PlannedStopWindow window;
+};
+
+/// Bounds on the configured number of retained planned-stop windows.
+/// One is the smallest useful store (an operator can still declare a stop);
+/// ten thousand is well past any plant's yearly count and keeps the table from
+/// growing for the life of a deployment.
+constexpr int64_t kMinPlannedStopWindows = 1;
+constexpr int64_t kMaxPlannedStopWindows = 10000;
+constexpr int64_t kDefaultPlannedStopWindows = 100;
+
+/// Bring a configured window bound into [kMinPlannedStopWindows,
+/// kMaxPlannedStopWindows], reporting through @p clamped whether it had to move.
+///
+/// Takes int64_t because that is what a ROS parameter is. Narrowing first would
+/// let a value above INT_MAX wrap back into the legal band and pass the check
+/// unnoticed, which is how a documented cap silently stops existing.
+inline int64_t clamp_planned_stop_windows(int64_t requested, bool & clamped) {
+  clamped = !(requested >= kMinPlannedStopWindows && requested <= kMaxPlannedStopWindows);
+  if (requested < kMinPlannedStopWindows) {
+    return kMinPlannedStopWindows;
+  }
+  if (requested > kMaxPlannedStopWindows) {
+    return kMaxPlannedStopWindows;
+  }
+  return requested;
+}
+
 /// Abstract interface for fault storage backends
 class FaultStorage {
  public:
@@ -450,6 +529,32 @@ class FaultStorage {
   /// so a HEALED row left by a previous (healing-enabled) run does not behave inconsistently under
   /// the latch. Default is a no-op (in-memory storage starts empty).
   /// @return fault codes of the reclassified faults, so the caller can audit each transition
+  /// Store a planned-stop window. Returns false when a window with that id
+  /// already exists; the stored one is left untouched. Applies the retention
+  /// bound afterwards using the new window's declared_at_ns as "now".
+  virtual bool declare_planned_stop(const PlannedStopWindow & window) = 0;
+
+  /// Cut a window short at @p at_ns: ends_at_ns moves there and ended_early is
+  /// set. Refused when the window's end has already passed, so that the record
+  /// of when a stop actually finished cannot be rewritten after the fact.
+  virtual EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) = 0;
+
+  /// One window by id, or nothing when no window carries that id.
+  virtual std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const = 0;
+
+  /// Every stored window, newest declaration first.
+  virtual std::vector<PlannedStopWindow> list_planned_stops() const = 0;
+
+  /// Bound the number of stored windows and apply the bound now. Returns how
+  /// many stored windows the bound dropped.
+  ///
+  /// Only windows that have already ended at @p now_ns are candidates, oldest
+  /// declaration first; a window still running is never pruned. The stored count
+  /// can therefore exceed @p max_count while more than that many windows are
+  /// live, which is deliberate - a live window must not vanish under the
+  /// operator who declared it.
+  virtual size_t set_max_planned_stops(size_t max_count, int64_t now_ns) = 0;
+
   virtual std::vector<std::string> reclassify_healed_as_cleared() {
     return {};
   }
@@ -520,6 +625,12 @@ class InMemoryFaultStorage : public FaultStorage {
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
+  bool declare_planned_stop(const PlannedStopWindow & window) override;
+  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) override;
+  std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
+  std::vector<PlannedStopWindow> list_planned_stops() const override;
+  size_t set_max_planned_stops(size_t max_count, int64_t now_ns) override;
+
  private:
   /// Update fault status based on debounce counter and given config
   void update_status(FaultState & state, const DebounceConfig & config);
@@ -535,6 +646,10 @@ class InMemoryFaultStorage : public FaultStorage {
 
   /// Whether any row at all still references @p file_path. Caller holds mutex_.
   bool path_referenced(const std::string & file_path) const;
+
+  /// Drop ended windows, oldest declaration first, until at most
+  /// max_planned_stops_ remain. Returns how many went. Caller holds mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns);
 
   mutable std::mutex mutex_;
   std::map<std::string, FaultState> faults_;
@@ -564,6 +679,12 @@ class InMemoryFaultStorage : public FaultStorage {
   size_t max_snapshots_per_fault_{0};  ///< 0 = unlimited
   bool retain_snapshots_on_clear_{false};
   size_t max_near_misses_per_fault_{0};  ///< 0 = unlimited
+
+  /// Declared windows in insertion order. A vector rather than a map keyed by id
+  /// because retention walks them by declared_at_ns and the store is bounded to
+  /// a few hundred rows.
+  std::vector<PlannedStopWindow> planned_stops_;
+  size_t max_planned_stops_{static_cast<size_t>(kDefaultPlannedStopWindows)};
 };
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -242,14 +242,15 @@ struct PlannedStopWindow {
 /// different HTTP answers (200 / 404 / 400), so they are distinguished
 /// structurally rather than by inspecting a message string.
 enum class EndPlannedStopOutcome : uint8_t {
-  Ended,        ///< The window was running and now ends at the requested instant
-  Cancelled,    ///< The window had not started yet, so it was removed instead
-  NotFound,     ///< No window with that id
-  AlreadyEnded  ///< The window had already ended, early or on its own; it is not moved again
+  Ended,         ///< The window was running and now ends at the requested instant
+  Cancelled,     ///< The window had not started yet, so it was removed instead
+  NotFound,      ///< No window with that id
+  AlreadyEnded,  ///< The window had already finished, early or on its own; it is not moved again
+  InvalidAt      ///< The window is running, but the requested instant is not one it could end at
 };
 
-/// Result of an end-early request. `window` is the window as stored afterwards
-/// and is meaningful only when `outcome` is Ended.
+/// Result of an end request. `window` is the window as stored afterwards for
+/// Ended, as it was for Cancelled, and as it stands untouched for the refusals.
 struct EndPlannedStopResult {
   EndPlannedStopOutcome outcome{EndPlannedStopOutcome::NotFound};
   PlannedStopWindow window;
@@ -544,17 +545,25 @@ class FaultStorage {
   /// candidate for its own eviction.
   virtual bool declare_planned_stop(const PlannedStopWindow & window) = 0;
 
-  /// Stop a window at @p at_ns.
+  /// Stop a window.
   ///
-  /// Three answers, because there are three situations. A window still running
-  /// at that instant is CUT SHORT: ends_at_ns moves there and ended_early is
-  /// set. A window that has not STARTED by then is CANCELLED - removed, with
-  /// `cancelled` set on the returned copy - because it marked nothing and
-  /// storing ends_at <= starts_at would contradict the message's own promise.
-  /// A window that has already ended, early or on its own, is refused: when a
-  /// stop actually finished is not something a later request gets to rewrite,
-  /// backdated `at` included.
-  virtual EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) = 0;
+  /// Which of the three situations a window is in is decided against @p now_ns -
+  /// the caller's wall clock - and NEVER against @p at_ns. Judging on the
+  /// supplied instant let the caller pick the answer: a backdated `at` inside the
+  /// original span re-ended a window that had already finished on its own, and
+  /// one before the start deleted a finished window outright.
+  ///
+  /// - Already finished at @p now_ns (`ends_at_ns <= now_ns`), early or on its
+  ///   own: refused. When a stop finished is not something a later request gets
+  ///   to rewrite.
+  /// - Not started at @p now_ns (`starts_at_ns > now_ns`): CANCELLED - removed,
+  ///   with `cancelled` set on the returned copy. It marked nothing, and storing
+  ///   ends_at <= starts_at would contradict the message's own promise.
+  /// - Running: CUT SHORT at @p at_ns, which may only REFINE the end instant
+  ///   within `[starts_at_ns, now_ns]`. Outside that it is not an instant the
+  ///   window could have ended at, and the request is refused rather than
+  ///   clamped - a silently moved end is a wrong record, not a corrected one.
+  virtual EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) = 0;
 
   /// One window by id, or nothing when no window carries that id.
   virtual std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const = 0;
@@ -565,11 +574,13 @@ class FaultStorage {
   /// Bound the number of stored windows and apply the bound now. Returns how
   /// many stored windows the bound dropped.
   ///
-  /// Only windows that have already ended at @p now_ns are candidates, oldest
-  /// declaration first; a window still running is never pruned. The stored count
-  /// can therefore exceed @p max_count while more than that many windows are
-  /// live, which is deliberate - a live window must not vanish under the
-  /// operator who declared it.
+  /// The bound counts windows that are NO LONGER ACTIVE at @p now_ns. Those are
+  /// the only candidates, oldest declaration first; an active window is always
+  /// kept and is never dropped to make room for anything, not even for the
+  /// declaration that triggered the prune. The whole table is therefore bounded
+  /// by @p max_count PLUS the number of active windows - a live window must not
+  /// vanish under the operator who declared it, and that is worth a table a few
+  /// rows over its nominal bound.
   virtual size_t set_max_planned_stops(size_t max_count, int64_t now_ns) = 0;
 
   virtual std::vector<std::string> reclassify_healed_as_cleared() {
@@ -643,7 +654,7 @@ class InMemoryFaultStorage : public FaultStorage {
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
   bool declare_planned_stop(const PlannedStopWindow & window) override;
-  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) override;
+  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) override;
   std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
   std::vector<PlannedStopWindow> list_planned_stops() const override;
   size_t set_max_planned_stops(size_t max_count, int64_t now_ns) override;

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/fault_storage.hpp
@@ -238,6 +238,13 @@ struct PlannedStopWindow {
   }
 };
 
+/// Why a declaration was or was not stored.
+enum class DeclarePlannedStopOutcome : uint8_t {
+  Stored,       ///< The window is in the table
+  DuplicateId,  ///< A window with that id already exists; the stored one is untouched
+  CapFull       ///< The bound is reached and every stored window has yet to end
+};
+
 /// Why an end-early request did or did not change a window. The three cases carry
 /// different HTTP answers (200 / 404 / 400), so they are distinguished
 /// structurally rather than by inspecting a message string.
@@ -536,14 +543,19 @@ class FaultStorage {
   /// so a HEALED row left by a previous (healing-enabled) run does not behave inconsistently under
   /// the latch. Default is a no-op (in-memory storage starts empty).
   /// @return fault codes of the reclassified faults, so the caller can audit each transition
-  /// Store a planned-stop window. Returns false when a window with that id
-  /// already exists; the stored one is left untouched. Applies the retention
-  /// bound afterwards using the new window's declared_at_ns as "now", with the
-  /// window just declared EXEMPT: a declaration that is reported as stored has
-  /// to still be there afterwards, and without the exemption a cap already
-  /// filled by an unprunable (running) window made the new row the only
-  /// candidate for its own eviction.
-  virtual bool declare_planned_stop(const PlannedStopWindow & window) = 0;
+  /// Store a planned-stop window.
+  ///
+  /// Room is made FIRST, by pruning windows that have already ended at the new
+  /// window's declared_at_ns, oldest declaration first. If the bound is still
+  /// reached afterwards - every stored window has yet to end - the declaration is
+  /// REFUSED and nothing is stored. The bound is hard: a window that has not
+  /// ended can never be pruned, so without a refusal a caller could grow the
+  /// table without limit by declaring windows that start tomorrow, and
+  /// `planned_stop.max_windows` would bound nothing.
+  ///
+  /// Pruning before inserting is also what makes "reported as stored" true: the
+  /// row cannot be evicted by its own declaration, because it is not there yet.
+  virtual DeclarePlannedStopOutcome declare_planned_stop(const PlannedStopWindow & window) = 0;
 
   /// Stop a window.
   ///
@@ -574,13 +586,12 @@ class FaultStorage {
   /// Bound the number of stored windows and apply the bound now. Returns how
   /// many stored windows the bound dropped.
   ///
-  /// The bound counts windows that are NO LONGER ACTIVE at @p now_ns. Those are
-  /// the only candidates, oldest declaration first; an active window is always
-  /// kept and is never dropped to make room for anything, not even for the
-  /// declaration that triggered the prune. The whole table is therefore bounded
-  /// by @p max_count PLUS the number of active windows - a live window must not
-  /// vanish under the operator who declared it, and that is worth a table a few
-  /// rows over its nominal bound.
+  /// Only windows that have already ENDED at @p now_ns are pruned, oldest
+  /// declaration first: a window that has not ended must not vanish under the
+  /// operator who declared it. A table loaded from disk can therefore still sit
+  /// above a bound that was lowered between runs, until those windows end; a new
+  /// DECLARATION in that state is refused rather than admitted (see
+  /// declare_planned_stop), which is what keeps the bound hard going forward.
   virtual size_t set_max_planned_stops(size_t max_count, int64_t now_ns) = 0;
 
   virtual std::vector<std::string> reclassify_healed_as_cleared() {
@@ -653,7 +664,7 @@ class InMemoryFaultStorage : public FaultStorage {
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
-  bool declare_planned_stop(const PlannedStopWindow & window) override;
+  DeclarePlannedStopOutcome declare_planned_stop(const PlannedStopWindow & window) override;
   EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) override;
   std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
   std::vector<PlannedStopWindow> list_planned_stops() const override;
@@ -675,10 +686,9 @@ class InMemoryFaultStorage : public FaultStorage {
   /// Whether any row at all still references @p file_path. Caller holds mutex_.
   bool path_referenced(const std::string & file_path) const;
 
-  /// Drop ended windows, oldest declaration first, until at most
-  /// max_planned_stops_ remain. Returns how many went. @p exempt_id is never
-  /// dropped. Caller holds mutex_.
-  size_t prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id = {});
+  /// Drop ended windows, oldest declaration first, until at most @p target
+  /// remain. Returns how many went. Caller holds mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns, size_t target);
 
   mutable std::mutex mutex_;
   std::map<std::string, FaultState> faults_;

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
@@ -95,7 +95,7 @@ class SqliteFaultStorage : public FaultStorage {
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
-  bool declare_planned_stop(const PlannedStopWindow & window) override;
+  DeclarePlannedStopOutcome declare_planned_stop(const PlannedStopWindow & window) override;
   EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) override;
   std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
   std::vector<PlannedStopWindow> list_planned_stops() const override;
@@ -133,10 +133,12 @@ class SqliteFaultStorage : public FaultStorage {
   /// Whether any fault at all still references @p file_path. Caller holds mutex_.
   bool path_referenced(const std::string & file_path) const;
 
-  /// Delete ended windows, oldest declaration first, until at most
-  /// max_planned_stops_ rows remain. Returns how many rows went. @p exempt_id is
-  /// never deleted. Caller holds mutex_.
-  size_t prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id = {});
+  /// Delete ended windows, oldest declaration first, until at most @p target
+  /// rows remain. Returns how many rows went. Caller holds mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns, size_t target);
+
+  /// Number of stored windows. Caller holds mutex_.
+  size_t planned_stop_count_locked() const;
 
   /// store_rosbag_file body without taking mutex_. Caller holds mutex_ and
   /// unlinks the returned replaced-bag path once the row change is durable.

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
@@ -96,7 +96,7 @@ class SqliteFaultStorage : public FaultStorage {
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
   bool declare_planned_stop(const PlannedStopWindow & window) override;
-  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) override;
+  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) override;
   std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
   std::vector<PlannedStopWindow> list_planned_stops() const override;
   size_t set_max_planned_stops(size_t max_count, int64_t now_ns) override;

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
@@ -134,9 +134,9 @@ class SqliteFaultStorage : public FaultStorage {
   bool path_referenced(const std::string & file_path) const;
 
   /// Delete ended windows, oldest declaration first, until at most
-  /// max_planned_stops_ rows remain. Returns how many rows went. Caller holds
-  /// mutex_.
-  size_t prune_planned_stops_locked(int64_t now_ns);
+  /// max_planned_stops_ rows remain. Returns how many rows went. @p exempt_id is
+  /// never deleted. Caller holds mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id = {});
 
   /// store_rosbag_file body without taking mutex_. Caller holds mutex_ and
   /// unlinks the returned replaced-bag path once the row change is durable.

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/sqlite_fault_storage.hpp
@@ -95,6 +95,12 @@ class SqliteFaultStorage : public FaultStorage {
   std::vector<ros2_medkit_msgs::msg::Fault> get_all_faults() const override;
   std::vector<std::string> reclassify_healed_as_cleared() override;
 
+  bool declare_planned_stop(const PlannedStopWindow & window) override;
+  EndPlannedStopResult end_planned_stop(const std::string & id, int64_t at_ns) override;
+  std::optional<PlannedStopWindow> get_planned_stop(const std::string & id) const override;
+  std::vector<PlannedStopWindow> list_planned_stops() const override;
+  size_t set_max_planned_stops(size_t max_count, int64_t now_ns) override;
+
   /// Get the database path
   const std::string & db_path() const {
     return db_path_;
@@ -126,6 +132,11 @@ class SqliteFaultStorage : public FaultStorage {
 
   /// Whether any fault at all still references @p file_path. Caller holds mutex_.
   bool path_referenced(const std::string & file_path) const;
+
+  /// Delete ended windows, oldest declaration first, until at most
+  /// max_planned_stops_ rows remain. Returns how many rows went. Caller holds
+  /// mutex_.
+  size_t prune_planned_stops_locked(int64_t now_ns);
 
   /// store_rosbag_file body without taking mutex_. Caller holds mutex_ and
   /// unlinks the returned replaced-bag path once the row change is durable.
@@ -172,6 +183,7 @@ class SqliteFaultStorage : public FaultStorage {
   /// Defaults to 1, the pre-#620 behaviour: a new recording replaces the old one.
   /// 0 = unlimited, bounded only by max_total_storage_mb.
   size_t max_rosbags_per_fault_{1};
+  size_t max_planned_stops_{static_cast<size_t>(kDefaultPlannedStopWindows)};
 };
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/time_utils.hpp
+++ b/src/ros2_medkit_fault_manager/include/ros2_medkit_fault_manager/time_utils.hpp
@@ -14,9 +14,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
+#include <limits>
 
 #include "rclcpp/rclcpp.hpp"
+#include "builtin_interfaces/msg/time.hpp"
 
 namespace ros2_medkit_fault_manager {
 
@@ -31,6 +35,39 @@ inline int64_t get_wall_clock_ns() {
 /// This is not affected by use_sim_time parameter.
 inline rclcpp::Time get_wall_clock_time() {
   return rclcpp::Time(get_wall_clock_ns(), RCL_SYSTEM_TIME);
+}
+
+/// builtin_interfaces/Time -> nanoseconds since the Unix epoch.
+inline int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
+  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
+}
+
+/// Nanoseconds since the Unix epoch -> builtin_interfaces/Time.
+///
+/// Floor division, not C's truncation towards zero. `nanosec` is UNSIGNED, so
+/// for an instant before the epoch the remainder is negative and casting it
+/// yields nanosec near 4e9 - a message that is not a time at all and that no
+/// reader can interpret. -1 ns is second -1 plus 999999999 ns, and that is what
+/// this returns.
+///
+/// The seconds are clamped to what the int32 field can carry. A caller must not
+/// hand this an instant outside that range - the API refuses those long before
+/// here - but saturating is the one behaviour that cannot turn an absurd input
+/// into a plausible-looking output.
+inline builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
+  constexpr int64_t kNsPerSec = 1000000000LL;
+  int64_t sec = ns / kNsPerSec;
+  int64_t nsec = ns % kNsPerSec;
+  if (nsec < 0) {
+    nsec += kNsPerSec;
+    --sec;
+  }
+
+  builtin_interfaces::msg::Time t;
+  t.sec = static_cast<int32_t>(
+      std::clamp<int64_t>(sec, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()));
+  t.nanosec = static_cast<uint32_t>(nsec);
+  return t;
 }
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -1677,6 +1677,7 @@ ros2_medkit_msgs::msg::PlannedStop window_to_msg(const PlannedStopWindow & w) {
   msg.declared_by = w.declared_by;
   msg.declared_at = ns_to_time_msg(w.declared_at_ns);
   msg.ended_early = w.ended_early;
+  msg.cancelled = w.cancelled;
   return msg;
 }
 
@@ -1685,20 +1686,31 @@ ros2_medkit_msgs::msg::PlannedStop window_to_msg(const PlannedStopWindow & w) {
 void FaultManagerNode::handle_declare_planned_stop(
     const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Request> & request,
     const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Response> & response) {
+  using Response = ros2_medkit_msgs::srv::DeclarePlannedStop::Response;
   const int64_t now_ns = get_wall_clock_ns();
 
   PlannedStopWindow window;
-  // A zero start means "now": declaring a stop as it begins is the common case
-  // and typing the current instant into the request would only add a race.
-  const int64_t requested_start = time_msg_to_ns(request->starts_at);
-  window.starts_at_ns = requested_start == 0 ? now_ns : requested_start;
+  window.starts_at_ns = time_msg_to_ns(request->starts_at);
   window.ends_at_ns = time_msg_to_ns(request->ends_at);
   window.reason = request->reason;
   window.declared_by = request->declared_by.empty() ? std::string("anonymous") : request->declared_by;
   window.declared_at_ns = now_ns;
 
+  // Zero is NOT "now". It is what an unset builtin_interfaces/Time reads as, and
+  // a sentinel that is also a legal value cannot tell a caller who meant the
+  // epoch from one who filled in nothing. A caller who wants the current instant
+  // sends the current instant; the gateway does exactly that when a REST body
+  // omits `from`.
+  if (window.starts_at_ns <= 0 || window.ends_at_ns <= 0) {
+    response->success = false;
+    response->outcome = Response::OUTCOME_INVALID_INSTANT;
+    response->message = "starts_at and ends_at must be after the Unix epoch";
+    return;
+  }
+
   if (window.ends_at_ns <= window.starts_at_ns) {
     response->success = false;
+    response->outcome = Response::OUTCOME_INVALID_INTERVAL;
     response->message = "ends_at must be strictly after starts_at";
     return;
   }
@@ -1707,13 +1719,28 @@ void FaultManagerNode::handle_declare_planned_stop(
 
   if (!storage_->declare_planned_stop(window)) {
     response->success = false;
+    response->outcome = Response::OUTCOME_DUPLICATE_ID;
     response->message = "a planned stop with id '" + window.id + "' already exists";
     return;
   }
 
+  // Read back rather than assume. The declaration is exempt from the pruning it
+  // triggers, so this should never fire - but "should never" is exactly the
+  // claim that once let the service answer success with a window that was
+  // inserted, immediately evicted, and then answered 404 on its own Location.
   auto stored = storage_->get_planned_stop(window.id);
+  if (!stored.has_value()) {
+    response->success = false;
+    response->outcome = Response::OUTCOME_NOT_RETAINED;
+    response->message = "planned stop '" + window.id + "' was not retained by the configured bound";
+    RCLCPP_WARN(get_logger(), "Planned stop '%s' was not retained; planned_stop.max_windows may be too small",
+                window.id.c_str());
+    return;
+  }
+
   response->success = true;
-  response->stop = window_to_msg(stored.value_or(window));
+  response->outcome = Response::OUTCOME_STORED;
+  response->stop = window_to_msg(*stored);
   RCLCPP_INFO(get_logger(), "Planned stop '%s' declared by '%s': %s", window.id.c_str(), window.declared_by.c_str(),
               window.reason.c_str());
 }
@@ -1721,24 +1748,45 @@ void FaultManagerNode::handle_declare_planned_stop(
 void FaultManagerNode::handle_end_planned_stop(
     const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Request> & request,
     const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Response> & response) {
+  using Response = ros2_medkit_msgs::srv::EndPlannedStop::Response;
   const int64_t requested_at = time_msg_to_ns(request->at);
+
+  // Zero here means "the fault manager's own wall clock", and unlike a window
+  // BOUND that is not a value anyone can mean: `at` names the moment of this
+  // request, and the clock that moment has to be measured against is the one the
+  // fault timestamps come from. A negative instant is still refused.
+  if (requested_at < 0) {
+    response->success = false;
+    response->outcome = Response::OUTCOME_NOT_FOUND;
+    response->message = "at must not be before the Unix epoch";
+    return;
+  }
   const int64_t at_ns = requested_at == 0 ? get_wall_clock_ns() : requested_at;
 
   const auto result = storage_->end_planned_stop(request->id, at_ns);
   switch (result.outcome) {
     case EndPlannedStopOutcome::Ended:
       response->success = true;
+      response->outcome = Response::OUTCOME_ENDED;
       response->stop = window_to_msg(result.window);
       RCLCPP_INFO(get_logger(), "Planned stop '%s' ended early", request->id.c_str());
       return;
+    case EndPlannedStopOutcome::Cancelled:
+      response->success = true;
+      response->outcome = Response::OUTCOME_CANCELLED;
+      response->stop = window_to_msg(result.window);
+      RCLCPP_INFO(get_logger(), "Planned stop '%s' cancelled before it started", request->id.c_str());
+      return;
     case EndPlannedStopOutcome::AlreadyEnded:
       response->success = false;
+      response->outcome = Response::OUTCOME_ALREADY_ENDED;
       response->message = "planned stop '" + request->id + "' has already ended";
       response->stop = window_to_msg(result.window);
       return;
     case EndPlannedStopOutcome::NotFound:
     default:
       response->success = false;
+      response->outcome = Response::OUTCOME_NOT_FOUND;
       response->message = "no planned stop with id '" + request->id + "'";
       return;
   }

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -217,6 +217,10 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
   // Planned-stop retention. Bounded by COUNT rather than by age: a window that
   // has ended is still the reason a fault from last month reads as expected, so
   // it cannot be dropped for being old, only for being one of too many.
+  //
+  // The bound counts windows that are NO LONGER ACTIVE. An active window is
+  // always kept and is never dropped to make room, so the table holds at most
+  // this many plus however many windows are currently running.
   // declare_parameter<int64_t> deliberately: <int> narrows silently, so a value
   // above INT_MAX would wrap back into the legal band and pass the range check.
   bool planned_stop_bound_clamped = false;
@@ -1749,6 +1753,7 @@ void FaultManagerNode::handle_end_planned_stop(
     const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Request> & request,
     const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Response> & response) {
   using Response = ros2_medkit_msgs::srv::EndPlannedStop::Response;
+  const int64_t now_ns = get_wall_clock_ns();
   const int64_t requested_at = time_msg_to_ns(request->at);
 
   // Zero here means "the fault manager's own wall clock", and unlike a window
@@ -1757,13 +1762,15 @@ void FaultManagerNode::handle_end_planned_stop(
   // fault timestamps come from. A negative instant is still refused.
   if (requested_at < 0) {
     response->success = false;
-    response->outcome = Response::OUTCOME_NOT_FOUND;
+    response->outcome = Response::OUTCOME_INVALID_AT;
     response->message = "at must not be before the Unix epoch";
     return;
   }
-  const int64_t at_ns = requested_at == 0 ? get_wall_clock_ns() : requested_at;
+  const int64_t at_ns = requested_at == 0 ? now_ns : requested_at;
 
-  const auto result = storage_->end_planned_stop(request->id, at_ns);
+  // now_ns decides which situation the window is in; at_ns only refines where a
+  // running one ends.
+  const auto result = storage_->end_planned_stop(request->id, at_ns, now_ns);
   switch (result.outcome) {
     case EndPlannedStopOutcome::Ended:
       response->success = true;
@@ -1781,6 +1788,12 @@ void FaultManagerNode::handle_end_planned_stop(
       response->success = false;
       response->outcome = Response::OUTCOME_ALREADY_ENDED;
       response->message = "planned stop '" + request->id + "' has already ended";
+      response->stop = window_to_msg(result.window);
+      return;
+    case EndPlannedStopOutcome::InvalidAt:
+      response->success = false;
+      response->outcome = Response::OUTCOME_INVALID_AT;
+      response->message = "at must lie between the window's start and now";
       response->stop = window_to_msg(result.window);
       return;
     case EndPlannedStopOutcome::NotFound:

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -1664,20 +1664,9 @@ void FaultManagerNode::handle_list_rosbags(
 
 namespace {
 
-/// builtin_interfaces/Time -> nanoseconds since the Unix epoch.
-int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
-  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
-}
-
-/// nanoseconds since the Unix epoch -> builtin_interfaces/Time.
-builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
-  builtin_interfaces::msg::Time t;
-  const int64_t sec = ns / 1000000000LL;
-  const int64_t nsec = ns % 1000000000LL;
-  t.sec = static_cast<int32_t>(sec);
-  t.nanosec = static_cast<uint32_t>(nsec);
-  return t;
-}
+// time_msg_to_ns / ns_to_time_msg live in time_utils.hpp: the conversion has to
+// be floor division for an instant before the epoch, and one copy of that rule
+// is easier to keep right than two.
 
 ros2_medkit_msgs::msg::PlannedStop window_to_msg(const PlannedStopWindow & w) {
   ros2_medkit_msgs::msg::PlannedStop msg;

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -1758,11 +1758,24 @@ void FaultManagerNode::handle_declare_planned_stop(
 
   window.id = std::to_string(now_ns) + "-" + std::to_string(planned_stop_seq_.fetch_add(1) + 1);
 
-  if (!storage_->declare_planned_stop(window)) {
-    response->success = false;
-    response->outcome = Response::OUTCOME_DUPLICATE_ID;
-    response->message = "a planned stop with id '" + window.id + "' already exists";
-    return;
+  switch (storage_->declare_planned_stop(window)) {
+    case DeclarePlannedStopOutcome::DuplicateId:
+      response->success = false;
+      response->outcome = Response::OUTCOME_DUPLICATE_ID;
+      response->message = "a planned stop with id '" + window.id + "' already exists";
+      return;
+    case DeclarePlannedStopOutcome::CapFull:
+      response->success = false;
+      response->outcome = Response::OUTCOME_NOT_RETAINED;
+      response->message = "planned_stop.max_windows is full of windows that have not ended; end one or raise the bound";
+      RCLCPP_WARN(get_logger(),
+                  "Planned stop refused: all %zu retained windows have yet to end. Raise "
+                  "planned_stop.max_windows or end one.",
+                  static_cast<size_t>(storage_->list_planned_stops().size()));
+      return;
+    case DeclarePlannedStopOutcome::Stored:
+    default:
+      break;
   }
 
   // Read back rather than assume. The declaration is exempt from the pruning it
@@ -1849,7 +1862,11 @@ void FaultManagerNode::handle_list_planned_stops(
   const int64_t now_ns = requested_now == 0 ? get_wall_clock_ns() : requested_now;
 
   for (const auto & window : storage_->list_planned_stops()) {
-    if (request->active_only && !window.covers(now_ns)) {
+    // "Active" is "has not ended", the same notion retention and the end guards
+    // use. Filtering on covers(now) instead hid exactly the windows that are
+    // unprunable - the ones that have not started - so an operator could not
+    // enumerate what was holding the bound.
+    if (request->active_only && !window.active_at(now_ns)) {
       continue;
     }
     response->stops.push_back(window_to_msg(window));

--- a/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_manager_node.cpp
@@ -32,6 +32,7 @@
 #include "ros2_medkit_msgs/msg/environment_data.hpp"
 #include "ros2_medkit_msgs/msg/extended_data_records.hpp"
 #include "ros2_medkit_msgs/msg/muted_fault_info.hpp"
+#include "ros2_medkit_msgs/msg/planned_stop.hpp"
 #include "ros2_medkit_msgs/msg/snapshot.hpp"
 
 namespace ros2_medkit_fault_manager {
@@ -213,6 +214,19 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
     max_near_misses = kDefaultMaxNearMissesPerFault;
   }
 
+  // Planned-stop retention. Bounded by COUNT rather than by age: a window that
+  // has ended is still the reason a fault from last month reads as expected, so
+  // it cannot be dropped for being old, only for being one of too many.
+  // declare_parameter<int64_t> deliberately: <int> narrows silently, so a value
+  // above INT_MAX would wrap back into the legal band and pass the range check.
+  bool planned_stop_bound_clamped = false;
+  const int64_t max_planned_stops = clamp_planned_stop_windows(
+      declare_parameter<int64_t>("planned_stop.max_windows", kDefaultPlannedStopWindows), planned_stop_bound_clamped);
+  if (planned_stop_bound_clamped) {
+    RCLCPP_WARN(get_logger(), "planned_stop.max_windows must be in [%ld, %ld]. Using %ld.", kMinPlannedStopWindows,
+                kMaxPlannedStopWindows, max_planned_stops);
+  }
+
   // Create storage backend
   storage_ = create_storage();
 
@@ -235,6 +249,17 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
                 "near_miss.max_per_fault=%ld dropped %zu stored near-miss entries that exceeded the bound. "
                 "Raise the bound or set it to 0 before restarting if that history was needed.",
                 max_near_misses, evicted_near_misses);
+  }
+
+  // Apply the planned-stop bound. Applying it also trims what a previous run left
+  // over a now-smaller bound, which deletes declarations for good, so say when it does.
+  const size_t evicted_windows =
+      storage_->set_max_planned_stops(static_cast<size_t>(max_planned_stops), get_wall_clock_ns());
+  if (evicted_windows > 0) {
+    RCLCPP_WARN(get_logger(),
+                "planned_stop.max_windows=%ld dropped %zu stored planned-stop windows that exceeded the bound. "
+                "Faults whose cycle started inside a dropped window no longer read as expected.",
+                max_planned_stops, evicted_windows);
   }
 
   // Create event publisher for SSE streaming
@@ -362,6 +387,26 @@ FaultManagerNode::FaultManagerNode(const rclcpp::NodeOptions & options) : Node("
       [this](const std::shared_ptr<ros2_medkit_msgs::srv::ListFaultsForEntity::Request> & request,
              const std::shared_ptr<ros2_medkit_msgs::srv::ListFaultsForEntity::Response> & response) {
         handle_list_faults_for_entity(request, response);
+      });
+
+  declare_planned_stop_srv_ = create_service<ros2_medkit_msgs::srv::DeclarePlannedStop>(
+      "~/declare_planned_stop",
+      [this](const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Request> & request,
+             const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Response> & response) {
+        handle_declare_planned_stop(request, response);
+      });
+
+  end_planned_stop_srv_ = create_service<ros2_medkit_msgs::srv::EndPlannedStop>(
+      "~/end_planned_stop", [this](const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Request> & request,
+                                   const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Response> & response) {
+        handle_end_planned_stop(request, response);
+      });
+
+  list_planned_stops_srv_ = create_service<ros2_medkit_msgs::srv::ListPlannedStops>(
+      "~/list_planned_stops",
+      [this](const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Request> & request,
+             const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Response> & response) {
+        handle_list_planned_stops(request, response);
       });
 
   // Initialize snapshot capture
@@ -1605,6 +1650,123 @@ void FaultManagerNode::handle_list_rosbags(
   response->success = true;
   RCLCPP_DEBUG(get_logger(), "ListRosbags returned %zu rosbags for entity '%s'", response->fault_codes.size(),
                request->entity_fqn.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// Planned-stop windows
+//
+// These three handlers are the only code in the fault manager that touches a
+// window. Nothing on the report / confirm / heal / clear path consults them: an
+// expected fault takes exactly the same journey through storage, debounce,
+// capture and the audit log as any other, and the window only lets a reader tell
+// the two apart afterwards.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// builtin_interfaces/Time -> nanoseconds since the Unix epoch.
+int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
+  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
+}
+
+/// nanoseconds since the Unix epoch -> builtin_interfaces/Time.
+builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
+  builtin_interfaces::msg::Time t;
+  const int64_t sec = ns / 1000000000LL;
+  const int64_t nsec = ns % 1000000000LL;
+  t.sec = static_cast<int32_t>(sec);
+  t.nanosec = static_cast<uint32_t>(nsec);
+  return t;
+}
+
+ros2_medkit_msgs::msg::PlannedStop window_to_msg(const PlannedStopWindow & w) {
+  ros2_medkit_msgs::msg::PlannedStop msg;
+  msg.id = w.id;
+  msg.starts_at = ns_to_time_msg(w.starts_at_ns);
+  msg.ends_at = ns_to_time_msg(w.ends_at_ns);
+  msg.reason = w.reason;
+  msg.declared_by = w.declared_by;
+  msg.declared_at = ns_to_time_msg(w.declared_at_ns);
+  msg.ended_early = w.ended_early;
+  return msg;
+}
+
+}  // namespace
+
+void FaultManagerNode::handle_declare_planned_stop(
+    const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Request> & request,
+    const std::shared_ptr<ros2_medkit_msgs::srv::DeclarePlannedStop::Response> & response) {
+  const int64_t now_ns = get_wall_clock_ns();
+
+  PlannedStopWindow window;
+  // A zero start means "now": declaring a stop as it begins is the common case
+  // and typing the current instant into the request would only add a race.
+  const int64_t requested_start = time_msg_to_ns(request->starts_at);
+  window.starts_at_ns = requested_start == 0 ? now_ns : requested_start;
+  window.ends_at_ns = time_msg_to_ns(request->ends_at);
+  window.reason = request->reason;
+  window.declared_by = request->declared_by.empty() ? std::string("anonymous") : request->declared_by;
+  window.declared_at_ns = now_ns;
+
+  if (window.ends_at_ns <= window.starts_at_ns) {
+    response->success = false;
+    response->message = "ends_at must be strictly after starts_at";
+    return;
+  }
+
+  window.id = std::to_string(now_ns) + "-" + std::to_string(planned_stop_seq_.fetch_add(1) + 1);
+
+  if (!storage_->declare_planned_stop(window)) {
+    response->success = false;
+    response->message = "a planned stop with id '" + window.id + "' already exists";
+    return;
+  }
+
+  auto stored = storage_->get_planned_stop(window.id);
+  response->success = true;
+  response->stop = window_to_msg(stored.value_or(window));
+  RCLCPP_INFO(get_logger(), "Planned stop '%s' declared by '%s': %s", window.id.c_str(), window.declared_by.c_str(),
+              window.reason.c_str());
+}
+
+void FaultManagerNode::handle_end_planned_stop(
+    const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Request> & request,
+    const std::shared_ptr<ros2_medkit_msgs::srv::EndPlannedStop::Response> & response) {
+  const int64_t requested_at = time_msg_to_ns(request->at);
+  const int64_t at_ns = requested_at == 0 ? get_wall_clock_ns() : requested_at;
+
+  const auto result = storage_->end_planned_stop(request->id, at_ns);
+  switch (result.outcome) {
+    case EndPlannedStopOutcome::Ended:
+      response->success = true;
+      response->stop = window_to_msg(result.window);
+      RCLCPP_INFO(get_logger(), "Planned stop '%s' ended early", request->id.c_str());
+      return;
+    case EndPlannedStopOutcome::AlreadyEnded:
+      response->success = false;
+      response->message = "planned stop '" + request->id + "' has already ended";
+      response->stop = window_to_msg(result.window);
+      return;
+    case EndPlannedStopOutcome::NotFound:
+    default:
+      response->success = false;
+      response->message = "no planned stop with id '" + request->id + "'";
+      return;
+  }
+}
+
+void FaultManagerNode::handle_list_planned_stops(
+    const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Request> & request,
+    const std::shared_ptr<ros2_medkit_msgs::srv::ListPlannedStops::Response> & response) {
+  const int64_t requested_now = time_msg_to_ns(request->now);
+  const int64_t now_ns = requested_now == 0 ? get_wall_clock_ns() : requested_now;
+
+  for (const auto & window : storage_->list_planned_stops()) {
+    if (request->active_only && !window.covers(now_ns)) {
+      continue;
+    }
+    response->stops.push_back(window_to_msg(window));
+  }
 }
 
 void FaultManagerNode::handle_list_faults_for_entity(

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -879,19 +879,29 @@ std::vector<std::string> InMemoryFaultStorage::reclassify_healed_as_cleared() {
 // Planned-stop windows
 // ---------------------------------------------------------------------------
 
-bool InMemoryFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
+DeclarePlannedStopOutcome InMemoryFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   const bool exists = std::any_of(planned_stops_.begin(), planned_stops_.end(), [&window](const PlannedStopWindow & w) {
     return w.id == window.id;
   });
   if (exists) {
-    return false;
+    return DeclarePlannedStopOutcome::DuplicateId;
+  }
+
+  // Room first, then the insert. The row cannot be evicted by its own
+  // declaration this way, and the bound stays hard: if pruning the ended windows
+  // does not free a slot, every stored window has yet to end and there is
+  // nowhere to put this one.
+  if (max_planned_stops_ > 0) {
+    prune_planned_stops_locked(window.declared_at_ns, max_planned_stops_ - 1);
+    if (planned_stops_.size() >= max_planned_stops_) {
+      return DeclarePlannedStopOutcome::CapFull;
+    }
   }
 
   planned_stops_.push_back(window);
-  prune_planned_stops_locked(window.declared_at_ns, window.id);
-  return true;
+  return DeclarePlannedStopOutcome::Stored;
 }
 
 EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) {
@@ -917,7 +927,10 @@ EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & 
     planned_stops_.erase(it);
     return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, cancelled};
   }
-  if (at_ns < it->starts_at_ns || at_ns > now_ns) {
+  // Strictly after the start: ending AT the start would store
+  // ends_at == starts_at, which is not an interval and which the message
+  // promises can never happen.
+  if (at_ns <= it->starts_at_ns || at_ns > now_ns) {
     return EndPlannedStopResult{EndPlannedStopOutcome::InvalidAt, *it};
   }
 
@@ -956,19 +969,22 @@ std::vector<PlannedStopWindow> InMemoryFaultStorage::list_planned_stops() const 
 size_t InMemoryFaultStorage::set_max_planned_stops(size_t max_count, int64_t now_ns) {
   std::lock_guard<std::mutex> lock(mutex_);
   max_planned_stops_ = max_count;
-  return prune_planned_stops_locked(now_ns);
+  return prune_planned_stops_locked(now_ns, max_count);
 }
 
-size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id) {
-  if (max_planned_stops_ == 0 || planned_stops_.size() <= max_planned_stops_) {
+size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns, size_t target) {
+  if (max_planned_stops_ == 0 || planned_stops_.size() <= target) {
     return 0;
   }
 
   // Prune candidates: windows that have already ended, oldest declaration first.
+  // A window that has not ended is never a candidate - it must not vanish under
+  // the operator who declared it - which is why a table with nothing but those
+  // in it refuses new declarations instead of growing.
   std::vector<size_t> candidates;
   candidates.reserve(planned_stops_.size());
   for (size_t i = 0; i < planned_stops_.size(); ++i) {
-    if (!planned_stops_[i].active_at(now_ns) && planned_stops_[i].id != exempt_id) {
+    if (!planned_stops_[i].active_at(now_ns)) {
       candidates.push_back(i);
     }
   }
@@ -979,7 +995,7 @@ size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns, const st
     return planned_stops_[a].id < planned_stops_[b].id;
   });
 
-  const size_t over = planned_stops_.size() - max_planned_stops_;
+  const size_t over = planned_stops_.size() - target;
   const size_t to_drop = std::min(over, candidates.size());
   if (to_drop == 0) {
     return 0;

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -894,7 +894,7 @@ bool InMemoryFaultStorage::declare_planned_stop(const PlannedStopWindow & window
   return true;
 }
 
-EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns) {
+EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   auto it = std::find_if(planned_stops_.begin(), planned_stops_.end(), [&id](const PlannedStopWindow & w) {
@@ -903,15 +903,22 @@ EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & 
   if (it == planned_stops_.end()) {
     return EndPlannedStopResult{EndPlannedStopOutcome::NotFound, {}};
   }
-  if (at_ns < it->starts_at_ns) {
+
+  // Every branch below tests now_ns, never at_ns. See the contract on
+  // FaultStorage::end_planned_stop for why: judging on the supplied instant let
+  // the caller choose which of the three situations the window was in.
+  if (!it->active_at(now_ns)) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, *it};
+  }
+  if (it->starts_at_ns > now_ns) {
     // It never started: cancelled, not ended early.
     PlannedStopWindow cancelled = *it;
     cancelled.cancelled = true;
     planned_stops_.erase(it);
     return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, cancelled};
   }
-  if (it->ended_early || !it->active_at(at_ns)) {
-    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, *it};
+  if (at_ns < it->starts_at_ns || at_ns > now_ns) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::InvalidAt, *it};
   }
 
   it->ends_at_ns = at_ns;

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -890,7 +890,7 @@ bool InMemoryFaultStorage::declare_planned_stop(const PlannedStopWindow & window
   }
 
   planned_stops_.push_back(window);
-  prune_planned_stops_locked(window.declared_at_ns);
+  prune_planned_stops_locked(window.declared_at_ns, window.id);
   return true;
 }
 
@@ -903,7 +903,14 @@ EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & 
   if (it == planned_stops_.end()) {
     return EndPlannedStopResult{EndPlannedStopOutcome::NotFound, {}};
   }
-  if (!it->active_at(at_ns)) {
+  if (at_ns < it->starts_at_ns) {
+    // It never started: cancelled, not ended early.
+    PlannedStopWindow cancelled = *it;
+    cancelled.cancelled = true;
+    planned_stops_.erase(it);
+    return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, cancelled};
+  }
+  if (it->ended_early || !it->active_at(at_ns)) {
     return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, *it};
   }
 
@@ -945,7 +952,7 @@ size_t InMemoryFaultStorage::set_max_planned_stops(size_t max_count, int64_t now
   return prune_planned_stops_locked(now_ns);
 }
 
-size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
+size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id) {
   if (max_planned_stops_ == 0 || planned_stops_.size() <= max_planned_stops_) {
     return 0;
   }
@@ -954,7 +961,7 @@ size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
   std::vector<size_t> candidates;
   candidates.reserve(planned_stops_.size());
   for (size_t i = 0; i < planned_stops_.size(); ++i) {
-    if (!planned_stops_[i].active_at(now_ns)) {
+    if (!planned_stops_[i].active_at(now_ns) && planned_stops_[i].id != exempt_id) {
       candidates.push_back(i);
     }
   }

--- a/src/ros2_medkit_fault_manager/src/fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/fault_storage.cpp
@@ -875,4 +875,112 @@ std::vector<std::string> InMemoryFaultStorage::reclassify_healed_as_cleared() {
   return reclassified;
 }
 
+// ---------------------------------------------------------------------------
+// Planned-stop windows
+// ---------------------------------------------------------------------------
+
+bool InMemoryFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  const bool exists = std::any_of(planned_stops_.begin(), planned_stops_.end(), [&window](const PlannedStopWindow & w) {
+    return w.id == window.id;
+  });
+  if (exists) {
+    return false;
+  }
+
+  planned_stops_.push_back(window);
+  prune_planned_stops_locked(window.declared_at_ns);
+  return true;
+}
+
+EndPlannedStopResult InMemoryFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = std::find_if(planned_stops_.begin(), planned_stops_.end(), [&id](const PlannedStopWindow & w) {
+    return w.id == id;
+  });
+  if (it == planned_stops_.end()) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::NotFound, {}};
+  }
+  if (!it->active_at(at_ns)) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, *it};
+  }
+
+  it->ends_at_ns = at_ns;
+  it->ended_early = true;
+  return EndPlannedStopResult{EndPlannedStopOutcome::Ended, *it};
+}
+
+std::optional<PlannedStopWindow> InMemoryFaultStorage::get_planned_stop(const std::string & id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  auto it = std::find_if(planned_stops_.begin(), planned_stops_.end(), [&id](const PlannedStopWindow & w) {
+    return w.id == id;
+  });
+  if (it == planned_stops_.end()) {
+    return std::nullopt;
+  }
+  return *it;
+}
+
+std::vector<PlannedStopWindow> InMemoryFaultStorage::list_planned_stops() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  std::vector<PlannedStopWindow> out(planned_stops_.begin(), planned_stops_.end());
+  // Newest declaration first, ties broken by id so two windows declared in the
+  // same nanosecond do not order differently from one call to the next.
+  std::stable_sort(out.begin(), out.end(), [](const PlannedStopWindow & a, const PlannedStopWindow & b) {
+    if (a.declared_at_ns != b.declared_at_ns) {
+      return a.declared_at_ns > b.declared_at_ns;
+    }
+    return a.id > b.id;
+  });
+  return out;
+}
+
+size_t InMemoryFaultStorage::set_max_planned_stops(size_t max_count, int64_t now_ns) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  max_planned_stops_ = max_count;
+  return prune_planned_stops_locked(now_ns);
+}
+
+size_t InMemoryFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
+  if (max_planned_stops_ == 0 || planned_stops_.size() <= max_planned_stops_) {
+    return 0;
+  }
+
+  // Prune candidates: windows that have already ended, oldest declaration first.
+  std::vector<size_t> candidates;
+  candidates.reserve(planned_stops_.size());
+  for (size_t i = 0; i < planned_stops_.size(); ++i) {
+    if (!planned_stops_[i].active_at(now_ns)) {
+      candidates.push_back(i);
+    }
+  }
+  std::sort(candidates.begin(), candidates.end(), [this](size_t a, size_t b) {
+    if (planned_stops_[a].declared_at_ns != planned_stops_[b].declared_at_ns) {
+      return planned_stops_[a].declared_at_ns < planned_stops_[b].declared_at_ns;
+    }
+    return planned_stops_[a].id < planned_stops_[b].id;
+  });
+
+  const size_t over = planned_stops_.size() - max_planned_stops_;
+  const size_t to_drop = std::min(over, candidates.size());
+  if (to_drop == 0) {
+    return 0;
+  }
+
+  std::set<std::string> doomed;
+  for (size_t i = 0; i < to_drop; ++i) {
+    doomed.insert(planned_stops_[candidates[i]].id);
+  }
+  planned_stops_.erase(std::remove_if(planned_stops_.begin(), planned_stops_.end(),
+                                      [&doomed](const PlannedStopWindow & w) {
+                                        return doomed.count(w.id) > 0;
+                                      }),
+                       planned_stops_.end());
+  return to_drop;
+}
+
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -1943,7 +1943,7 @@ bool SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) 
     throw std::runtime_error(std::string("Failed to insert planned stop: ") + sqlite3_errmsg(db_));
   }
 
-  prune_planned_stops_locked(window.declared_at_ns);
+  prune_planned_stops_locked(window.declared_at_ns, window.id);
   return true;
 }
 
@@ -1961,7 +1961,17 @@ EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id
     current = read_planned_stop_row(stmt);
   }
 
-  if (!current.active_at(at_ns)) {
+  if (at_ns < current.starts_at_ns) {
+    // It never started: cancelled, not ended early.
+    SqliteStatement remove(db_, "DELETE FROM planned_stops WHERE id = ?");
+    remove.bind_text(1, id);
+    if (remove.step() != SQLITE_DONE) {
+      throw std::runtime_error(std::string("Failed to cancel planned stop: ") + sqlite3_errmsg(db_));
+    }
+    current.cancelled = true;
+    return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, current};
+  }
+  if (current.ended_early || !current.active_at(at_ns)) {
     return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, current};
   }
 
@@ -2012,7 +2022,7 @@ size_t SqliteFaultStorage::set_max_planned_stops(size_t max_count, int64_t now_n
   return prune_planned_stops_locked(now_ns);
 }
 
-size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
+size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id) {
   if (max_planned_stops_ == 0) {
     return 0;
   }
@@ -2037,11 +2047,12 @@ size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
   // pruned, so the row count can stay above the bound while many are live.
   SqliteStatement del(db_,
                       "DELETE FROM planned_stops WHERE id IN ("
-                      "  SELECT id FROM planned_stops WHERE ends_at_ns <= ?"
+                      "  SELECT id FROM planned_stops WHERE ends_at_ns <= ? AND id != ?"
                       "  ORDER BY declared_at_ns ASC, id ASC LIMIT ?"
                       ")");
   del.bind_int64(1, now_ns);
-  del.bind_int64(2, static_cast<int64_t>(over));
+  del.bind_text(2, exempt_id);
+  del.bind_int64(3, static_cast<int64_t>(over));
   if (del.step() != SQLITE_DONE) {
     throw std::runtime_error(std::string("Failed to prune planned stops: ") + sqlite3_errmsg(db_));
   }

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -1917,14 +1917,33 @@ constexpr const char * kPlannedStopColumns =
 
 }  // namespace
 
-bool SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
+size_t SqliteFaultStorage::planned_stop_count_locked() const {
+  SqliteStatement count(db_, "SELECT COUNT(*) FROM planned_stops");
+  if (count.step() != SQLITE_ROW) {
+    return 0;
+  }
+  return static_cast<size_t>(std::max<int64_t>(0, count.column_int64(0)));
+}
+
+DeclarePlannedStopOutcome SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   {
     SqliteStatement exists(db_, "SELECT 1 FROM planned_stops WHERE id = ?");
     exists.bind_text(1, window.id);
     if (exists.step() == SQLITE_ROW) {
-      return false;
+      return DeclarePlannedStopOutcome::DuplicateId;
+    }
+  }
+
+  // Room first, then the insert. The row cannot be evicted by its own
+  // declaration this way, and the bound stays hard: if pruning the ended windows
+  // does not free a slot, every stored window has yet to end and there is
+  // nowhere to put this one.
+  if (max_planned_stops_ > 0) {
+    prune_planned_stops_locked(window.declared_at_ns, max_planned_stops_ - 1);
+    if (planned_stop_count_locked() >= max_planned_stops_) {
+      return DeclarePlannedStopOutcome::CapFull;
     }
   }
 
@@ -1943,8 +1962,7 @@ bool SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) 
     throw std::runtime_error(std::string("Failed to insert planned stop: ") + sqlite3_errmsg(db_));
   }
 
-  prune_planned_stops_locked(window.declared_at_ns, window.id);
-  return true;
+  return DeclarePlannedStopOutcome::Stored;
 }
 
 EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) {
@@ -1977,7 +1995,10 @@ EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id
     current.cancelled = true;
     return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, current};
   }
-  if (at_ns < current.starts_at_ns || at_ns > now_ns) {
+  // Strictly after the start: ending AT the start would store
+  // ends_at == starts_at, which is not an interval and which the message
+  // promises can never happen.
+  if (at_ns <= current.starts_at_ns || at_ns > now_ns) {
     return EndPlannedStopResult{EndPlannedStopOutcome::InvalidAt, current};
   }
 
@@ -2025,40 +2046,29 @@ std::vector<PlannedStopWindow> SqliteFaultStorage::list_planned_stops() const {
 size_t SqliteFaultStorage::set_max_planned_stops(size_t max_count, int64_t now_ns) {
   std::lock_guard<std::mutex> lock(mutex_);
   max_planned_stops_ = max_count;
-  return prune_planned_stops_locked(now_ns);
+  return prune_planned_stops_locked(now_ns, max_count);
 }
 
-size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns, const std::string & exempt_id) {
+size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns, size_t target) {
   if (max_planned_stops_ == 0) {
     return 0;
   }
 
-  size_t total = 0;
-  {
-    SqliteStatement count(db_, "SELECT COUNT(*) FROM planned_stops");
-    if (count.step() == SQLITE_ROW) {
-      total = static_cast<size_t>(std::max<int64_t>(0, count.column_int64(0)));
-    }
-  }
-  if (total <= max_planned_stops_) {
+  const size_t total = planned_stop_count_locked();
+  if (total <= target) {
     return 0;
   }
 
-  const size_t over = total - max_planned_stops_;
-  if (over > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
-    return 0;
-  }
-
-  // Only windows whose end has passed are candidates; a running window is never
-  // pruned, so the row count can stay above the bound while many are live.
+  // Only windows whose end has passed are candidates; one that has not ended is
+  // never pruned, which is why a table full of those refuses new declarations
+  // rather than growing past the bound.
   SqliteStatement del(db_,
                       "DELETE FROM planned_stops WHERE id IN ("
-                      "  SELECT id FROM planned_stops WHERE ends_at_ns <= ? AND id != ?"
+                      "  SELECT id FROM planned_stops WHERE ends_at_ns <= ?"
                       "  ORDER BY declared_at_ns ASC, id ASC LIMIT ?"
                       ")");
   del.bind_int64(1, now_ns);
-  del.bind_text(2, exempt_id);
-  del.bind_int64(3, static_cast<int64_t>(over));
+  del.bind_int64(2, static_cast<int64_t>(total - target));
   if (del.step() != SQLITE_DONE) {
     throw std::runtime_error(std::string("Failed to prune planned stops: ") + sqlite3_errmsg(db_));
   }

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -1947,7 +1947,7 @@ bool SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) 
   return true;
 }
 
-EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns) {
+EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns, int64_t now_ns) {
   std::lock_guard<std::mutex> lock(mutex_);
 
   PlannedStopWindow current;
@@ -1961,7 +1961,13 @@ EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id
     current = read_planned_stop_row(stmt);
   }
 
-  if (at_ns < current.starts_at_ns) {
+  // Every branch below tests now_ns, never at_ns. See the contract on
+  // FaultStorage::end_planned_stop for why: judging on the supplied instant let
+  // the caller choose which of the three situations the window was in.
+  if (!current.active_at(now_ns)) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, current};
+  }
+  if (current.starts_at_ns > now_ns) {
     // It never started: cancelled, not ended early.
     SqliteStatement remove(db_, "DELETE FROM planned_stops WHERE id = ?");
     remove.bind_text(1, id);
@@ -1971,8 +1977,8 @@ EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id
     current.cancelled = true;
     return EndPlannedStopResult{EndPlannedStopOutcome::Cancelled, current};
   }
-  if (current.ended_early || !current.active_at(at_ns)) {
-    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, current};
+  if (at_ns < current.starts_at_ns || at_ns > now_ns) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::InvalidAt, current};
   }
 
   SqliteStatement update(db_, "UPDATE planned_stops SET ends_at_ns = ?, ended_early = 1 WHERE id = ?");

--- a/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
+++ b/src/ros2_medkit_fault_manager/src/sqlite_fault_storage.cpp
@@ -14,6 +14,7 @@
 
 #include "ros2_medkit_fault_manager/sqlite_fault_storage.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <limits>
 #include <set>
@@ -293,6 +294,33 @@ void SqliteFaultStorage::initialize_schema() {
     std::string error = err_msg ? err_msg : "Unknown error";
     sqlite3_free(err_msg);
     throw std::runtime_error("Failed to create near_misses table: " + error);
+  }
+
+  // Create planned_stops table: one row per declared window during which faults
+  // are expected. Nothing in the fault pipeline reads it - it exists so a reader
+  // can tell an expected fault from a surprise, and it lives next to the faults
+  // it describes so a window survives a restart along with them.
+  //
+  // starts_at_ns / ends_at_ns rather than from / to because those are not column
+  // names anyone can write without quoting, and because the ROS message uses the
+  // same pair.
+  const char * create_planned_stops_table_sql = R"(
+    CREATE TABLE IF NOT EXISTS planned_stops (
+      id TEXT PRIMARY KEY,
+      starts_at_ns INTEGER NOT NULL,
+      ends_at_ns INTEGER NOT NULL,
+      reason TEXT NOT NULL DEFAULT '',
+      declared_by TEXT NOT NULL DEFAULT '',
+      declared_at_ns INTEGER NOT NULL,
+      ended_early INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_planned_stops_declared_at ON planned_stops(declared_at_ns);
+  )";
+
+  if (sqlite3_exec(db_, create_planned_stops_table_sql, nullptr, nullptr, &err_msg) != SQLITE_OK) {
+    std::string error = err_msg ? err_msg : "Unknown error";
+    sqlite3_free(err_msg);
+    throw std::runtime_error("Failed to create planned_stops table: " + error);
   }
 
   // Migration: rows written before resulting_status existed keep their data; the column arrives
@@ -1863,6 +1891,161 @@ std::vector<ros2_medkit_msgs::msg::Fault> SqliteFaultStorage::get_all_faults() c
   }
 
   return result;
+}
+
+// ---------------------------------------------------------------------------
+// Planned-stop windows
+// ---------------------------------------------------------------------------
+
+namespace {
+
+/// Read one planned_stops row in the column order every query below selects.
+PlannedStopWindow read_planned_stop_row(SqliteStatement & stmt) {
+  PlannedStopWindow w;
+  w.id = stmt.column_text(0);
+  w.starts_at_ns = stmt.column_int64(1);
+  w.ends_at_ns = stmt.column_int64(2);
+  w.reason = stmt.column_text(3);
+  w.declared_by = stmt.column_text(4);
+  w.declared_at_ns = stmt.column_int64(5);
+  w.ended_early = stmt.column_int64(6) != 0;
+  return w;
+}
+
+constexpr const char * kPlannedStopColumns =
+    "id, starts_at_ns, ends_at_ns, reason, declared_by, declared_at_ns, ended_early";
+
+}  // namespace
+
+bool SqliteFaultStorage::declare_planned_stop(const PlannedStopWindow & window) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  {
+    SqliteStatement exists(db_, "SELECT 1 FROM planned_stops WHERE id = ?");
+    exists.bind_text(1, window.id);
+    if (exists.step() == SQLITE_ROW) {
+      return false;
+    }
+  }
+
+  SqliteStatement stmt(db_,
+                       "INSERT INTO planned_stops "
+                       "(id, starts_at_ns, ends_at_ns, reason, declared_by, declared_at_ns, ended_early) "
+                       "VALUES (?, ?, ?, ?, ?, ?, ?)");
+  stmt.bind_text(1, window.id);
+  stmt.bind_int64(2, window.starts_at_ns);
+  stmt.bind_int64(3, window.ends_at_ns);
+  stmt.bind_text(4, window.reason);
+  stmt.bind_text(5, window.declared_by);
+  stmt.bind_int64(6, window.declared_at_ns);
+  stmt.bind_int64(7, window.ended_early ? 1 : 0);
+  if (stmt.step() != SQLITE_DONE) {
+    throw std::runtime_error(std::string("Failed to insert planned stop: ") + sqlite3_errmsg(db_));
+  }
+
+  prune_planned_stops_locked(window.declared_at_ns);
+  return true;
+}
+
+EndPlannedStopResult SqliteFaultStorage::end_planned_stop(const std::string & id, int64_t at_ns) {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  PlannedStopWindow current;
+  {
+    SqliteStatement stmt(
+        db_, std::string("SELECT ").append(kPlannedStopColumns).append(" FROM planned_stops WHERE id = ?").c_str());
+    stmt.bind_text(1, id);
+    if (stmt.step() != SQLITE_ROW) {
+      return EndPlannedStopResult{EndPlannedStopOutcome::NotFound, {}};
+    }
+    current = read_planned_stop_row(stmt);
+  }
+
+  if (!current.active_at(at_ns)) {
+    return EndPlannedStopResult{EndPlannedStopOutcome::AlreadyEnded, current};
+  }
+
+  SqliteStatement update(db_, "UPDATE planned_stops SET ends_at_ns = ?, ended_early = 1 WHERE id = ?");
+  update.bind_int64(1, at_ns);
+  update.bind_text(2, id);
+  if (update.step() != SQLITE_DONE) {
+    throw std::runtime_error(std::string("Failed to end planned stop: ") + sqlite3_errmsg(db_));
+  }
+
+  current.ends_at_ns = at_ns;
+  current.ended_early = true;
+  return EndPlannedStopResult{EndPlannedStopOutcome::Ended, current};
+}
+
+std::optional<PlannedStopWindow> SqliteFaultStorage::get_planned_stop(const std::string & id) const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  SqliteStatement stmt(
+      db_, std::string("SELECT ").append(kPlannedStopColumns).append(" FROM planned_stops WHERE id = ?").c_str());
+  stmt.bind_text(1, id);
+  if (stmt.step() != SQLITE_ROW) {
+    return std::nullopt;
+  }
+  return read_planned_stop_row(stmt);
+}
+
+std::vector<PlannedStopWindow> SqliteFaultStorage::list_planned_stops() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  // Ties on declared_at_ns are broken by id DESC, matching the in-memory backend:
+  // two windows declared in the same nanosecond must not order differently
+  // between the two backends or between two calls.
+  SqliteStatement stmt(db_, std::string("SELECT ")
+                                .append(kPlannedStopColumns)
+                                .append(" FROM planned_stops ORDER BY declared_at_ns DESC, id DESC")
+                                .c_str());
+  std::vector<PlannedStopWindow> out;
+  while (stmt.step() == SQLITE_ROW) {
+    out.push_back(read_planned_stop_row(stmt));
+  }
+  return out;
+}
+
+size_t SqliteFaultStorage::set_max_planned_stops(size_t max_count, int64_t now_ns) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  max_planned_stops_ = max_count;
+  return prune_planned_stops_locked(now_ns);
+}
+
+size_t SqliteFaultStorage::prune_planned_stops_locked(int64_t now_ns) {
+  if (max_planned_stops_ == 0) {
+    return 0;
+  }
+
+  size_t total = 0;
+  {
+    SqliteStatement count(db_, "SELECT COUNT(*) FROM planned_stops");
+    if (count.step() == SQLITE_ROW) {
+      total = static_cast<size_t>(std::max<int64_t>(0, count.column_int64(0)));
+    }
+  }
+  if (total <= max_planned_stops_) {
+    return 0;
+  }
+
+  const size_t over = total - max_planned_stops_;
+  if (over > static_cast<size_t>(std::numeric_limits<int64_t>::max())) {
+    return 0;
+  }
+
+  // Only windows whose end has passed are candidates; a running window is never
+  // pruned, so the row count can stay above the bound while many are live.
+  SqliteStatement del(db_,
+                      "DELETE FROM planned_stops WHERE id IN ("
+                      "  SELECT id FROM planned_stops WHERE ends_at_ns <= ?"
+                      "  ORDER BY declared_at_ns ASC, id ASC LIMIT ?"
+                      ")");
+  del.bind_int64(1, now_ns);
+  del.bind_int64(2, static_cast<int64_t>(over));
+  if (del.step() != SQLITE_DONE) {
+    throw std::runtime_error(std::string("Failed to prune planned stops: ") + sqlite3_errmsg(db_));
+  }
+  return static_cast<size_t>(std::max(0, sqlite3_changes(db_)));
 }
 
 }  // namespace ros2_medkit_fault_manager

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Planned-stop windows against a real fault_manager over SQLite.
+"""
+Planned-stop windows against a real fault_manager over SQLite.
 
 Every case here needs a node whose lifetime the test controls - a different
 retention bound per case, and one case that kills the node and brings it back on
@@ -75,7 +76,8 @@ def to_float(time_msg):
 
 
 class PlannedStopFixture(unittest.TestCase):
-    """One fault_manager per test, under a node name only that test uses.
+    """
+    One fault_manager per test, under a node name only that test uses.
 
     Three lessons are baked into this fixture, each learned by watching this file
     fail. A manager that outlives its test keeps answering /fault_manager/* and

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planned-stop windows against a real fault_manager over SQLite.
+
+Every case here needs a node whose lifetime the test controls - a different
+retention bound per case, and one case that kills the node and brings it back on
+the same database - so the launch description starts nothing and each test spawns
+its own fault_manager. SQLite rather than the in-memory backend because that is
+the shipped default and the only one a restart can be asked about at all.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+
+from ament_index_python.packages import get_package_prefix
+from builtin_interfaces.msg import Time
+import launch
+import launch_testing
+import launch_testing.actions
+import launch_testing.markers
+import rclpy
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import (
+    ClearFault,
+    DeclarePlannedStop,
+    EndPlannedStop,
+    ListFaults,
+    ListPlannedStops,
+    ReportFault,
+)
+
+
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    """Start nothing: every case owns its fault_manager process."""
+    return launch.LaunchDescription([launch_testing.actions.ReadyToTest()])
+
+
+def fault_manager_executable():
+    prefix = get_package_prefix('ros2_medkit_fault_manager')
+    return os.path.join(prefix, 'lib', 'ros2_medkit_fault_manager', 'fault_manager_node')
+
+
+def to_time(seconds_float):
+    """Convert float seconds since the epoch to builtin_interfaces/Time."""
+    msg = Time()
+    msg.sec = int(seconds_float)
+    msg.nanosec = int(round((seconds_float - msg.sec) * 1e9))
+    if msg.nanosec >= 1000000000:
+        msg.sec += 1
+        msg.nanosec -= 1000000000
+    return msg
+
+
+def to_float(time_msg):
+    return time_msg.sec + time_msg.nanosec * 1e-9
+
+
+class PlannedStopFixture(unittest.TestCase):
+    """One fault_manager per test, under a node name only that test uses.
+
+    Three lessons are baked into this fixture, each learned by watching this file
+    fail. A manager that outlives its test keeps answering /fault_manager/* and
+    the assertions then describe somebody else's database, so every START gets a
+    node name no other manager has ever used - a restart included, which also
+    makes "the second process is a different process" something the test states
+    rather than assumes. Waiting for a killed node's services to LEAVE the graph
+    is not a usable substitute: the departure rides on the participant lease and
+    takes tens of seconds. And a child holding the launch harness's stdout turns
+    a five-second suite into a ctest timeout, so children get no inherited pipes.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node('planned_stop_test_driver')
+        cls.workdir = tempfile.mkdtemp(prefix='planned_stops_')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+        shutil.rmtree(cls.workdir, ignore_errors=True)
+
+    manager_serial = 0
+
+    def setUp(self):
+        self.proc = None
+        self.manager_name = ''
+        self.db_path = os.path.join(self.workdir, f'{self.id().rsplit(".", 1)[-1][:40]}.db')
+
+    def tearDown(self):
+        self._stop_manager()
+
+    # --- process control ---------------------------------------------------
+
+    def _start_manager(self, extra_params=None):
+        self._stop_manager()
+        PlannedStopFixture.manager_serial += 1
+        self.manager_name = f'fm_{PlannedStopFixture.manager_serial}'
+        args = [
+            fault_manager_executable(),
+            '--ros-args',
+            '-r', f'__node:={self.manager_name}',
+            '-p', 'storage_type:=sqlite',
+            '-p', f'database_path:={self.db_path}',
+            '-p', 'confirmation_threshold:=-1',
+            '-p', 'healing_enabled:=true',
+            '-p', 'healing_threshold:=1',
+            '-p', 'snapshots.enabled:=false',
+            '-p', 'snapshots.rosbag.enabled:=false',
+        ]
+        for key, value in (extra_params or {}).items():
+            args.extend(['-p', f'{key}:={value}'])
+        self.proc = subprocess.Popen(
+            args,
+            env=os.environ.copy(),
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Nothing may be asserted until the node this test started is answering.
+        self._client(ListPlannedStops, 'list_planned_stops')
+
+    def _stop_manager(self):
+        if self.proc is None:
+            return
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait(timeout=15)
+        self.proc = None
+
+    # --- service plumbing --------------------------------------------------
+
+    def _client(self, srv_type, name, timeout=30.0):
+        client = self.node.create_client(srv_type, f'/{self.manager_name}/{name}')
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=timeout),
+            f'{name} service never appeared on {self.manager_name}',
+        )
+        return client
+
+    def _call(self, client, request, timeout=15.0):
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=timeout)
+        result = future.result()
+        self.assertIsNotNone(result, 'service call timed out')
+        return result
+
+    def _declare(self, starts_at, ends_at, reason='changeover', declared_by='tester'):
+        request = DeclarePlannedStop.Request()
+        request.starts_at = to_time(starts_at)
+        request.ends_at = to_time(ends_at)
+        request.reason = reason
+        request.declared_by = declared_by
+        return self._call(self._client(DeclarePlannedStop, 'declare_planned_stop'), request)
+
+    def _list_stops(self, active_only=False, now=None):
+        request = ListPlannedStops.Request()
+        request.active_only = active_only
+        request.now = to_time(now) if now is not None else Time()
+        return self._call(self._client(ListPlannedStops, 'list_planned_stops'), request)
+
+    def _report(self, fault_code, event_type, source_id='/test/reporter'):
+        request = ReportFault.Request()
+        request.fault_code = fault_code
+        request.event_type = event_type
+        request.severity = Fault.SEVERITY_ERROR
+        request.description = 'planned stop parity fault'
+        request.source_id = source_id
+        return self._call(self._client(ReportFault, 'report_fault'), request)
+
+    def _get_fault(self, fault_code, statuses=None):
+        request = ListFaults.Request()
+        request.statuses = statuses or [
+            Fault.STATUS_PREFAILED,
+            Fault.STATUS_PREPASSED,
+            Fault.STATUS_CONFIRMED,
+            Fault.STATUS_HEALED,
+            Fault.STATUS_CLEARED,
+        ]
+        response = self._call(self._client(ListFaults, 'list_faults'), request)
+        for fault in response.faults:
+            if fault.fault_code == fault_code:
+                return fault
+        return None
+
+    def _wait_for_status(self, fault_code, status, timeout=20.0):
+        deadline = time.monotonic() + timeout
+        last = None
+        while time.monotonic() < deadline:
+            last = self._get_fault(fault_code)
+            if last is not None and last.status == status:
+                return last
+            time.sleep(0.3)
+        raise AssertionError(
+            f'{fault_code} never reached {status}; last seen: '
+            f'{last.status if last else "absent"}'
+        )
+
+
+class TestPlannedStops(PlannedStopFixture):
+    """Planned-stop windows end to end against a real fault_manager."""
+
+    RETENTION_CAP = 5
+
+    def test_window_survives_a_restart_and_still_covers_new_faults(self):
+        self._start_manager()
+
+        now = time.time()
+        declared = self._declare(now - 60.0, now + 900.0, reason='maintenance weekend')
+        self.assertTrue(declared.success, declared.message)
+        window_id = declared.stop.id
+        starts_at = to_float(declared.stop.starts_at)
+        ends_at = to_float(declared.stop.ends_at)
+
+        # The fault manager must be gone, not merely quiet, before the second one
+        # opens the same database file.
+        self._stop_manager()
+        self._start_manager()
+
+        listed = self._list_stops()
+        ids = [stop.id for stop in listed.stops]
+        self.assertIn(window_id, ids, 'the declared window did not survive the restart')
+
+        survivor = next(stop for stop in listed.stops if stop.id == window_id)
+        self.assertEqual(survivor.reason, 'maintenance weekend')
+        self.assertAlmostEqual(to_float(survivor.starts_at), starts_at, places=6)
+        self.assertAlmostEqual(to_float(survivor.ends_at), ends_at, places=6)
+
+        # A fault raised after the restart falls inside the window that predates it.
+        self._report('RESTART_INSIDE_WINDOW', ReportFault.Request.EVENT_FAILED)
+        fault = self._wait_for_status('RESTART_INSIDE_WINDOW', Fault.STATUS_CONFIRMED)
+        first_occurred = to_float(fault.first_occurred)
+        self.assertGreaterEqual(first_occurred, starts_at)
+        self.assertLessEqual(first_occurred, ends_at)
+
+        active = self._list_stops(active_only=True)
+        self.assertIn(window_id, [stop.id for stop in active.stops])
+
+    def test_expected_and_unexpected_faults_take_the_same_path(self):
+        """An expected fault must be indistinguishable from a surprise in storage."""
+        self._start_manager()
+
+        now = time.time()
+        declared = self._declare(now - 5.0, now + 600.0)
+        self.assertTrue(declared.success, declared.message)
+        inside_start = to_float(declared.stop.starts_at)
+        inside_end = to_float(declared.stop.ends_at)
+
+        # Both faults are driven through the identical sequence, at the same
+        # moment, inside the same window; only the assertion below distinguishes
+        # them, and it must find nothing to distinguish.
+        codes = ('PARITY_INSIDE_WINDOW', 'PARITY_OUTSIDE_WINDOW')
+        for code in codes:
+            self._report(code, ReportFault.Request.EVENT_FAILED)
+        records = {code: self._wait_for_status(code, Fault.STATUS_CONFIRMED) for code in codes}
+
+        inside = records['PARITY_INSIDE_WINDOW']
+        self.assertGreaterEqual(to_float(inside.first_occurred), inside_start)
+        self.assertLessEqual(to_float(inside.first_occurred), inside_end)
+
+        for code in codes:
+            self.assertEqual(records[code].status, Fault.STATUS_CONFIRMED)
+            self.assertEqual(records[code].occurrence_count, 1)
+            self.assertEqual(records[code].severity, Fault.SEVERITY_ERROR)
+            self.assertEqual(list(records[code].reporting_sources), ['/test/reporter'])
+
+        # Heal both, then reactivate both: the cycle counter must move identically.
+        for code in codes:
+            self._report(code, ReportFault.Request.EVENT_PASSED)
+            self._report(code, ReportFault.Request.EVENT_PASSED)
+        healed = {code: self._wait_for_status(code, Fault.STATUS_HEALED) for code in codes}
+        for code in codes:
+            self.assertEqual(healed[code].occurrence_count, 1)
+            self.assertNotEqual(to_float(healed[code].last_passed), 0.0)
+
+        for code in codes:
+            clear_request = ClearFault.Request()
+            clear_request.fault_code = code
+            cleared = self._call(self._client(ClearFault, 'clear_fault'), clear_request)
+            self.assertTrue(cleared.success, f'{code}: {cleared.message}')
+
+        for code in codes:
+            self._report(code, ReportFault.Request.EVENT_FAILED)
+        reactivated = {code: self._wait_for_status(code, Fault.STATUS_CONFIRMED) for code in codes}
+        for code in codes:
+            self.assertEqual(
+                reactivated[code].occurrence_count, 2,
+                f'{code}: a re-raise after a clear is a new cycle, window or not',
+            )
+
+        fields = ('status', 'occurrence_count', 'severity')
+        for field in fields:
+            self.assertEqual(
+                getattr(reactivated['PARITY_INSIDE_WINDOW'], field),
+                getattr(reactivated['PARITY_OUTSIDE_WINDOW'], field),
+                f'the window changed {field}, which it must never do',
+            )
+
+    def test_bound_of_one_keeps_the_newest_ended_window(self):
+        """CONFIG SWEEP: the smallest legal bound."""
+        self._start_manager({'planned_stop.max_windows': 1})
+
+        now = time.time()
+        first = self._declare(now - 100.0, now - 90.0, reason='old changeover')
+        self.assertTrue(first.success, first.message)
+        second = self._declare(now - 50.0, now - 40.0, reason='newer changeover')
+        self.assertTrue(second.success, second.message)
+
+        listed = self._list_stops()
+        self.assertEqual(len(listed.stops), 1)
+        self.assertEqual(listed.stops[0].id, second.stop.id)
+
+    def test_default_bound_keeps_every_window_of_a_small_run(self):
+        """CONFIG SWEEP: the shipped default keeps far more than a handful."""
+        self._start_manager()
+
+        now = time.time()
+        declared_ids = []
+        for i in range(12):
+            start = now - 1000.0 + i * 10.0
+            response = self._declare(start, start + 5.0)
+            self.assertTrue(response.success, response.message)
+            declared_ids.append(response.stop.id)
+
+        listed = self._list_stops()
+        self.assertEqual(len(listed.stops), 12)
+        self.assertEqual(sorted(stop.id for stop in listed.stops), sorted(declared_ids))
+
+    def test_declaring_past_the_cap_prunes_ended_windows_and_spares_the_live_one(self):
+        """SCALE: past the cap, where the guard actually engages."""
+        self._start_manager({'planned_stop.max_windows': self.RETENTION_CAP})
+
+        now = time.time()
+        ended_ids = []
+        for i in range(self.RETENTION_CAP + 4):
+            start = now - 2000.0 + i * 10.0
+            response = self._declare(start, start + 5.0, reason=f'ended_{i}')
+            self.assertTrue(response.success, response.message)
+            ended_ids.append(response.stop.id)
+
+        live = self._declare(now - 5.0, now + 3600.0, reason='live')
+        self.assertTrue(live.success, live.message)
+
+        listed = self._list_stops()
+        self.assertLessEqual(
+            len(listed.stops), self.RETENTION_CAP,
+            'the stored count must never exceed the configured bound while ended windows remain',
+        )
+
+        surviving = [stop.id for stop in listed.stops]
+        self.assertIn(live.stop.id, surviving, 'a running window must survive the cap')
+        self.assertNotIn(ended_ids[0], surviving, 'the oldest declaration goes first')
+        self.assertNotIn(ended_ids[1], surviving)
+        self.assertIn(ended_ids[-1], surviving, 'the newest ended declarations stay')
+
+        active = self._list_stops(active_only=True)
+        self.assertEqual([stop.id for stop in active.stops], [live.stop.id])
+
+    def test_ending_early_moves_the_end_and_cannot_be_repeated(self):
+        """CHANGE: ending a window mid-run moves where the boundary sits."""
+        self._start_manager()
+
+        now = time.time()
+        declared = self._declare(now - 30.0, now + 3600.0)
+        self.assertTrue(declared.success, declared.message)
+        window_id = declared.stop.id
+
+        end_request = EndPlannedStop.Request()
+        end_request.id = window_id
+        end_request.at = Time()  # zero = now
+        ended = self._call(self._client(EndPlannedStop, 'end_planned_stop'), end_request)
+        self.assertTrue(ended.success, ended.message)
+        self.assertTrue(ended.stop.ended_early)
+        new_end = to_float(ended.stop.ends_at)
+        self.assertLess(new_end, now + 3600.0, 'ending early must pull ends_at back')
+        self.assertGreaterEqual(new_end, now - 30.0)
+
+        # The window no longer covers now, so it is not active any more.
+        active = self._list_stops(active_only=True)
+        self.assertNotIn(window_id, [stop.id for stop in active.stops])
+
+        again = self._call(self._client(EndPlannedStop, 'end_planned_stop'), end_request)
+        self.assertFalse(again.success)
+        self.assertIn('already ended', again.message)
+
+        unknown = EndPlannedStop.Request()
+        unknown.id = 'no_such_window'
+        missing = self._call(self._client(EndPlannedStop, 'end_planned_stop'), unknown)
+        self.assertFalse(missing.success)
+        self.assertIn('no planned stop', missing.message)
+
+    def test_a_window_that_is_not_an_interval_is_refused(self):
+        self._start_manager()
+
+        now = time.time()
+        equal = self._declare(now, now)
+        self.assertFalse(equal.success, 'a zero-length window is not an interval')
+        self.assertIn('strictly after', equal.message)
+
+        reversed_window = self._declare(now + 60.0, now)
+        self.assertFalse(reversed_window.success)
+
+        self.assertEqual(len(self._list_stops().stops), 0)

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -383,19 +383,9 @@ class TestPlannedStops(PlannedStopFixture):
         self.assertTrue(live.success, live.message)
 
         listed = self._list_stops()
-        # The bound counts windows that are no longer active; an active one is
-        # always kept and is never dropped to make room. So the table holds at
-        # most the cap plus however many are still running.
-        active = sum(
-            1 for stop in listed.stops if to_float(stop.ends_at) > time.time()
-        )
         self.assertLessEqual(
-            len(listed.stops), self.RETENTION_CAP + active,
-            'stored count must be at most the cap plus the active windows',
-        )
-        self.assertLessEqual(
-            len(listed.stops) - active, self.RETENTION_CAP,
-            'the ended windows alone must fit the configured bound',
+            len(listed.stops), self.RETENTION_CAP,
+            'the configured bound is a hard bound on stored windows',
         )
 
         surviving = [stop.id for stop in listed.stops]
@@ -459,24 +449,72 @@ class TestPlannedStops(PlannedStopFixture):
         self.assertIn('epoch', response.message)
         self.assertEqual(len(self._list_stops().stops), 0)
 
-    def test_a_declaration_reported_as_stored_is_there_afterwards(self):
-        """A cap filled by a window that cannot be pruned must not eat the new one."""
+    def test_a_full_bound_refuses_rather_than_growing(self):
+        """R20: the bound is hard, and a live window is never sacrificed for it."""
         self._start_manager({'planned_stop.max_windows': 1})
 
         now = time.time()
         live = self._declare(now - 10.0, now + 3600.0, reason='running')
         self.assertTrue(live.success, live.message)
 
-        ended = self._declare(now - 500.0, now - 400.0, reason='already over')
-        self.assertTrue(ended.success, ended.message)
-        self.assertEqual(ended.outcome, DeclarePlannedStop.Response.OUTCOME_STORED)
+        refused = self._declare(now - 500.0, now - 400.0, reason='no room')
+        self.assertFalse(refused.success, 'the bound is full of windows that have not ended')
+        self.assertEqual(refused.outcome, DeclarePlannedStop.Response.OUTCOME_NOT_RETAINED)
+        self.assertIn('max_windows', refused.message)
+
+        ids = [stop.id for stop in self._list_stops().stops]
+        self.assertEqual(ids, [live.stop.id], 'nothing was stored and nothing was dropped')
+
+        # End the live one and the next declaration fits.
+        request = EndPlannedStop.Request()
+        request.id = live.stop.id
+        request.at = Time()
+        self.assertTrue(
+            self._call(self._client(EndPlannedStop, 'end_planned_stop'), request).success
+        )
+        accepted = self._declare(now - 500.0, now - 400.0, reason='room now')
+        self.assertTrue(accepted.success, accepted.message)
+        self.assertEqual(accepted.outcome, DeclarePlannedStop.Response.OUTCOME_STORED)
+
+    def test_a_declaration_reported_as_stored_is_there_afterwards(self):
+        """Room is made before the insert, so a stored window cannot be evicted by it."""
+        self._start_manager({'planned_stop.max_windows': 2})
+
+        now = time.time()
+        older = self._declare(now - 900.0, now - 800.0, reason='oldest')
+        self.assertTrue(older.success, older.message)
+        newer = self._declare(now - 700.0, now - 600.0, reason='newer')
+        self.assertTrue(newer.success, newer.message)
+
+        newest = self._declare(now - 500.0, now - 400.0, reason='newest')
+        self.assertTrue(newest.success, newest.message)
+        self.assertEqual(newest.outcome, DeclarePlannedStop.Response.OUTCOME_STORED)
 
         ids = [stop.id for stop in self._list_stops().stops]
         self.assertIn(
-            ended.stop.id, ids,
+            newest.stop.id, ids,
             'the declaration answered success and then was not there'
         )
-        self.assertIn(live.stop.id, ids, 'and a running window is still never pruned')
+        self.assertNotIn(older.stop.id, ids, 'the oldest ended window made room')
+
+    def test_active_only_lists_the_windows_that_have_not_ended(self):
+        """`active_only` is "not ended", which is what holds the retention bound."""
+        self._start_manager()
+
+        now = time.time()
+        running = self._declare(now - 100.0, now + 3600.0, reason='running')
+        future = self._declare(now + 3600.0, now + 7200.0, reason='not started yet')
+        past = self._declare(now - 900.0, now - 800.0, reason='over')
+        for response in (running, future, past):
+            self.assertTrue(response.success, response.message)
+
+        active_ids = [stop.id for stop in self._list_stops(active_only=True).stops]
+        self.assertIn(running.stop.id, active_ids)
+        self.assertIn(
+            future.stop.id, active_ids,
+            'a window that has not started is unprunable, so an operator must be able to see it'
+        )
+        self.assertNotIn(past.stop.id, active_ids)
 
     def test_a_window_that_never_started_is_cancelled(self):
         """R12: it marked nothing, so it is removed rather than inverted."""

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -107,10 +107,14 @@ class PlannedStopFixture(unittest.TestCase):
     def setUp(self):
         self.proc = None
         self.manager_name = ''
+        self._clients = {}
         self.db_path = os.path.join(self.workdir, f'{self.id().rsplit(".", 1)[-1][:40]}.db')
 
     def tearDown(self):
         self._stop_manager()
+        for client in self._clients.values():
+            self.node.destroy_client(client)
+        self._clients = {}
 
     # --- process control ---------------------------------------------------
 
@@ -155,7 +159,20 @@ class PlannedStopFixture(unittest.TestCase):
     # --- service plumbing --------------------------------------------------
 
     def _client(self, srv_type, name, timeout=30.0):
-        client = self.node.create_client(srv_type, f'/{self.manager_name}/{name}')
+        """
+        Keep one client per (manager, service) and reuse it for the test.
+
+        Creating a fresh client for every call churns the DDS graph: each one
+        discovers the service again, and under the load of the whole integration
+        suite one of them eventually costs more than the call budget. The keys
+        carry the manager's node name, which is unique per START, so a restart
+        gets fresh clients without any cache invalidation.
+        """
+        key = (self.manager_name, name)
+        client = self._clients.get(key)
+        if client is None:
+            client = self.node.create_client(srv_type, f'/{self.manager_name}/{name}')
+            self._clients[key] = client
         self.assertTrue(
             client.wait_for_service(timeout_sec=timeout),
             f'{name} service never appeared on {self.manager_name}',

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -413,12 +413,102 @@ class TestPlannedStops(PlannedStopFixture):
         self.assertFalse(missing.success)
         self.assertIn('no planned stop', missing.message)
 
+    def test_the_service_refuses_an_unset_start(self):
+        """R14: zero is what an unset Time reads as, not a request for "now"."""
+        self._start_manager()
+
+        request = DeclarePlannedStop.Request()
+        request.starts_at = Time()  # unset
+        request.ends_at = to_time(time.time() + 600.0)
+        request.reason = 'no start given'
+        response = self._call(
+            self._client(DeclarePlannedStop, 'declare_planned_stop'), request
+        )
+        self.assertFalse(response.success)
+        self.assertEqual(
+            response.outcome,
+            DeclarePlannedStop.Response.OUTCOME_INVALID_INSTANT,
+        )
+        self.assertIn('epoch', response.message)
+        self.assertEqual(len(self._list_stops().stops), 0)
+
+    def test_a_declaration_reported_as_stored_is_there_afterwards(self):
+        """A cap filled by a window that cannot be pruned must not eat the new one."""
+        self._start_manager({'planned_stop.max_windows': 1})
+
+        now = time.time()
+        live = self._declare(now - 10.0, now + 3600.0, reason='running')
+        self.assertTrue(live.success, live.message)
+
+        ended = self._declare(now - 500.0, now - 400.0, reason='already over')
+        self.assertTrue(ended.success, ended.message)
+        self.assertEqual(ended.outcome, DeclarePlannedStop.Response.OUTCOME_STORED)
+
+        ids = [stop.id for stop in self._list_stops().stops]
+        self.assertIn(
+            ended.stop.id, ids,
+            'the declaration answered success and then was not there'
+        )
+        self.assertIn(live.stop.id, ids, 'and a running window is still never pruned')
+
+    def test_a_window_that_never_started_is_cancelled(self):
+        """R12: it marked nothing, so it is removed rather than inverted."""
+        self._start_manager()
+
+        now = time.time()
+        future = self._declare(now + 3600.0, now + 7200.0, reason='next weekend')
+        self.assertTrue(future.success, future.message)
+
+        request = EndPlannedStop.Request()
+        request.id = future.stop.id
+        request.at = Time()  # now, which is before the window starts
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), request)
+
+        self.assertTrue(response.success, response.message)
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_CANCELLED)
+        self.assertTrue(response.stop.cancelled)
+        self.assertFalse(response.stop.ended_early)
+        self.assertNotIn(
+            future.stop.id, [stop.id for stop in self._list_stops().stops],
+            'a cancelled window is gone, not stored with an inverted interval'
+        )
+
+    def test_a_backdated_end_cannot_rewrite_when_a_stop_finished(self):
+        self._start_manager()
+
+        now = time.time()
+        window = self._declare(now - 600.0, now + 600.0, reason='running')
+        self.assertTrue(window.success, window.message)
+
+        first = EndPlannedStop.Request()
+        first.id = window.stop.id
+        first.at = to_time(now)
+        ended = self._call(self._client(EndPlannedStop, 'end_planned_stop'), first)
+        self.assertTrue(ended.success, ended.message)
+        self.assertEqual(ended.outcome, EndPlannedStop.Response.OUTCOME_ENDED)
+        settled_end = to_float(ended.stop.ends_at)
+
+        backdated = EndPlannedStop.Request()
+        backdated.id = window.stop.id
+        backdated.at = to_time(now - 300.0)
+        again = self._call(self._client(EndPlannedStop, 'end_planned_stop'), backdated)
+        self.assertFalse(again.success)
+        self.assertEqual(again.outcome, EndPlannedStop.Response.OUTCOME_ALREADY_ENDED)
+
+        stored = next(
+            stop for stop in self._list_stops().stops if stop.id == window.stop.id
+        )
+        self.assertAlmostEqual(to_float(stored.ends_at), settled_end, places=6)
+
     def test_a_window_that_is_not_an_interval_is_refused(self):
         self._start_manager()
 
         now = time.time()
         equal = self._declare(now, now)
         self.assertFalse(equal.success, 'a zero-length window is not an interval')
+        self.assertEqual(
+            equal.outcome, DeclarePlannedStop.Response.OUTCOME_INVALID_INTERVAL
+        )
         self.assertIn('strictly after', equal.message)
 
         reversed_window = self._declare(now + 60.0, now)

--- a/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
+++ b/src/ros2_medkit_fault_manager/test/integration/test_planned_stops.test.py
@@ -366,9 +366,19 @@ class TestPlannedStops(PlannedStopFixture):
         self.assertTrue(live.success, live.message)
 
         listed = self._list_stops()
+        # The bound counts windows that are no longer active; an active one is
+        # always kept and is never dropped to make room. So the table holds at
+        # most the cap plus however many are still running.
+        active = sum(
+            1 for stop in listed.stops if to_float(stop.ends_at) > time.time()
+        )
         self.assertLessEqual(
-            len(listed.stops), self.RETENTION_CAP,
-            'the stored count must never exceed the configured bound while ended windows remain',
+            len(listed.stops), self.RETENTION_CAP + active,
+            'stored count must be at most the cap plus the active windows',
+        )
+        self.assertLessEqual(
+            len(listed.stops) - active, self.RETENTION_CAP,
+            'the ended windows alone must fit the configured bound',
         )
 
         surviving = [stop.id for stop in listed.stops]
@@ -499,6 +509,88 @@ class TestPlannedStops(PlannedStopFixture):
             stop for stop in self._list_stops().stops if stop.id == window.stop.id
         )
         self.assertAlmostEqual(to_float(stored.ends_at), settled_end, places=6)
+
+    def test_a_finished_window_cannot_be_re_ended_by_a_backdated_at(self):
+        """R15: which situation a window is in is judged against the manager's clock."""
+        self._start_manager()
+
+        now = time.time()
+        # Declared and finished in the past. Its end is a fact now.
+        window = self._declare(now - 600.0, now - 300.0, reason='already over')
+        self.assertTrue(window.success, window.message)
+        original_end = to_float(window.stop.ends_at)
+
+        # An instant INSIDE the original span, which the old rule read as "still
+        # running at that instant" and accepted.
+        backdated = EndPlannedStop.Request()
+        backdated.id = window.stop.id
+        backdated.at = to_time(now - 450.0)
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), backdated)
+
+        self.assertFalse(response.success, 'a finished window is immutable')
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_ALREADY_ENDED)
+
+        stored = next(
+            stop for stop in self._list_stops().stops if stop.id == window.stop.id
+        )
+        self.assertAlmostEqual(to_float(stored.ends_at), original_end, places=6)
+        self.assertFalse(stored.ended_early)
+
+    def test_a_finished_window_is_not_cancelled_by_an_at_before_its_start(self):
+        """The cancel branch must test the clock, not the instant it was handed."""
+        self._start_manager()
+
+        now = time.time()
+        window = self._declare(now - 600.0, now - 300.0, reason='already over')
+        self.assertTrue(window.success, window.message)
+
+        request = EndPlannedStop.Request()
+        request.id = window.stop.id
+        request.at = to_time(now - 900.0)  # before the window even started
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), request)
+
+        self.assertFalse(response.success)
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_ALREADY_ENDED)
+        self.assertIn(
+            window.stop.id, [stop.id for stop in self._list_stops().stops],
+            'a finished window must not be deleted by a request that cannot touch it'
+        )
+
+    def test_at_outside_the_running_span_is_refused(self):
+        """`at` may only refine where a RUNNING window ends."""
+        self._start_manager()
+
+        now = time.time()
+        window = self._declare(now - 300.0, now + 300.0, reason='running')
+        self.assertTrue(window.success, window.message)
+
+        too_early = EndPlannedStop.Request()
+        too_early.id = window.stop.id
+        too_early.at = to_time(now - 600.0)
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), too_early)
+        self.assertFalse(response.success)
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_INVALID_AT)
+
+        too_late = EndPlannedStop.Request()
+        too_late.id = window.stop.id
+        too_late.at = to_time(now + 200.0)  # has not happened yet
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), too_late)
+        self.assertFalse(response.success)
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_INVALID_AT)
+
+        stored = next(
+            stop for stop in self._list_stops().stops if stop.id == window.stop.id
+        )
+        self.assertFalse(stored.ended_early, 'a refused request must not have moved anything')
+
+        # And an instant inside the running span is accepted.
+        legal = EndPlannedStop.Request()
+        legal.id = window.stop.id
+        legal.at = to_time(now - 10.0)
+        response = self._call(self._client(EndPlannedStop, 'end_planned_stop'), legal)
+        self.assertTrue(response.success, response.message)
+        self.assertEqual(response.outcome, EndPlannedStop.Response.OUTCOME_ENDED)
+        self.assertAlmostEqual(to_float(response.stop.ends_at), now - 10.0, places=3)
 
     def test_a_window_that_is_not_an_interval_is_refused(self):
         self._start_manager()

--- a/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
@@ -1,0 +1,371 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// Planned-stop window storage, run against BOTH backends.
+///
+/// Every behavioural assertion is parameterised over the in-memory and the SQLite
+/// backend, because the shipped default is SQLite and the in-memory one is what
+/// the fast tests use: a rule enforced in only one of them is a rule that holds
+/// on nobody's deployment. The SQLite-only fixture below adds what has no
+/// in-memory equivalent - surviving a close and reopen.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_fault_manager/fault_storage.hpp"
+#include "ros2_medkit_fault_manager/sqlite_fault_storage.hpp"
+
+using ros2_medkit_fault_manager::clamp_planned_stop_windows;
+using ros2_medkit_fault_manager::EndPlannedStopOutcome;
+using ros2_medkit_fault_manager::FaultStorage;
+using ros2_medkit_fault_manager::InMemoryFaultStorage;
+using ros2_medkit_fault_manager::kMaxPlannedStopWindows;
+using ros2_medkit_fault_manager::kMinPlannedStopWindows;
+using ros2_medkit_fault_manager::PlannedStopWindow;
+using ros2_medkit_fault_manager::SqliteFaultStorage;
+
+namespace {
+
+constexpr int64_t kSec = 1'000'000'000;
+
+/// A window with sane defaults; the caller overrides what the case is about.
+PlannedStopWindow make_window(const std::string & id, int64_t starts_at_ns, int64_t ends_at_ns,
+                              int64_t declared_at_ns) {
+  PlannedStopWindow w;
+  w.id = id;
+  w.starts_at_ns = starts_at_ns;
+  w.ends_at_ns = ends_at_ns;
+  w.reason = "changeover";
+  w.declared_by = "operator_a";
+  w.declared_at_ns = declared_at_ns;
+  return w;
+}
+
+std::filesystem::path unique_db_path() {
+  std::random_device rd;
+  std::mt19937_64 gen(rd());
+  std::uniform_int_distribution<uint64_t> dist;
+  return std::filesystem::temp_directory_path() / ("test_planned_stops_" + std::to_string(dist(gen)) + ".db");
+}
+
+enum class Backend : uint8_t { Memory, Sqlite };
+
+}  // namespace
+
+class PlannedStopStorageTest : public ::testing::TestWithParam<Backend> {
+ protected:
+  void SetUp() override {
+    if (GetParam() == Backend::Sqlite) {
+      db_path_ = unique_db_path();
+      storage_ = std::make_unique<SqliteFaultStorage>(db_path_.string());
+    } else {
+      storage_ = std::make_unique<InMemoryFaultStorage>();
+    }
+  }
+
+  void TearDown() override {
+    storage_.reset();
+    if (!db_path_.empty()) {
+      std::filesystem::remove(db_path_);
+      std::filesystem::remove(db_path_.string() + "-wal");
+      std::filesystem::remove(db_path_.string() + "-shm");
+    }
+  }
+
+  std::filesystem::path db_path_;
+  std::unique_ptr<FaultStorage> storage_;
+};
+
+INSTANTIATE_TEST_SUITE_P(BothBackends, PlannedStopStorageTest, ::testing::Values(Backend::Memory, Backend::Sqlite),
+                         [](const ::testing::TestParamInfo<Backend> & param_info) {
+                           return param_info.param == Backend::Memory ? "Memory" : "Sqlite";
+                         });
+
+TEST_P(PlannedStopStorageTest, DeclareStoresEveryFieldVerbatim) {
+  auto w = make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec);
+  w.reason = "weekend maintenance";
+  w.declared_by = "line_lead";
+  ASSERT_TRUE(storage_->declare_planned_stop(w));
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->id, "w1");
+  EXPECT_EQ(stored->starts_at_ns, 10 * kSec);
+  EXPECT_EQ(stored->ends_at_ns, 20 * kSec);
+  EXPECT_EQ(stored->reason, "weekend maintenance");
+  EXPECT_EQ(stored->declared_by, "line_lead");
+  EXPECT_EQ(stored->declared_at_ns, 5 * kSec);
+  EXPECT_FALSE(stored->ended_early);
+}
+
+TEST_P(PlannedStopStorageTest, DeclareRefusesADuplicateId) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
+  EXPECT_FALSE(storage_->declare_planned_stop(make_window("w1", 30 * kSec, 40 * kSec, 25 * kSec)));
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->starts_at_ns, 10 * kSec) << "the second declaration must not overwrite the first";
+}
+
+TEST_P(PlannedStopStorageTest, GetUnknownIdIsEmpty) {
+  EXPECT_FALSE(storage_->get_planned_stop("never_declared").has_value());
+}
+
+TEST_P(PlannedStopStorageTest, ListReturnsNewestDeclarationFirst) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("older", 10 * kSec, 20 * kSec, 1 * kSec)));
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("newer", 30 * kSec, 40 * kSec, 2 * kSec)));
+
+  auto all = storage_->list_planned_stops();
+  ASSERT_EQ(all.size(), 2u);
+  EXPECT_EQ(all[0].id, "newer");
+  EXPECT_EQ(all[1].id, "older");
+}
+
+// The closed interval is the contract the gateway derives `expected` from, so it
+// is asserted at the boundary and one nanosecond outside it on both sides.
+TEST_P(PlannedStopStorageTest, CoversIsClosedAtBothEnds) {
+  const auto w = make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec);
+  EXPECT_TRUE(w.covers(10 * kSec)) << "exactly at the start";
+  EXPECT_TRUE(w.covers(20 * kSec)) << "exactly at the end";
+  EXPECT_TRUE(w.covers(15 * kSec));
+  EXPECT_FALSE(w.covers(10 * kSec - 1)) << "one nanosecond before the start";
+  EXPECT_FALSE(w.covers(20 * kSec + 1)) << "one nanosecond after the end";
+}
+
+TEST_P(PlannedStopStorageTest, EndEarlyMovesEndsAtAndFlagsIt) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+
+  auto result = storage_->end_planned_stop("w1", 30 * kSec);
+  ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Ended);
+  EXPECT_EQ(result.window.ends_at_ns, 30 * kSec);
+  EXPECT_TRUE(result.window.ended_early);
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 30 * kSec) << "the stored window, not just the returned copy, must move";
+  EXPECT_TRUE(stored->ended_early);
+  EXPECT_EQ(stored->starts_at_ns, 10 * kSec) << "ending early must not move the start";
+}
+
+TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec).outcome, EndPlannedStopOutcome::Ended);
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_TRUE(stored->covers(20 * kSec)) << "a fault raised before the early end stays expected";
+  EXPECT_FALSE(stored->covers(40 * kSec)) << "a fault raised after the early end is not expected";
+}
+
+TEST_P(PlannedStopStorageTest, EndUnknownIdIsNotFound) {
+  auto result = storage_->end_planned_stop("never_declared", 30 * kSec);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::NotFound);
+}
+
+TEST_P(PlannedStopStorageTest, EndingATwiceEndedWindowIsRefused) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec).outcome, EndPlannedStopOutcome::Ended);
+
+  auto again = storage_->end_planned_stop("w1", 50 * kSec);
+  EXPECT_EQ(again.outcome, EndPlannedStopOutcome::AlreadyEnded);
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 30 * kSec) << "the refused second end must not move ends_at again";
+}
+
+TEST_P(PlannedStopStorageTest, EndingAWindowThatAlreadyExpiredIsRefused) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
+
+  // 40s is past the declared end: the window closed on its own.
+  auto result = storage_->end_planned_stop("w1", 40 * kSec);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::AlreadyEnded);
+
+  auto stored = storage_->get_planned_stop("w1");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 20 * kSec);
+  EXPECT_FALSE(stored->ended_early);
+}
+
+// SCALE: the cap engages only past itself, so the case has to sit past it.
+TEST_P(PlannedStopStorageTest, RetentionPrunesOldestEndedAndKeepsTheActiveOne) {
+  const size_t cap = 5;
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(cap, now);
+
+  // cap + 5 declarations: the first cap + 4 have already ended, the last is live.
+  for (int i = 0; i < static_cast<int>(cap) + 4; ++i) {
+    const int64_t declared = static_cast<int64_t>(i + 1) * kSec;
+    ASSERT_TRUE(
+        storage_->declare_planned_stop(make_window("ended_" + std::to_string(i), declared, declared + kSec, declared)));
+  }
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("active", now - kSec, now + 100 * kSec, now)));
+
+  auto all = storage_->list_planned_stops();
+  EXPECT_LE(all.size(), cap) << "the stored count must never exceed the cap while ended windows remain";
+
+  bool has_active = false;
+  for (const auto & w : all) {
+    if (w.id == "active") {
+      has_active = true;
+    }
+  }
+  EXPECT_TRUE(has_active) << "a live window must never vanish under an operator";
+  EXPECT_FALSE(storage_->get_planned_stop("ended_0").has_value()) << "the oldest declaration goes first";
+  EXPECT_FALSE(storage_->get_planned_stop("ended_1").has_value());
+}
+
+TEST_P(PlannedStopStorageTest, RetentionNeverPrunesAnActiveWindowEvenPastTheCap) {
+  const size_t cap = 2;
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(cap, now);
+
+  for (int i = 0; i < 5; ++i) {
+    const int64_t declared = now + static_cast<int64_t>(i) * kSec;
+    ASSERT_TRUE(storage_->declare_planned_stop(
+        make_window("live_" + std::to_string(i), now - kSec, now + 500 * kSec, declared)));
+  }
+
+  auto all = storage_->list_planned_stops();
+  EXPECT_EQ(all.size(), 5u) << "five live windows must all survive a cap of two";
+}
+
+// CONFIG SWEEP at the storage boundary: a cap of one keeps exactly the newest.
+TEST_P(PlannedStopStorageTest, RetentionOfOneKeepsOnlyTheNewestEndedWindow) {
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(1, now);
+
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("first", 1 * kSec, 2 * kSec, 1 * kSec)));
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("second", 3 * kSec, 4 * kSec, 3 * kSec)));
+
+  auto all = storage_->list_planned_stops();
+  ASSERT_EQ(all.size(), 1u);
+  EXPECT_EQ(all[0].id, "second");
+}
+
+// CHANGE: raising the bound after the windows are stored evicts nothing; lowering
+// it evicts on the spot, which is what a restart with a smaller cap must do.
+TEST_P(PlannedStopStorageTest, LoweringTheBoundEvictsStoredWindowsImmediately) {
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(10, now);
+  for (int i = 0; i < 6; ++i) {
+    const int64_t declared = static_cast<int64_t>(i + 1) * kSec;
+    ASSERT_TRUE(
+        storage_->declare_planned_stop(make_window("w" + std::to_string(i), declared, declared + kSec, declared)));
+  }
+  ASSERT_EQ(storage_->list_planned_stops().size(), 6u);
+
+  const size_t evicted = storage_->set_max_planned_stops(2, now);
+  EXPECT_EQ(evicted, 4u);
+  EXPECT_EQ(storage_->list_planned_stops().size(), 2u);
+  EXPECT_TRUE(storage_->get_planned_stop("w5").has_value()) << "the newest declarations survive";
+  EXPECT_TRUE(storage_->get_planned_stop("w4").has_value());
+  EXPECT_FALSE(storage_->get_planned_stop("w0").has_value());
+}
+
+// --- SQLite only: the half that has no in-memory meaning -------------------
+
+class SqlitePlannedStopTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    db_path_ = unique_db_path();
+  }
+
+  void TearDown() override {
+    std::filesystem::remove(db_path_);
+    std::filesystem::remove(db_path_.string() + "-wal");
+    std::filesystem::remove(db_path_.string() + "-shm");
+  }
+
+  std::filesystem::path db_path_;
+};
+
+TEST_F(SqlitePlannedStopTest, WindowsSurviveCloseAndReopen) {
+  {
+    SqliteFaultStorage storage(db_path_.string());
+    ASSERT_TRUE(storage.declare_planned_stop(make_window("survivor", 10 * kSec, 900 * kSec, 5 * kSec)));
+    ASSERT_EQ(storage.end_planned_stop("survivor", 500 * kSec).outcome, EndPlannedStopOutcome::Ended);
+  }
+
+  SqliteFaultStorage reopened(db_path_.string());
+  auto stored = reopened.get_planned_stop("survivor");
+  ASSERT_TRUE(stored.has_value()) << "a declared window must outlive the process that declared it";
+  EXPECT_EQ(stored->starts_at_ns, 10 * kSec);
+  EXPECT_EQ(stored->ends_at_ns, 500 * kSec) << "the early end must be persisted, not just held in memory";
+  EXPECT_TRUE(stored->ended_early);
+  EXPECT_EQ(stored->reason, "changeover");
+  EXPECT_EQ(stored->declared_by, "operator_a");
+}
+
+// A database written before this feature existed has no planned_stops table.
+// Opening it must add the table rather than fail, which is the whole point of
+// running the schema step on every open.
+TEST_F(SqlitePlannedStopTest, OpeningADatabaseWithoutThePlannedStopsTableAddsIt) {
+  {
+    SqliteFaultStorage storage(db_path_.string());
+    ASSERT_TRUE(storage.declare_planned_stop(make_window("pre", 1 * kSec, 2 * kSec, 1 * kSec)));
+  }
+  {
+    sqlite3 * raw = nullptr;
+    ASSERT_EQ(sqlite3_open(db_path_.string().c_str(), &raw), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(raw, "DROP TABLE planned_stops", nullptr, nullptr, nullptr), SQLITE_OK);
+    sqlite3_close(raw);
+  }
+
+  SqliteFaultStorage reopened(db_path_.string());
+  EXPECT_TRUE(reopened.list_planned_stops().empty());
+  EXPECT_TRUE(reopened.declare_planned_stop(make_window("post", 3 * kSec, 4 * kSec, 3 * kSec)));
+  EXPECT_TRUE(reopened.get_planned_stop("post").has_value());
+}
+
+// --- The configured bound, swept across its whole declared range ------------
+
+TEST(PlannedStopWindowBoundTest, ClampSweepsTheDeclaredRange) {
+  bool clamped = false;
+
+  EXPECT_EQ(clamp_planned_stop_windows(100, clamped), 100);
+  EXPECT_FALSE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(kMinPlannedStopWindows, clamped), kMinPlannedStopWindows);
+  EXPECT_FALSE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(kMaxPlannedStopWindows, clamped), kMaxPlannedStopWindows);
+  EXPECT_FALSE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(0, clamped), kMinPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(-1, clamped), kMinPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(kMaxPlannedStopWindows + 1, clamped), kMaxPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+
+  // ROS parameters arrive as int64. A value above INT_MAX must be clamped
+  // BEFORE it is narrowed, or it wraps back into the legal band and passes.
+  EXPECT_EQ(clamp_planned_stop_windows(std::numeric_limits<int64_t>::max(), clamped), kMaxPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+  EXPECT_EQ(clamp_planned_stop_windows(4'294'967'396, clamped), kMaxPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+
+  EXPECT_EQ(clamp_planned_stop_windows(std::numeric_limits<int64_t>::min(), clamped), kMinPlannedStopWindows);
+  EXPECT_TRUE(clamped);
+}

--- a/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
@@ -32,6 +32,7 @@
 
 #include "ros2_medkit_fault_manager/fault_storage.hpp"
 #include "ros2_medkit_fault_manager/sqlite_fault_storage.hpp"
+#include "ros2_medkit_fault_manager/time_utils.hpp"
 
 using ros2_medkit_fault_manager::clamp_planned_stop_windows;
 using ros2_medkit_fault_manager::EndPlannedStopOutcome;
@@ -334,6 +335,47 @@ TEST_F(SqlitePlannedStopTest, OpeningADatabaseWithoutThePlannedStopsTableAddsIt)
   EXPECT_TRUE(reopened.list_planned_stops().empty());
   EXPECT_TRUE(reopened.declare_planned_stop(make_window("post", 3 * kSec, 4 * kSec, 3 * kSec)));
   EXPECT_TRUE(reopened.get_planned_stop("post").has_value());
+}
+
+// --- nanoseconds <-> builtin_interfaces/Time ---------------------------------
+
+TEST(TimeMsgConversion, NegativeInstantsStayWellFormed) {
+  using ros2_medkit_fault_manager::ns_to_time_msg;
+  using ros2_medkit_fault_manager::time_msg_to_ns;
+
+  // builtin_interfaces/Time carries `nanosec` as an UNSIGNED field, so the
+  // conversion has to floor rather than truncate towards zero: -1 ns is one
+  // nanosecond before the epoch, which is second -1 plus 999999999 ns. C's
+  // remainder gives -1 there, and casting that to uint32 produced 4294967295 -
+  // a message no reader can interpret.
+  auto t = ns_to_time_msg(-1);
+  EXPECT_EQ(t.sec, -1);
+  EXPECT_EQ(t.nanosec, 999999999u);
+  EXPECT_LT(t.nanosec, 1000000000u);
+  EXPECT_EQ(time_msg_to_ns(t), -1) << "and the round trip must come back";
+
+  t = ns_to_time_msg(-1500000000LL);
+  EXPECT_EQ(t.sec, -2);
+  EXPECT_EQ(t.nanosec, 500000000u);
+  EXPECT_EQ(time_msg_to_ns(t), -1500000000LL);
+
+  // INT64_MIN cannot be carried by an int32 second field at all. The conversion
+  // must not wrap into a plausible-looking instant; it saturates, and the API
+  // refuses such a value long before it gets here.
+  t = ns_to_time_msg(std::numeric_limits<int64_t>::min());
+  EXPECT_LT(t.nanosec, 1000000000u) << "whatever it saturates to must still be a legal Time";
+}
+
+TEST(TimeMsgConversion, PositiveInstantsRoundTrip) {
+  using ros2_medkit_fault_manager::ns_to_time_msg;
+  using ros2_medkit_fault_manager::time_msg_to_ns;
+
+  const int64_t samples[] = {0, 1, kSec, kSec + 999999999LL, 1788698096LL * kSec};
+  for (int64_t ns : samples) {
+    const auto t = ns_to_time_msg(ns);
+    EXPECT_LT(t.nanosec, 1000000000u) << "for " << ns;
+    EXPECT_EQ(time_msg_to_ns(t), ns);
+  }
 }
 
 // --- The configured bound, swept across its whole declared range ------------

--- a/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
@@ -176,6 +176,68 @@ TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
   EXPECT_FALSE(stored->covers(40 * kSec)) << "a fault raised after the early end is not expected";
 }
 
+// R12: a window that has not started has marked nothing, and storing
+// ends_at <= starts_at would contradict the message's own promise. It is
+// cancelled - removed - rather than "ended early".
+TEST_P(PlannedStopStorageTest, AWindowThatHasNotStartedIsCancelledNotEnded) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
+
+  auto result = storage_->end_planned_stop("future", 60 * kSec);
+  ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Cancelled);
+  EXPECT_TRUE(result.window.cancelled);
+  EXPECT_FALSE(result.window.ended_early) << "it never ran, so it did not end early";
+  EXPECT_EQ(result.window.starts_at_ns, 100 * kSec) << "the window is returned as it was";
+  EXPECT_EQ(result.window.ends_at_ns, 200 * kSec);
+
+  EXPECT_FALSE(storage_->get_planned_stop("future").has_value()) << "a cancelled window is gone, not stored inverted";
+}
+
+TEST_P(PlannedStopStorageTest, NoStoredWindowEverHasAnEndAtOrBeforeItsStart) {
+  // The message promises ends_at is strictly after starts_at. Every path that
+  // can move ends_at is driven here, and the invariant is asserted over the
+  // whole store afterwards.
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("running", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 5 * kSec)));
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("past", 1 * kSec, 2 * kSec, 1 * kSec)));
+
+  storage_->end_planned_stop("running", 30 * kSec);  // ends early
+  storage_->end_planned_stop("future", 60 * kSec);   // cancels
+  storage_->end_planned_stop("past", 1 * kSec + 1);  // refused: already over
+  storage_->end_planned_stop("running", 15 * kSec);  // refused: already ended
+
+  for (const auto & window : storage_->list_planned_stops()) {
+    EXPECT_GT(window.ends_at_ns, window.starts_at_ns) << "window " << window.id;
+  }
+}
+
+// A backdated `at` used to walk the end BACKWARDS on a window that had already
+// finished, rewriting when the stop actually stopped.
+TEST_P(PlannedStopStorageTest, ABackdatedEndCannotMoveAnEndThatAlreadyPassed) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(storage_->end_planned_stop("w", 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
+
+  auto backdated = storage_->end_planned_stop("w", 20 * kSec);
+  EXPECT_EQ(backdated.outcome, EndPlannedStopOutcome::AlreadyEnded);
+
+  auto stored = storage_->get_planned_stop("w");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 50 * kSec) << "the record of when the stop finished is not rewritable";
+}
+
+TEST_P(PlannedStopStorageTest, ABackdatedEndCannotReopenAWindowThatRanOut) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+
+  // 15 s is inside the window but the window's own end has passed in wall-clock
+  // terms; the guard is the stored end, not the caller's instant.
+  auto backdated = storage_->end_planned_stop("w", 15 * kSec);
+  EXPECT_EQ(backdated.outcome, EndPlannedStopOutcome::Ended)
+      << "a window still running at the requested instant may be ended there";
+
+  auto again = storage_->end_planned_stop("w", 12 * kSec);
+  EXPECT_EQ(again.outcome, EndPlannedStopOutcome::AlreadyEnded);
+  EXPECT_EQ(storage_->get_planned_stop("w")->ends_at_ns, 15 * kSec);
+}
+
 TEST_P(PlannedStopStorageTest, EndUnknownIdIsNotFound) {
   auto result = storage_->end_planned_stop("never_declared", 30 * kSec);
   EXPECT_EQ(result.outcome, EndPlannedStopOutcome::NotFound);
@@ -250,6 +312,21 @@ TEST_P(PlannedStopStorageTest, RetentionNeverPrunesAnActiveWindowEvenPastTheCap)
 }
 
 // CONFIG SWEEP at the storage boundary: a cap of one keeps exactly the newest.
+// The window being declared is exempt from the pruning its own declaration
+// triggers. Without that, a cap already filled by a window that cannot be pruned
+// (a live one) made the NEW row the only candidate: it was inserted, deleted,
+// and reported as stored.
+TEST_P(PlannedStopStorageTest, ADeclarationSurvivesThePruningItTriggers) {
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(1, now);
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("live", now - kSec, now + 500 * kSec, now - kSec)));
+
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("just_declared", 1 * kSec, 2 * kSec, now)));
+  EXPECT_TRUE(storage_->get_planned_stop("just_declared").has_value())
+      << "a declaration reported as stored must be there afterwards";
+  EXPECT_TRUE(storage_->get_planned_stop("live").has_value()) << "and a running window is still never pruned";
+}
+
 TEST_P(PlannedStopStorageTest, RetentionOfOneKeepsOnlyTheNewestEndedWindow) {
   const int64_t now = 1000 * kSec;
   storage_->set_max_planned_stops(1, now);

--- a/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
@@ -35,6 +35,7 @@
 #include "ros2_medkit_fault_manager/time_utils.hpp"
 
 using ros2_medkit_fault_manager::clamp_planned_stop_windows;
+using ros2_medkit_fault_manager::DeclarePlannedStopOutcome;
 using ros2_medkit_fault_manager::EndPlannedStopOutcome;
 using ros2_medkit_fault_manager::FaultStorage;
 using ros2_medkit_fault_manager::InMemoryFaultStorage;
@@ -104,7 +105,7 @@ TEST_P(PlannedStopStorageTest, DeclareStoresEveryFieldVerbatim) {
   auto w = make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec);
   w.reason = "weekend maintenance";
   w.declared_by = "line_lead";
-  ASSERT_TRUE(storage_->declare_planned_stop(w));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored, storage_->declare_planned_stop(w));
 
   auto stored = storage_->get_planned_stop("w1");
   ASSERT_TRUE(stored.has_value());
@@ -118,8 +119,10 @@ TEST_P(PlannedStopStorageTest, DeclareStoresEveryFieldVerbatim) {
 }
 
 TEST_P(PlannedStopStorageTest, DeclareRefusesADuplicateId) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
-  EXPECT_FALSE(storage_->declare_planned_stop(make_window("w1", 30 * kSec, 40 * kSec, 25 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
+  EXPECT_EQ(DeclarePlannedStopOutcome::DuplicateId,
+            storage_->declare_planned_stop(make_window("w1", 30 * kSec, 40 * kSec, 25 * kSec)));
 
   auto stored = storage_->get_planned_stop("w1");
   ASSERT_TRUE(stored.has_value());
@@ -131,8 +134,10 @@ TEST_P(PlannedStopStorageTest, GetUnknownIdIsEmpty) {
 }
 
 TEST_P(PlannedStopStorageTest, ListReturnsNewestDeclarationFirst) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("older", 10 * kSec, 20 * kSec, 1 * kSec)));
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("newer", 30 * kSec, 40 * kSec, 2 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("older", 10 * kSec, 20 * kSec, 1 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("newer", 30 * kSec, 40 * kSec, 2 * kSec)));
 
   auto all = storage_->list_planned_stops();
   ASSERT_EQ(all.size(), 2u);
@@ -152,7 +157,8 @@ TEST_P(PlannedStopStorageTest, CoversIsClosedAtBothEnds) {
 }
 
 TEST_P(PlannedStopStorageTest, EndEarlyMovesEndsAtAndFlagsIt) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
 
   auto result = storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec);
   ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Ended);
@@ -167,7 +173,8 @@ TEST_P(PlannedStopStorageTest, EndEarlyMovesEndsAtAndFlagsIt) {
 }
 
 TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
   ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
   auto stored = storage_->get_planned_stop("w1");
@@ -184,7 +191,8 @@ TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
 
 TEST_P(PlannedStopStorageTest, AWindowThatHasNotStartedIsCancelledNotEnded) {
   const int64_t now = 60 * kSec;
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
 
   auto result = storage_->end_planned_stop("future", now, now);
   ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Cancelled);
@@ -198,7 +206,8 @@ TEST_P(PlannedStopStorageTest, AWindowThatHasNotStartedIsCancelledNotEnded) {
 
 TEST_P(PlannedStopStorageTest, ANotStartedWindowIsCancelledWhateverAtSays) {
   const int64_t now = 60 * kSec;
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
 
   // `at` inside the window's own span, which under the old rule would have made
   // it an "end". The window has not started at NOW, so it is a cancellation.
@@ -212,14 +221,23 @@ TEST_P(PlannedStopStorageTest, NoStoredWindowEverHasAnEndAtOrBeforeItsStart) {
   // can move ends_at is driven here, and the invariant is asserted over the
   // whole store afterwards.
   const int64_t now = 50 * kSec;
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("running", 10 * kSec, 100 * kSec, 5 * kSec)));
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 5 * kSec)));
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("past", 1 * kSec, 2 * kSec, 1 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("running", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("past", 1 * kSec, 2 * kSec, 1 * kSec)));
 
   storage_->end_planned_stop("running", 30 * kSec, now);  // ends early
   storage_->end_planned_stop("future", now, now);         // cancels
   storage_->end_planned_stop("past", 1 * kSec + 1, now);  // refused: already over
   storage_->end_planned_stop("running", 15 * kSec, now);  // refused: already ended
+
+  // The input that used to store ends_at == starts_at: an `at` exactly on the
+  // start of a window that is running.
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("at_its_start", 20 * kSec, 90 * kSec, 5 * kSec)));
+  EXPECT_EQ(storage_->end_planned_stop("at_its_start", 20 * kSec, now).outcome, EndPlannedStopOutcome::InvalidAt);
 
   for (const auto & window : storage_->list_planned_stops()) {
     EXPECT_GT(window.ends_at_ns, window.starts_at_ns) << "window " << window.id;
@@ -229,7 +247,8 @@ TEST_P(PlannedStopStorageTest, NoStoredWindowEverHasAnEndAtOrBeforeItsStart) {
 // The reported case: a window that finished on its own, re-ended with a
 // backdated instant that still fell inside its original span.
 TEST_P(PlannedStopStorageTest, ANaturallyFinishedWindowIsImmutable) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
   const int64_t now = 40 * kSec;  // the window ran out ten seconds ago
 
   auto backdated = storage_->end_planned_stop("w", 15 * kSec, now);
@@ -242,7 +261,8 @@ TEST_P(PlannedStopStorageTest, ANaturallyFinishedWindowIsImmutable) {
 }
 
 TEST_P(PlannedStopStorageTest, AFinishedWindowIsNotCancelledByAnAtBeforeItsStart) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
   const int64_t now = 40 * kSec;
 
   // Under the old rule this took the cancel branch and DELETED a window that had
@@ -253,7 +273,8 @@ TEST_P(PlannedStopStorageTest, AFinishedWindowIsNotCancelledByAnAtBeforeItsStart
 }
 
 TEST_P(PlannedStopStorageTest, ABackdatedEndCannotMoveAnEndThatAlreadyPassed) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
   ASSERT_EQ(storage_->end_planned_stop("w", 50 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
   auto backdated = storage_->end_planned_stop("w", 20 * kSec, 60 * kSec);
@@ -267,7 +288,8 @@ TEST_P(PlannedStopStorageTest, ABackdatedEndCannotMoveAnEndThatAlreadyPassed) {
 // `at` only REFINES the end instant of a window that is running now. Outside
 // [starts_at, now] it is not an instant the window could have ended at.
 TEST_P(PlannedStopStorageTest, AtBeforeTheStartOfARunningWindowIsRefused) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
 
   auto result = storage_->end_planned_stop("w", 5 * kSec, 50 * kSec);
   EXPECT_EQ(result.outcome, EndPlannedStopOutcome::InvalidAt);
@@ -279,7 +301,8 @@ TEST_P(PlannedStopStorageTest, AtBeforeTheStartOfARunningWindowIsRefused) {
 }
 
 TEST_P(PlannedStopStorageTest, AtInTheFutureOfARunningWindowIsRefused) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
 
   // 60 s has not happened yet at now = 50 s; a stop cannot end in the future.
   auto result = storage_->end_planned_stop("w", 60 * kSec, 50 * kSec);
@@ -288,18 +311,26 @@ TEST_P(PlannedStopStorageTest, AtInTheFutureOfARunningWindowIsRefused) {
 }
 
 TEST_P(PlannedStopStorageTest, AtWithinTheRunningSpanEndsTheWindowThere) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
 
   auto result = storage_->end_planned_stop("w", 30 * kSec, 50 * kSec);
   ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Ended);
   EXPECT_EQ(result.window.ends_at_ns, 30 * kSec);
   EXPECT_TRUE(result.window.ended_early);
 
-  // Both ends of the legal range are legal.
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("at_start", 10 * kSec, 100 * kSec, 5 * kSec)));
-  EXPECT_EQ(storage_->end_planned_stop("at_start", 10 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("at_now", 10 * kSec, 100 * kSec, 5 * kSec)));
+  // `now` is a legal end. The START is not: ending there would store
+  // ends_at == starts_at, which the message says can never happen.
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("at_now", 10 * kSec, 100 * kSec, 5 * kSec)));
   EXPECT_EQ(storage_->end_planned_stop("at_now", 50 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
+
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("at_start", 10 * kSec, 100 * kSec, 5 * kSec)));
+  EXPECT_EQ(storage_->end_planned_stop("at_start", 10 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::InvalidAt)
+      << "a window cannot end at the instant it started - that is a zero-length window";
+  EXPECT_EQ(storage_->end_planned_stop("at_start", 10 * kSec + 1, 50 * kSec).outcome, EndPlannedStopOutcome::Ended)
+      << "one nanosecond after the start is an interval, however short";
 }
 
 TEST_P(PlannedStopStorageTest, EndUnknownIdIsNotFound) {
@@ -308,7 +339,8 @@ TEST_P(PlannedStopStorageTest, EndUnknownIdIsNotFound) {
 }
 
 TEST_P(PlannedStopStorageTest, EndingATwiceEndedWindowIsRefused) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
   ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
   auto again = storage_->end_planned_stop("w1", 50 * kSec, 60 * kSec);
@@ -320,7 +352,8 @@ TEST_P(PlannedStopStorageTest, EndingATwiceEndedWindowIsRefused) {
 }
 
 TEST_P(PlannedStopStorageTest, EndingAWindowThatAlreadyExpiredIsRefused) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
 
   // 40s is past the declared end: the window closed on its own.
   auto result = storage_->end_planned_stop("w1", 40 * kSec, 40 * kSec);
@@ -341,23 +374,15 @@ TEST_P(PlannedStopStorageTest, RetentionPrunesOldestEndedAndKeepsTheActiveOne) {
   // cap + 5 declarations: the first cap + 4 have already ended, the last is live.
   for (int i = 0; i < static_cast<int>(cap) + 4; ++i) {
     const int64_t declared = static_cast<int64_t>(i + 1) * kSec;
-    ASSERT_TRUE(
+    ASSERT_EQ(
+        DeclarePlannedStopOutcome::Stored,
         storage_->declare_planned_stop(make_window("ended_" + std::to_string(i), declared, declared + kSec, declared)));
   }
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("active", now - kSec, now + 100 * kSec, now)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("active", now - kSec, now + 100 * kSec, now)));
 
   auto all = storage_->list_planned_stops();
-  // The cap bounds windows that are no longer active. An active window is always
-  // kept and is never dropped to make room, so the bound on the whole table is
-  // the cap PLUS however many windows are still running.
-  size_t active = 0;
-  for (const auto & w : all) {
-    if (w.active_at(now)) {
-      ++active;
-    }
-  }
-  EXPECT_LE(all.size(), cap + active) << "stored count must be at most the cap plus the active windows";
-  EXPECT_LE(all.size() - active, cap) << "and the ended ones alone must fit the cap";
+  EXPECT_LE(all.size(), cap) << "the cap is a hard bound on stored windows";
 
   bool has_active = false;
   for (const auto & w : all) {
@@ -370,55 +395,87 @@ TEST_P(PlannedStopStorageTest, RetentionPrunesOldestEndedAndKeepsTheActiveOne) {
   EXPECT_FALSE(storage_->get_planned_stop("ended_1").has_value());
 }
 
-TEST_P(PlannedStopStorageTest, RetentionNeverPrunesAnActiveWindowEvenPastTheCap) {
+// A window that has not ended is never pruned - not even to make room. Under the
+// hard bound that means the DECLARATION is refused, rather than a live window
+// vanishing under the operator who declared it.
+TEST_P(PlannedStopStorageTest, AnActiveWindowIsNeverPrunedToMakeRoom) {
   const size_t cap = 2;
   const int64_t now = 1000 * kSec;
   storage_->set_max_planned_stops(cap, now);
 
-  for (int i = 0; i < 5; ++i) {
-    const int64_t declared = now + static_cast<int64_t>(i) * kSec;
-    ASSERT_TRUE(storage_->declare_planned_stop(
-        make_window("live_" + std::to_string(i), now - kSec, now + 500 * kSec, declared)));
+  for (size_t i = 0; i < cap; ++i) {
+    const int64_t declared = now + static_cast<int64_t>(i);
+    ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+              storage_->declare_planned_stop(
+                  make_window("live_" + std::to_string(i), now - kSec, now + 500 * kSec, declared)));
   }
 
+  EXPECT_EQ(storage_->declare_planned_stop(make_window("refused", now - kSec, now + 500 * kSec, now + 9)),
+            DeclarePlannedStopOutcome::CapFull);
   auto all = storage_->list_planned_stops();
-  EXPECT_EQ(all.size(), 5u) << "five live windows must all survive a cap of two";
+  EXPECT_EQ(all.size(), cap) << "the bound holds and no live window was sacrificed for it";
+  for (const auto & w : all) {
+    EXPECT_TRUE(w.active_at(now)) << "window " << w.id << " should still be running";
+  }
+}
+
+TEST_P(PlannedStopStorageTest, ADeclarationIsRefusedWhenTheCapIsFullOfLiveWindows) {
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(1, now);
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("live", now - kSec, now + 500 * kSec, now - kSec)));
+
+  EXPECT_EQ(storage_->declare_planned_stop(make_window("refused", 1 * kSec, 2 * kSec, now)),
+            DeclarePlannedStopOutcome::CapFull);
+  EXPECT_FALSE(storage_->get_planned_stop("refused").has_value()) << "a refused declaration must not be stored at all";
+  EXPECT_EQ(storage_->list_planned_stops().size(), 1u) << "the bound is hard";
+
+  ASSERT_EQ(storage_->end_planned_stop("live", now, now).outcome, EndPlannedStopOutcome::Ended);
+  EXPECT_EQ(storage_->declare_planned_stop(make_window("accepted", 1 * kSec, 2 * kSec, now + kSec)),
+            DeclarePlannedStopOutcome::Stored);
+  EXPECT_EQ(storage_->list_planned_stops().size(), 1u) << "and the ended one made room by going";
+}
+
+TEST_P(PlannedStopStorageTest, FutureWindowsCannotGrowTheTablePastTheCap) {
+  const int64_t now = 1000 * kSec;
+  const size_t cap = 3;
+  storage_->set_max_planned_stops(cap, now);
+
+  for (size_t i = 0; i < cap; ++i) {
+    ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+              storage_->declare_planned_stop(make_window("future_" + std::to_string(i), now + 100 * kSec,
+                                                         now + 200 * kSec, now + static_cast<int64_t>(i))));
+  }
+  EXPECT_EQ(storage_->declare_planned_stop(make_window("one_too_many", now + 100 * kSec, now + 200 * kSec, now + 9)),
+            DeclarePlannedStopOutcome::CapFull);
+  EXPECT_EQ(storage_->list_planned_stops().size(), cap);
+}
+
+TEST_P(PlannedStopStorageTest, ADeclarationPrunesEndedWindowsToMakeRoomForItself) {
+  const int64_t now = 1000 * kSec;
+  storage_->set_max_planned_stops(2, now);
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("old", 1 * kSec, 2 * kSec, 1 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("newer", 3 * kSec, 4 * kSec, 3 * kSec)));
+
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("newest", 5 * kSec, 6 * kSec, 5 * kSec)));
+  EXPECT_TRUE(storage_->get_planned_stop("newest").has_value())
+      << "a declaration reported as stored must be there afterwards";
+  EXPECT_FALSE(storage_->get_planned_stop("old").has_value()) << "the oldest ended window made room";
+  EXPECT_EQ(storage_->list_planned_stops().size(), 2u);
 }
 
 // CONFIG SWEEP at the storage boundary: a cap of one keeps exactly the newest.
-// The window being declared is exempt from the pruning its own declaration
-// triggers. Without that, a cap already filled by a window that cannot be pruned
-// (a live one) made the NEW row the only candidate: it was inserted, deleted,
-// and reported as stored.
-TEST_P(PlannedStopStorageTest, ADeclarationSurvivesThePruningItTriggers) {
-  const int64_t now = 1000 * kSec;
-  storage_->set_max_planned_stops(1, now);
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("live", now - kSec, now + 500 * kSec, now - kSec)));
-
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("just_declared", 1 * kSec, 2 * kSec, now)));
-  EXPECT_TRUE(storage_->get_planned_stop("just_declared").has_value())
-      << "a declaration reported as stored must be there afterwards";
-  EXPECT_TRUE(storage_->get_planned_stop("live").has_value()) << "and a running window is still never pruned";
-
-  // Two rows against a cap of one, and that is the documented bound: one active
-  // window plus one ended one. The cap counts what is no longer active.
-  auto all = storage_->list_planned_stops();
-  ASSERT_EQ(all.size(), 2u);
-  size_t ended = 0;
-  for (const auto & w : all) {
-    if (!w.active_at(now)) {
-      ++ended;
-    }
-  }
-  EXPECT_EQ(ended, 1u) << "the ended half of the table must fit the cap exactly";
-}
-
 TEST_P(PlannedStopStorageTest, RetentionOfOneKeepsOnlyTheNewestEndedWindow) {
   const int64_t now = 1000 * kSec;
   storage_->set_max_planned_stops(1, now);
 
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("first", 1 * kSec, 2 * kSec, 1 * kSec)));
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("second", 3 * kSec, 4 * kSec, 3 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("first", 1 * kSec, 2 * kSec, 1 * kSec)));
+  ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+            storage_->declare_planned_stop(make_window("second", 3 * kSec, 4 * kSec, 3 * kSec)));
 
   auto all = storage_->list_planned_stops();
   ASSERT_EQ(all.size(), 1u);
@@ -432,8 +489,8 @@ TEST_P(PlannedStopStorageTest, LoweringTheBoundEvictsStoredWindowsImmediately) {
   storage_->set_max_planned_stops(10, now);
   for (int i = 0; i < 6; ++i) {
     const int64_t declared = static_cast<int64_t>(i + 1) * kSec;
-    ASSERT_TRUE(
-        storage_->declare_planned_stop(make_window("w" + std::to_string(i), declared, declared + kSec, declared)));
+    ASSERT_EQ(DeclarePlannedStopOutcome::Stored, storage_->declare_planned_stop(make_window(
+                                                     "w" + std::to_string(i), declared, declared + kSec, declared)));
   }
   ASSERT_EQ(storage_->list_planned_stops().size(), 6u);
 
@@ -465,7 +522,8 @@ class SqlitePlannedStopTest : public ::testing::Test {
 TEST_F(SqlitePlannedStopTest, WindowsSurviveCloseAndReopen) {
   {
     SqliteFaultStorage storage(db_path_.string());
-    ASSERT_TRUE(storage.declare_planned_stop(make_window("survivor", 10 * kSec, 900 * kSec, 5 * kSec)));
+    ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+              storage.declare_planned_stop(make_window("survivor", 10 * kSec, 900 * kSec, 5 * kSec)));
     ASSERT_EQ(storage.end_planned_stop("survivor", 500 * kSec, 500 * kSec).outcome, EndPlannedStopOutcome::Ended);
   }
 
@@ -485,7 +543,8 @@ TEST_F(SqlitePlannedStopTest, WindowsSurviveCloseAndReopen) {
 TEST_F(SqlitePlannedStopTest, OpeningADatabaseWithoutThePlannedStopsTableAddsIt) {
   {
     SqliteFaultStorage storage(db_path_.string());
-    ASSERT_TRUE(storage.declare_planned_stop(make_window("pre", 1 * kSec, 2 * kSec, 1 * kSec)));
+    ASSERT_EQ(DeclarePlannedStopOutcome::Stored,
+              storage.declare_planned_stop(make_window("pre", 1 * kSec, 2 * kSec, 1 * kSec)));
   }
   {
     sqlite3 * raw = nullptr;
@@ -496,7 +555,8 @@ TEST_F(SqlitePlannedStopTest, OpeningADatabaseWithoutThePlannedStopsTableAddsIt)
 
   SqliteFaultStorage reopened(db_path_.string());
   EXPECT_TRUE(reopened.list_planned_stops().empty());
-  EXPECT_TRUE(reopened.declare_planned_stop(make_window("post", 3 * kSec, 4 * kSec, 3 * kSec)));
+  EXPECT_EQ(DeclarePlannedStopOutcome::Stored,
+            reopened.declare_planned_stop(make_window("post", 3 * kSec, 4 * kSec, 3 * kSec)));
   EXPECT_TRUE(reopened.get_planned_stop("post").has_value());
 }
 

--- a/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
+++ b/src/ros2_medkit_fault_manager/test/test_planned_stops.cpp
@@ -154,7 +154,7 @@ TEST_P(PlannedStopStorageTest, CoversIsClosedAtBothEnds) {
 TEST_P(PlannedStopStorageTest, EndEarlyMovesEndsAtAndFlagsIt) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
 
-  auto result = storage_->end_planned_stop("w1", 30 * kSec);
+  auto result = storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec);
   ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Ended);
   EXPECT_EQ(result.window.ends_at_ns, 30 * kSec);
   EXPECT_TRUE(result.window.ended_early);
@@ -168,7 +168,7 @@ TEST_P(PlannedStopStorageTest, EndEarlyMovesEndsAtAndFlagsIt) {
 
 TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
-  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec).outcome, EndPlannedStopOutcome::Ended);
+  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
   auto stored = storage_->get_planned_stop("w1");
   ASSERT_TRUE(stored.has_value());
@@ -176,13 +176,17 @@ TEST_P(PlannedStopStorageTest, EndEarlyKeepsCoveringWhatCameBeforeTheEnd) {
   EXPECT_FALSE(stored->covers(40 * kSec)) << "a fault raised after the early end is not expected";
 }
 
-// R12: a window that has not started has marked nothing, and storing
-// ends_at <= starts_at would contradict the message's own promise. It is
-// cancelled - removed - rather than "ended early".
+// R12/R15: which of the three situations a window is in is decided against NOW -
+// the fault manager's wall clock - never against the `at` the caller supplied.
+// Judging on `at` let a caller pick the answer: a backdated instant inside the
+// original span re-ended a window that had already finished on its own, and one
+// before the start deleted a finished window outright.
+
 TEST_P(PlannedStopStorageTest, AWindowThatHasNotStartedIsCancelledNotEnded) {
+  const int64_t now = 60 * kSec;
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
 
-  auto result = storage_->end_planned_stop("future", 60 * kSec);
+  auto result = storage_->end_planned_stop("future", now, now);
   ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Cancelled);
   EXPECT_TRUE(result.window.cancelled);
   EXPECT_FALSE(result.window.ended_early) << "it never ran, so it did not end early";
@@ -192,31 +196,67 @@ TEST_P(PlannedStopStorageTest, AWindowThatHasNotStartedIsCancelledNotEnded) {
   EXPECT_FALSE(storage_->get_planned_stop("future").has_value()) << "a cancelled window is gone, not stored inverted";
 }
 
+TEST_P(PlannedStopStorageTest, ANotStartedWindowIsCancelledWhateverAtSays) {
+  const int64_t now = 60 * kSec;
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 50 * kSec)));
+
+  // `at` inside the window's own span, which under the old rule would have made
+  // it an "end". The window has not started at NOW, so it is a cancellation.
+  auto result = storage_->end_planned_stop("future", 150 * kSec, now);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::Cancelled);
+  EXPECT_FALSE(storage_->get_planned_stop("future").has_value());
+}
+
 TEST_P(PlannedStopStorageTest, NoStoredWindowEverHasAnEndAtOrBeforeItsStart) {
   // The message promises ends_at is strictly after starts_at. Every path that
   // can move ends_at is driven here, and the invariant is asserted over the
   // whole store afterwards.
+  const int64_t now = 50 * kSec;
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("running", 10 * kSec, 100 * kSec, 5 * kSec)));
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("future", 100 * kSec, 200 * kSec, 5 * kSec)));
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("past", 1 * kSec, 2 * kSec, 1 * kSec)));
 
-  storage_->end_planned_stop("running", 30 * kSec);  // ends early
-  storage_->end_planned_stop("future", 60 * kSec);   // cancels
-  storage_->end_planned_stop("past", 1 * kSec + 1);  // refused: already over
-  storage_->end_planned_stop("running", 15 * kSec);  // refused: already ended
+  storage_->end_planned_stop("running", 30 * kSec, now);  // ends early
+  storage_->end_planned_stop("future", now, now);         // cancels
+  storage_->end_planned_stop("past", 1 * kSec + 1, now);  // refused: already over
+  storage_->end_planned_stop("running", 15 * kSec, now);  // refused: already ended
 
   for (const auto & window : storage_->list_planned_stops()) {
     EXPECT_GT(window.ends_at_ns, window.starts_at_ns) << "window " << window.id;
   }
 }
 
-// A backdated `at` used to walk the end BACKWARDS on a window that had already
-// finished, rewriting when the stop actually stopped.
+// The reported case: a window that finished on its own, re-ended with a
+// backdated instant that still fell inside its original span.
+TEST_P(PlannedStopStorageTest, ANaturallyFinishedWindowIsImmutable) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+  const int64_t now = 40 * kSec;  // the window ran out ten seconds ago
+
+  auto backdated = storage_->end_planned_stop("w", 15 * kSec, now);
+  EXPECT_EQ(backdated.outcome, EndPlannedStopOutcome::AlreadyEnded);
+
+  auto stored = storage_->get_planned_stop("w");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 20 * kSec) << "when a stop finished is not rewritable";
+  EXPECT_FALSE(stored->ended_early) << "and it did not become an early end retroactively";
+}
+
+TEST_P(PlannedStopStorageTest, AFinishedWindowIsNotCancelledByAnAtBeforeItsStart) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+  const int64_t now = 40 * kSec;
+
+  // Under the old rule this took the cancel branch and DELETED a window that had
+  // already run - erasing the reason a month of faults reads as expected.
+  auto result = storage_->end_planned_stop("w", 1 * kSec, now);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::AlreadyEnded);
+  EXPECT_TRUE(storage_->get_planned_stop("w").has_value()) << "the row must still be there";
+}
+
 TEST_P(PlannedStopStorageTest, ABackdatedEndCannotMoveAnEndThatAlreadyPassed) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
-  ASSERT_EQ(storage_->end_planned_stop("w", 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
+  ASSERT_EQ(storage_->end_planned_stop("w", 50 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
-  auto backdated = storage_->end_planned_stop("w", 20 * kSec);
+  auto backdated = storage_->end_planned_stop("w", 20 * kSec, 60 * kSec);
   EXPECT_EQ(backdated.outcome, EndPlannedStopOutcome::AlreadyEnded);
 
   auto stored = storage_->get_planned_stop("w");
@@ -224,30 +264,54 @@ TEST_P(PlannedStopStorageTest, ABackdatedEndCannotMoveAnEndThatAlreadyPassed) {
   EXPECT_EQ(stored->ends_at_ns, 50 * kSec) << "the record of when the stop finished is not rewritable";
 }
 
-TEST_P(PlannedStopStorageTest, ABackdatedEndCannotReopenAWindowThatRanOut) {
-  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 20 * kSec, 5 * kSec)));
+// `at` only REFINES the end instant of a window that is running now. Outside
+// [starts_at, now] it is not an instant the window could have ended at.
+TEST_P(PlannedStopStorageTest, AtBeforeTheStartOfARunningWindowIsRefused) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
 
-  // 15 s is inside the window but the window's own end has passed in wall-clock
-  // terms; the guard is the stored end, not the caller's instant.
-  auto backdated = storage_->end_planned_stop("w", 15 * kSec);
-  EXPECT_EQ(backdated.outcome, EndPlannedStopOutcome::Ended)
-      << "a window still running at the requested instant may be ended there";
+  auto result = storage_->end_planned_stop("w", 5 * kSec, 50 * kSec);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::InvalidAt);
 
-  auto again = storage_->end_planned_stop("w", 12 * kSec);
-  EXPECT_EQ(again.outcome, EndPlannedStopOutcome::AlreadyEnded);
-  EXPECT_EQ(storage_->get_planned_stop("w")->ends_at_ns, 15 * kSec);
+  auto stored = storage_->get_planned_stop("w");
+  ASSERT_TRUE(stored.has_value());
+  EXPECT_EQ(stored->ends_at_ns, 100 * kSec);
+  EXPECT_FALSE(stored->ended_early);
+}
+
+TEST_P(PlannedStopStorageTest, AtInTheFutureOfARunningWindowIsRefused) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+
+  // 60 s has not happened yet at now = 50 s; a stop cannot end in the future.
+  auto result = storage_->end_planned_stop("w", 60 * kSec, 50 * kSec);
+  EXPECT_EQ(result.outcome, EndPlannedStopOutcome::InvalidAt);
+  EXPECT_EQ(storage_->get_planned_stop("w")->ends_at_ns, 100 * kSec);
+}
+
+TEST_P(PlannedStopStorageTest, AtWithinTheRunningSpanEndsTheWindowThere) {
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("w", 10 * kSec, 100 * kSec, 5 * kSec)));
+
+  auto result = storage_->end_planned_stop("w", 30 * kSec, 50 * kSec);
+  ASSERT_EQ(result.outcome, EndPlannedStopOutcome::Ended);
+  EXPECT_EQ(result.window.ends_at_ns, 30 * kSec);
+  EXPECT_TRUE(result.window.ended_early);
+
+  // Both ends of the legal range are legal.
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("at_start", 10 * kSec, 100 * kSec, 5 * kSec)));
+  EXPECT_EQ(storage_->end_planned_stop("at_start", 10 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
+  ASSERT_TRUE(storage_->declare_planned_stop(make_window("at_now", 10 * kSec, 100 * kSec, 5 * kSec)));
+  EXPECT_EQ(storage_->end_planned_stop("at_now", 50 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 }
 
 TEST_P(PlannedStopStorageTest, EndUnknownIdIsNotFound) {
-  auto result = storage_->end_planned_stop("never_declared", 30 * kSec);
+  auto result = storage_->end_planned_stop("never_declared", 30 * kSec, 50 * kSec);
   EXPECT_EQ(result.outcome, EndPlannedStopOutcome::NotFound);
 }
 
 TEST_P(PlannedStopStorageTest, EndingATwiceEndedWindowIsRefused) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 100 * kSec, 5 * kSec)));
-  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec).outcome, EndPlannedStopOutcome::Ended);
+  ASSERT_EQ(storage_->end_planned_stop("w1", 30 * kSec, 50 * kSec).outcome, EndPlannedStopOutcome::Ended);
 
-  auto again = storage_->end_planned_stop("w1", 50 * kSec);
+  auto again = storage_->end_planned_stop("w1", 50 * kSec, 60 * kSec);
   EXPECT_EQ(again.outcome, EndPlannedStopOutcome::AlreadyEnded);
 
   auto stored = storage_->get_planned_stop("w1");
@@ -259,7 +323,7 @@ TEST_P(PlannedStopStorageTest, EndingAWindowThatAlreadyExpiredIsRefused) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("w1", 10 * kSec, 20 * kSec, 5 * kSec)));
 
   // 40s is past the declared end: the window closed on its own.
-  auto result = storage_->end_planned_stop("w1", 40 * kSec);
+  auto result = storage_->end_planned_stop("w1", 40 * kSec, 40 * kSec);
   EXPECT_EQ(result.outcome, EndPlannedStopOutcome::AlreadyEnded);
 
   auto stored = storage_->get_planned_stop("w1");
@@ -283,7 +347,17 @@ TEST_P(PlannedStopStorageTest, RetentionPrunesOldestEndedAndKeepsTheActiveOne) {
   ASSERT_TRUE(storage_->declare_planned_stop(make_window("active", now - kSec, now + 100 * kSec, now)));
 
   auto all = storage_->list_planned_stops();
-  EXPECT_LE(all.size(), cap) << "the stored count must never exceed the cap while ended windows remain";
+  // The cap bounds windows that are no longer active. An active window is always
+  // kept and is never dropped to make room, so the bound on the whole table is
+  // the cap PLUS however many windows are still running.
+  size_t active = 0;
+  for (const auto & w : all) {
+    if (w.active_at(now)) {
+      ++active;
+    }
+  }
+  EXPECT_LE(all.size(), cap + active) << "stored count must be at most the cap plus the active windows";
+  EXPECT_LE(all.size() - active, cap) << "and the ended ones alone must fit the cap";
 
   bool has_active = false;
   for (const auto & w : all) {
@@ -325,6 +399,18 @@ TEST_P(PlannedStopStorageTest, ADeclarationSurvivesThePruningItTriggers) {
   EXPECT_TRUE(storage_->get_planned_stop("just_declared").has_value())
       << "a declaration reported as stored must be there afterwards";
   EXPECT_TRUE(storage_->get_planned_stop("live").has_value()) << "and a running window is still never pruned";
+
+  // Two rows against a cap of one, and that is the documented bound: one active
+  // window plus one ended one. The cap counts what is no longer active.
+  auto all = storage_->list_planned_stops();
+  ASSERT_EQ(all.size(), 2u);
+  size_t ended = 0;
+  for (const auto & w : all) {
+    if (!w.active_at(now)) {
+      ++ended;
+    }
+  }
+  EXPECT_EQ(ended, 1u) << "the ended half of the table must fit the cap exactly";
 }
 
 TEST_P(PlannedStopStorageTest, RetentionOfOneKeepsOnlyTheNewestEndedWindow) {
@@ -380,7 +466,7 @@ TEST_F(SqlitePlannedStopTest, WindowsSurviveCloseAndReopen) {
   {
     SqliteFaultStorage storage(db_path_.string());
     ASSERT_TRUE(storage.declare_planned_stop(make_window("survivor", 10 * kSec, 900 * kSec, 5 * kSec)));
-    ASSERT_EQ(storage.end_planned_stop("survivor", 500 * kSec).outcome, EndPlannedStopOutcome::Ended);
+    ASSERT_EQ(storage.end_planned_stop("survivor", 500 * kSec, 500 * kSec).outcome, EndPlannedStopOutcome::Ended);
   }
 
   SqliteFaultStorage reopened(db_path_.string());

--- a/src/ros2_medkit_gateway/CMakeLists.txt
+++ b/src/ros2_medkit_gateway/CMakeLists.txt
@@ -194,6 +194,7 @@ add_library(gateway_ros2 STATIC
   src/http/handlers/lock_handlers.cpp
   src/http/handlers/log_handlers.cpp
   src/http/handlers/operation_handlers.cpp
+  src/http/handlers/planned_stop_handlers.cpp
   src/http/handlers/script_handlers.cpp
   src/http/handlers/sse_fault_handler.cpp
   src/http/handlers/sse_transport_provider.cpp
@@ -411,6 +412,23 @@ if(BUILD_TESTING)
   set_tests_properties(gateway_core_smoke PROPERTIES LABELS "unit")
   # gateway_core only, no rclcpp on the link line, so no ROS entity to isolate.
   medkit_test_needs_no_domain(gateway_core_smoke)
+
+  # ─── Planned-stop window predicate (gateway_core only) ─────────────────────
+  # Pure logic: which window covers an instant, and how an ISO 8601 string on the
+  # wire becomes a nanosecond count. No rclcpp on the link line.
+  add_executable(test_planned_stop_window test/test_planned_stop_window.cpp)
+  target_link_libraries(test_planned_stop_window
+    PRIVATE
+      gateway_core
+      GTest::gtest
+      GTest::gtest_main
+  )
+  add_test(
+    NAME planned_stop_window
+    COMMAND $<TARGET_FILE:test_planned_stop_window>
+  )
+  set_tests_properties(planned_stop_window PROPERTIES LABELS "unit")
+  medkit_test_needs_no_domain(planned_stop_window)
 
   # ─── DataAccessManager routing test (gateway_core only) ────────────────────
   # Mock-transport coverage proving the manager body compiles + links against

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -1011,10 +1011,11 @@ curl "http://localhost:8080/api/v1/faults?status=all&expected=false"   # what br
 
 Each item carries `x-medkit.expected`, and `x-medkit.planned_stop_id` when it is true; the
 list's own `x-medkit.expected_count` is the tally, counted after any peer merge. The same pair
-rides every `GET /api/v1/faults/stream` frame - except while the gateway has never managed to
-read the declared windows, when the frame carries no `expected` key rather than claiming the
-fault was unexpected. See "Planned Stops" in `docs/api/rest.rst` for how a window is declared,
-what makes a fault fall inside one, and why the comparison is at millisecond resolution.
+rides every `GET /api/v1/faults/stream` frame - except while the gateway cannot read the declared
+windows, when no surface says anything: no `expected` key on the frames, none on the list items,
+and no `expected_count` on the list. See "Planned Stops" in `docs/api/rest.rst` for how a window is
+declared, what makes a fault fall inside one, and exactly what "millisecond resolution" means at
+the boundary.
 
 **Response (200 OK):**
 ```json

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -149,6 +149,13 @@ loaded plugin mounts, provided it exports `describe_plugin_routes`; those carry
 
 `GET /status` always returns a response. For apps, the status is read from the ROS 2 lifecycle `GetState` service when the node is a managed lifecycle node (`active` -> `ready`; any other state, or an unreachable/timed-out read, -> `notReady`); plain (unmanaged) nodes fall back to graph presence (`is_online`). For components, the host component is `ready` while the gateway is reachable; any other local component is `notReady` when it hosts apps and all of them are offline, and `ready` otherwise (including when it hosts no apps). `PUT /status/{action}` returns `501 Not Implemented` until a substrate plugin registers a `LifecycleProvider` for the entity. Accepted transitions return `202` with a `Location` header pointing back to `GET /status`.
 
+### Planned-Stop Endpoints
+
+- `POST /api/v1/x-medkit-planned-stops` - Declare a window during which faults are expected (operator)
+- `GET /api/v1/x-medkit-planned-stops` - List declared windows; `?active=true` keeps only the ones containing now
+- `GET /api/v1/x-medkit-planned-stops/{planned_stop_id}` - Read one window
+- `DELETE /api/v1/x-medkit-planned-stops/{planned_stop_id}` - End a window early (operator)
+
 ### Vendor Extension Endpoints
 
 - `GET /api/v1/{entity}/{id}/x-medkit-topic-beacon` - Topic beacon metadata
@@ -993,12 +1000,19 @@ List all faults across the system. This is a convenience API for dashboards and 
 
 **Query Parameters:**
 - `status` - Filter by fault status: `pending`, `confirmed`, `cleared`, `all` (default: `pending` + `confirmed`)
+- `expected` - Filter by planned stop: `true` (only faults whose cycle started inside a declared window), `false` (only the rest), `all` (default)
 
 **Example:**
 ```bash
 curl http://localhost:8080/api/v1/faults
 curl http://localhost:8080/api/v1/faults?status=all
+curl "http://localhost:8080/api/v1/faults?status=all&expected=false"   # what broke outside the stop
 ```
+
+Each item carries `x-medkit.expected`, and `x-medkit.planned_stop_id` when it is true; the
+list's own `x-medkit.expected_count` is the tally. The same pair rides every
+`GET /api/v1/faults/stream` frame. See "Planned Stops" in `docs/api/rest.rst` for how a window
+is declared and what makes a fault fall inside one.
 
 **Response (200 OK):**
 ```json

--- a/src/ros2_medkit_gateway/README.md
+++ b/src/ros2_medkit_gateway/README.md
@@ -154,7 +154,7 @@ loaded plugin mounts, provided it exports `describe_plugin_routes`; those carry
 - `POST /api/v1/x-medkit-planned-stops` - Declare a window during which faults are expected (operator)
 - `GET /api/v1/x-medkit-planned-stops` - List declared windows; `?active=true` keeps only the ones containing now
 - `GET /api/v1/x-medkit-planned-stops/{planned_stop_id}` - Read one window
-- `DELETE /api/v1/x-medkit-planned-stops/{planned_stop_id}` - End a window early (operator)
+- `DELETE /api/v1/x-medkit-planned-stops/{planned_stop_id}` - End a running window early, or cancel one that has not started (operator)
 
 ### Vendor Extension Endpoints
 
@@ -1010,9 +1010,11 @@ curl "http://localhost:8080/api/v1/faults?status=all&expected=false"   # what br
 ```
 
 Each item carries `x-medkit.expected`, and `x-medkit.planned_stop_id` when it is true; the
-list's own `x-medkit.expected_count` is the tally. The same pair rides every
-`GET /api/v1/faults/stream` frame. See "Planned Stops" in `docs/api/rest.rst` for how a window
-is declared and what makes a fault fall inside one.
+list's own `x-medkit.expected_count` is the tally, counted after any peer merge. The same pair
+rides every `GET /api/v1/faults/stream` frame - except while the gateway has never managed to
+read the declared windows, when the frame carries no `expected` key rather than claiming the
+fault was unexpected. See "Planned Stops" in `docs/api/rest.rst` for how a window is declared,
+what makes a fault fall inside one, and why the comparison is at millisecond resolution.
 
 **Response (200 OK):**
 ```json

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
@@ -57,7 +57,15 @@ struct PlannedStopWindow {
   std::string reason;
   std::string declared_by;
   int64_t declared_at_ns{0};
+
+  /// True when an operator cut the window short, which moved to_ns to the moment
+  /// of that request.
   bool ended_early{false};
+
+  /// True on the window returned by a cancellation - one stopped before it ever
+  /// started, and therefore removed rather than shortened. Never true on a
+  /// window a list or a read returns.
+  bool cancelled{false};
 
   /// Whether @p when_ns falls inside the window. CLOSED at both ends, and
   /// compared at MILLISECOND resolution on both sides (see kNsPerMillisecond):
@@ -131,6 +139,15 @@ inline bool is_representable_instant(int64_t ns) {
 const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> & windows,
                                            const nlohmann::json & fault_json);
 
+/// Write `expected_count` into a fault collection's `x-medkit` object, creating
+/// that object when the emitter did not send one.
+///
+/// A plugin's fault list need not carry a vendor extension at all, and writing
+/// through `collection["x-medkit"]["expected_count"]` while only guarding on
+/// `is_object()` left the collection answering `"x-medkit": null` - neither the
+/// count nor the absence of one. A non-object collection is left alone.
+void set_expected_count(nlohmann::json & collection, int64_t count);
+
 /// Attach `expected` - and `planned_stop_id` when it is true - to the fault's own
 /// `x-medkit` object, preserving anything already there. Returns whether the
 /// fault was expected, so a caller can keep a count without deriving twice.
@@ -174,6 +191,13 @@ class PlannedStopCache {
   /// event stream must not stall waiting to find out.
   bool last_refresh_failed() const;
 
+  /// Whether a window set has ever been read successfully. False is "this
+  /// gateway does not know", which is NOT the same as "no windows are declared"
+  /// - an empty successful read is knowledge, an outage is not. The event stream
+  /// omits the flag entirely in the first case, because a consumer must not read
+  /// an unreachable fault manager as "nothing is expected".
+  bool has_knowledge() const;
+
   /// Whether the last refresh attempt - successful or not - is older than
   /// @p ttl. True before the first one.
   bool is_stale(std::chrono::steady_clock::duration ttl) const;
@@ -187,6 +211,7 @@ class PlannedStopCache {
   mutable std::mutex mutex_;
   std::vector<PlannedStopWindow> windows_;
   bool ever_attempted_{false};
+  bool ever_stored_{false};
   bool last_refresh_failed_{false};
   std::chrono::steady_clock::time_point attempted_at_{};
 };

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
@@ -1,0 +1,152 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace ros2_medkit_gateway {
+namespace faults {
+
+/// A window of wall-clock time during which faults are expected, as the gateway
+/// holds it.
+///
+/// The fault manager owns the windows; the gateway only derives from them. This
+/// is the gateway-side shape - nanoseconds since the Unix epoch rather than
+/// builtin_interfaces/Time - so the neutral layer never sees a ROS type.
+struct PlannedStopWindow {
+  std::string id;
+  int64_t from_ns{0};
+  int64_t to_ns{0};
+  std::string reason;
+  std::string declared_by;
+  int64_t declared_at_ns{0};
+  bool ended_early{false};
+
+  /// Whether @p when_ns falls inside the window. CLOSED at both ends, matching
+  /// PlannedStopWindow::covers in the fault manager: a fault reported at the
+  /// instant a window opens or closes must read the same on both sides.
+  bool covers(int64_t when_ns) const {
+    return when_ns >= from_ns && when_ns <= to_ns;
+  }
+};
+
+/// The window that makes a fault at @p when_ns expected, or nullptr when none
+/// does.
+///
+/// When several windows cover the instant, the EARLIEST-STARTING one wins, and a
+/// tie on the start is broken by id. Both rules exist so that two readers of the
+/// same data - the fault list and the event stream, or two gateways in a fleet -
+/// name the same window; "whichever came first in the list" would not, because
+/// the fault manager is free to order its answer as it likes.
+///
+/// The returned pointer aliases @p windows and is valid only while it lives.
+const PlannedStopWindow * find_covering_window(const std::vector<PlannedStopWindow> & windows, int64_t when_ns);
+
+/// Parse an ISO 8601 instant in UTC into nanoseconds since the Unix epoch, or
+/// nothing when the text is not one.
+///
+/// Deliberately strict. `Z`, `+00:00` and `-00:00` are the only accepted zones:
+/// a string without a zone means a different instant to every reader, and a real
+/// offset is a shape this API does not take, so both are refused rather than
+/// guessed at. Fractional seconds are kept to nanosecond resolution and any
+/// further digits are truncated - the instant is still unambiguous.
+std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text);
+
+/// Seconds-with-a-fraction (how a fault carries first_occurred on the wire) into
+/// nanoseconds since the Unix epoch.
+int64_t seconds_to_ns(double seconds);
+
+/// Which window covers the fault carried in @p fault_json, or nullptr.
+///
+/// Reads `first_occurred` - seconds since the Unix epoch, the shape
+/// `fault_to_json` emits - because that is the start of the fault's CURRENT
+/// cycle. A code that failed inside a window, was cleared, and failed again
+/// afterwards is therefore expected for the first cycle and not for the second,
+/// which is what an operator asking "did anything break outside the stop" means.
+///
+/// A fault carrying no usable `first_occurred` is never expected: the gateway
+/// cannot place a cycle it cannot date, and marking it anyway would put the flag
+/// on faults nobody planned for.
+const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> & windows,
+                                           const nlohmann::json & fault_json);
+
+/// Attach `expected` - and `planned_stop_id` when it is true - to the fault's own
+/// `x-medkit` object, preserving anything already there. Returns whether the
+/// fault was expected, so a caller can keep a count without deriving twice.
+bool annotate_fault_with_planned_stop(nlohmann::json & fault_json, const std::vector<PlannedStopWindow> & windows);
+
+/// The windows this gateway last read from the fault manager.
+///
+/// A window can be declared straight through the ROS service, so the event path
+/// cannot rely on having seen every declaration itself; it re-reads on a time to
+/// live instead. Writes through this gateway invalidate the cache so an operator
+/// never watches their own declaration take effect late.
+///
+/// Thread-safe. `snapshot()` returns a copy on purpose: callers hold the result
+/// while formatting an event, and handing out a reference into the cache would
+/// tie that formatting to the refresh.
+class PlannedStopCache {
+ public:
+  PlannedStopCache() = default;
+  ~PlannedStopCache() = default;
+  PlannedStopCache(const PlannedStopCache &) = delete;
+  PlannedStopCache & operator=(const PlannedStopCache &) = delete;
+  PlannedStopCache(PlannedStopCache &&) = delete;
+  PlannedStopCache & operator=(PlannedStopCache &&) = delete;
+
+  /// Replace what is known and mark it fresh. An empty list is an answer, not a
+  /// miss: every window having ended is a state the stream must reflect.
+  void store(std::vector<PlannedStopWindow> windows);
+
+  /// A copy of what is known.
+  std::vector<PlannedStopWindow> snapshot() const;
+
+  /// Record that a refresh was attempted and did not produce windows, without
+  /// touching what is known. This is what stops an unreachable fault manager
+  /// from costing the transport's timeout on EVERY read: the attempt counts
+  /// against the time to live exactly as a successful one does.
+  void note_failed_refresh();
+
+  /// Whether the most recent refresh attempt failed. A caller uses it to back
+  /// off further than the normal time to live, because a fault manager that did
+  /// not answer once will usually not answer the next event either, and the
+  /// event stream must not stall waiting to find out.
+  bool last_refresh_failed() const;
+
+  /// Whether the last refresh attempt - successful or not - is older than
+  /// @p ttl. True before the first one.
+  bool is_stale(std::chrono::steady_clock::duration ttl) const;
+
+  /// Ask for a refresh on the next read without discarding what is known - a
+  /// gateway that just wrote a window should show it, but must not blank the
+  /// flag for every other fault while the re-read is in flight.
+  void invalidate();
+
+ private:
+  mutable std::mutex mutex_;
+  std::vector<PlannedStopWindow> windows_;
+  bool ever_attempted_{false};
+  bool last_refresh_failed_{false};
+  std::chrono::steady_clock::time_point attempted_at_{};
+};
+
+}  // namespace faults
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
@@ -20,6 +20,7 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace ros2_medkit_gateway {
@@ -27,7 +28,8 @@ namespace faults {
 
 /// The resolution the planned-stop API works at, end to end: the parser rounds
 /// down to it, storage keeps that value, responses return it unchanged (so a GET
-/// equals the POST that made it), and the covering test floors both sides to it.
+/// equals the POST that made it), the covering test floors the window's bounds
+/// to it, and a fault's own instant is rounded to the NEAREST one.
 ///
 /// One millisecond rather than one nanosecond because an operator declares a
 /// stop at minute or second precision, and the REST fault item carries
@@ -67,10 +69,18 @@ struct PlannedStopWindow {
   /// window a list or a read returns.
   bool cancelled{false};
 
-  /// Whether @p when_ns falls inside the window. CLOSED at both ends, and
-  /// compared at MILLISECOND resolution on both sides (see kNsPerMillisecond):
-  /// a fault reported anywhere inside the millisecond a window opens or closes
-  /// is inside the window.
+  /// Whether @p when_ns falls inside the window, at MILLISECOND resolution.
+  ///
+  /// Both bounds are floored to their millisecond and the interval is closed on
+  /// those, so the covered set is `[floor_ms(from), floor_ms(to)]` counted in
+  /// milliseconds. "Closed at both ends" is exact only at that resolution: a
+  /// window declared with sub-millisecond bounds through the ROS service opens
+  /// at the START of `from`'s millisecond, up to 999999 ns before the instant
+  /// asked for.
+  ///
+  /// The fault's own instant is rounded to the NEAREST millisecond before it
+  /// gets here (seconds_to_ns), so an instant within half a millisecond of a
+  /// bound lands on that bound.
   bool covers(int64_t when_ns) const {
     const int64_t when_ms = floor_to_ms_ns(when_ns);
     return when_ms >= floor_to_ms_ns(from_ns) && when_ms <= floor_to_ms_ns(to_ns);
@@ -100,8 +110,19 @@ const PlannedStopWindow * find_covering_window(const std::vector<PlannedStopWind
 std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text);
 
 /// Seconds-with-a-fraction (how a fault carries first_occurred on the wire) into
-/// nanoseconds since the Unix epoch.
-int64_t seconds_to_ns(double seconds);
+/// nanoseconds since the Unix epoch, ROUNDED TO THE NEAREST MILLISECOND.
+///
+/// Nearest, not floored: the double came from an exact nanosecond instant and
+/// carries an error far below a millisecond, so rounding recovers the instant
+/// that was meant. Flooring the nanoseconds first does not - at second
+/// 1788724271, 375 of the 1000 exact-millisecond instants land just under their
+/// own millisecond as a double and would floor to the previous one, which makes
+/// the closed boundary this API promises false for a third of the instants a
+/// fault can carry.
+///
+/// Nothing when @p seconds is not a usable instant: not finite, or so large that
+/// the conversion would be undefined rather than merely wrong.
+std::optional<int64_t> seconds_to_ns(double seconds);
 
 /// The range of instants a window can actually be stored at.
 ///
@@ -125,6 +146,17 @@ inline bool is_representable_instant(int64_t ns) {
   return ns >= kMinRepresentableNs && ns <= kMaxRepresentableNs;
 }
 
+/// What this gateway knows about the declared windows at one instant.
+///
+/// `known` false is "this gateway has not been able to read them", which is NOT
+/// "no window is declared". Every surface that reports the flag has to tell the
+/// two apart: a consumer must not read an unreachable fault manager as "nothing
+/// is expected", and that is as true of `GET /faults` as it is of the stream.
+struct PlannedStopKnowledge {
+  bool known{false};
+  std::vector<PlannedStopWindow> windows;
+};
+
 /// Which window covers the fault carried in @p fault_json, or nullptr.
 ///
 /// Reads `first_occurred` - seconds since the Unix epoch, the shape
@@ -135,9 +167,19 @@ inline bool is_representable_instant(int64_t ns) {
 ///
 /// A fault carrying no usable `first_occurred` is never expected: the gateway
 /// cannot place a cycle it cannot date, and marking it anyway would put the flag
-/// on faults nobody planned for.
+/// on faults nobody planned for. "Usable" includes being in range - a plugin's
+/// fault list is JSON this gateway did not write, and rounding an absurd double
+/// into a nanosecond count is undefined behaviour, not a big number.
 const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> & windows,
                                            const nlohmann::json & fault_json);
+
+/// How many DISTINCT fault codes in @p items say they were expected.
+///
+/// Distinct, because an aggregating gateway serves a code raised on two
+/// gateways as two items and counting both would say two stops' worth of
+/// expected faults where the plant had one. An item carrying no `expected` key
+/// is counted by neither side: its flag is unknown, and unknown is not false.
+int64_t count_expected_items(const nlohmann::json & items);
 
 /// Write `expected_count` into a fault collection's `x-medkit` object, creating
 /// that object when the emitter did not send one.
@@ -149,9 +191,14 @@ const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> 
 void set_expected_count(nlohmann::json & collection, int64_t count);
 
 /// Attach `expected` - and `planned_stop_id` when it is true - to the fault's own
-/// `x-medkit` object, preserving anything already there. Returns whether the
-/// fault was expected, so a caller can keep a count without deriving twice.
-bool annotate_fault_with_planned_stop(nlohmann::json & fault_json, const std::vector<PlannedStopWindow> & windows);
+/// `x-medkit` object, preserving anything already there.
+///
+/// Returns whether the fault was expected, so a caller can keep a count without
+/// deriving twice, or nothing when @p knowledge says the windows are unknown. In
+/// that case the item is left EXACTLY as it was: no key is written, because the
+/// honest answer is silence rather than `false`.
+std::optional<bool> annotate_fault_with_planned_stop(nlohmann::json & fault_json,
+                                                     const PlannedStopKnowledge & knowledge);
 
 /// The windows this gateway last read from the fault manager.
 ///
@@ -191,12 +238,19 @@ class PlannedStopCache {
   /// event stream must not stall waiting to find out.
   bool last_refresh_failed() const;
 
-  /// Whether a window set has ever been read successfully. False is "this
-  /// gateway does not know", which is NOT the same as "no windows are declared"
-  /// - an empty successful read is knowledge, an outage is not. The event stream
-  /// omits the flag entirely in the first case, because a consumer must not read
-  /// an unreachable fault manager as "nothing is expected".
-  bool has_knowledge() const;
+  /// Whether a window set was read successfully within @p max_age.
+  ///
+  /// False is "this gateway does not know", which is NOT the same as "no windows
+  /// are declared" - an empty successful read is knowledge, an outage is not.
+  /// Every surface that reports the flag omits it entirely in the first case.
+  ///
+  /// Knowledge EXPIRES. Without that, a gateway that read a window set once
+  /// served it for the life of the process: replace the fault manager and
+  /// `GET /x-medkit-planned-stops` answers 503 while `GET /faults` keeps naming
+  /// a window that exists nowhere, indefinitely and with no way to tell. The
+  /// bound is a small multiple of the refresh period, so a set that is merely
+  /// being re-read never blinks, and one nothing can refresh goes quiet.
+  bool has_knowledge(std::chrono::steady_clock::duration max_age) const;
 
   /// Whether the last refresh attempt - successful or not - is older than
   /// @p ttl. True before the first one.
@@ -214,6 +268,7 @@ class PlannedStopCache {
   bool ever_stored_{false};
   bool last_refresh_failed_{false};
   std::chrono::steady_clock::time_point attempted_at_{};
+  std::chrono::steady_clock::time_point stored_at_{};
 };
 
 }  // namespace faults

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
@@ -25,6 +25,25 @@
 namespace ros2_medkit_gateway {
 namespace faults {
 
+/// The resolution the planned-stop API works at, end to end: the parser rounds
+/// down to it, storage keeps that value, responses return it unchanged (so a GET
+/// equals the POST that made it), and the covering test floors both sides to it.
+///
+/// One millisecond rather than one nanosecond because an operator declares a
+/// stop at minute or second precision, and the REST fault item carries
+/// `first_occurred` as a double whose resolution at today's epoch is about a
+/// quarter of a microsecond. A boundary defined more finely than the data can
+/// express is a boundary nobody can rely on.
+constexpr int64_t kNsPerMillisecond = 1000000;
+
+/// Round @p ns DOWN to a whole millisecond. A true floor, not a truncation: it
+/// must not round towards zero for a negative instant, or the boundary would sit
+/// on the wrong side of it.
+inline int64_t floor_to_ms_ns(int64_t ns) {
+  const int64_t remainder = ns % kNsPerMillisecond;
+  return remainder < 0 ? ns - remainder - kNsPerMillisecond : ns - remainder;
+}
+
 /// A window of wall-clock time during which faults are expected, as the gateway
 /// holds it.
 ///
@@ -40,11 +59,13 @@ struct PlannedStopWindow {
   int64_t declared_at_ns{0};
   bool ended_early{false};
 
-  /// Whether @p when_ns falls inside the window. CLOSED at both ends, matching
-  /// PlannedStopWindow::covers in the fault manager: a fault reported at the
-  /// instant a window opens or closes must read the same on both sides.
+  /// Whether @p when_ns falls inside the window. CLOSED at both ends, and
+  /// compared at MILLISECOND resolution on both sides (see kNsPerMillisecond):
+  /// a fault reported anywhere inside the millisecond a window opens or closes
+  /// is inside the window.
   bool covers(int64_t when_ns) const {
-    return when_ns >= from_ns && when_ns <= to_ns;
+    const int64_t when_ms = floor_to_ms_ns(when_ns);
+    return when_ms >= floor_to_ms_ns(from_ns) && when_ms <= floor_to_ms_ns(to_ns);
   }
 };
 
@@ -76,12 +97,18 @@ int64_t seconds_to_ns(double seconds);
 
 /// The range of instants a window can actually be stored at.
 ///
-/// `builtin_interfaces/Time` carries its seconds in an int32, so the
-/// representable range runs from the Unix epoch to January 2038. An instant
-/// outside it must be REFUSED rather than converted: the narrowing wraps, and a
-/// window asked for in 2099 comes back with a negative end, covering nothing,
-/// while the operator is told it was accepted.
-constexpr int64_t kMinRepresentableNs = 0;
+/// The upper bound is `builtin_interfaces/Time`, whose seconds are an int32, so
+/// the range ends in January 2038. An instant past it must be REFUSED rather
+/// than converted: the narrowing wraps, and a window asked for in 2099 comes
+/// back with a negative end, covering nothing, while the operator is told it was
+/// accepted.
+///
+/// The lower bound is one millisecond after the Unix epoch, not the epoch
+/// itself. Zero is what an omitted or unset `builtin_interfaces/Time` reads as,
+/// and a sentinel that is also a legal value is two bugs waiting: a window
+/// declared to start at the epoch would be indistinguishable from one whose
+/// start nobody set.
+constexpr int64_t kMinRepresentableNs = kNsPerMillisecond;
 constexpr int64_t kMaxRepresentableNs = static_cast<int64_t>(2147483647) * 1000000000LL + 999999999LL;
 
 /// Whether @p ns can be carried by a builtin_interfaces/Time. Written as a

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/faults/planned_stop.hpp
@@ -74,6 +74,22 @@ std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text);
 /// nanoseconds since the Unix epoch.
 int64_t seconds_to_ns(double seconds);
 
+/// The range of instants a window can actually be stored at.
+///
+/// `builtin_interfaces/Time` carries its seconds in an int32, so the
+/// representable range runs from the Unix epoch to January 2038. An instant
+/// outside it must be REFUSED rather than converted: the narrowing wraps, and a
+/// window asked for in 2099 comes back with a negative end, covering nothing,
+/// while the operator is told it was accepted.
+constexpr int64_t kMinRepresentableNs = 0;
+constexpr int64_t kMaxRepresentableNs = static_cast<int64_t>(2147483647) * 1000000000LL + 999999999LL;
+
+/// Whether @p ns can be carried by a builtin_interfaces/Time. Written as a
+/// positive range test on purpose.
+inline bool is_representable_instant(int64_t ns) {
+  return ns >= kMinRepresentableNs && ns <= kMaxRepresentableNs;
+}
+
 /// Which window covers the fault carried in @p fault_json, or nullptr.
 ///
 /// Reads `first_occurred` - seconds since the Unix epoch, the shape

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/error_codes.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/error_codes.hpp
@@ -143,6 +143,12 @@ constexpr const char * ERR_X_MEDKIT_ENTITY_MISMATCH = "x-medkit-entity-mismatch"
 /// Vendor-specific: unsupported subscription protocol
 constexpr const char * ERR_X_MEDKIT_UNSUPPORTED_PROTOCOL = "x-medkit-unsupported-protocol";
 
+/// Vendor: a planned-stop window whose end has already passed cannot be ended
+/// again (400). Distinct from a 404 on an unknown id: the window is there, and
+/// the record of when the stop actually finished is not something a later
+/// request gets to rewrite.
+constexpr const char * ERR_X_MEDKIT_PLANNED_STOP_ENDED = "x-medkit-planned-stop-ended";
+
 /// SOVD standard: client's lock was broken by another client (409)
 constexpr const char * ERR_LOCK_BROKEN = "lock-broken";
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/handlers.hpp
@@ -43,4 +43,5 @@
 #include "ros2_medkit_gateway/http/handlers/cyclic_subscription_handlers.hpp"
 #include "ros2_medkit_gateway/http/handlers/fault_handlers.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
+#include "ros2_medkit_gateway/http/handlers/planned_stop_handlers.hpp"
 #include "ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp"

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/health_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/handlers/health_handlers.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <utility>
 
@@ -58,6 +59,16 @@ class HealthHandlers {
     : ctx_(ctx), route_registry_(route_registry), sse_tracker_(std::move(sse_tracker)) {
   }
 
+  /// Where /health reads the fault stream's received-event counter from.
+  ///
+  /// Set after construction because the SSE handler is built later than this
+  /// one. It counts events the gateway ACCEPTED from the fault manager, which
+  /// is the only thing that distinguishes "no faults are happening" from "the
+  /// thread that takes them is stuck".
+  void set_sse_event_counter(std::function<uint64_t()> counter) {
+    sse_events_received_ = std::move(counter);
+  }
+
   /// GET /health - Health check endpoint
   http::Result<dto::Health> get_health(const http::TypedRequest & req);
 
@@ -71,6 +82,7 @@ class HealthHandlers {
   HandlerContext & ctx_;
   const openapi::RouteRegistry * route_registry_{nullptr};
   std::shared_ptr<const SSEClientTracker> sse_tracker_;
+  std::function<uint64_t()> sse_events_received_;
 };
 
 }  // namespace handlers

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/http_utils.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/http_utils.hpp
@@ -189,8 +189,16 @@ inline FaultStatusFilter parse_fault_status_param(const std::optional<std::strin
  *         or "1970-01-01T00:00:00.000Z" on conversion failure
  */
 inline std::string format_timestamp_ns(int64_t ns) {
+  // Floor division, not C's truncation towards zero. For an instant before the
+  // epoch the remainder is negative, and "%03d" of -500 prints "-500", which
+  // renders 1969-12-31T23:59:59 as "...59.-500Z" - not a timestamp any reader
+  // can parse, and worse than a wrong one because it still looks like data.
   auto seconds = ns / 1'000'000'000;
   auto nanos = ns % 1'000'000'000;
+  if (nanos < 0) {
+    nanos += 1'000'000'000;
+    --seconds;
+  }
 
   std::time_t time = static_cast<std::time_t>(seconds);
   std::tm tm_buf{};

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/rest_server.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/http/rest_server.hpp
@@ -134,6 +134,7 @@ class RESTServer {
   std::unique_ptr<handlers::OperationHandlers> operation_handlers_;
   std::unique_ptr<handlers::ConfigHandlers> config_handlers_;
   std::unique_ptr<handlers::FaultHandlers> fault_handlers_;
+  std::unique_ptr<handlers::PlannedStopHandlers> planned_stop_handlers_;
   std::unique_ptr<handlers::AuthHandlers> auth_handlers_;
   std::shared_ptr<SSEClientTracker> sse_client_tracker_;
   std::unique_ptr<handlers::SSEFaultHandler> sse_fault_handler_;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
@@ -20,7 +20,10 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
+#include <vector>
+
 #include "ros2_medkit_gateway/core/faults/fault_types.hpp"
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
 #include "ros2_medkit_gateway/core/transports/fault_service_transport.hpp"
 
 namespace ros2_medkit_gateway {
@@ -93,6 +96,46 @@ class FaultManager {
   /// Get all rosbag files for an entity (batch operation).
   FaultResult list_rosbags(const std::string & entity_fqn);
 
+  /// Declare a planned-stop window. `from_ns` of 0 asks the fault manager for
+  /// its own wall clock, which is the clock the fault timestamps come from.
+  PlannedStopResult declare_planned_stop(int64_t from_ns, int64_t to_ns, const std::string & reason,
+                                         const std::string & declared_by);
+
+  /// Cut a window short. Refused for an unknown id and for one that has ended.
+  PlannedStopResult end_planned_stop(const std::string & id);
+
+  /// The declared windows, straight from the fault manager.
+  PlannedStopResult list_planned_stops(bool active_only = false);
+
+  /// The windows to derive `expected` from, served from a cache the read path
+  /// refreshes at most once per kPlannedStopCacheTtl.
+  ///
+  /// Never fails and never blocks longer than one transport timeout: a fault
+  /// manager that did not answer leaves the last known windows in place and the
+  /// next attempt waits out kPlannedStopFailureBackoff, not the normal time to
+  /// live. Without that back-off an unreachable fault manager costs the
+  /// transport's timeout on every single event of the fault stream, which stalls
+  /// the stream rather than degrading it. Callers that must see their own write
+  /// pass force_refresh, or call invalidate_planned_stop_cache() first.
+  std::vector<faults::PlannedStopWindow> planned_stop_windows(bool force_refresh = false);
+
+  /// Ask the next planned_stop_windows() to re-read. Called after this gateway
+  /// writes a window so an operator never watches their own declaration take
+  /// effect a cache lifetime late.
+  void invalidate_planned_stop_cache();
+
+  /// How long the derived flag may lag a window declared straight through the
+  /// ROS service. Short enough that a stop declared elsewhere shows up while an
+  /// operator is still looking, long enough that a busy event stream does not
+  /// turn into one service call per event.
+  static constexpr std::chrono::seconds kPlannedStopCacheTtl{2};
+
+  /// How long to wait after a refresh that got no answer. Longer than the normal
+  /// time to live because the cost of finding out is the transport's timeout,
+  /// and paying it every couple of seconds on a busy stream is a worse outage
+  /// than a flag that lags.
+  static constexpr std::chrono::seconds kPlannedStopFailureBackoff{30};
+
   /// Check if fault manager services are available.
   bool is_available() const;
 
@@ -101,6 +144,7 @@ class FaultManager {
 
  private:
   std::shared_ptr<FaultServiceTransport> transport_;
+  faults::PlannedStopCache planned_stop_cache_;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
@@ -107,6 +107,18 @@ class FaultManager {
   /// The declared windows, straight from the fault manager.
   PlannedStopResult list_planned_stops(bool active_only = false);
 
+  /// Refresh the window cache if it is due. Makes at most one fault-manager RPC
+  /// and must therefore be called with NO lock held: it is the blocking half,
+  /// split out from the read so a caller can pay it on its own thread before
+  /// touching anything shared. The SSE stream loop calls it before it takes the
+  /// queue mutex - a service call under that mutex stalls the executor thread
+  /// and every other client behind one client's formatting pass.
+  void refresh_planned_stop_windows(bool force = false);
+
+  /// What is known right now: no RPC, no blocking, no refresh. Safe under a
+  /// lock.
+  faults::PlannedStopKnowledge planned_stop_snapshot() const;
+
   /// The windows to derive `expected` from, served from a cache the read path
   /// refreshes at most once per kPlannedStopCacheTtl.
   ///
@@ -117,13 +129,7 @@ class FaultManager {
   /// transport's timeout on every single event of the fault stream, which stalls
   /// the stream rather than degrading it. Callers that must see their own write
   /// pass force_refresh, or call invalidate_planned_stop_cache() first.
-  std::vector<faults::PlannedStopWindow> planned_stop_windows(bool force_refresh = false);
-
-  /// Whether this gateway has ever read the declared windows. False means it
-  /// does not KNOW, which is not the same as knowing that none are declared: the
-  /// event stream omits the flag entirely in that case, because a consumer must
-  /// not read an unreachable fault manager as "nothing is expected".
-  bool planned_stops_known() const;
+  faults::PlannedStopKnowledge planned_stop_windows(bool force_refresh = false);
 
   /// Ask the next planned_stop_windows() to re-read. Called after this gateway
   /// writes a window so an operator never watches their own declaration take
@@ -141,6 +147,13 @@ class FaultManager {
   /// and paying it every couple of seconds on a busy stream is a worse outage
   /// than a flag that lags.
   static constexpr std::chrono::seconds kPlannedStopFailureBackoff{30};
+
+  /// How old a successfully read window set may be and still be reported. A
+  /// small multiple of the refresh period: long enough that a set being re-read
+  /// normally never blinks, short enough that one nothing can refresh - a fault
+  /// manager replaced, or one without the service - goes quiet within seconds
+  /// instead of being served for the life of the process.
+  static constexpr std::chrono::seconds kPlannedStopKnowledgeMaxAge{3 * kPlannedStopCacheTtl.count()};
 
   /// Check if fault manager services are available.
   bool is_available() const;

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/managers/fault_manager.hpp
@@ -119,6 +119,12 @@ class FaultManager {
   /// pass force_refresh, or call invalidate_planned_stop_cache() first.
   std::vector<faults::PlannedStopWindow> planned_stop_windows(bool force_refresh = false);
 
+  /// Whether this gateway has ever read the declared windows. False means it
+  /// does not KNOW, which is not the same as knowing that none are declared: the
+  /// event stream omits the flag entirely in that case, because a consumer must
+  /// not read an unreachable fault manager as "nothing is expected".
+  bool planned_stops_known() const;
+
   /// Ask the next planned_stop_windows() to re-read. Called after this gateway
   /// writes a window so an operator never watches their own declaration take
   /// effect a cache lifetime late.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
@@ -107,6 +107,14 @@ class FaultServiceTransport {
   virtual bool wait_for_services(std::chrono::duration<double> timeout) = 0;
 
   virtual bool is_available() const = 0;
+
+  /// Whether the planned-stop services are ready, specifically.
+  ///
+  /// Separate from is_available(), which gates only the four core fault
+  /// services: a fault manager from before planned stops answers those and has
+  /// no `~/list_planned_stops`, and asking it anyway cost a full service timeout
+  /// on the fault-list path, once per back-off window, for nothing.
+  virtual bool planned_stops_available() const = 0;
 };
 
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
@@ -19,7 +19,10 @@
 #include <nlohmann/json.hpp>
 #include <string>
 
+#include <vector>
+
 #include "ros2_medkit_gateway/core/faults/fault_types.hpp"
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
 
 namespace ros2_medkit_gateway {
 
@@ -27,6 +30,20 @@ namespace ros2_medkit_gateway {
 /// package. The transport wraps `rclcpp::Client<ros2_medkit_msgs::srv::*>`,
 /// converts message types to JSON internally, and returns the neutral
 /// FaultResult / FaultWithEnvJsonResult structs already filled.
+/// Outcome of a planned-stop operation. `stops` carries the single stored window
+/// for a declare or an end, and every window for a list; it stays empty on any
+/// failure.
+///
+/// `failure` defaults to `Declined` for the same reason FaultResult's does: a
+/// producer that reports a failure without classifying it must not be able to
+/// manufacture a 503. Only a transport that got no answer at all asks for one.
+struct PlannedStopResult {
+  bool success{false};
+  std::vector<faults::PlannedStopWindow> stops;
+  std::string error_message;
+  FaultFailure failure{FaultFailure::Declined};
+};
+
 class FaultServiceTransport {
  public:
   FaultServiceTransport() = default;
@@ -59,6 +76,18 @@ class FaultServiceTransport {
   virtual FaultResult get_rosbag(const std::string & fault_code) = 0;
 
   virtual FaultResult list_rosbags(const std::string & entity_fqn) = 0;
+
+  /// Declare a planned-stop window. Only `from_ns`, `to_ns`, `reason` and
+  /// `declared_by` are read from @p request; the id and the declaration time are
+  /// the fault manager's to assign, and come back on the result.
+  virtual PlannedStopResult declare_planned_stop(const faults::PlannedStopWindow & request) = 0;
+
+  /// Cut a window short at the fault manager's current wall clock.
+  virtual PlannedStopResult end_planned_stop(const std::string & id) = 0;
+
+  /// Every declared window, or only those covering the fault manager's current
+  /// wall clock when @p active_only is set.
+  virtual PlannedStopResult list_planned_stops(bool active_only) = 0;
 
   virtual bool wait_for_services(std::chrono::duration<double> timeout) = 0;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/core/transports/fault_service_transport.hpp
@@ -30,6 +30,20 @@ namespace ros2_medkit_gateway {
 /// package. The transport wraps `rclcpp::Client<ros2_medkit_msgs::srv::*>`,
 /// converts message types to JSON internally, and returns the neutral
 /// FaultResult / FaultWithEnvJsonResult structs already filled.
+/// Why the fault manager refused a planned-stop request, when it refused one.
+///
+/// Structural, not textual: the five refusals map onto three different HTTP
+/// answers, and the fault manager is free to reword its messages. Reading the
+/// prose to decide a status is how a rewording becomes an outage.
+enum class PlannedStopRefusal : uint8_t {
+  None,            ///< Not a refusal
+  InvalidRequest,  ///< The interval or an instant was not one the API accepts
+  DuplicateId,     ///< A window with that id already exists
+  NotRetained,     ///< Accepted but not kept: the configured bound had no room
+  NotFound,        ///< No window with that id
+  AlreadyEnded     ///< The window had already ended; its end is not rewritable
+};
+
 /// Outcome of a planned-stop operation. `stops` carries the single stored window
 /// for a declare or an end, and every window for a list; it stays empty on any
 /// failure.
@@ -42,6 +56,7 @@ struct PlannedStopResult {
   std::vector<faults::PlannedStopWindow> stops;
   std::string error_message;
   FaultFailure failure{FaultFailure::Declined};
+  PlannedStopRefusal refusal{PlannedStopRefusal::None};
 };
 
 class FaultServiceTransport {

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/enums.hpp
@@ -37,6 +37,12 @@ inline constexpr std::string_view kFaultAggregatedStatusValues[] = {"active", "p
 /// handler-accepted value (the OpenAPI callability test sends enum[0]).
 inline constexpr std::string_view kFaultStatusFilterValues[] = {"pending", "confirmed", "cleared", "healed", "all"};
 
+/// Planned-stop filter on the fault lists. "all" is what an omitted parameter
+/// means: the flag is extra information about a fault, never a reason to hide it
+/// by default. The leading entry must be a handler-accepted value (the OpenAPI
+/// callability test sends enum[0]).
+inline constexpr std::string_view kFaultExpectedFilterValues[] = {"all", "true", "false"};
+
 /// Log aggregation level (log_entry_list_schema - x-medkit.aggregation_level).
 inline constexpr std::string_view kLogAggregationLevelValues[] = {"function", "area", "component"};
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -230,8 +230,9 @@ inline constexpr auto dto_fields<FaultListXMedkit> = std::make_tuple(
     field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items),
     field("expected_count", &FaultListXMedkit::expected_count,
           "How many of the returned items started their current cycle inside a planned-stop window. Counts the "
-          "items this gateway derived a flag for; items merged from a peer carry the peer's own flag and are "
-          "not recounted here."));
+          "list that was actually served: items this gateway flagged, plus items an aggregated peer flagged "
+          "that survived the `expected` filter. A peer's items are counted on the flag the PEER derived from "
+          "its own windows; this gateway never re-derives them."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListXMedkit> = "FaultListXMedkit";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -65,7 +65,8 @@ inline constexpr auto dto_fields<FaultXMedkit> = std::make_tuple(
           "healed, cleared, captured and audited exactly as any other."),
     field("planned_stop_id", &FaultXMedkit::planned_stop_id,
           "Which window made it expected - the earliest-starting one covering the fault when several overlap. "
-          "Present only when `expected` is true; read it back with `GET /x-medkit-planned-stops/{id}`."));
+          "Present only when `expected` is true. The window's `reason` is NOT carried on the fault: resolve "
+          "the id with `GET /x-medkit-planned-stops/{id}`, which also answers who declared it and when."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultXMedkit> = "FaultXMedkit";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -107,8 +107,10 @@ inline constexpr auto dto_fields<FaultListItem> = std::make_tuple(
     field("reporting_sources", &FaultListItem::reporting_sources),
     field_enum("severity_label", &FaultListItem::severity_label, kFaultSeverityLabelValues),
     field("x-medkit", &FaultListItem::x_medkit,
-          "Vendor extension carrying `expected` and `planned_stop_id` for this fault. Absent when the gateway "
-          "could not read the planned-stop windows, which is not the same as the fault being unexpected."));
+          "Vendor extension carrying `expected` and `planned_stop_id` for this fault. The `expected` key is "
+          "absent - on every item, and with it the collection's `expected_count` - when the gateway cannot "
+          "read the planned-stop windows, which is not the same as the fault being unexpected. That is the "
+          "same rule the fault stream follows."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListItem> = "FaultListItem";
@@ -222,17 +224,27 @@ struct FaultListXMedkit {
 
 template <>
 inline constexpr auto dto_fields<FaultListXMedkit> = std::make_tuple(
-    field("count", &FaultListXMedkit::count), field("muted_count", &FaultListXMedkit::muted_count),
-    field("cluster_count", &FaultListXMedkit::cluster_count), field("entity_id", &FaultListXMedkit::entity_id),
-    field("source_id", &FaultListXMedkit::source_id), field("muted_faults", &FaultListXMedkit::muted_faults),
-    field("clusters", &FaultListXMedkit::clusters), field("partial", &FaultListXMedkit::partial),
-    field("failed_peers", &FaultListXMedkit::failed_peers), field("peer_failures", &FaultListXMedkit::peer_failures),
+    field("count", &FaultListXMedkit::count,
+          "How many items this response carries - the length of `items` after any peer merge and after the "
+          "`status` and `expected` filters. Note this is the SERVED list, not the fault manager's own total: "
+          "`muted_count` and `cluster_count` beside it are still the local unfiltered numbers the fault "
+          "manager reported, so a filtered request can answer `count: 1` next to `muted_count: 7`."),
+    field("muted_count", &FaultListXMedkit::muted_count), field("cluster_count", &FaultListXMedkit::cluster_count),
+    field("entity_id", &FaultListXMedkit::entity_id), field("source_id", &FaultListXMedkit::source_id),
+    field("muted_faults", &FaultListXMedkit::muted_faults), field("clusters", &FaultListXMedkit::clusters),
+    field("partial", &FaultListXMedkit::partial), field("failed_peers", &FaultListXMedkit::failed_peers),
+    field("peer_failures", &FaultListXMedkit::peer_failures),
     field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items),
     field("expected_count", &FaultListXMedkit::expected_count,
-          "How many of the returned items started their current cycle inside a planned-stop window. Counts the "
-          "list that was actually served: items this gateway flagged, plus items an aggregated peer flagged "
-          "that survived the `expected` filter. A peer's items are counted on the flag the PEER derived from "
-          "its own windows; this gateway never re-derives them."));
+          "How many DISTINCT fault codes in the served list started their current cycle inside a planned-stop "
+          "window. Counted after the peer merge and after the `expected` filter, over the items actually "
+          "returned; a peer's item is counted on the flag the PEER derived from its own windows, never "
+          "re-derived here. Distinct, because an aggregating gateway serves a code raised on two gateways as "
+          "two items and counting both would report two stops' worth of expected faults where the plant had "
+          "one. An item carrying no `expected` key is counted by neither side - its flag is unknown, and "
+          "unknown is not false - and such an item is served only under `expected=all`. **Absent entirely** "
+          "when this gateway cannot read the planned-stop windows: a count of zero would read as \"nothing "
+          "was expected\"."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListXMedkit> = "FaultListXMedkit";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/faults.hpp
@@ -37,6 +37,40 @@ namespace ros2_medkit_gateway {
 namespace dto {
 
 // =============================================================================
+// FaultXMedkit - x-medkit vendor extension carried both inside FaultDetail and
+// on each item of a fault list. Declared ahead of FaultListItem because that
+// struct holds one by value.
+//
+// Wire keys (from build_sovd_fault_response):
+//   occurrence_count, reporting_sources, severity_label, status_raw
+// =============================================================================
+struct FaultXMedkit {
+  std::optional<int64_t> occurrence_count;
+  std::optional<std::vector<std::string>> reporting_sources;
+  std::optional<std::string> severity_label;
+  std::optional<std::string> status_raw;
+  std::optional<bool> expected;
+  std::optional<std::string> planned_stop_id;
+};
+
+template <>
+inline constexpr auto dto_fields<FaultXMedkit> = std::make_tuple(
+    field("occurrence_count", &FaultXMedkit::occurrence_count),
+    field("reporting_sources", &FaultXMedkit::reporting_sources),
+    field("severity_label", &FaultXMedkit::severity_label), field("status_raw", &FaultXMedkit::status_raw),
+    field("expected", &FaultXMedkit::expected,
+          "Whether this fault's current cycle started inside a declared planned-stop window. Derived from "
+          "`first_occurred`, so a code that failed during a stop and failed again afterwards is expected for "
+          "the first cycle and not for the second. The flag changes nothing about the fault: it was confirmed, "
+          "healed, cleared, captured and audited exactly as any other."),
+    field("planned_stop_id", &FaultXMedkit::planned_stop_id,
+          "Which window made it expected - the earliest-starting one covering the fault when several overlap. "
+          "Present only when `expected` is true; read it back with `GET /x-medkit-planned-stops/{id}`."));
+
+template <>
+inline constexpr std::string_view dto_name<FaultXMedkit> = "FaultXMedkit";
+
+// =============================================================================
 // FaultListItem - flat fault list item emitted by fault_msg_conversions.cpp
 // (fault_to_json shape), wrapped in Collection<FaultListItem> for list endpoints.
 //
@@ -56,6 +90,11 @@ struct FaultListItem {
   std::string status;
   std::optional<std::vector<std::string>> reporting_sources;
   std::optional<std::string> severity_label;  // enum: INFO|WARN|ERROR|CRITICAL|UNKNOWN
+
+  /// Vendor extension on the item itself, carrying the planned-stop flag. Absent
+  /// on a fault the gateway could not derive a flag for - which is not the same
+  /// as `expected: false`, and is why it is an object rather than a bare bool.
+  std::optional<FaultXMedkit> x_medkit;  // wire key: "x-medkit"
 };
 
 template <>
@@ -65,7 +104,10 @@ inline constexpr auto dto_fields<FaultListItem> = std::make_tuple(
     field("last_occurred", &FaultListItem::last_occurred), field("last_passed", &FaultListItem::last_passed),
     field("occurrence_count", &FaultListItem::occurrence_count), field("status", &FaultListItem::status),
     field("reporting_sources", &FaultListItem::reporting_sources),
-    field_enum("severity_label", &FaultListItem::severity_label, kFaultSeverityLabelValues));
+    field_enum("severity_label", &FaultListItem::severity_label, kFaultSeverityLabelValues),
+    field("x-medkit", &FaultListItem::x_medkit,
+          "Vendor extension carrying `expected` and `planned_stop_id` for this fault. Absent when the gateway "
+          "could not read the planned-stop windows, which is not the same as the fault being unexpected."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListItem> = "FaultListItem";
@@ -170,6 +212,11 @@ struct FaultListXMedkit {
   /// existing client already reads.
   std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
+
+  /// How many of the items were expected. A sibling of `count`, not a
+  /// replacement: "three faults, two of them during the changeover" is the
+  /// sentence an operator wants, and it needs both numbers.
+  std::optional<int64_t> expected_count;
 };
 
 template <>
@@ -179,7 +226,11 @@ inline constexpr auto dto_fields<FaultListXMedkit> = std::make_tuple(
     field("source_id", &FaultListXMedkit::source_id), field("muted_faults", &FaultListXMedkit::muted_faults),
     field("clusters", &FaultListXMedkit::clusters), field("partial", &FaultListXMedkit::partial),
     field("failed_peers", &FaultListXMedkit::failed_peers), field("peer_failures", &FaultListXMedkit::peer_failures),
-    field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items));
+    field("peer_dropped_items", &FaultListXMedkit::peer_dropped_items),
+    field("expected_count", &FaultListXMedkit::expected_count,
+          "How many of the returned items started their current cycle inside a planned-stop window. Counts the "
+          "items this gateway derived a flag for; items merged from a peer carry the peer's own flag and are "
+          "not recounted here."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListXMedkit> = "FaultListXMedkit";
@@ -219,6 +270,9 @@ struct FaultListAggXMedkit {
   /// existing client already reads.
   std::optional<std::vector<PeerFailure>> peer_failures;
   std::optional<std::vector<DroppedItem>> peer_dropped_items;
+
+  /// How many of the items were expected; see FaultListXMedkit::expected_count.
+  std::optional<int64_t> expected_count;
 };
 
 template <>
@@ -233,33 +287,13 @@ inline constexpr auto dto_fields<FaultListAggXMedkit> =
                     field("count", &FaultListAggXMedkit::count), field("partial", &FaultListAggXMedkit::partial),
                     field("failed_peers", &FaultListAggXMedkit::failed_peers),
                     field("peer_failures", &FaultListAggXMedkit::peer_failures),
-                    field("peer_dropped_items", &FaultListAggXMedkit::peer_dropped_items));
+                    field("peer_dropped_items", &FaultListAggXMedkit::peer_dropped_items),
+                    field("expected_count", &FaultListAggXMedkit::expected_count,
+                          "How many of the returned items started their current cycle inside a planned-stop "
+                          "window."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultListAggXMedkit> = "FaultListAggXMedkit";
-
-// =============================================================================
-// FaultXMedkit - x-medkit vendor extension inside FaultDetail
-//
-// Wire keys (from build_sovd_fault_response):
-//   occurrence_count, reporting_sources, severity_label, status_raw
-// =============================================================================
-struct FaultXMedkit {
-  std::optional<int64_t> occurrence_count;
-  std::optional<std::vector<std::string>> reporting_sources;
-  std::optional<std::string> severity_label;
-  std::optional<std::string> status_raw;
-};
-
-template <>
-inline constexpr auto dto_fields<FaultXMedkit> =
-    std::make_tuple(field("occurrence_count", &FaultXMedkit::occurrence_count),
-                    field("reporting_sources", &FaultXMedkit::reporting_sources),
-                    field("severity_label", &FaultXMedkit::severity_label),
-                    field("status_raw", &FaultXMedkit::status_raw));
-
-template <>
-inline constexpr std::string_view dto_name<FaultXMedkit> = "FaultXMedkit";
 
 // =============================================================================
 // FaultDetail - SOVD nested fault detail response
@@ -540,6 +574,7 @@ struct FaultListQuery {
   std::optional<std::string> status;
   bool include_muted = false;
   bool include_clusters = false;
+  std::optional<std::string> expected;
 };
 
 template <>
@@ -548,7 +583,10 @@ inline constexpr auto dto_fields<FaultListQuery> = std::make_tuple(
                "Filter by fault status: pending, confirmed, cleared, healed, or all"),
     field("include_muted", &FaultListQuery::include_muted, Presence::kOptional, "Include muted faults in the response"),
     field("include_clusters", &FaultListQuery::include_clusters, Presence::kOptional,
-          "Include fault clusters in the response"));
+          "Include fault clusters in the response"),
+    field_enum("expected", &FaultListQuery::expected, kFaultExpectedFilterValues,
+               "Keep only faults whose current cycle started inside a planned-stop window (`true`), only those "
+               "that did not (`false`), or both, which is what omitting it means (`all`)."));
 
 // FaultEntityListQuery - query parameters for the per-entity GET /{entity}/faults
 // route. Only `status` applies: include_muted / include_clusters are honored
@@ -558,12 +596,16 @@ inline constexpr auto dto_fields<FaultListQuery> = std::make_tuple(
 // exactly what the handler reads (no spec-vs-runtime drift on the declared axis).
 struct FaultEntityListQuery {
   std::optional<std::string> status;
+  std::optional<std::string> expected;
 };
 
 template <>
-inline constexpr auto dto_fields<FaultEntityListQuery> =
-    std::make_tuple(field_enum("status", &FaultEntityListQuery::status, kFaultStatusFilterValues,
-                               "Filter by fault status: pending, confirmed, cleared, healed, or all"));
+inline constexpr auto dto_fields<FaultEntityListQuery> = std::make_tuple(
+    field_enum("status", &FaultEntityListQuery::status, kFaultStatusFilterValues,
+               "Filter by fault status: pending, confirmed, cleared, healed, or all"),
+    field_enum("expected", &FaultEntityListQuery::expected, kFaultExpectedFilterValues,
+               "Keep only faults whose current cycle started inside a planned-stop window (`true`), only those "
+               "that did not (`false`), or both, which is what omitting it means (`all`)."));
 
 // FaultClearQuery - query parameters for DELETE /faults (clear all). Only the
 // status filter applies; the correlation flags are list-only.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/health.hpp
@@ -164,7 +164,9 @@ struct Health {
   std::optional<nlohmann::json> x_medkit_data_provider;          // wire key: "x-medkit-data-provider"
   std::optional<nlohmann::json> x_medkit_subscription_executor;  // wire key: "x-medkit-subscription-executor"
   std::optional<nlohmann::json> x_medkit_entity_cache;           // wire key: "x-medkit-entity-cache"
-  /// How much of `sse.max_clients` is in use. Wire key: "x-medkit-sse".
+  /// How much of `sse.max_clients` is in use, plus `events_received`: fault
+  /// events the gateway has accepted from the fault manager since start. Wire
+  /// key: "x-medkit-sse".
   ///
   /// The cap is small - two by default - and an aggregating gateway now
   /// consumes one slot on each of its peers for as long as somebody is

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
@@ -57,7 +57,9 @@ inline constexpr auto dto_fields<PlannedStop> = std::make_tuple(
           "resolution."),
     field("to", &PlannedStop::to,
           "When the window closes, ISO 8601 in UTC, to the millisecond. Always strictly after `from`."),
-    field("reason", &PlannedStop::reason, "Why the plant is stopping, as the operator wrote it."),
+    field("reason", &PlannedStop::reason,
+          "Why the plant is stopping, as the operator wrote it. Read here, on the window: a fault the window "
+          "marks carries only `planned_stop_id`."),
     field("declared_by", &PlannedStop::declared_by,
           "The authenticated client that declared the window, or `anonymous` when the declaration arrived "
           "without authentication."),
@@ -111,8 +113,9 @@ inline constexpr auto dto_fields<PlannedStopCreateRequest> = std::make_tuple(
           "with 400, as is a `to` before `from`. There is no maximum duration, but the instant must lie in the "
           "same range as `from`, and it is recorded to the millisecond."),
     field("reason", &PlannedStopCreateRequest::reason,
-          "Why the plant is stopping. Carried verbatim on every fault the window marks, so write what an "
-          "engineer reading the fault next month needs.",
+          "Why the plant is stopping. NOT carried on the faults the window marks - a marked fault carries the "
+          "window's id and nothing else from it - so write what an engineer who follows that id back to "
+          "`GET /x-medkit-planned-stops/{id}` next month needs.",
           FieldConstraints{{}, {}, /*max_length=*/512U, {}, {}}),
     field("declared_by", &PlannedStopCreateRequest::declared_by,
           "Who is declaring the stop. Omit it and the gateway fills in the authenticated client id, or "

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
@@ -44,6 +44,7 @@ struct PlannedStop {
   std::string declared_by;
   std::string declared_at;
   bool ended_early{false};
+  bool cancelled{false};
 };
 
 template <>
@@ -51,9 +52,11 @@ inline constexpr auto dto_fields<PlannedStop> = std::make_tuple(
     field("id", &PlannedStop::id,
           "Identifier assigned by the fault manager. Unique within one fault manager, not across a fleet."),
     field("from", &PlannedStop::from,
-          "When the window opens, ISO 8601 in UTC. A fault whose current cycle started at or after this instant "
-          "and at or before `to` is reported as expected."),
-    field("to", &PlannedStop::to, "When the window closes, ISO 8601 in UTC. Always strictly after `from`."),
+          "When the window opens, ISO 8601 in UTC, to the millisecond. A fault whose current cycle started at "
+          "or after this instant and at or before `to` is reported as expected, compared at millisecond "
+          "resolution."),
+    field("to", &PlannedStop::to,
+          "When the window closes, ISO 8601 in UTC, to the millisecond. Always strictly after `from`."),
     field("reason", &PlannedStop::reason, "Why the plant is stopping, as the operator wrote it."),
     field("declared_by", &PlannedStop::declared_by,
           "The authenticated client that declared the window, or `anonymous` when the declaration arrived "
@@ -62,7 +65,11 @@ inline constexpr auto dto_fields<PlannedStop> = std::make_tuple(
           "When the declaration was recorded, ISO 8601 in UTC. Later than `to` for a window declared after the "
           "stop it describes, which is allowed."),
     field("ended_early", &PlannedStop::ended_early,
-          "True when an operator cut the window short, which moved `to` to the moment of that request."));
+          "True when an operator cut the window short, which moved `to` to the moment of that request."),
+    field("cancelled", &PlannedStop::cancelled,
+          "True on the window returned by a DELETE that arrived before the window had STARTED: it marked "
+          "nothing, so it was removed rather than shortened, and `ended_early` stays false. Never true on a "
+          "window a list or a GET returns - a cancelled window is gone."));
 
 template <>
 inline constexpr std::string_view dto_name<PlannedStop> = "PlannedStop";
@@ -95,11 +102,14 @@ template <>
 inline constexpr auto dto_fields<PlannedStopCreateRequest> = std::make_tuple(
     field("from", &PlannedStopCreateRequest::from,
           "When the window opens, ISO 8601 in UTC (`Z` or `+00:00`; a real offset is rejected). Omit it for a "
-          "stop that starts now. A window wholly in the past is accepted and marks the faults it covers - a "
-          "stop is a fact about the plant, not about when someone typed it in."),
+          "stop that starts now - the gateway fills in its own clock. A window wholly in the past is accepted "
+          "and marks the faults it covers: a stop is a fact about the plant, not about when someone typed it "
+          "in. The instant must be after the Unix epoch and no later than 2038-01-19T03:14:07Z, and it is "
+          "recorded to the millisecond."),
     field("to", &PlannedStopCreateRequest::to,
           "When the window closes, ISO 8601 in UTC. Must be strictly after `from`; equal instants are rejected "
-          "with 400, as is a `to` before `from`. There is no maximum duration."),
+          "with 400, as is a `to` before `from`. There is no maximum duration, but the instant must lie in the "
+          "same range as `from`, and it is recorded to the millisecond."),
     field("reason", &PlannedStopCreateRequest::reason,
           "Why the plant is stopping. Carried verbatim on every fault the window marks, so write what an "
           "engineer reading the fault next month needs.",

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
@@ -145,8 +145,10 @@ struct PlannedStopListQuery {
 template <>
 inline constexpr auto dto_fields<PlannedStopListQuery> = std::make_tuple(
     field("active", &PlannedStopListQuery::active, Presence::kOptional,
-          "Return only the windows containing this instant. Omitted or false returns every declared window, "
-          "ended ones included - they are the reason older faults read as expected."));
+          "Return only the windows that have NOT ENDED: running and not-yet-started alike. That is the same "
+          "notion retention uses, so this lists exactly the windows holding the `planned_stop.max_windows` "
+          "bound. Omitted or false returns every declared window, ended ones included - they are the reason "
+          "older faults read as expected."));
 
 // =============================================================================
 // Collection<PlannedStop> - named "PlannedStopList"

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/planned_stops.hpp
@@ -1,0 +1,145 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+
+#include "ros2_medkit_gateway/dto/contract.hpp"
+#include "ros2_medkit_gateway/dto/entities.hpp"
+#include "ros2_medkit_gateway/dto/sample.hpp"
+#include "ros2_medkit_gateway/dto/schema_writer.hpp"
+
+namespace ros2_medkit_gateway {
+namespace dto {
+
+// =============================================================================
+// PlannedStop - one declared window, as every planned-stop route emits it.
+//
+// The window's bounds are `from` and `to` here, where the ROS message calls them
+// starts_at / ends_at: a message field named `from` is a Python keyword and
+// rosidl cannot generate a binding for it, but nothing stops a JSON key.
+//
+// Wire keys: id, from, to, reason, declared_by, declared_at, ended_early
+// =============================================================================
+struct PlannedStop {
+  std::string id;
+  std::string from;
+  std::string to;
+  std::string reason;
+  std::string declared_by;
+  std::string declared_at;
+  bool ended_early{false};
+};
+
+template <>
+inline constexpr auto dto_fields<PlannedStop> = std::make_tuple(
+    field("id", &PlannedStop::id,
+          "Identifier assigned by the fault manager. Unique within one fault manager, not across a fleet."),
+    field("from", &PlannedStop::from,
+          "When the window opens, ISO 8601 in UTC. A fault whose current cycle started at or after this instant "
+          "and at or before `to` is reported as expected."),
+    field("to", &PlannedStop::to, "When the window closes, ISO 8601 in UTC. Always strictly after `from`."),
+    field("reason", &PlannedStop::reason, "Why the plant is stopping, as the operator wrote it."),
+    field("declared_by", &PlannedStop::declared_by,
+          "The authenticated client that declared the window, or `anonymous` when the declaration arrived "
+          "without authentication."),
+    field("declared_at", &PlannedStop::declared_at,
+          "When the declaration was recorded, ISO 8601 in UTC. Later than `to` for a window declared after the "
+          "stop it describes, which is allowed."),
+    field("ended_early", &PlannedStop::ended_early,
+          "True when an operator cut the window short, which moved `to` to the moment of that request."));
+
+template <>
+inline constexpr std::string_view dto_name<PlannedStop> = "PlannedStop";
+
+template <>
+struct dto_sample<PlannedStop> {
+  static PlannedStop make() {
+    PlannedStop obj;
+    obj.id = "1788716982473405798-1";
+    obj.from = "2026-09-06T18:00:00.000Z";
+    obj.to = "2026-09-06T22:00:00.000Z";
+    obj.reason = "line changeover";
+    obj.declared_by = "shift_lead";
+    obj.declared_at = "2026-09-06T17:58:12.004Z";
+    return obj;
+  }
+};
+
+// =============================================================================
+// PlannedStopCreateRequest - POST /x-medkit-planned-stops request body.
+// =============================================================================
+struct PlannedStopCreateRequest {
+  std::optional<std::string> from;
+  std::string to;
+  std::string reason;
+  std::optional<std::string> declared_by;
+};
+
+template <>
+inline constexpr auto dto_fields<PlannedStopCreateRequest> = std::make_tuple(
+    field("from", &PlannedStopCreateRequest::from,
+          "When the window opens, ISO 8601 in UTC (`Z` or `+00:00`; a real offset is rejected). Omit it for a "
+          "stop that starts now. A window wholly in the past is accepted and marks the faults it covers - a "
+          "stop is a fact about the plant, not about when someone typed it in."),
+    field("to", &PlannedStopCreateRequest::to,
+          "When the window closes, ISO 8601 in UTC. Must be strictly after `from`; equal instants are rejected "
+          "with 400, as is a `to` before `from`. There is no maximum duration."),
+    field("reason", &PlannedStopCreateRequest::reason,
+          "Why the plant is stopping. Carried verbatim on every fault the window marks, so write what an "
+          "engineer reading the fault next month needs.",
+          FieldConstraints{{}, {}, /*max_length=*/512U, {}, {}}),
+    field("declared_by", &PlannedStopCreateRequest::declared_by,
+          "Who is declaring the stop. Omit it and the gateway fills in the authenticated client id, or "
+          "`anonymous` when authentication is off.",
+          FieldConstraints{{}, {}, /*max_length=*/256U, {}, {}}));
+
+template <>
+inline constexpr std::string_view dto_name<PlannedStopCreateRequest> = "PlannedStopCreateRequest";
+
+template <>
+struct dto_sample<PlannedStopCreateRequest> {
+  static PlannedStopCreateRequest make() {
+    PlannedStopCreateRequest obj;
+    obj.to = "2026-09-06T22:00:00Z";
+    obj.reason = "line changeover";
+    return obj;
+  }
+};
+
+// =============================================================================
+// PlannedStopListQuery - query parameters for GET /x-medkit-planned-stops.
+// =============================================================================
+struct PlannedStopListQuery {
+  bool active = false;
+};
+
+template <>
+inline constexpr auto dto_fields<PlannedStopListQuery> = std::make_tuple(
+    field("active", &PlannedStopListQuery::active, Presence::kOptional,
+          "Return only the windows containing this instant. Omitted or false returns every declared window, "
+          "ended ones included - they are the reason older faults read as expected."));
+
+// =============================================================================
+// Collection<PlannedStop> - named "PlannedStopList"
+// =============================================================================
+template <>
+inline constexpr std::string_view dto_name<Collection<PlannedStop>> = "PlannedStopList";
+
+}  // namespace dto
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/registry.hpp
@@ -36,6 +36,7 @@
 #include "ros2_medkit_gateway/dto/locks.hpp"
 #include "ros2_medkit_gateway/dto/logs.hpp"
 #include "ros2_medkit_gateway/dto/operations.hpp"
+#include "ros2_medkit_gateway/dto/planned_stops.hpp"
 #include "ros2_medkit_gateway/dto/schema_writer.hpp"
 #include "ros2_medkit_gateway/dto/scripts.hpp"
 #include "ros2_medkit_gateway/dto/sse_frames.hpp"
@@ -74,6 +75,8 @@ using AllDtos =
                DataListResult, DataValue,
                // Lock domain DTOs
                Lock, Collection<Lock>, AcquireLockRequest, ExtendLockRequest,
+               // Planned-stop domain DTOs
+               PlannedStop, Collection<PlannedStop>, PlannedStopCreateRequest,
                // Trigger domain DTOs
                Trigger, Collection<Trigger>, TriggerCreateRequest, TriggerUpdateRequest,
                // Cyclic subscription domain DTOs

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/sse_frames.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/dto/sse_frames.hpp
@@ -103,16 +103,26 @@ inline constexpr std::string_view dto_name<TriggerEventFrame> = "TriggerEventFra
 // lexicographically first.
 // -----------------------------------------------------------------------------
 struct FaultStreamXMedkit {
-  std::string entity_type;
-  std::string entity_id;
+  std::optional<std::string> entity_type;
+  std::optional<std::string> entity_id;
+  std::optional<bool> expected;
+  std::optional<std::string> planned_stop_id;
 };
 
 template <>
 inline constexpr auto dto_fields<FaultStreamXMedkit> = std::make_tuple(
-    field("entity_type", &FaultStreamXMedkit::entity_type, "`areas`, `components`, `apps` or `functions`."),
+    field("entity_type", &FaultStreamXMedkit::entity_type,
+          "`areas`, `components`, `apps` or `functions`. Absent when the reporting source resolves to no known "
+          "entity - the object itself is still sent, because it also carries the planned-stop flag."),
     field("entity_id", &FaultStreamXMedkit::entity_id,
           "Entity to address for this fault's rosbag: "
-          "`GET /{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}`."));
+          "`GET /{entity_type}/{entity_id}/bulk-data/rosbags/{fault_code}`."),
+    field("expected", &FaultStreamXMedkit::expected,
+          "Whether the fault's current cycle started inside a declared planned-stop window. Sent as an explicit "
+          "`false` rather than omitted, so a consumer can tell \"not expected\" from \"this gateway could not "
+          "say\"."),
+    field("planned_stop_id", &FaultStreamXMedkit::planned_stop_id,
+          "Which window made it expected. Present only when `expected` is true."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultStreamXMedkit> = "FaultStreamXMedkit";
@@ -145,8 +155,8 @@ inline constexpr auto dto_fields<FaultStreamEvent> = std::make_tuple(
           "Event time as seconds since the Unix epoch, with nanosecond precision in the fraction. Note this "
           "is a number, where the subscription and trigger frames send an ISO 8601 string."),
     field("x-medkit", &FaultStreamEvent::x_medkit,
-          "Where to fetch this fault's bulk-data. Absent when the reporting source resolves to no known "
-          "entity."));
+          "Vendor extension: where to fetch this fault's bulk-data, and whether the fault was expected. Absent "
+          "only on a frame relayed from a peer, which carries the peer's own payload verbatim."));
 
 template <>
 inline constexpr std::string_view dto_name<FaultStreamEvent> = "FaultStreamEvent";

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
@@ -146,17 +146,19 @@ class FaultHandlers {
    * @param fault_json Per-fault JSON (as produced by the transport adapter).
    * @param env_data_json Environment-data JSON (as produced by the transport).
    * @param entity_path Entity path used to construct rosbag bulk_data_uri.
-   * @param planned_stops Declared planned-stop windows, used to derive
-   *        `x-medkit.expected`. Pass an empty vector and the flag reads false,
-   *        which is the honest answer for a gateway with no windows; the detail
-   *        and the list derive it from the same data so a UI that opens a fault
-   *        it just saw flagged does not find the flag gone.
+   * @param planned_stops What this gateway knows about the declared windows,
+   *        used to derive `x-medkit.expected`. Knowledge that is not `known`
+   *        leaves the flag OFF the response entirely, exactly as the list and
+   *        the stream do - the detail and the list derive it from the same data
+   *        so a UI that opens a fault it just saw flagged does not find the flag
+   *        gone, and neither of them turns an unreadable fault manager into
+   *        "nothing was expected".
    * @return SOVD-compliant FaultDetail DTO
    */
   static dto::FaultDetail build_sovd_fault_response(const nlohmann::json & fault_json,
                                                     const nlohmann::json & env_data_json,
                                                     const std::string & entity_path,
-                                                    const std::vector<faults::PlannedStopWindow> & planned_stops);
+                                                    const faults::PlannedStopKnowledge & planned_stops);
 
   /**
    * @brief Scope check used by per-entity fault routes.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/fault_handlers.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "ros2_medkit_gateway/core/faults/fault_types.hpp"
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
 #include "ros2_medkit_gateway/dto/faults.hpp"
 #include "ros2_medkit_gateway/entity_freeze_frame_capture.hpp"
 #include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
@@ -145,11 +146,17 @@ class FaultHandlers {
    * @param fault_json Per-fault JSON (as produced by the transport adapter).
    * @param env_data_json Environment-data JSON (as produced by the transport).
    * @param entity_path Entity path used to construct rosbag bulk_data_uri.
+   * @param planned_stops Declared planned-stop windows, used to derive
+   *        `x-medkit.expected`. Pass an empty vector and the flag reads false,
+   *        which is the honest answer for a gateway with no windows; the detail
+   *        and the list derive it from the same data so a UI that opens a fault
+   *        it just saw flagged does not find the flag gone.
    * @return SOVD-compliant FaultDetail DTO
    */
   static dto::FaultDetail build_sovd_fault_response(const nlohmann::json & fault_json,
                                                     const nlohmann::json & env_data_json,
-                                                    const std::string & entity_path);
+                                                    const std::string & entity_path,
+                                                    const std::vector<faults::PlannedStopWindow> & planned_stops);
 
   /**
    * @brief Scope check used by per-entity fault routes.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/planned_stop_handlers.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/planned_stop_handlers.hpp
@@ -1,0 +1,90 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <tl/expected.hpp>
+
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
+#include "ros2_medkit_gateway/dto/entities.hpp"
+#include "ros2_medkit_gateway/dto/planned_stops.hpp"
+#include "ros2_medkit_gateway/http/handlers/handler_context.hpp"
+#include "ros2_medkit_gateway/http/response_types.hpp"
+#include "ros2_medkit_gateway/http/typed_router.hpp"
+
+namespace ros2_medkit_gateway {
+namespace handlers {
+
+/**
+ * @brief HTTP handlers for planned-stop windows.
+ *
+ * A planned stop is a window of wall-clock time during which faults are
+ * expected. These four routes are the operator's side of it:
+ *
+ * - POST   /x-medkit-planned-stops        - declare a window (201)
+ * - GET    /x-medkit-planned-stops        - list windows, `?active=true` filters
+ * - GET    /x-medkit-planned-stops/{id}   - one window
+ * - DELETE /x-medkit-planned-stops/{id}   - end a window early (200 + the window)
+ *
+ * The windows themselves live in the fault manager, next to the faults they
+ * describe; this class only translates between the REST shape (ISO 8601 strings)
+ * and the transport's nanosecond counts. Deriving `expected` for a fault is the
+ * fault-list and event-stream code's job, not this one's.
+ *
+ * DELETE answers 200 with the ended window rather than 204: `to` moved to the
+ * moment of the request, and the caller needs to be told where.
+ */
+class PlannedStopHandlers {
+ public:
+  explicit PlannedStopHandlers(HandlerContext & ctx) : ctx_(ctx) {
+  }
+
+  ~PlannedStopHandlers() = default;
+  PlannedStopHandlers(const PlannedStopHandlers &) = delete;
+  PlannedStopHandlers & operator=(const PlannedStopHandlers &) = delete;
+  PlannedStopHandlers(PlannedStopHandlers &&) = delete;
+  PlannedStopHandlers & operator=(PlannedStopHandlers &&) = delete;
+
+  /// POST /x-medkit-planned-stops
+  http::Result<std::pair<http::Created<dto::PlannedStop>, http::ResponseAttachments>>
+  declare_stop(const http::TypedRequest & req, dto::PlannedStopCreateRequest body);
+
+  /// GET /x-medkit-planned-stops
+  http::Result<dto::Collection<dto::PlannedStop>> list_stops(const http::TypedRequest & req);
+
+  /// GET /x-medkit-planned-stops/{planned_stop_id}
+  http::Result<dto::PlannedStop> get_stop(const http::TypedRequest & req);
+
+  /// DELETE /x-medkit-planned-stops/{planned_stop_id}
+  http::Result<dto::PlannedStop> end_stop(const http::TypedRequest & req);
+
+  /// Convert a stored window into the wire shape. Public because the OpenAPI
+  /// example recorder and the tests build one without going through a route.
+  static dto::PlannedStop to_dto(const faults::PlannedStopWindow & window);
+
+ private:
+  /// Who to record as the declarer: the authenticated client id when the
+  /// request carries a valid token, otherwise the literal `anonymous`. A
+  /// caller-supplied `declared_by` wins - a maintenance system declaring on
+  /// somebody's behalf is a real case, and the token identifies the machine.
+  std::string resolve_declared_by(const http::TypedRequest & req, const dto::PlannedStopCreateRequest & body) const;
+
+  HandlerContext & ctx_;
+};
+
+}  // namespace handlers
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -278,8 +278,14 @@ class SSEFaultHandler {
   /// path through the replay buffer.
   void enqueue(QueuedEvent queued);
 
-  /// Format a fault event as SSE message
-  static std::string format_sse_event(const QueuedEvent & queued);
+  /// Format a fault event as SSE message.
+  ///
+  /// Not static any more: the frame carries `x-medkit.expected`, which is
+  /// derived from the planned-stop windows this gateway holds. A window can be
+  /// declared straight through the ROS service, so the windows are re-read on a
+  /// short time to live rather than assumed unchanged - see
+  /// FaultManager::planned_stop_windows.
+  std::string format_sse_event(const QueuedEvent & queued) const;
 
   /// Resolve the owning entity for a fault, snapshotting the cache. Manifest
   /// / hybrid mode uses the cache's node-to-app index; runtime mode falls

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp
@@ -278,6 +278,14 @@ class SSEFaultHandler {
   /// path through the replay buffer.
   void enqueue(QueuedEvent queued);
 
+  /// Bring the planned-stop window cache up to date if it is due.
+  ///
+  /// Called from the streaming loop with NO lock held. The blocking half of the
+  /// derivation lives here on purpose: `format_sse_event` runs under
+  /// `queue_mutex_`, which the subscription callback takes to enqueue, so a
+  /// service call there stalls the executor and every other client.
+  void refresh_planned_stops() const;
+
   /// Format a fault event as SSE message.
   ///
   /// Not static any more: the frame carries `x-medkit.expected`, which is

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/conversions/fault_msg_conversions.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/conversions/fault_msg_conversions.hpp
@@ -14,6 +14,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+#include <builtin_interfaces/msg/time.hpp>
 #include <nlohmann/json.hpp>
 
 #include "ros2_medkit_msgs/msg/environment_data.hpp"
@@ -33,6 +38,35 @@ namespace ros2_medkit_gateway::ros2::conversions {
 /// FaultEvent topic directly), and the trigger fault subscriber. Keeping the
 /// helper free standing avoids code duplication while preserving the neutral
 /// FaultManager contract.
+/// builtin_interfaces/Time -> nanoseconds since the Unix epoch.
+inline int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
+  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
+}
+
+/// Nanoseconds since the Unix epoch -> builtin_interfaces/Time.
+///
+/// Floor division, not C's truncation towards zero. `nanosec` is UNSIGNED, so
+/// for an instant before the epoch the remainder is negative and casting it
+/// yields nanosec near 4e9 - a message that is not a time at all. -1 ns is
+/// second -1 plus 999999999 ns, and that is what this returns. The seconds
+/// saturate at the int32 field's range rather than wrapping an absurd input
+/// into a plausible-looking instant.
+inline builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
+  constexpr int64_t kNsPerSec = 1000000000LL;
+  int64_t sec = ns / kNsPerSec;
+  int64_t nsec = ns % kNsPerSec;
+  if (nsec < 0) {
+    nsec += kNsPerSec;
+    --sec;
+  }
+
+  builtin_interfaces::msg::Time t;
+  t.sec = static_cast<int32_t>(
+      std::clamp<int64_t>(sec, std::numeric_limits<int32_t>::min(), std::numeric_limits<int32_t>::max()));
+  t.nanosec = static_cast<uint32_t>(nsec);
+  return t;
+}
+
 nlohmann::json fault_to_json(const ros2_medkit_msgs::msg::Fault & fault);
 
 /// Convert a ros2_medkit_msgs::msg::EnvironmentData to JSON.

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_fault_service_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_fault_service_transport.hpp
@@ -95,6 +95,8 @@ class Ros2FaultServiceTransport : public FaultServiceTransport {
 
   bool is_available() const override;
 
+  bool planned_stops_available() const override;
+
  private:
   rclcpp::Node * node_;
 

--- a/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_fault_service_transport.hpp
+++ b/src/ros2_medkit_gateway/include/ros2_medkit_gateway/ros2/transports/ros2_fault_service_transport.hpp
@@ -23,10 +23,13 @@
 
 #include "ros2_medkit_gateway/core/transports/fault_service_transport.hpp"
 #include "ros2_medkit_msgs/srv/clear_fault.hpp"
+#include "ros2_medkit_msgs/srv/declare_planned_stop.hpp"
+#include "ros2_medkit_msgs/srv/end_planned_stop.hpp"
 #include "ros2_medkit_msgs/srv/get_fault.hpp"
 #include "ros2_medkit_msgs/srv/get_rosbag.hpp"
 #include "ros2_medkit_msgs/srv/get_snapshots.hpp"
 #include "ros2_medkit_msgs/srv/list_faults.hpp"
+#include "ros2_medkit_msgs/srv/list_planned_stops.hpp"
 #include "ros2_medkit_msgs/srv/list_rosbags.hpp"
 #include "ros2_medkit_msgs/srv/report_fault.hpp"
 
@@ -82,6 +85,12 @@ class Ros2FaultServiceTransport : public FaultServiceTransport {
 
   FaultResult list_rosbags(const std::string & entity_fqn) override;
 
+  PlannedStopResult declare_planned_stop(const faults::PlannedStopWindow & request) override;
+
+  PlannedStopResult end_planned_stop(const std::string & id) override;
+
+  PlannedStopResult list_planned_stops(bool active_only) override;
+
   bool wait_for_services(std::chrono::duration<double> timeout) override;
 
   bool is_available() const override;
@@ -105,6 +114,9 @@ class Ros2FaultServiceTransport : public FaultServiceTransport {
   rclcpp::Client<ros2_medkit_msgs::srv::GetSnapshots>::SharedPtr get_snapshots_client_;
   rclcpp::Client<ros2_medkit_msgs::srv::GetRosbag>::SharedPtr get_rosbag_client_;
   rclcpp::Client<ros2_medkit_msgs::srv::ListRosbags>::SharedPtr list_rosbags_client_;
+  rclcpp::Client<ros2_medkit_msgs::srv::DeclarePlannedStop>::SharedPtr declare_planned_stop_client_;
+  rclcpp::Client<ros2_medkit_msgs::srv::EndPlannedStop>::SharedPtr end_planned_stop_client_;
+  rclcpp::Client<ros2_medkit_msgs::srv::ListPlannedStops>::SharedPtr list_planned_stops_client_;
 
   double service_timeout_sec_{5.0};
   std::string fault_manager_base_path_{"/fault_manager"};

--- a/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
@@ -159,8 +159,18 @@ std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text) {
   // stored. Refusing here leaves the representable-instant guard downstream
   // looking at a real value rather than at wreckage.
   constexpr int64_t kMaxSecondsInInt64Ns = std::numeric_limits<int64_t>::max() / kNsPerSecond;
+  constexpr int64_t kFractionHeadroomNs = std::numeric_limits<int64_t>::max() % kNsPerSecond;
   const auto seconds_i64 = static_cast<int64_t>(seconds);
   if (seconds_i64 > kMaxSecondsInInt64Ns || seconds_i64 < -kMaxSecondsInInt64Ns) {
+    return std::nullopt;
+  }
+  // At the maximal second the fraction is what can still overflow: bounding the
+  // seconds alone and adding the fraction afterwards made
+  // "2262-04-11T23:47:16.9Z" undefined behaviour on a route that promises 400.
+  if (seconds_i64 == kMaxSecondsInInt64Ns && fraction_ns > kFractionHeadroomNs) {
+    return std::nullopt;
+  }
+  if (seconds_i64 == -kMaxSecondsInInt64Ns && fraction_ns > kFractionHeadroomNs) {
     return std::nullopt;
   }
   // timegm normalises, so a day that does not exist in that month (31 April)
@@ -175,11 +185,18 @@ std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text) {
   return floor_to_ms_ns(seconds_i64 * kNsPerSecond + fraction_ns);
 }
 
-int64_t seconds_to_ns(double seconds) {
-  if (!std::isfinite(seconds)) {
-    return 0;
+std::optional<int64_t> seconds_to_ns(double seconds) {
+  // Positive form: every comparison against NaN is false, so "outside the range"
+  // written as a pair of ORs would let NaN through into llround, which is
+  // undefined. The bound is in MILLISECONDS because that is the unit the result
+  // is expressed in, and it leaves llround far inside its own range.
+  constexpr double kMaxMs = 9.0e15;
+  const double milliseconds = seconds * 1000.0;
+  const bool usable = std::isfinite(milliseconds) && milliseconds >= -kMaxMs && milliseconds <= kMaxMs;
+  if (!usable) {
+    return std::nullopt;
   }
-  return static_cast<int64_t>(std::llround(seconds * static_cast<double>(kNsPerSecond)));
+  return std::llround(milliseconds) * kNsPerMillisecond;
 }
 
 const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> & windows,
@@ -191,11 +208,35 @@ const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> 
   if (it == fault_json.end() || !it->is_number()) {
     return nullptr;
   }
-  const double first_occurred_sec = it->get<double>();
-  if (!std::isfinite(first_occurred_sec)) {
+  const auto first_occurred_ns = seconds_to_ns(it->get<double>());
+  if (!first_occurred_ns) {
     return nullptr;
   }
-  return find_covering_window(windows, seconds_to_ns(first_occurred_sec));
+  return find_covering_window(windows, *first_occurred_ns);
+}
+
+int64_t count_expected_items(const nlohmann::json & items) {
+  if (!items.is_array()) {
+    return 0;
+  }
+  std::set<std::string> seen;
+  for (const auto & item : items) {
+    if (!item.is_object()) {
+      continue;
+    }
+    const auto extension = item.find("x-medkit");
+    if (extension == item.end() || !extension->is_object()) {
+      continue;
+    }
+    const auto flag = extension->find("expected");
+    if (flag == extension->end() || !flag->is_boolean() || !flag->get<bool>()) {
+      continue;
+    }
+    const auto code = item.find("fault_code");
+    seen.insert(code != item.end() && code->is_string() ? code->get<std::string>()
+                                                        : std::string("<unnamed>") + std::to_string(seen.size()));
+  }
+  return static_cast<int64_t>(seen.size());
 }
 
 void set_expected_count(nlohmann::json & collection, int64_t count) {
@@ -209,11 +250,16 @@ void set_expected_count(nlohmann::json & collection, int64_t count) {
   extension["expected_count"] = count;
 }
 
-bool annotate_fault_with_planned_stop(nlohmann::json & fault_json, const std::vector<PlannedStopWindow> & windows) {
+std::optional<bool> annotate_fault_with_planned_stop(nlohmann::json & fault_json,
+                                                     const PlannedStopKnowledge & knowledge) {
   if (!fault_json.is_object()) {
-    return false;
+    return std::nullopt;
   }
-  const auto * covering = window_for_fault(windows, fault_json);
+  if (!knowledge.known) {
+    // Silence, not `false`. See PlannedStopKnowledge.
+    return std::nullopt;
+  }
+  const auto * covering = window_for_fault(knowledge.windows, fault_json);
 
   // Merge rather than assign: an item may already carry vendor keys, and the
   // flag is an addition to them, not a replacement.
@@ -237,6 +283,7 @@ void PlannedStopCache::store(std::vector<PlannedStopWindow> windows) {
   ever_stored_ = true;
   last_refresh_failed_ = false;
   attempted_at_ = std::chrono::steady_clock::now();
+  stored_at_ = attempted_at_;
 }
 
 void PlannedStopCache::note_failed_refresh() {
@@ -246,9 +293,12 @@ void PlannedStopCache::note_failed_refresh() {
   attempted_at_ = std::chrono::steady_clock::now();
 }
 
-bool PlannedStopCache::has_knowledge() const {
+bool PlannedStopCache::has_knowledge(std::chrono::steady_clock::duration max_age) const {
   const std::lock_guard<std::mutex> lock(mutex_);
-  return ever_stored_;
+  if (!ever_stored_) {
+    return false;
+  }
+  return std::chrono::steady_clock::now() - stored_at_ < max_age;
 }
 
 bool PlannedStopCache::last_refresh_failed() const {

--- a/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <cstdio>
 #include <ctime>
+#include <limits>
 #include <utility>
 
 namespace ros2_medkit_gateway {
@@ -152,6 +153,16 @@ std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text) {
   if (seconds == static_cast<std::time_t>(-1)) {
     return std::nullopt;
   }
+  // Bounded BEFORE the multiply. int64 nanoseconds run out in April 2262, and
+  // seconds * kNsPerSecond wraps silently past that - a stop declared for the
+  // year 2600 came back as one in 2015, inside the accepted range, and was
+  // stored. Refusing here leaves the representable-instant guard downstream
+  // looking at a real value rather than at wreckage.
+  constexpr int64_t kMaxSecondsInInt64Ns = std::numeric_limits<int64_t>::max() / kNsPerSecond;
+  const auto seconds_i64 = static_cast<int64_t>(seconds);
+  if (seconds_i64 > kMaxSecondsInInt64Ns || seconds_i64 < -kMaxSecondsInInt64Ns) {
+    return std::nullopt;
+  }
   // timegm normalises, so a day that does not exist in that month (31 April)
   // comes back as the first of the next one. Refusing it here keeps the parse
   // total rather than creative.
@@ -159,7 +170,9 @@ std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text) {
     return std::nullopt;
   }
 
-  return static_cast<int64_t>(seconds) * kNsPerSecond + fraction_ns;
+  // Rounded down to the API's resolution here rather than at every reader, so
+  // what is stored, what is compared and what is served are the same number.
+  return floor_to_ms_ns(seconds_i64 * kNsPerSecond + fraction_ns);
 }
 
 int64_t seconds_to_ns(double seconds) {

--- a/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
@@ -1,0 +1,248 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <ctime>
+#include <utility>
+
+namespace ros2_medkit_gateway {
+namespace faults {
+
+namespace {
+
+constexpr int64_t kNsPerSecond = 1'000'000'000;
+
+/// Read exactly @p digits decimal digits starting at @p pos, advancing it.
+/// Returns nothing when any of them is not a digit, which is what keeps
+/// "2026-9-6T..." and "2026-09-06T1:2:3Z" out.
+std::optional<int> read_fixed_digits(const std::string & text, size_t & pos, size_t digits) {
+  if (pos + digits > text.size()) {
+    return std::nullopt;
+  }
+  int value = 0;
+  for (size_t i = 0; i < digits; ++i) {
+    const char c = text[pos + i];
+    if (c < '0' || c > '9') {
+      return std::nullopt;
+    }
+    value = value * 10 + (c - '0');
+  }
+  pos += digits;
+  return value;
+}
+
+bool expect_char(const std::string & text, size_t & pos, char expected) {
+  if (pos >= text.size() || text[pos] != expected) {
+    return false;
+  }
+  ++pos;
+  return true;
+}
+
+}  // namespace
+
+const PlannedStopWindow * find_covering_window(const std::vector<PlannedStopWindow> & windows, int64_t when_ns) {
+  const PlannedStopWindow * best = nullptr;
+  for (const auto & candidate : windows) {
+    if (!candidate.covers(when_ns)) {
+      continue;
+    }
+    if (best == nullptr || candidate.from_ns < best->from_ns ||
+        (candidate.from_ns == best->from_ns && candidate.id < best->id)) {
+      best = &candidate;
+    }
+  }
+  return best;
+}
+
+std::optional<int64_t> parse_iso8601_utc_ns(const std::string & text) {
+  size_t pos = 0;
+
+  const auto year = read_fixed_digits(text, pos, 4);
+  if (!year || !expect_char(text, pos, '-')) {
+    return std::nullopt;
+  }
+  const auto month = read_fixed_digits(text, pos, 2);
+  if (!month || !expect_char(text, pos, '-')) {
+    return std::nullopt;
+  }
+  const auto day = read_fixed_digits(text, pos, 2);
+  if (!day || !expect_char(text, pos, 'T')) {
+    return std::nullopt;
+  }
+  const auto hour = read_fixed_digits(text, pos, 2);
+  if (!hour || !expect_char(text, pos, ':')) {
+    return std::nullopt;
+  }
+  const auto minute = read_fixed_digits(text, pos, 2);
+  if (!minute || !expect_char(text, pos, ':')) {
+    return std::nullopt;
+  }
+  const auto second = read_fixed_digits(text, pos, 2);
+  if (!second) {
+    return std::nullopt;
+  }
+
+  // Range check before timegm, which normalises out-of-range fields instead of
+  // refusing them: month 13 would quietly become January of the next year.
+  // Second 60 is refused with the rest - a leap second has no representation in
+  // a Unix timestamp, so accepting it would move the instant by one second.
+  if (*month < 1 || *month > 12 || *day < 1 || *day > 31 || *hour > 23 || *minute > 59 || *second > 59) {
+    return std::nullopt;
+  }
+
+  int64_t fraction_ns = 0;
+  if (pos < text.size() && text[pos] == '.') {
+    ++pos;
+    const size_t fraction_start = pos;
+    int64_t scale = kNsPerSecond;
+    while (pos < text.size() && text[pos] >= '0' && text[pos] <= '9') {
+      if (scale > 1) {
+        scale /= 10;
+        fraction_ns += static_cast<int64_t>(text[pos] - '0') * scale;
+      }
+      ++pos;
+    }
+    if (pos == fraction_start) {
+      return std::nullopt;  // a dot with no digits behind it
+    }
+  }
+
+  // The zone. Only UTC, spelled any of the three legal ways.
+  if (pos < text.size() && (text[pos] == 'Z' || text[pos] == 'z')) {
+    ++pos;
+  } else if (pos + 6 <= text.size() && (text[pos] == '+' || text[pos] == '-')) {
+    const std::string offset = text.substr(pos + 1, 5);
+    if (offset != "00:00") {
+      return std::nullopt;
+    }
+    pos += 6;
+  } else {
+    return std::nullopt;
+  }
+
+  if (pos != text.size()) {
+    return std::nullopt;  // trailing junk
+  }
+
+  std::tm tm_value{};
+  tm_value.tm_year = *year - 1900;
+  tm_value.tm_mon = *month - 1;
+  tm_value.tm_mday = *day;
+  tm_value.tm_hour = *hour;
+  tm_value.tm_min = *minute;
+  tm_value.tm_sec = *second;
+  tm_value.tm_isdst = 0;
+
+  const std::time_t seconds = timegm(&tm_value);
+  if (seconds == static_cast<std::time_t>(-1)) {
+    return std::nullopt;
+  }
+  // timegm normalises, so a day that does not exist in that month (31 April)
+  // comes back as the first of the next one. Refusing it here keeps the parse
+  // total rather than creative.
+  if (tm_value.tm_mday != *day || tm_value.tm_mon != *month - 1) {
+    return std::nullopt;
+  }
+
+  return static_cast<int64_t>(seconds) * kNsPerSecond + fraction_ns;
+}
+
+int64_t seconds_to_ns(double seconds) {
+  if (!std::isfinite(seconds)) {
+    return 0;
+  }
+  return static_cast<int64_t>(std::llround(seconds * static_cast<double>(kNsPerSecond)));
+}
+
+const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> & windows,
+                                           const nlohmann::json & fault_json) {
+  if (!fault_json.is_object()) {
+    return nullptr;
+  }
+  const auto it = fault_json.find("first_occurred");
+  if (it == fault_json.end() || !it->is_number()) {
+    return nullptr;
+  }
+  const double first_occurred_sec = it->get<double>();
+  if (!std::isfinite(first_occurred_sec)) {
+    return nullptr;
+  }
+  return find_covering_window(windows, seconds_to_ns(first_occurred_sec));
+}
+
+bool annotate_fault_with_planned_stop(nlohmann::json & fault_json, const std::vector<PlannedStopWindow> & windows) {
+  if (!fault_json.is_object()) {
+    return false;
+  }
+  const auto * covering = window_for_fault(windows, fault_json);
+
+  // Merge rather than assign: an item may already carry vendor keys, and the
+  // flag is an addition to them, not a replacement.
+  nlohmann::json & extension = fault_json["x-medkit"];
+  if (!extension.is_object()) {
+    extension = nlohmann::json::object();
+  }
+  extension["expected"] = covering != nullptr;
+  if (covering != nullptr) {
+    extension["planned_stop_id"] = covering->id;
+  } else {
+    extension.erase("planned_stop_id");
+  }
+  return covering != nullptr;
+}
+
+void PlannedStopCache::store(std::vector<PlannedStopWindow> windows) {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  windows_ = std::move(windows);
+  ever_attempted_ = true;
+  last_refresh_failed_ = false;
+  attempted_at_ = std::chrono::steady_clock::now();
+}
+
+void PlannedStopCache::note_failed_refresh() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  ever_attempted_ = true;
+  last_refresh_failed_ = true;
+  attempted_at_ = std::chrono::steady_clock::now();
+}
+
+bool PlannedStopCache::last_refresh_failed() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return last_refresh_failed_;
+}
+
+std::vector<PlannedStopWindow> PlannedStopCache::snapshot() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return windows_;
+}
+
+bool PlannedStopCache::is_stale(std::chrono::steady_clock::duration ttl) const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (!ever_attempted_) {
+    return true;
+  }
+  return std::chrono::steady_clock::now() - attempted_at_ >= ttl;
+}
+
+void PlannedStopCache::invalidate() {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  ever_attempted_ = false;
+}
+
+}  // namespace faults
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
+++ b/src/ros2_medkit_gateway/src/core/faults/planned_stop.cpp
@@ -198,6 +198,17 @@ const PlannedStopWindow * window_for_fault(const std::vector<PlannedStopWindow> 
   return find_covering_window(windows, seconds_to_ns(first_occurred_sec));
 }
 
+void set_expected_count(nlohmann::json & collection, int64_t count) {
+  if (!collection.is_object()) {
+    return;
+  }
+  nlohmann::json & extension = collection["x-medkit"];
+  if (!extension.is_object()) {
+    extension = nlohmann::json::object();
+  }
+  extension["expected_count"] = count;
+}
+
 bool annotate_fault_with_planned_stop(nlohmann::json & fault_json, const std::vector<PlannedStopWindow> & windows) {
   if (!fault_json.is_object()) {
     return false;
@@ -223,6 +234,7 @@ void PlannedStopCache::store(std::vector<PlannedStopWindow> windows) {
   const std::lock_guard<std::mutex> lock(mutex_);
   windows_ = std::move(windows);
   ever_attempted_ = true;
+  ever_stored_ = true;
   last_refresh_failed_ = false;
   attempted_at_ = std::chrono::steady_clock::now();
 }
@@ -232,6 +244,11 @@ void PlannedStopCache::note_failed_refresh() {
   ever_attempted_ = true;
   last_refresh_failed_ = true;
   attempted_at_ = std::chrono::steady_clock::now();
+}
+
+bool PlannedStopCache::has_knowledge() const {
+  const std::lock_guard<std::mutex> lock(mutex_);
+  return ever_stored_;
 }
 
 bool PlannedStopCache::last_refresh_failed() const {

--- a/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
@@ -96,28 +96,41 @@ PlannedStopResult FaultManager::list_planned_stops(bool active_only) {
   return transport_->list_planned_stops(active_only);
 }
 
-std::vector<faults::PlannedStopWindow> FaultManager::planned_stop_windows(bool force_refresh) {
+void FaultManager::refresh_planned_stop_windows(bool force) {
   const auto ttl = planned_stop_cache_.last_refresh_failed() ? kPlannedStopFailureBackoff : kPlannedStopCacheTtl;
-  if (force_refresh || planned_stop_cache_.is_stale(ttl)) {
-    // Checked before the call, not instead of it: list_planned_stops blocks for
-    // the transport's whole timeout when the services are absent, and this read
-    // sits on the fault-stream formatting path.
-    auto fetched =
-        transport_->is_available() ? transport_->list_planned_stops(/*active_only=*/false) : PlannedStopResult{};
-    if (fetched.success) {
-      planned_stop_cache_.store(std::move(fetched.stops));
-    } else {
-      // Keep what is known - a fault that briefly loses its flag reads as a
-      // surprise, and a surprise is the one thing an expected fault must not
-      // look like - but stop asking for a while.
-      planned_stop_cache_.note_failed_refresh();
-    }
+  if (!force && !planned_stop_cache_.is_stale(ttl)) {
+    return;
   }
-  return planned_stop_cache_.snapshot();
+
+  // Both readiness checks before the call, not instead of it. is_available()
+  // covers the four core services; planned_stops_available() covers the one this
+  // actually reads, because a fault manager from before planned stops answers
+  // the first four and has no ~/list_planned_stops - asking it anyway cost a
+  // full service timeout on the fault-list path for nothing.
+  const bool worth_asking = transport_->is_available() && transport_->planned_stops_available();
+  auto fetched = worth_asking ? transport_->list_planned_stops(/*active_only=*/false) : PlannedStopResult{};
+  if (fetched.success) {
+    planned_stop_cache_.store(std::move(fetched.stops));
+  } else {
+    // Keep what is known for a little longer - a fault that briefly loses its
+    // flag reads as a surprise - but stop asking for a while, and let the
+    // knowledge age out if nothing renews it.
+    planned_stop_cache_.note_failed_refresh();
+  }
 }
 
-bool FaultManager::planned_stops_known() const {
-  return planned_stop_cache_.has_knowledge();
+faults::PlannedStopKnowledge FaultManager::planned_stop_snapshot() const {
+  faults::PlannedStopKnowledge knowledge;
+  knowledge.known = planned_stop_cache_.has_knowledge(kPlannedStopKnowledgeMaxAge);
+  if (knowledge.known) {
+    knowledge.windows = planned_stop_cache_.snapshot();
+  }
+  return knowledge;
+}
+
+faults::PlannedStopKnowledge FaultManager::planned_stop_windows(bool force_refresh) {
+  refresh_planned_stop_windows(force_refresh);
+  return planned_stop_snapshot();
 }
 
 void FaultManager::invalidate_planned_stop_cache() {

--- a/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
@@ -65,4 +65,59 @@ bool FaultManager::wait_for_services(std::chrono::duration<double> timeout) {
   return transport_->wait_for_services(timeout);
 }
 
+// ---------------------------------------------------------------------------
+// Planned-stop windows
+// ---------------------------------------------------------------------------
+
+PlannedStopResult FaultManager::declare_planned_stop(int64_t from_ns, int64_t to_ns, const std::string & reason,
+                                                     const std::string & declared_by) {
+  faults::PlannedStopWindow request;
+  request.from_ns = from_ns;
+  request.to_ns = to_ns;
+  request.reason = reason;
+  request.declared_by = declared_by;
+
+  auto result = transport_->declare_planned_stop(request);
+  if (result.success) {
+    planned_stop_cache_.invalidate();
+  }
+  return result;
+}
+
+PlannedStopResult FaultManager::end_planned_stop(const std::string & id) {
+  auto result = transport_->end_planned_stop(id);
+  if (result.success) {
+    planned_stop_cache_.invalidate();
+  }
+  return result;
+}
+
+PlannedStopResult FaultManager::list_planned_stops(bool active_only) {
+  return transport_->list_planned_stops(active_only);
+}
+
+std::vector<faults::PlannedStopWindow> FaultManager::planned_stop_windows(bool force_refresh) {
+  const auto ttl = planned_stop_cache_.last_refresh_failed() ? kPlannedStopFailureBackoff : kPlannedStopCacheTtl;
+  if (force_refresh || planned_stop_cache_.is_stale(ttl)) {
+    // Checked before the call, not instead of it: list_planned_stops blocks for
+    // the transport's whole timeout when the services are absent, and this read
+    // sits on the fault-stream formatting path.
+    auto fetched =
+        transport_->is_available() ? transport_->list_planned_stops(/*active_only=*/false) : PlannedStopResult{};
+    if (fetched.success) {
+      planned_stop_cache_.store(std::move(fetched.stops));
+    } else {
+      // Keep what is known - a fault that briefly loses its flag reads as a
+      // surprise, and a surprise is the one thing an expected fault must not
+      // look like - but stop asking for a while.
+      planned_stop_cache_.note_failed_refresh();
+    }
+  }
+  return planned_stop_cache_.snapshot();
+}
+
+void FaultManager::invalidate_planned_stop_cache() {
+  planned_stop_cache_.invalidate();
+}
+
 }  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
+++ b/src/ros2_medkit_gateway/src/core/managers/fault_manager.cpp
@@ -116,6 +116,10 @@ std::vector<faults::PlannedStopWindow> FaultManager::planned_stop_windows(bool f
   return planned_stop_cache_.snapshot();
 }
 
+bool FaultManager::planned_stops_known() const {
+  return planned_stop_cache_.has_knowledge();
+}
+
 void FaultManager::invalidate_planned_stop_cache() {
   planned_stop_cache_.invalidate();
 }

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -28,6 +28,7 @@
 
 #include "ros2_medkit_gateway/aggregation/aggregation_manager.hpp"
 #include "ros2_medkit_gateway/core/faults/fault_scope.hpp"
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
 #include "ros2_medkit_gateway/core/http/entity_path_utils.hpp"
 #include "ros2_medkit_gateway/core/http/error_codes.hpp"
 #include "ros2_medkit_gateway/core/http/fan_out_helpers.hpp"
@@ -196,6 +197,57 @@ json extract_primary_value(const std::string & message_type, const json & full_d
   return full_data;
 }
 
+/// How the `expected` query parameter narrows a fault list.
+enum class ExpectedFilter : uint8_t { All, OnlyExpected, OnlyUnexpected };
+
+tl::expected<ExpectedFilter, ErrorInfo> read_expected_filter(const std::optional<std::string> & value,
+                                                             json params = json::object()) {
+  if (!value.has_value() || value->empty() || *value == "all") {
+    return ExpectedFilter::All;
+  }
+  if (*value == "true") {
+    return ExpectedFilter::OnlyExpected;
+  }
+  if (*value == "false") {
+    return ExpectedFilter::OnlyUnexpected;
+  }
+  params["parameter"] = "expected";
+  params["value"] = *value;
+  return tl::make_unexpected(
+      make_error(400, ERR_INVALID_PARAMETER, "expected must be one of: true, false, all", std::move(params)));
+}
+
+/// Mark each item with the planned-stop flag, drop what the filter excludes, and
+/// report how many of the survivors were expected.
+///
+/// Runs on the LOCAL items only, before any peer merge: a peer's gateway derives
+/// its own flag from its own fault manager's windows, and this gateway has no
+/// business re-deciding it from windows the peer never saw.
+int64_t apply_planned_stops(json & items, FaultManager & fault_mgr, ExpectedFilter filter) {
+  if (!items.is_array()) {
+    return 0;
+  }
+  const auto windows = fault_mgr.planned_stop_windows();
+
+  json kept = json::array();
+  int64_t expected_count = 0;
+  for (auto & item : items) {
+    const bool expected = faults::annotate_fault_with_planned_stop(item, windows);
+    if (filter == ExpectedFilter::OnlyExpected && !expected) {
+      continue;
+    }
+    if (filter == ExpectedFilter::OnlyUnexpected && expected) {
+      continue;
+    }
+    if (expected) {
+      ++expected_count;
+    }
+    kept.push_back(item);
+  }
+  items = std::move(kept);
+  return expected_count;
+}
+
 /// Wrap a built JSON list payload in a typed FaultListResult envelope.
 dto::FaultListResult wrap_list_result(json payload) {
   dto::FaultListResult out;
@@ -287,8 +339,10 @@ json FaultHandlers::merge_entity_freeze_frames(json env_data,
 // The transport adapter performs ros2_medkit_msgs -> JSON translation; the
 // handler post-processes the intermediate snapshot shape (freeze_frame parse,
 // rosbag bulk_data_uri) using the entity_path it has at request time.
-dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_json, const json & env_data_json,
-                                                          const std::string & entity_path) {
+dto::FaultDetail
+FaultHandlers::build_sovd_fault_response(const json & fault_json, const json & env_data_json,
+                                         const std::string & entity_path,
+                                         const std::vector<faults::PlannedStopWindow> & planned_stops) {
   const std::string fault_code = fault_json.value("fault_code", "");
   const std::string status = fault_json.value("status", "");
   const uint8_t severity = fault_json.value("severity", static_cast<uint8_t>(0));
@@ -424,6 +478,12 @@ dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_jso
   }
   xm.severity_label = severity_to_label(severity);
   xm.status_raw = status;
+  if (const auto * covering = faults::window_for_fault(planned_stops, fault_json)) {
+    xm.expected = true;
+    xm.planned_stop_id = covering->id;
+  } else {
+    xm.expected = false;
+  }
   detail.x_medkit = std::move(xm);
 
   return detail;
@@ -442,6 +502,12 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
     }
     const auto filter = *filter_result;
 
+    auto expected_result = read_expected_filter(q.expected);
+    if (!expected_result) {
+      return tl::make_unexpected(expected_result.error());
+    }
+    const auto expected_filter = *expected_result;
+
     auto fault_mgr = ctx_.node()->get_fault_manager();
     // Empty source_id = no filtering, return all faults
     auto result = fault_mgr->list_faults("", filter.include_pending, filter.include_confirmed, filter.include_cleared,
@@ -453,10 +519,12 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
 
     // Format: items array at top level
     json response = {{"items", result.data["faults"]}};
+    const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
 
     // x-medkit extension for ros2_medkit-specific fields (typed DTO)
     dto::FaultListXMedkit xm;
-    xm.count = result.data.value("count", static_cast<int64_t>(0));
+    xm.count = static_cast<int64_t>(response["items"].size());
+    xm.expected_count = expected_count;
     xm.muted_count = result.data.value("muted_count", static_cast<int64_t>(0));
     xm.cluster_count = result.data.value("cluster_count", static_cast<int64_t>(0));
 
@@ -532,6 +600,22 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
             return tl::make_unexpected(
                 make_plugin_error(result.error().http_status, result.error().message, json{{"entity_id", entity_id}}));
           }
+          // The plugin's records describe faults on the same plant, so they get
+          // the same derivation. Reaching into the returned JSON rather than
+          // asking the plugin keeps the flag a gateway concern: no FaultProvider
+          // has to know that planned stops exist.
+          auto plugin_query = req.query<dto::FaultEntityListQuery>();
+          auto plugin_filter = read_expected_filter(plugin_query.expected, json{{"entity_id", entity_id}});
+          if (!plugin_filter) {
+            return tl::make_unexpected(plugin_filter.error());
+          }
+          if (result->content.is_object() && result->content.contains("items")) {
+            const int64_t plugin_expected =
+                apply_planned_stops(result->content["items"], *ctx_.node()->get_fault_manager(), *plugin_filter);
+            if (result->content["x-medkit"].is_object()) {
+              result->content["x-medkit"]["expected_count"] = plugin_expected;
+            }
+          }
           return std::move(*result);
         } catch (const std::exception & e) {
           RCLCPP_ERROR(HandlerContext::logger(), "Plugin FaultProvider threw for entity '%s': %s", entity_id.c_str(),
@@ -560,6 +644,12 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
       return tl::make_unexpected(filter_result.error());
     }
     const auto filter = *filter_result;
+
+    auto expected_result = read_expected_filter(q.expected, json{{entity_info.id_field, entity_id}});
+    if (!expected_result) {
+      return tl::make_unexpected(expected_result.error());
+    }
+    const auto expected_filter = *expected_result;
 
     // Note: the per-entity query DTO (FaultEntityListQuery) deliberately omits
     // include_muted / include_clusters - the underlying service returns
@@ -592,10 +682,12 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
       json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], source_fqns);
       json response = {{"items", filtered_faults}};
+      const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
 
       // x-medkit extension (typed DTO)
       dto::FaultListAggXMedkit xm;
       xm.entity_id = entity_id;
+      xm.expected_count = expected_count;
       const bool is_function = entity_info.type == EntityType::FUNCTION;
       xm.aggregation_level = is_function ? "function" : "component";
       xm.aggregated = true;
@@ -639,9 +731,11 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
       json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], app_fqns);
       json response = {{"items", filtered_faults}};
+      const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
 
       dto::FaultListAggXMedkit xm;
       xm.entity_id = entity_id;
+      xm.expected_count = expected_count;
       xm.aggregation_level = "area";
       xm.aggregated = true;
       xm.component_count = static_cast<int64_t>(cache.get_components_for_area(entity_id).size());
@@ -678,10 +772,12 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
     json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], app_fqns);
     json response = {{"items", filtered_faults}};
+    const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
 
     // x-medkit extension for ros2_medkit-specific fields (typed DTO)
     dto::FaultListXMedkit xm;
     xm.entity_id = entity_id;
+    xm.expected_count = expected_count;
     xm.source_id = entity_info.namespace_path;
 
     if (result.data.contains("muted_faults")) {
@@ -772,7 +868,8 @@ http::Result<dto::FaultDetailResult> FaultHandlers::get_fault(const http::TypedR
               if (auto * capture = ctx_.node()->get_entity_freeze_frame_capture()) {
                 env_data_json = merge_entity_freeze_frames(std::move(env_data_json), capture->frames_for(fault_code));
               }
-              auto detail = build_sovd_fault_response(owned_fault_json, env_data_json, entity_path_info->entity_path);
+              auto detail = build_sovd_fault_response(owned_fault_json, env_data_json, entity_path_info->entity_path,
+                                                      fault_mgr->planned_stop_windows());
               return wrap_detail_result(dto::JsonWriter<dto::FaultDetail>::write(detail));
             }
           }
@@ -826,7 +923,8 @@ http::Result<dto::FaultDetailResult> FaultHandlers::get_fault(const http::TypedR
     if (auto * capture = ctx_.node()->get_entity_freeze_frame_capture()) {
       env_data_json = merge_entity_freeze_frames(std::move(env_data_json), capture->frames_for(fault_code));
     }
-    auto detail = build_sovd_fault_response(fault_json, env_data_json, entity_path_info->entity_path);
+    auto detail = build_sovd_fault_response(fault_json, env_data_json, entity_path_info->entity_path,
+                                            fault_mgr->planned_stop_windows());
 
     return wrap_detail_result(dto::JsonWriter<dto::FaultDetail>::write(detail));
   } catch (const std::exception & e) {

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -234,16 +234,26 @@ std::optional<bool> peer_item_expected_flag(const json & item) {
   return flag->get<bool>();
 }
 
-bool peer_item_is_expected(const json & item) {
-  return peer_item_expected_flag(item).value_or(false);
-}
-
 /// Mark each item with the planned-stop flag, drop what the filter excludes, and
 /// report how many of the survivors were expected.
 ///
 /// Runs on the LOCAL items only, before any peer merge: a peer's gateway derives
 /// its own flag from its own fault manager's windows, and this gateway has no
 /// business re-deciding it from windows the peer never saw.
+/// True when no item in @p items carries an `expected` key at all - so no count
+/// can be stated about them. A list of items from an older peer looks like this.
+bool peer_flags_unknown_only(const json & items) {
+  if (!items.is_array()) {
+    return true;
+  }
+  for (const auto & item : items) {
+    if (peer_item_expected_flag(item).has_value()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// Whether a peer's item survives the `expected` filter. An item whose flag the
 /// peer did not send is dropped by BOTH `true` and `false`: this gateway cannot
 /// claim it was expected, and it cannot claim it was not either.
@@ -258,29 +268,43 @@ bool keep_peer_item(const json & item, ExpectedFilter filter) {
   return filter == ExpectedFilter::OnlyExpected ? *flag : !*flag;
 }
 
-int64_t apply_planned_stops(json & items, FaultManager & fault_mgr, ExpectedFilter filter) {
+/// Mark each item, drop what the filter excludes, and report whether the flag
+/// could be derived at all.
+///
+/// Nothing when this gateway has no window knowledge: no item carries an
+/// `expected` key then, and the collection carries no `expected_count` either.
+/// "The fault manager could not be read" and "no window covers this" are
+/// different answers, and only one of them is a fact - the rule is the same on
+/// every surface, list and stream alike.
+///
+/// When the flag cannot be derived the filter cannot be honoured either, so
+/// `expected=true` and `expected=false` both keep nothing rather than claiming
+/// a half of a set nobody knows.
+std::optional<bool> apply_planned_stops(json & items, FaultManager & fault_mgr, ExpectedFilter filter) {
   if (!items.is_array()) {
-    return 0;
+    return std::nullopt;
   }
-  const auto windows = fault_mgr.planned_stop_windows();
+  const auto knowledge = fault_mgr.planned_stop_windows();
+  if (!knowledge.known) {
+    if (filter != ExpectedFilter::All) {
+      items = json::array();
+    }
+    return std::nullopt;
+  }
 
   json kept = json::array();
-  int64_t expected_count = 0;
   for (auto & item : items) {
-    const bool expected = faults::annotate_fault_with_planned_stop(item, windows);
+    const bool expected = faults::annotate_fault_with_planned_stop(item, knowledge).value_or(false);
     if (filter == ExpectedFilter::OnlyExpected && !expected) {
       continue;
     }
     if (filter == ExpectedFilter::OnlyUnexpected && expected) {
       continue;
     }
-    if (expected) {
-      ++expected_count;
-    }
     kept.push_back(item);
   }
   items = std::move(kept);
-  return expected_count;
+  return true;
 }
 
 /// Wrap a built JSON list payload in a typed FaultListResult envelope.
@@ -374,10 +398,9 @@ json FaultHandlers::merge_entity_freeze_frames(json env_data,
 // The transport adapter performs ros2_medkit_msgs -> JSON translation; the
 // handler post-processes the intermediate snapshot shape (freeze_frame parse,
 // rosbag bulk_data_uri) using the entity_path it has at request time.
-dto::FaultDetail
-FaultHandlers::build_sovd_fault_response(const json & fault_json, const json & env_data_json,
-                                         const std::string & entity_path,
-                                         const std::vector<faults::PlannedStopWindow> & planned_stops) {
+dto::FaultDetail FaultHandlers::build_sovd_fault_response(const json & fault_json, const json & env_data_json,
+                                                          const std::string & entity_path,
+                                                          const faults::PlannedStopKnowledge & planned_stops) {
   const std::string fault_code = fault_json.value("fault_code", "");
   const std::string status = fault_json.value("status", "");
   const uint8_t severity = fault_json.value("severity", static_cast<uint8_t>(0));
@@ -513,11 +536,13 @@ FaultHandlers::build_sovd_fault_response(const json & fault_json, const json & e
   }
   xm.severity_label = severity_to_label(severity);
   xm.status_raw = status;
-  if (const auto * covering = faults::window_for_fault(planned_stops, fault_json)) {
-    xm.expected = true;
-    xm.planned_stop_id = covering->id;
-  } else {
-    xm.expected = false;
+  if (planned_stops.known) {
+    if (const auto * covering = faults::window_for_fault(planned_stops.windows, fault_json)) {
+      xm.expected = true;
+      xm.planned_stop_id = covering->id;
+    } else {
+      xm.expected = false;
+    }
   }
   detail.x_medkit = std::move(xm);
 
@@ -554,7 +579,7 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
 
     // Format: items array at top level
     json response = {{"items", result.data["faults"]}};
-    int64_t expected_count_total = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
+    const bool flag_known = apply_planned_stops(response["items"], *fault_mgr, expected_filter).has_value();
 
     // x-medkit extension for ros2_medkit-specific fields (typed DTO)
     dto::FaultListXMedkit xm;
@@ -594,9 +619,6 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
           if (!keep_peer_item(item, expected_filter)) {
             continue;
           }
-          if (peer_item_is_expected(item)) {
-            ++expected_count_total;
-          }
           response["items"].push_back(item);
         }
       }
@@ -607,10 +629,19 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
       }
     }
 
-    // Counted after the merge, so the numbers describe the list that was
-    // actually served rather than the local half of it.
+    // Both numbers describe the list that was actually SERVED - after the peer
+    // merge and after the filter - not the fault manager's own totals.
+    // `muted_count` and `cluster_count` beside them are still the local
+    // unfiltered numbers the fault manager reported.
     xm.count = static_cast<int64_t>(response["items"].size());
-    xm.expected_count = expected_count_total;
+    // Counted over the merged list, by distinct fault code: an aggregating
+    // gateway serves a code raised on two gateways twice, and counting both
+    // would report two stops' worth of expected faults where the plant had one.
+    // Omitted entirely when the flag could not be derived - a count of zero
+    // would read as "nothing was expected".
+    if (flag_known || !peer_flags_unknown_only(response["items"])) {
+      xm.expected_count = faults::count_expected_items(response["items"]);
+    }
 
     response["x-medkit"] = dto::JsonWriter<dto::FaultListXMedkit>::write(xm);
     return wrap_list_result(std::move(response));
@@ -663,13 +694,22 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
             return tl::make_unexpected(plugin_filter.error());
           }
           if (result->content.is_object() && result->content.contains("items")) {
-            const int64_t plugin_expected =
-                apply_planned_stops(result->content["items"], *ctx_.node()->get_fault_manager(), *plugin_filter);
-            // set_expected_count CREATES the extension. Writing through
-            // `content["x-medkit"]["expected_count"]` behind an is_object()
-            // guard left a plugin that sends no vendor extension answering
-            // `"x-medkit": null` - neither the count nor the absence of one.
-            faults::set_expected_count(result->content, plugin_expected);
+            const bool plugin_flag_known =
+                apply_planned_stops(result->content["items"], *ctx_.node()->get_fault_manager(), *plugin_filter)
+                    .has_value();
+            if (plugin_flag_known) {
+              // set_expected_count CREATES the extension. Writing through
+              // `content["x-medkit"]["expected_count"]` behind an is_object()
+              // guard left a plugin that sends no vendor extension answering
+              // `"x-medkit": null` - neither the count nor the absence of one.
+              faults::set_expected_count(result->content, faults::count_expected_items(result->content["items"]));
+            }
+            // A plugin's own `count`, if it sent one, described the list before
+            // the filter ran. Bring it back in line with what is served rather
+            // than leaving a collection that says five and carries one.
+            if (result->content["x-medkit"].is_object() && result->content["x-medkit"].contains("count")) {
+              result->content["x-medkit"]["count"] = static_cast<int64_t>(result->content["items"].size());
+            }
           }
           return std::move(*result);
         } catch (const std::exception & e) {
@@ -737,12 +777,14 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
       json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], source_fqns);
       json response = {{"items", filtered_faults}};
-      const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
+      const bool flag_known = apply_planned_stops(response["items"], *fault_mgr, expected_filter).has_value();
 
       // x-medkit extension (typed DTO)
       dto::FaultListAggXMedkit xm;
       xm.entity_id = entity_id;
-      xm.expected_count = expected_count;
+      if (flag_known) {
+        xm.expected_count = faults::count_expected_items(response["items"]);
+      }
       const bool is_function = entity_info.type == EntityType::FUNCTION;
       xm.aggregation_level = is_function ? "function" : "component";
       xm.aggregated = true;
@@ -786,11 +828,13 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
       json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], app_fqns);
       json response = {{"items", filtered_faults}};
-      const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
+      const bool flag_known = apply_planned_stops(response["items"], *fault_mgr, expected_filter).has_value();
 
       dto::FaultListAggXMedkit xm;
       xm.entity_id = entity_id;
-      xm.expected_count = expected_count;
+      if (flag_known) {
+        xm.expected_count = faults::count_expected_items(response["items"]);
+      }
       xm.aggregation_level = "area";
       xm.aggregated = true;
       xm.component_count = static_cast<int64_t>(cache.get_components_for_area(entity_id).size());
@@ -827,12 +871,14 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
 
     json filtered_faults = faults::filter_faults_by_sources(result.data["faults"], app_fqns);
     json response = {{"items", filtered_faults}};
-    const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
+    const bool flag_known = apply_planned_stops(response["items"], *fault_mgr, expected_filter).has_value();
 
     // x-medkit extension for ros2_medkit-specific fields (typed DTO)
     dto::FaultListXMedkit xm;
     xm.entity_id = entity_id;
-    xm.expected_count = expected_count;
+    if (flag_known) {
+      xm.expected_count = faults::count_expected_items(response["items"]);
+    }
     xm.source_id = entity_info.namespace_path;
 
     if (result.data.contains("muted_faults")) {

--- a/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/fault_handlers.cpp
@@ -217,12 +217,47 @@ tl::expected<ExpectedFilter, ErrorInfo> read_expected_filter(const std::optional
       make_error(400, ERR_INVALID_PARAMETER, "expected must be one of: true, false, all", std::move(params)));
 }
 
+/// Whether a peer's item says it was expected. Reads the flag the PEER derived;
+/// an item that carries none says nothing either way.
+std::optional<bool> peer_item_expected_flag(const json & item) {
+  if (!item.is_object()) {
+    return std::nullopt;
+  }
+  const auto ext = item.find("x-medkit");
+  if (ext == item.end() || !ext->is_object()) {
+    return std::nullopt;
+  }
+  const auto flag = ext->find("expected");
+  if (flag == ext->end() || !flag->is_boolean()) {
+    return std::nullopt;
+  }
+  return flag->get<bool>();
+}
+
+bool peer_item_is_expected(const json & item) {
+  return peer_item_expected_flag(item).value_or(false);
+}
+
 /// Mark each item with the planned-stop flag, drop what the filter excludes, and
 /// report how many of the survivors were expected.
 ///
 /// Runs on the LOCAL items only, before any peer merge: a peer's gateway derives
 /// its own flag from its own fault manager's windows, and this gateway has no
 /// business re-deciding it from windows the peer never saw.
+/// Whether a peer's item survives the `expected` filter. An item whose flag the
+/// peer did not send is dropped by BOTH `true` and `false`: this gateway cannot
+/// claim it was expected, and it cannot claim it was not either.
+bool keep_peer_item(const json & item, ExpectedFilter filter) {
+  if (filter == ExpectedFilter::All) {
+    return true;
+  }
+  const auto flag = peer_item_expected_flag(item);
+  if (!flag.has_value()) {
+    return false;
+  }
+  return filter == ExpectedFilter::OnlyExpected ? *flag : !*flag;
+}
+
 int64_t apply_planned_stops(json & items, FaultManager & fault_mgr, ExpectedFilter filter) {
   if (!items.is_array()) {
     return 0;
@@ -519,12 +554,10 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
 
     // Format: items array at top level
     json response = {{"items", result.data["faults"]}};
-    const int64_t expected_count = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
+    int64_t expected_count_total = apply_planned_stops(response["items"], *fault_mgr, expected_filter);
 
     // x-medkit extension for ros2_medkit-specific fields (typed DTO)
     dto::FaultListXMedkit xm;
-    xm.count = static_cast<int64_t>(response["items"].size());
-    xm.expected_count = expected_count;
     xm.muted_count = result.data.value("muted_count", static_cast<int64_t>(0));
     xm.cluster_count = result.data.value("cluster_count", static_cast<int64_t>(0));
 
@@ -546,9 +579,24 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       const auto & raw_req = req.raw_for_framework();
 #pragma GCC diagnostic pop
-      auto fan_result = agg->fan_out_get(raw_req.path, raw_req.get_header_value("Authorization"));
+      // build_fan_out_path, not raw path: `?expected=` and `?status=` are the
+      // client's question, and a peer answering a different question is not an
+      // answer. Forwarding `raw_req.path` dropped the query outright, so
+      // `?expected=true` came back carrying the peer's unexpected faults.
+      auto fan_result = agg->fan_out_get(build_fan_out_path(raw_req), raw_req.get_header_value("Authorization"));
       if (fan_result.merged_items.is_array()) {
         for (const auto & item : fan_result.merged_items) {
+          // Filtered again here, on the flag the PEER derived from ITS OWN
+          // windows - this gateway has no business re-deriving it, and an older
+          // peer that ignored the parameter must not put items through. An item
+          // with no flag is not known to satisfy either side of the filter, so
+          // it is dropped by both.
+          if (!keep_peer_item(item, expected_filter)) {
+            continue;
+          }
+          if (peer_item_is_expected(item)) {
+            ++expected_count_total;
+          }
           response["items"].push_back(item);
         }
       }
@@ -558,6 +606,11 @@ http::Result<dto::FaultListResult> FaultHandlers::list_all_faults(const http::Ty
         xm.peer_failures = fan_result.peer_failures;
       }
     }
+
+    // Counted after the merge, so the numbers describe the list that was
+    // actually served rather than the local half of it.
+    xm.count = static_cast<int64_t>(response["items"].size());
+    xm.expected_count = expected_count_total;
 
     response["x-medkit"] = dto::JsonWriter<dto::FaultListXMedkit>::write(xm);
     return wrap_list_result(std::move(response));
@@ -612,9 +665,11 @@ http::Result<dto::FaultListResult> FaultHandlers::list_faults(const http::TypedR
           if (result->content.is_object() && result->content.contains("items")) {
             const int64_t plugin_expected =
                 apply_planned_stops(result->content["items"], *ctx_.node()->get_fault_manager(), *plugin_filter);
-            if (result->content["x-medkit"].is_object()) {
-              result->content["x-medkit"]["expected_count"] = plugin_expected;
-            }
+            // set_expected_count CREATES the extension. Writing through
+            // `content["x-medkit"]["expected_count"]` behind an is_object()
+            // guard left a plugin that sends no vendor extension answering
+            // `"x-medkit": null` - neither the count nor the absence of one.
+            faults::set_expected_count(result->content, plugin_expected);
           }
           return std::move(*result);
         } catch (const std::exception & e) {

--- a/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/health_handlers.cpp
@@ -149,8 +149,14 @@ http::Result<dto::Health> HealthHandlers::get_health(const http::TypedRequest & 
     // by the aggregator's fault-stream relay rather than by anyone an operator
     // can see. A 503 on /faults/stream is otherwise unexplainable from outside.
     if (sse_tracker_) {
-      response.x_medkit_sse =
-          json{{"connected_clients", sse_tracker_->connected_clients()}, {"max_clients", sse_tracker_->max_clients()}};
+      json sse{{"connected_clients", sse_tracker_->connected_clients()}, {"max_clients", sse_tracker_->max_clients()}};
+      if (sse_events_received_) {
+        // Fault events accepted from the fault manager since start. A counter
+        // that stops moving while faults are being reported says the thread
+        // that accepts them is blocked, which nothing else on /health can show.
+        sse["events_received"] = sse_events_received_();
+      }
+      response.x_medkit_sse = std::move(sse);
     }
 
     // Add peer status when aggregation is active

--- a/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
@@ -1,0 +1,220 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ros2_medkit_gateway/http/handlers/planned_stop_handlers.hpp"
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/auth/auth_middleware.hpp"
+#include "ros2_medkit_gateway/core/http/error_codes.hpp"
+#include "ros2_medkit_gateway/core/http/http_utils.hpp"
+#include "ros2_medkit_gateway/gateway_node.hpp"
+#include "ros2_medkit_gateway/http/handlers/handler_support.hpp"
+
+namespace ros2_medkit_gateway {
+namespace handlers {
+
+using json = nlohmann::json;
+
+namespace {
+
+/// Map a transport failure onto an HTTP answer. Only a transport that got no
+/// answer at all yields 503; a fault manager that answered and declined is
+/// healthy and the request was at fault.
+ErrorInfo transport_error(const PlannedStopResult & result, const std::string & what) {
+  if (result.failure == FaultFailure::Unavailable) {
+    return make_error(503, ERR_SERVICE_UNAVAILABLE, "Fault manager unavailable",
+                      json{{"details", result.error_message}, {"operation", what}});
+  }
+  return make_error(400, ERR_INVALID_REQUEST, result.error_message.empty() ? what : result.error_message,
+                    json{{"operation", what}});
+}
+
+}  // namespace
+
+dto::PlannedStop PlannedStopHandlers::to_dto(const faults::PlannedStopWindow & window) {
+  dto::PlannedStop out;
+  out.id = window.id;
+  out.from = format_timestamp_ns(window.from_ns);
+  out.to = format_timestamp_ns(window.to_ns);
+  out.reason = window.reason;
+  out.declared_by = window.declared_by;
+  out.declared_at = format_timestamp_ns(window.declared_at_ns);
+  out.ended_early = window.ended_early;
+  return out;
+}
+
+std::string PlannedStopHandlers::resolve_declared_by(const http::TypedRequest & req,
+                                                     const dto::PlannedStopCreateRequest & body) const {
+  if (body.declared_by.has_value() && !body.declared_by->empty()) {
+    return *body.declared_by;
+  }
+
+  auto * auth = ctx_.auth_manager();
+  if (auth != nullptr && auth->is_enabled()) {
+    if (auto header = req.header("Authorization")) {
+      if (auto token = AuthMiddleware::extract_bearer_token(*header)) {
+        const auto validation = auth->validate_token(*token);
+        if (validation.valid && validation.claims.has_value() && !validation.claims->sub.empty()) {
+          return validation.claims->sub;
+        }
+      }
+    }
+  }
+  // Authentication off, or a token this route never had to see: the honest
+  // record is that nobody signed the declaration.
+  return "anonymous";
+}
+
+http::Result<std::pair<http::Created<dto::PlannedStop>, http::ResponseAttachments>>
+PlannedStopHandlers::declare_stop(const http::TypedRequest & req, dto::PlannedStopCreateRequest body) {
+  try {
+    // A zero start is the transport's way of saying "the fault manager's own
+    // wall clock". That is the right default here too: the fault timestamps the
+    // window will be compared against come from that clock, so filling in the
+    // gateway's would put the difference between the two into the window.
+    int64_t from_ns = 0;
+    if (body.from.has_value() && !body.from->empty()) {
+      const auto parsed = faults::parse_iso8601_utc_ns(*body.from);
+      if (!parsed) {
+        return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, "from is not an ISO 8601 instant in UTC",
+                                         json{{"parameter", "from"}, {"value", *body.from}}));
+      }
+      from_ns = *parsed;
+    }
+
+    const auto to_ns = faults::parse_iso8601_utc_ns(body.to);
+    if (!to_ns) {
+      return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, "to is not an ISO 8601 instant in UTC",
+                                       json{{"parameter", "to"}, {"value", body.to}}));
+    }
+    // Checked here as well as in the fault manager so a caller who spelled the
+    // window wrong is told which field, rather than being handed the service's
+    // prose. from_ns == 0 means "now", which no client-supplied instant can be,
+    // so the comparison is skipped for it.
+    if (from_ns != 0 && *to_ns <= from_ns) {
+      return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, "to must be strictly after from",
+                                       json{{"parameter", "to"}, {"from", *body.from}, {"to", body.to}}));
+    }
+
+    auto fault_mgr = ctx_.node()->get_fault_manager();
+    auto result = fault_mgr->declare_planned_stop(from_ns, *to_ns, body.reason, resolve_declared_by(req, body));
+    if (!result.success || result.stops.empty()) {
+      return tl::unexpected(transport_error(result, "declare planned stop"));
+    }
+
+    auto stop = to_dto(result.stops.front());
+    http::ResponseAttachments att;
+    att.with_location(api_path("/x-medkit-planned-stops/" + stop.id));
+    return std::make_pair(http::Created<dto::PlannedStop>{std::move(stop)}, std::move(att));
+  } catch (const std::exception & e) {
+    return tl::unexpected(
+        make_error(500, ERR_INTERNAL_ERROR, "Failed to declare planned stop", json{{"details", e.what()}}));
+  }
+}
+
+http::Result<dto::Collection<dto::PlannedStop>> PlannedStopHandlers::list_stops(const http::TypedRequest & req) {
+  try {
+    const auto q = req.query<dto::PlannedStopListQuery>();
+
+    auto fault_mgr = ctx_.node()->get_fault_manager();
+    auto result = fault_mgr->list_planned_stops(q.active);
+    if (!result.success) {
+      return tl::unexpected(transport_error(result, "list planned stops"));
+    }
+
+    dto::Collection<dto::PlannedStop> out;
+    out.items.reserve(result.stops.size());
+    for (const auto & window : result.stops) {
+      out.items.push_back(to_dto(window));
+    }
+    return out;
+  } catch (const std::exception & e) {
+    return tl::unexpected(
+        make_error(500, ERR_INTERNAL_ERROR, "Failed to list planned stops", json{{"details", e.what()}}));
+  }
+}
+
+http::Result<dto::PlannedStop> PlannedStopHandlers::get_stop(const http::TypedRequest & req) {
+  try {
+    auto id = req.path_param("1");
+    if (!id) {
+      return tl::unexpected(id.error());
+    }
+
+    auto fault_mgr = ctx_.node()->get_fault_manager();
+    auto result = fault_mgr->list_planned_stops(/*active_only=*/false);
+    if (!result.success) {
+      return tl::unexpected(transport_error(result, "get planned stop"));
+    }
+
+    const auto found =
+        std::find_if(result.stops.begin(), result.stops.end(), [&id](const faults::PlannedStopWindow & window) {
+          return window.id == *id;
+        });
+    if (found == result.stops.end()) {
+      return tl::unexpected(
+          make_error(404, ERR_RESOURCE_NOT_FOUND, "Planned stop not found", json{{"planned_stop_id", *id}}));
+    }
+    return to_dto(*found);
+  } catch (const std::exception & e) {
+    return tl::unexpected(
+        make_error(500, ERR_INTERNAL_ERROR, "Failed to read planned stop", json{{"details", e.what()}}));
+  }
+}
+
+http::Result<dto::PlannedStop> PlannedStopHandlers::end_stop(const http::TypedRequest & req) {
+  try {
+    auto id = req.path_param("1");
+    if (!id) {
+      return tl::unexpected(id.error());
+    }
+
+    auto fault_mgr = ctx_.node()->get_fault_manager();
+    auto result = fault_mgr->end_planned_stop(*id);
+    if (result.success && !result.stops.empty()) {
+      return to_dto(result.stops.front());
+    }
+    if (result.failure == FaultFailure::Unavailable) {
+      return tl::unexpected(transport_error(result, "end planned stop"));
+    }
+
+    // The fault manager refused. Which answer that is - "no such window" or
+    // "that window has already ended" - is decided by looking the id up rather
+    // than by reading the refusal's prose, which the fault manager is free to
+    // reword. A window that disappeared between the two calls reads as 404,
+    // which is what it now is.
+    auto listed = fault_mgr->list_planned_stops(/*active_only=*/false);
+    const bool exists = listed.success && std::any_of(listed.stops.begin(), listed.stops.end(),
+                                                      [&id](const faults::PlannedStopWindow & window) {
+                                                        return window.id == *id;
+                                                      });
+    if (!exists) {
+      return tl::unexpected(
+          make_error(404, ERR_RESOURCE_NOT_FOUND, "Planned stop not found", json{{"planned_stop_id", *id}}));
+    }
+    return tl::unexpected(make_error(400, ERR_X_MEDKIT_PLANNED_STOP_ENDED,
+                                     "Planned stop has already ended and cannot be ended again",
+                                     json{{"planned_stop_id", *id}, {"details", result.error_message}}));
+  } catch (const std::exception & e) {
+    return tl::unexpected(
+        make_error(500, ERR_INTERNAL_ERROR, "Failed to end planned stop", json{{"details", e.what()}}));
+  }
+}
+
+}  // namespace handlers
+}  // namespace ros2_medkit_gateway

--- a/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
@@ -15,6 +15,7 @@
 #include "ros2_medkit_gateway/http/handlers/planned_stop_handlers.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <string>
 #include <utility>
 #include <vector>
@@ -35,13 +36,33 @@ namespace {
 /// Map a transport failure onto an HTTP answer. Only a transport that got no
 /// answer at all yields 503; a fault manager that answered and declined is
 /// healthy and the request was at fault.
-ErrorInfo transport_error(const PlannedStopResult & result, const std::string & what) {
+///
+/// Which refusal it was comes from the service's structured outcome, never from
+/// its message: the refusals map onto three different statuses, and reading
+/// prose to pick one turns a rewording into an outage.
+ErrorInfo transport_error(const PlannedStopResult & result, const std::string & what, json params = json::object()) {
+  params["operation"] = what;
   if (result.failure == FaultFailure::Unavailable) {
-    return make_error(503, ERR_SERVICE_UNAVAILABLE, "Fault manager unavailable",
-                      json{{"details", result.error_message}, {"operation", what}});
+    params["details"] = result.error_message;
+    return make_error(503, ERR_SERVICE_UNAVAILABLE, "Fault manager unavailable", std::move(params));
   }
-  return make_error(400, ERR_INVALID_REQUEST, result.error_message.empty() ? what : result.error_message,
-                    json{{"operation", what}});
+  const std::string message = result.error_message.empty() ? what : result.error_message;
+  switch (result.refusal) {
+    case PlannedStopRefusal::NotFound:
+      return make_error(404, ERR_RESOURCE_NOT_FOUND, "Planned stop not found", std::move(params));
+    case PlannedStopRefusal::AlreadyEnded:
+      return make_error(400, ERR_X_MEDKIT_PLANNED_STOP_ENDED,
+                        "Planned stop has already ended and cannot be ended again", std::move(params));
+    case PlannedStopRefusal::DuplicateId:
+    case PlannedStopRefusal::NotRetained:
+      // 409, not 400: the request was well formed and the store could not take
+      // it. Raise planned_stop.max_windows, or end a window, and retry.
+      return make_error(409, ERR_PRECONDITION_NOT_FULFILLED, message, std::move(params));
+    case PlannedStopRefusal::InvalidRequest:
+    case PlannedStopRefusal::None:
+    default:
+      return make_error(400, ERR_INVALID_REQUEST, message, std::move(params));
+  }
 }
 
 }  // namespace
@@ -55,6 +76,7 @@ dto::PlannedStop PlannedStopHandlers::to_dto(const faults::PlannedStopWindow & w
   out.declared_by = window.declared_by;
   out.declared_at = format_timestamp_ns(window.declared_at_ns);
   out.ended_early = window.ended_early;
+  out.cancelled = window.cancelled;
   return out;
 }
 
@@ -83,11 +105,13 @@ std::string PlannedStopHandlers::resolve_declared_by(const http::TypedRequest & 
 http::Result<std::pair<http::Created<dto::PlannedStop>, http::ResponseAttachments>>
 PlannedStopHandlers::declare_stop(const http::TypedRequest & req, dto::PlannedStopCreateRequest body) {
   try {
-    // A zero start is the transport's way of saying "the fault manager's own
-    // wall clock". That is the right default here too: the fault timestamps the
-    // window will be compared against come from that clock, so filling in the
-    // gateway's would put the difference between the two into the window.
-    int64_t from_ns = 0;
+    // An omitted `from` is filled in HERE, with this gateway's own clock, and an
+    // explicit instant always goes on the wire. Sending zero and letting the
+    // service read it as "now" made the epoch - a legal instant an operator can
+    // ask for - indistinguishable from a field nobody set.
+    int64_t from_ns = faults::floor_to_ms_ns(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch())
+            .count());
     if (body.from.has_value() && !body.from->empty()) {
       const auto parsed = faults::parse_iso8601_utc_ns(*body.from);
       if (!parsed) {
@@ -97,8 +121,8 @@ PlannedStopHandlers::declare_stop(const http::TypedRequest & req, dto::PlannedSt
       from_ns = *parsed;
       if (!faults::is_representable_instant(from_ns)) {
         return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER,
-                                         "from is outside the range a planned stop can be stored at "
-                                         "(1970-01-01T00:00:00Z to 2038-01-19T03:14:07Z)",
+                                         "from must be after 1970-01-01T00:00:00Z and no later than "
+                                         "2038-01-19T03:14:07Z",
                                          json{{"parameter", "from"}, {"value", *body.from}}));
       }
     }
@@ -110,17 +134,17 @@ PlannedStopHandlers::declare_stop(const http::TypedRequest & req, dto::PlannedSt
     }
     if (!faults::is_representable_instant(*to_ns)) {
       return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER,
-                                       "to is outside the range a planned stop can be stored at "
-                                       "(1970-01-01T00:00:00Z to 2038-01-19T03:14:07Z)",
+                                       "to must be after 1970-01-01T00:00:00Z and no later than "
+                                       "2038-01-19T03:14:07Z",
                                        json{{"parameter", "to"}, {"value", body.to}}));
     }
     // Checked here as well as in the fault manager so a caller who spelled the
     // window wrong is told which field, rather than being handed the service's
-    // prose. from_ns == 0 means "now", which no client-supplied instant can be,
-    // so the comparison is skipped for it.
-    if (from_ns != 0 && *to_ns <= from_ns) {
-      return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, "to must be strictly after from",
-                                       json{{"parameter", "to"}, {"from", *body.from}, {"to", body.to}}));
+    // prose.
+    if (*to_ns <= from_ns) {
+      return tl::unexpected(
+          make_error(400, ERR_INVALID_PARAMETER, "to must be strictly after from",
+                     json{{"parameter", "to"}, {"from", format_timestamp_ns(from_ns)}, {"to", body.to}}));
     }
 
     auto fault_mgr = ctx_.node()->get_fault_manager();
@@ -199,29 +223,12 @@ http::Result<dto::PlannedStop> PlannedStopHandlers::end_stop(const http::TypedRe
     auto fault_mgr = ctx_.node()->get_fault_manager();
     auto result = fault_mgr->end_planned_stop(*id);
     if (result.success && !result.stops.empty()) {
+      // Cut short, or cancelled outright when the window had not started yet.
+      // Both are 200 with the window; `cancelled` says which happened, and a
+      // cancelled window is gone, so a GET on this id now answers 404.
       return to_dto(result.stops.front());
     }
-    if (result.failure == FaultFailure::Unavailable) {
-      return tl::unexpected(transport_error(result, "end planned stop"));
-    }
-
-    // The fault manager refused. Which answer that is - "no such window" or
-    // "that window has already ended" - is decided by looking the id up rather
-    // than by reading the refusal's prose, which the fault manager is free to
-    // reword. A window that disappeared between the two calls reads as 404,
-    // which is what it now is.
-    auto listed = fault_mgr->list_planned_stops(/*active_only=*/false);
-    const bool exists = listed.success && std::any_of(listed.stops.begin(), listed.stops.end(),
-                                                      [&id](const faults::PlannedStopWindow & window) {
-                                                        return window.id == *id;
-                                                      });
-    if (!exists) {
-      return tl::unexpected(
-          make_error(404, ERR_RESOURCE_NOT_FOUND, "Planned stop not found", json{{"planned_stop_id", *id}}));
-    }
-    return tl::unexpected(make_error(400, ERR_X_MEDKIT_PLANNED_STOP_ENDED,
-                                     "Planned stop has already ended and cannot be ended again",
-                                     json{{"planned_stop_id", *id}, {"details", result.error_message}}));
+    return tl::unexpected(transport_error(result, "end planned stop", json{{"planned_stop_id", *id}}));
   } catch (const std::exception & e) {
     return tl::unexpected(
         make_error(500, ERR_INTERNAL_ERROR, "Failed to end planned stop", json{{"details", e.what()}}));

--- a/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/planned_stop_handlers.cpp
@@ -95,11 +95,23 @@ PlannedStopHandlers::declare_stop(const http::TypedRequest & req, dto::PlannedSt
                                          json{{"parameter", "from"}, {"value", *body.from}}));
       }
       from_ns = *parsed;
+      if (!faults::is_representable_instant(from_ns)) {
+        return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER,
+                                         "from is outside the range a planned stop can be stored at "
+                                         "(1970-01-01T00:00:00Z to 2038-01-19T03:14:07Z)",
+                                         json{{"parameter", "from"}, {"value", *body.from}}));
+      }
     }
 
     const auto to_ns = faults::parse_iso8601_utc_ns(body.to);
     if (!to_ns) {
       return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER, "to is not an ISO 8601 instant in UTC",
+                                       json{{"parameter", "to"}, {"value", body.to}}));
+    }
+    if (!faults::is_representable_instant(*to_ns)) {
+      return tl::unexpected(make_error(400, ERR_INVALID_PARAMETER,
+                                       "to is outside the range a planned stop can be stored at "
+                                       "(1970-01-01T00:00:00Z to 2038-01-19T03:14:07Z)",
                                        json{{"parameter", "to"}, {"value", body.to}}));
     }
     // Checked here as well as in the fault manager so a caller who spelled the

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -684,20 +684,28 @@ std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) const 
   }
 
   // Planned-stop flag. Emitted on every event, entity or no entity, so a stream
-  // consumer sees the same truth as a reader of `GET /faults` - and emitted as
-  // an explicit `false` rather than by omission, because "not expected" and "the
-  // gateway could not tell" are different things to react to. The x-medkit
-  // object is created here when the entity did not resolve, which is why the
-  // two fields it may otherwise carry are optional in the frame's schema.
+  // consumer sees the same truth as a reader of `GET /faults`. The x-medkit
+  // object is created here when the entity did not resolve, which is why the two
+  // fields it may otherwise carry are optional in the frame's schema.
+  //
+  // "Unknown" is NOT "false". While this gateway has never managed to read the
+  // declared windows - no fault manager, or none reachable since start - the
+  // frame carries no `expected` key at all. Sending `false` there would tell a
+  // consumer that nothing was expected, which is exactly what an operator
+  // watching a stop would act on, and the gateway does not know that.
   if (auto * fault_mgr = ctx_.node()->get_fault_manager(); fault_mgr != nullptr) {
+    // Read first: this call is what populates the cache, so asking whether the
+    // gateway knows anything before it would answer "no" for ever.
     const auto windows = fault_mgr->planned_stop_windows();
-    const auto * covering = faults::window_for_fault(windows, json_event["fault"]);
-    if (!json_event["x-medkit"].is_object()) {
-      json_event["x-medkit"] = nlohmann::json::object();
-    }
-    json_event["x-medkit"]["expected"] = covering != nullptr;
-    if (covering != nullptr) {
-      json_event["x-medkit"]["planned_stop_id"] = covering->id;
+    if (fault_mgr->planned_stops_known()) {
+      const auto * covering = faults::window_for_fault(windows, json_event["fault"]);
+      if (!json_event["x-medkit"].is_object()) {
+        json_event["x-medkit"] = nlohmann::json::object();
+      }
+      json_event["x-medkit"]["expected"] = covering != nullptr;
+      if (covering != nullptr) {
+        json_event["x-medkit"]["planned_stop_id"] = covering->id;
+      }
     }
   }
 

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -462,6 +462,7 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
 
     // First, send any buffered events the client missed (for reconnection)
     {
+      refresh_planned_stops();
       std::vector<std::pair<uint64_t, std::string>> pending;
       {
         std::lock_guard<std::mutex> lock(queue_mutex_);
@@ -486,20 +487,31 @@ std::function<bool(httplib::DataSink &)> SSEFaultHandler::make_stream_loop(uint6
 
       std::vector<std::pair<uint64_t, std::string>> pending;
       bool keepalive_due = false;
+      bool woke = false;
       {
         std::unique_lock<std::mutex> lock(queue_mutex_);
 
         // Predicate form: an event enqueued between the last flush and this
         // wait already spent its notify_all while nobody was waiting; a plain
         // wait_for would sleep the full keepalive interval on top of it.
-        const bool woke = queue_cv_.wait_for(lock, timeout, [this, &last_event_id, relay_peers] {
+        woke = queue_cv_.wait_for(lock, timeout, [this, &last_event_id, relay_peers] {
           return shutdown_flag_.load() || has_pending_locked(last_event_id, relay_peers);
         });
 
         if (shutdown_flag_.load()) {
           return false;  // Handler is shutting down
         }
+      }
 
+      // Between the wait and the formatting, and outside the lock on both
+      // counts. Before the wait it would be too early - a window declared while
+      // this loop slept would not be in the snapshot the woken event is
+      // formatted from - and under the lock it would be a blocking service call
+      // on the mutex the subscription callback needs to enqueue.
+      refresh_planned_stops();
+
+      {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
         pending = collect_pending();
         keepalive_due = !woke && pending.empty();
       }
@@ -639,6 +651,12 @@ uint64_t SSEFaultHandler::events_received() const {
   return next_event_id_.load(std::memory_order_relaxed) - 1;
 }
 
+void SSEFaultHandler::refresh_planned_stops() const {
+  if (auto * fault_mgr = ctx_.node()->get_fault_manager(); fault_mgr != nullptr) {
+    fault_mgr->refresh_planned_stop_windows();
+  }
+}
+
 std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) const {
   const auto sanitized_event_type = sanitize_sse_event_type(queued.event.event_type);
 
@@ -693,12 +711,16 @@ std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) const 
   // frame carries no `expected` key at all. Sending `false` there would tell a
   // consumer that nothing was expected, which is exactly what an operator
   // watching a stop would act on, and the gateway does not know that.
+  //
+  // Read from the cache ONLY. This runs under `queue_mutex_` (collect_pending
+  // holds it), and the subscription callback takes the same mutex to enqueue, so
+  // a service call here stalls the gateway's executor thread and every other
+  // client behind one client's formatting pass. The refresh happens on the
+  // stream's own thread, before the lock - see refresh_planned_stop_windows.
   if (auto * fault_mgr = ctx_.node()->get_fault_manager(); fault_mgr != nullptr) {
-    // Read first: this call is what populates the cache, so asking whether the
-    // gateway knows anything before it would answer "no" for ever.
-    const auto windows = fault_mgr->planned_stop_windows();
-    if (fault_mgr->planned_stops_known()) {
-      const auto * covering = faults::window_for_fault(windows, json_event["fault"]);
+    const auto knowledge = fault_mgr->planned_stop_snapshot();
+    if (knowledge.known) {
+      const auto * covering = faults::window_for_fault(knowledge.windows, json_event["fault"]);
       if (!json_event["x-medkit"].is_object()) {
         json_event["x-medkit"] = nlohmann::json::object();
       }

--- a/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/src/http/handlers/sse_fault_handler.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "ros2_medkit_gateway/http/handlers/sse_fault_handler.hpp"
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -638,7 +639,7 @@ uint64_t SSEFaultHandler::events_received() const {
   return next_event_id_.load(std::memory_order_relaxed) - 1;
 }
 
-std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) {
+std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) const {
   const auto sanitized_event_type = sanitize_sse_event_type(queued.event.event_type);
 
   // A relayed event is the peer's own payload. It is emitted under THIS
@@ -680,6 +681,24 @@ std::string SSEFaultHandler::format_sse_event(const QueuedEvent & queued) {
   // codes, not payload fields.
   if (queued.entity) {
     json_event["x-medkit"] = {{"entity_type", queued.entity->type}, {"entity_id", queued.entity->id}};
+  }
+
+  // Planned-stop flag. Emitted on every event, entity or no entity, so a stream
+  // consumer sees the same truth as a reader of `GET /faults` - and emitted as
+  // an explicit `false` rather than by omission, because "not expected" and "the
+  // gateway could not tell" are different things to react to. The x-medkit
+  // object is created here when the entity did not resolve, which is why the
+  // two fields it may otherwise carry are optional in the frame's schema.
+  if (auto * fault_mgr = ctx_.node()->get_fault_manager(); fault_mgr != nullptr) {
+    const auto windows = fault_mgr->planned_stop_windows();
+    const auto * covering = faults::window_for_fault(windows, json_event["fault"]);
+    if (!json_event["x-medkit"].is_object()) {
+      json_event["x-medkit"] = nlohmann::json::object();
+    }
+    json_event["x-medkit"]["expected"] = covering != nullptr;
+    if (covering != nullptr) {
+      json_event["x-medkit"]["planned_stop_id"] = covering->id;
+    }
   }
 
   std::ostringstream sse;

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -205,6 +205,13 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   }
   sse_fault_handler_ = std::make_unique<handlers::SSEFaultHandler>(*handler_ctx_, sse_client_tracker_,
                                                                    std::chrono::seconds(keepalive_used));
+  // Built after the SSE handler on purpose: /health reports its received-event
+  // counter, and the handler does not exist when HealthHandlers is constructed.
+  if (health_handlers_) {
+    health_handlers_->set_sse_event_counter([this]() -> uint64_t {
+      return sse_fault_handler_ ? sse_fault_handler_->events_received() : 0;
+    });
+  }
   bulkdata_handlers_ = std::make_unique<handlers::BulkDataHandlers>(*handler_ctx_);
   // Validated as int64 before narrowing: narrowing first wraps a value above
   // INT_MAX into a small positive one that passes the check, so 4294967300
@@ -2267,9 +2274,11 @@ void RESTServer::setup_routes() {
       .body_example(nlohmann::json{
           {"from", "2026-09-06T18:00:00Z"}, {"to", "2026-09-06T22:00:00Z"}, {"reason", "line changeover"}})
       .success_description("Planned stop declared")
+      // 409 when the bound on retained windows is full of windows that have not
+      // ended: the request was well formed and the store could not take it.
       // 503 when the fault manager cannot be reached - the windows are stored
       // there, so there is nowhere else to put the declaration.
-      .errors({503})
+      .errors({409, 503})
       .operation_id("declarePlannedStop");
 
   reg.get<dto::Collection<dto::PlannedStop>>(

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -29,6 +29,7 @@
 #include "ros2_medkit_gateway/core/http/parameter_error_classification.hpp"
 #include "ros2_medkit_gateway/core/thread_pool_config.hpp"
 #include "ros2_medkit_gateway/dto/fault_triggers.hpp"
+#include "ros2_medkit_gateway/dto/planned_stops.hpp"
 #include "ros2_medkit_gateway/dto/sse_frames.hpp"
 #include "ros2_medkit_gateway/gateway_node.hpp"
 #include "ros2_medkit_gateway/http/detail/status_recorder.hpp"
@@ -188,6 +189,7 @@ RESTServer::RESTServer(GatewayNode * node, const std::string & host, int port, c
   operation_handlers_ = std::make_unique<handlers::OperationHandlers>(*handler_ctx_);
   config_handlers_ = std::make_unique<handlers::ConfigHandlers>(*handler_ctx_);
   fault_handlers_ = std::make_unique<handlers::FaultHandlers>(*handler_ctx_);
+  planned_stop_handlers_ = std::make_unique<handlers::PlannedStopHandlers>(*handler_ctx_);
   log_handlers_ = std::make_unique<handlers::LogHandlers>(*handler_ctx_);
   auth_handlers_ = std::make_unique<handlers::AuthHandlers>(*handler_ctx_);
   // Documented range 1-3600 s. Clamped rather than refused, and the clamp is
@@ -2239,6 +2241,80 @@ void RESTServer::setup_routes() {
       .errors({503})
       .operation_id("clearAllFaults")
       .query<dto::FaultClearQuery>();
+
+  // === Planned stops ===
+  //
+  // A vendor extension, so the path carries the `/x-medkit-` prefix the
+  // convention reserves for one. The windows themselves live in the fault
+  // manager; these four routes are the operator's side of declaring them, and
+  // the flag they produce shows up on `GET /faults` and `/faults/stream` rather
+  // than here.
+  reg.post<dto::PlannedStopCreateRequest, http::Created<dto::PlannedStop>>(
+         "/x-medkit-planned-stops",
+         [this](http::TypedRequest req, dto::PlannedStopCreateRequest body)
+             -> http::Result<std::pair<http::Created<dto::PlannedStop>, http::ResponseAttachments>> {
+           return planned_stop_handlers_->declare_stop(req, std::move(body));
+         })
+      .tag("PlannedStops")
+      .requires_role(UserRole::OPERATOR)
+      .summary("Declare a planned stop")
+      .description(
+          "Declares a window during which faults are expected. Faults whose current cycle starts inside it are "
+          "reported with `x-medkit.expected` on `GET /faults` and on the fault stream. Nothing else changes: an "
+          "expected fault is still confirmed, healed, cleared, captured and audited exactly as any other, which "
+          "is what keeps the evidence describing the plant that existed. Windows may overlap and may be declared "
+          "after the stop they describe.")
+      .body_example(nlohmann::json{
+          {"from", "2026-09-06T18:00:00Z"}, {"to", "2026-09-06T22:00:00Z"}, {"reason", "line changeover"}})
+      .success_description("Planned stop declared")
+      // 503 when the fault manager cannot be reached - the windows are stored
+      // there, so there is nowhere else to put the declaration.
+      .errors({503})
+      .operation_id("declarePlannedStop");
+
+  reg.get<dto::Collection<dto::PlannedStop>>(
+         "/x-medkit-planned-stops",
+         [this](http::TypedRequest req) -> http::Result<dto::Collection<dto::PlannedStop>> {
+           return planned_stop_handlers_->list_stops(req);
+         })
+      .tag("PlannedStops")
+      .requires_role(UserRole::VIEWER)
+      .summary("List planned stops")
+      .description(
+          "Every declared window, newest declaration first. Ended windows are included by default - they are the "
+          "reason older faults read as expected. In an aggregated deployment this lists only THIS gateway's fault "
+          "manager: each peer keeps its own windows and its own gateway derives the flag for its own faults.")
+      .errors({503})
+      .operation_id("listPlannedStops")
+      .query<dto::PlannedStopListQuery>();
+
+  reg.get<dto::PlannedStop>("/x-medkit-planned-stops/{planned_stop_id}",
+                            [this](http::TypedRequest req) -> http::Result<dto::PlannedStop> {
+                              return planned_stop_handlers_->get_stop(req);
+                            })
+      .tag("PlannedStops")
+      .requires_role(UserRole::VIEWER)
+      .summary("Get a planned stop")
+      .description("The window `x-medkit.planned_stop_id` on a fault names.")
+      .errors({404, 503})
+      .operation_id("getPlannedStop");
+
+  reg.del<dto::PlannedStop>("/x-medkit-planned-stops/{planned_stop_id}",
+                            [this](http::TypedRequest req) -> http::Result<dto::PlannedStop> {
+                              return planned_stop_handlers_->end_stop(req);
+                            })
+      .tag("PlannedStops")
+      .requires_role(UserRole::OPERATOR)
+      .summary("End a planned stop early")
+      .description(
+          "Cuts the window short: `to` moves to the moment of this request and `ended_early` becomes true. Faults "
+          "whose cycle started before that instant stay expected; faults raised after it do not. Answers 200 with "
+          "the ended window rather than 204, because the caller needs to be told where `to` landed. A window "
+          "whose end has already passed answers 400 - when a stop finished is not something a later request gets "
+          "to rewrite.")
+      .response(400, "The window has already ended (x-medkit-planned-stop-ended)")
+      .errors({404, 503})
+      .operation_id("endPlannedStop");
 
   // === Software Updates ===
   //

--- a/src/ros2_medkit_gateway/src/http/rest_server.cpp
+++ b/src/ros2_medkit_gateway/src/http/rest_server.cpp
@@ -2310,10 +2310,12 @@ void RESTServer::setup_routes() {
           "Cuts the window short: `to` moves to the moment of this request and `ended_early` becomes true. Faults "
           "whose cycle started before that instant stay expected; faults raised after it do not. Answers 200 with "
           "the ended window rather than 204, because the caller needs to be told where `to` landed. A window "
-          "whose end has already passed answers 400 - when a stop finished is not something a later request gets "
-          "to rewrite.")
-      .response(400, "The window has already ended (x-medkit-planned-stop-ended)")
-      .errors({404, 503})
+          "whose end has already passed answers 400 with vendor code `x-medkit-planned-stop-ended` - when a stop "
+          "finished is not something a later request gets to rewrite.")
+      // 400 goes through .errors() like every other refusal, so the document
+      // renders it as a $ref to GenericError. Naming it with .response() instead
+      // publishes an inline schema no generated client can share.
+      .errors({400, 404, 503})
       .operation_id("endPlannedStop");
 
   // === Software Updates ===

--- a/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
+++ b/src/ros2_medkit_gateway/src/openapi/capability_generator.cpp
@@ -281,6 +281,7 @@ nlohmann::json CapabilityGenerator::generate_root() const {
       {"Bulk Data", "Large file downloads (rosbags, snapshots)"},
       {"Subscriptions", "Cyclic data subscriptions and event streaming"},
       {"Triggers", "Event-driven condition monitoring and notifications"},
+      {"PlannedStops", "Windows during which faults are expected, declared by an operator"},
       {"FaultTriggers", "Threshold rules on discovered data points that raise and auto-clear faults"},
       {"Locking", "Entity lock management for exclusive access"},
       {"Scripts", "Diagnostic script upload, execution, and management"},

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -512,16 +512,11 @@ FaultResult Ros2FaultServiceTransport::list_rosbags(const std::string & entity_f
 
 namespace {
 
-int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
-  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
-}
-
-builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
-  builtin_interfaces::msg::Time t;
-  t.sec = static_cast<int32_t>(ns / 1000000000LL);
-  t.nanosec = static_cast<uint32_t>(ns % 1000000000LL);
-  return t;
-}
+// time_msg_to_ns / ns_to_time_msg come from fault_msg_conversions.hpp: the
+// conversion has to be floor division for an instant before the epoch, and one
+// copy of that rule is easier to keep right than two.
+using conversions::ns_to_time_msg;
+using conversions::time_msg_to_ns;
 
 faults::PlannedStopWindow window_from_msg(const ros2_medkit_msgs::msg::PlannedStop & msg) {
   faults::PlannedStopWindow w;

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -167,6 +167,12 @@ bool Ros2FaultServiceTransport::wait_for_services(std::chrono::duration<double> 
          list_faults_client_->wait_for_service(remaining()) && clear_fault_client_->wait_for_service(remaining());
 }
 
+bool Ros2FaultServiceTransport::planned_stops_available() const {
+  // The derivation reads through list_planned_stops, so that is the client whose
+  // readiness decides whether asking is worth a timeout.
+  return list_planned_stops_client_ && list_planned_stops_client_->service_is_ready();
+}
+
 bool Ros2FaultServiceTransport::is_available() const {
   return report_fault_client_->service_is_ready() && get_fault_client_->service_is_ready() &&
          list_faults_client_->service_is_ready() && clear_fault_client_->service_is_ready();

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -24,6 +24,7 @@
 #include "ros2_medkit_gateway/ros2/conversions/fault_msg_conversions.hpp"
 #include "ros2_medkit_msgs/msg/environment_data.hpp"
 #include "ros2_medkit_msgs/msg/fault.hpp"
+#include "ros2_medkit_msgs/msg/planned_stop.hpp"
 
 namespace ros2_medkit_gateway::ros2 {
 
@@ -119,6 +120,12 @@ Ros2FaultServiceTransport::Ros2FaultServiceTransport(rclcpp::Node * node) : node
       client_node_->create_client<ros2_medkit_msgs::srv::GetRosbag>(fault_manager_base_path_ + "/get_rosbag");
   list_rosbags_client_ =
       client_node_->create_client<ros2_medkit_msgs::srv::ListRosbags>(fault_manager_base_path_ + "/list_rosbags");
+  declare_planned_stop_client_ = client_node_->create_client<ros2_medkit_msgs::srv::DeclarePlannedStop>(
+      fault_manager_base_path_ + "/declare_planned_stop");
+  end_planned_stop_client_ = client_node_->create_client<ros2_medkit_msgs::srv::EndPlannedStop>(
+      fault_manager_base_path_ + "/end_planned_stop");
+  list_planned_stops_client_ = client_node_->create_client<ros2_medkit_msgs::srv::ListPlannedStops>(
+      fault_manager_base_path_ + "/list_planned_stops");
 
   RCLCPP_INFO(node_->get_logger(), "Ros2FaultServiceTransport initialized (base_path=%s, timeout=%.1fs)",
               fault_manager_base_path_.c_str(), service_timeout_sec_);
@@ -137,6 +144,9 @@ Ros2FaultServiceTransport::~Ros2FaultServiceTransport() {
   get_snapshots_client_.reset();
   get_rosbag_client_.reset();
   list_rosbags_client_.reset();
+  declare_planned_stop_client_.reset();
+  end_planned_stop_client_.reset();
+  list_planned_stops_client_.reset();
 
   executor_.reset();
   client_node_.reset();
@@ -493,6 +503,114 @@ FaultResult Ros2FaultServiceTransport::list_rosbags(const std::string & entity_f
     result.error_message = response->error_message;
   }
 
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Planned-stop windows
+// ---------------------------------------------------------------------------
+
+namespace {
+
+int64_t time_msg_to_ns(const builtin_interfaces::msg::Time & t) {
+  return static_cast<int64_t>(t.sec) * 1000000000LL + static_cast<int64_t>(t.nanosec);
+}
+
+builtin_interfaces::msg::Time ns_to_time_msg(int64_t ns) {
+  builtin_interfaces::msg::Time t;
+  t.sec = static_cast<int32_t>(ns / 1000000000LL);
+  t.nanosec = static_cast<uint32_t>(ns % 1000000000LL);
+  return t;
+}
+
+faults::PlannedStopWindow window_from_msg(const ros2_medkit_msgs::msg::PlannedStop & msg) {
+  faults::PlannedStopWindow w;
+  w.id = msg.id;
+  w.from_ns = time_msg_to_ns(msg.starts_at);
+  w.to_ns = time_msg_to_ns(msg.ends_at);
+  w.reason = msg.reason;
+  w.declared_by = msg.declared_by;
+  w.declared_at_ns = time_msg_to_ns(msg.declared_at);
+  w.ended_early = msg.ended_early;
+  return w;
+}
+
+}  // namespace
+
+PlannedStopResult Ros2FaultServiceTransport::declare_planned_stop(const faults::PlannedStopWindow & window) {
+  PlannedStopResult result;
+
+  auto request = std::make_shared<ros2_medkit_msgs::srv::DeclarePlannedStop::Request>();
+  request->starts_at = ns_to_time_msg(window.from_ns);
+  request->ends_at = ns_to_time_msg(window.to_ns);
+  request->reason = window.reason;
+  request->declared_by = window.declared_by;
+
+  auto response = invoke_fault_service<ros2_medkit_msgs::srv::DeclarePlannedStop>(
+      declare_planned_stop_client_, request, executor_, executor_mutex_,
+      std::chrono::duration<double>(service_timeout_sec_), "DeclarePlannedStop", result.error_message);
+  if (!response) {
+    result.failure = FaultFailure::Unavailable;
+    return result;
+  }
+
+  result.success = response->success;
+  if (!response->success) {
+    result.error_message = response->message;
+    return result;
+  }
+  result.stops.push_back(window_from_msg(response->stop));
+  return result;
+}
+
+PlannedStopResult Ros2FaultServiceTransport::end_planned_stop(const std::string & id) {
+  PlannedStopResult result;
+
+  auto request = std::make_shared<ros2_medkit_msgs::srv::EndPlannedStop::Request>();
+  request->id = id;
+  // A zero instant asks the fault manager for its own wall clock. Sending the
+  // gateway's would put the two clocks' difference into the record of when the
+  // stop finished, and the fault timestamps it will be compared against come
+  // from the fault manager's clock.
+  request->at = builtin_interfaces::msg::Time();
+
+  auto response = invoke_fault_service<ros2_medkit_msgs::srv::EndPlannedStop>(
+      end_planned_stop_client_, request, executor_, executor_mutex_,
+      std::chrono::duration<double>(service_timeout_sec_), "EndPlannedStop", result.error_message);
+  if (!response) {
+    result.failure = FaultFailure::Unavailable;
+    return result;
+  }
+
+  result.success = response->success;
+  if (!response->success) {
+    result.error_message = response->message;
+    return result;
+  }
+  result.stops.push_back(window_from_msg(response->stop));
+  return result;
+}
+
+PlannedStopResult Ros2FaultServiceTransport::list_planned_stops(bool active_only) {
+  PlannedStopResult result;
+
+  auto request = std::make_shared<ros2_medkit_msgs::srv::ListPlannedStops::Request>();
+  request->active_only = active_only;
+  request->now = builtin_interfaces::msg::Time();
+
+  auto response = invoke_fault_service<ros2_medkit_msgs::srv::ListPlannedStops>(
+      list_planned_stops_client_, request, executor_, executor_mutex_,
+      std::chrono::duration<double>(service_timeout_sec_), "ListPlannedStops", result.error_message);
+  if (!response) {
+    result.failure = FaultFailure::Unavailable;
+    return result;
+  }
+
+  result.success = true;
+  result.stops.reserve(response->stops.size());
+  for (const auto & stop : response->stops) {
+    result.stops.push_back(window_from_msg(stop));
+  }
   return result;
 }
 

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -596,8 +596,21 @@ PlannedStopResult Ros2FaultServiceTransport::end_planned_stop(const std::string 
   if (!response->success) {
     result.error_message = response->message;
     using Response = ros2_medkit_msgs::srv::EndPlannedStop::Response;
-    result.refusal = response->outcome == Response::OUTCOME_ALREADY_ENDED ? PlannedStopRefusal::AlreadyEnded
-                                                                          : PlannedStopRefusal::NotFound;
+    switch (response->outcome) {
+      case Response::OUTCOME_ALREADY_ENDED:
+        result.refusal = PlannedStopRefusal::AlreadyEnded;
+        break;
+      case Response::OUTCOME_INVALID_AT:
+        // Not reachable from REST - DELETE always asks the fault manager for its
+        // own clock, and "now" is always inside a running window's legal range -
+        // but a wrong instant is a bad request, not a missing window, and
+        // mislabelling it 404 would send a caller looking for the wrong thing.
+        result.refusal = PlannedStopRefusal::InvalidRequest;
+        break;
+      default:
+        result.refusal = PlannedStopRefusal::NotFound;
+        break;
+    }
     return result;
   }
   result.stops.push_back(window_from_msg(response->stop));

--- a/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
+++ b/src/ros2_medkit_gateway/src/ros2/transports/ros2_fault_service_transport.cpp
@@ -527,6 +527,7 @@ faults::PlannedStopWindow window_from_msg(const ros2_medkit_msgs::msg::PlannedSt
   w.declared_by = msg.declared_by;
   w.declared_at_ns = time_msg_to_ns(msg.declared_at);
   w.ended_early = msg.ended_early;
+  w.cancelled = msg.cancelled;
   return w;
 }
 
@@ -536,6 +537,8 @@ PlannedStopResult Ros2FaultServiceTransport::declare_planned_stop(const faults::
   PlannedStopResult result;
 
   auto request = std::make_shared<ros2_medkit_msgs::srv::DeclarePlannedStop::Request>();
+  // Always an explicit instant: the service refuses zero, and the caller has
+  // already filled in "now" when the body omitted a start.
   request->starts_at = ns_to_time_msg(window.from_ns);
   request->ends_at = ns_to_time_msg(window.to_ns);
   request->reason = window.reason;
@@ -552,6 +555,18 @@ PlannedStopResult Ros2FaultServiceTransport::declare_planned_stop(const faults::
   result.success = response->success;
   if (!response->success) {
     result.error_message = response->message;
+    using Response = ros2_medkit_msgs::srv::DeclarePlannedStop::Response;
+    switch (response->outcome) {
+      case Response::OUTCOME_DUPLICATE_ID:
+        result.refusal = PlannedStopRefusal::DuplicateId;
+        break;
+      case Response::OUTCOME_NOT_RETAINED:
+        result.refusal = PlannedStopRefusal::NotRetained;
+        break;
+      default:
+        result.refusal = PlannedStopRefusal::InvalidRequest;
+        break;
+    }
     return result;
   }
   result.stops.push_back(window_from_msg(response->stop));
@@ -580,6 +595,9 @@ PlannedStopResult Ros2FaultServiceTransport::end_planned_stop(const std::string 
   result.success = response->success;
   if (!response->success) {
     result.error_message = response->message;
+    using Response = ros2_medkit_msgs::srv::EndPlannedStop::Response;
+    result.refusal = response->outcome == Response::OUTCOME_ALREADY_ENDED ? PlannedStopRefusal::AlreadyEnded
+                                                                          : PlannedStopRefusal::NotFound;
     return result;
   }
   result.stops.push_back(window_from_msg(response->stop));

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -34,7 +34,11 @@
 
 /// No planned-stop windows declared: every fault in these cases is a surprise,
 /// which is what a gateway with an empty planned_stops table serves.
-static const std::vector<ros2_medkit_gateway::faults::PlannedStopWindow> kNoPlannedStops;
+/// No planned-stop windows declared, and the gateway KNOWS that: every fault in
+/// these cases is a surprise, which is what a gateway with an empty
+/// planned_stops table serves. `known` false would mean something else - see
+/// PlannedStopKnowledge - and would leave the flag off the response entirely.
+static const ros2_medkit_gateway::faults::PlannedStopKnowledge kNoPlannedStops{true, {}};
 
 using json = nlohmann::json;
 using namespace std::chrono_literals;

--- a/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
+++ b/src/ros2_medkit_gateway/test/test_entity_freeze_frame_capture.cpp
@@ -32,6 +32,10 @@
 #include "ros2_medkit_gateway/ros2_common/ros2_subscription_executor.hpp"
 #include "ros2_medkit_msgs/msg/fault_event.hpp"
 
+/// No planned-stop windows declared: every fault in these cases is a surprise,
+/// which is what a gateway with an empty planned_stops table serves.
+static const std::vector<ros2_medkit_gateway::faults::PlannedStopWindow> kNoPlannedStops;
+
 using json = nlohmann::json;
 using namespace std::chrono_literals;
 using ros2_medkit_gateway::DataProvider;
@@ -865,7 +869,7 @@ TEST(MergeEntityFreezeFrames, CarriesLinkStateAndSourceTimestampWhenKnown) {
 
   // And onto the wire: build_sovd_fault_response surfaces them in x-medkit.
   const auto detail = FaultHandlers::build_sovd_fault_response(
-      json{{"fault_code", "PLC_COMMS_LOST"}, {"status", "CONFIRMED"}}, merged, "/apps/plc_app");
+      json{{"fault_code", "PLC_COMMS_LOST"}, {"status", "CONFIRMED"}}, merged, "/apps/plc_app", kNoPlannedStops);
   ASSERT_TRUE(detail.environment_data.snapshots.has_value());
   const auto & wire = *detail.environment_data.snapshots;
   ASSERT_EQ(wire.size(), 2u);

--- a/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
@@ -28,7 +28,11 @@
 
 /// No planned-stop windows declared: every fault in these cases is a surprise,
 /// which is what a gateway with an empty planned_stops table serves.
-static const std::vector<ros2_medkit_gateway::faults::PlannedStopWindow> kNoPlannedStops;
+/// No planned-stop windows declared, and the gateway KNOWS that: every fault in
+/// these cases is a surprise, which is what a gateway with an empty
+/// planned_stops table serves. `known` false would mean something else - see
+/// PlannedStopKnowledge - and would leave the flag off the response entirely.
+static const ros2_medkit_gateway::faults::PlannedStopKnowledge kNoPlannedStops{true, {}};
 
 using json = nlohmann::json;
 using ros2_medkit_gateway::handlers::FaultHandlers;

--- a/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
@@ -721,3 +721,42 @@ TEST(ClassifyFaultFailureTest, UnavailableIsAServerError) {
     EXPECT_EQ(err.params["details"], message);
   }
 }
+
+// =============================================================================
+// nanoseconds <-> builtin_interfaces/Time
+//
+// The gateway sends window bounds to the fault manager through this pair. The
+// API refuses an instant before the epoch long before it gets here, so these
+// cases are about the helper being total rather than about a reachable request:
+// a conversion that can emit nanosec >= 1e9 is one refactor away from doing it.
+// =============================================================================
+
+TEST(TimeMsgConversion, NegativeInstantsStayWellFormed) {
+  using ros2_medkit_gateway::ros2::conversions::ns_to_time_msg;
+  using ros2_medkit_gateway::ros2::conversions::time_msg_to_ns;
+
+  auto t = ns_to_time_msg(-1);
+  EXPECT_EQ(t.sec, -1);
+  EXPECT_EQ(t.nanosec, 999999999u);
+  EXPECT_EQ(time_msg_to_ns(t), -1);
+
+  t = ns_to_time_msg(-1500000000LL);
+  EXPECT_EQ(t.sec, -2);
+  EXPECT_EQ(t.nanosec, 500000000u);
+  EXPECT_EQ(time_msg_to_ns(t), -1500000000LL);
+
+  t = ns_to_time_msg(std::numeric_limits<int64_t>::min());
+  EXPECT_LT(t.nanosec, 1000000000u);
+}
+
+TEST(TimeMsgConversion, PositiveInstantsRoundTrip) {
+  using ros2_medkit_gateway::ros2::conversions::ns_to_time_msg;
+  using ros2_medkit_gateway::ros2::conversions::time_msg_to_ns;
+
+  const int64_t samples[] = {0, 1, 1000000000LL, 1999999999LL, 1788698096000000000LL};
+  for (int64_t ns : samples) {
+    const auto t = ns_to_time_msg(ns);
+    EXPECT_LT(t.nanosec, 1000000000u) << "for " << ns;
+    EXPECT_EQ(time_msg_to_ns(t), ns);
+  }
+}

--- a/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_handlers.cpp
@@ -26,6 +26,10 @@
 #include "ros2_medkit_msgs/msg/fault.hpp"
 #include "ros2_medkit_msgs/msg/snapshot.hpp"
 
+/// No planned-stop windows declared: every fault in these cases is a surprise,
+/// which is what a gateway with an empty planned_stops table serves.
+static const std::vector<ros2_medkit_gateway::faults::PlannedStopWindow> kNoPlannedStops;
+
 using json = nlohmann::json;
 using ros2_medkit_gateway::handlers::FaultHandlers;
 namespace conversions = ros2_medkit_gateway::ros2::conversions;
@@ -68,8 +72,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseBasicFields) {
   env_data.extended_data_records.first_occurrence_ns = 1707044400000000000;
   env_data.extended_data_records.last_occurrence_ns = 1707044460000000000;
 
-  auto response = to_json(
-      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/motor_controller"));
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data),
+                                                                   "/apps/motor_controller", kNoPlannedStops));
 
   // Verify item structure
   EXPECT_EQ(response["item"]["code"], "TEST_FAULT");
@@ -106,8 +110,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseWithFreezeFrame) {
   freeze_frame.captured_at_ns = 1707044400000000000;
   env_data.snapshots.push_back(freeze_frame);
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/motor"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/motor", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["type"], "freeze_frame");
@@ -135,7 +139,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponsePropagatesCaptureOrigin) {
                                                {"captured_at_ns", 1234},
                                                {"capture_origin", "startup"}}})}};
 
-  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_data, "/apps/plc_app"));
+  auto response =
+      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_data, "/apps/plc_app", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["type"], "freeze_frame");
@@ -188,8 +193,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseWithRosbag) {
   rosbag.format = "mcap";
   env_data.snapshots.push_back(rosbag);
 
-  auto response = to_json(
-      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/motor_controller"));
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data),
+                                                                   "/apps/motor_controller", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["type"], "rosbag");
@@ -210,8 +215,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseNestedEntityPath) {
   rosbag.bulk_data_id = "NESTED_FAULT";
   env_data.snapshots.push_back(rosbag);
 
-  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data),
-                                                                   "/areas/perception/subareas/lidar"));
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(
+      fault_json(fault), env_json(env_data), "/areas/perception/subareas/lidar", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["bulk_data_uri"], "/areas/perception/subareas/lidar/bulk-data/rosbags/NESTED_FAULT");
@@ -225,8 +230,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseStatusCleared) {
 
   ros2_medkit_msgs::msg::EnvironmentData env_data;
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
 
   auto status = response["item"]["status"];
   EXPECT_EQ(status["aggregatedStatus"], "cleared");
@@ -243,8 +248,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseStatusPassive) {
 
   ros2_medkit_msgs::msg::EnvironmentData env_data;
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
 
   auto status = response["item"]["status"];
   EXPECT_EQ(status["aggregatedStatus"], "passive");
@@ -261,40 +266,40 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseSeverityLabels) {
   {
     ros2_medkit_msgs::msg::Fault fault;
     fault.severity = ros2_medkit_msgs::msg::Fault::SEVERITY_INFO;
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_EQ(response["x-medkit"]["severity_label"], "INFO");
   }
   // Test WARN (1)
   {
     ros2_medkit_msgs::msg::Fault fault;
     fault.severity = ros2_medkit_msgs::msg::Fault::SEVERITY_WARN;
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_EQ(response["x-medkit"]["severity_label"], "WARN");
   }
   // Test ERROR (2)
   {
     ros2_medkit_msgs::msg::Fault fault;
     fault.severity = ros2_medkit_msgs::msg::Fault::SEVERITY_ERROR;
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_EQ(response["x-medkit"]["severity_label"], "ERROR");
   }
   // Test CRITICAL (3)
   {
     ros2_medkit_msgs::msg::Fault fault;
     fault.severity = ros2_medkit_msgs::msg::Fault::SEVERITY_CRITICAL;
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_EQ(response["x-medkit"]["severity_label"], "CRITICAL");
   }
   // Test UNKNOWN (255) - any value outside the SEVERITY_* range
   {
     ros2_medkit_msgs::msg::Fault fault;
     fault.severity = 255;
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_EQ(response["x-medkit"]["severity_label"], "UNKNOWN");
   }
 }
@@ -313,8 +318,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseWithInvalidJson) {
   freeze_frame.message_type = "std_msgs/msg/String";
   env_data.snapshots.push_back(freeze_frame);
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["data"], "not valid json {");  // Raw data returned
@@ -330,8 +335,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseExtendedDataRecords) {
   env_data.extended_data_records.first_occurrence_ns = 1770458400000000000;  // 2026-02-08
   env_data.extended_data_records.last_occurrence_ns = 1770458460000000000;
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
 
   auto & edr = response["environment_data"]["extended_data_records"];
   std::string first = edr["first_occurrence"].get<std::string>();
@@ -358,8 +363,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponsePrimaryValueExtraction) {
     env_data.snapshots.clear();
     env_data.snapshots.push_back(snap);
 
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     EXPECT_DOUBLE_EQ(response["environment_data"]["snapshots"][0]["data"].get<double>(), 42.5);
   }
 
@@ -373,8 +378,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponsePrimaryValueExtraction) {
     env_data.snapshots.clear();
     env_data.snapshots.push_back(snap);
 
-    auto response =
-        to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+    auto response = to_json(
+        FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
     auto data = response["environment_data"]["snapshots"][0]["data"];
     EXPECT_EQ(data["foo"], "bar");
     EXPECT_EQ(data["baz"], 123);
@@ -389,8 +394,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseMultipleSources) {
 
   ros2_medkit_msgs::msg::EnvironmentData env_data;
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test"));
+  auto response = to_json(
+      FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/test", kNoPlannedStops));
 
   auto sources = response["x-medkit"]["reporting_sources"];
   ASSERT_EQ(sources.size(), 3);
@@ -423,8 +428,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseMixedSnapshots) {
   rosbag.format = "mcap";
   env_data.snapshots.push_back(rosbag);
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/components/motor"));
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data),
+                                                                   "/components/motor", kNoPlannedStops));
 
   ASSERT_EQ(response["environment_data"]["snapshots"].size(), 2);
 
@@ -589,8 +594,8 @@ TEST_F(FaultHandlersTest, BuildSovdFaultResponseExternalEntityFreezeFrame) {
   freeze_frame.captured_at_ns = 1707044400000000000;
   env_data.snapshots.push_back(freeze_frame);
 
-  auto response =
-      to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data), "/apps/process"));
+  auto response = to_json(FaultHandlers::build_sovd_fault_response(fault_json(fault), env_json(env_data),
+                                                                   "/apps/process", kNoPlannedStops));
 
   auto & snap = response["environment_data"]["snapshots"][0];
   EXPECT_EQ(snap["type"], "freeze_frame");

--- a/src/ros2_medkit_gateway/test/test_fault_manager_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_manager_routing.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "ros2_medkit_gateway/core/faults/fault_types.hpp"
 #include "ros2_medkit_gateway/core/managers/fault_manager.hpp"
@@ -130,6 +131,50 @@ class MockFaultServiceTransport : public FaultServiceTransport {
     return r;
   }
 
+  PlannedStopResult declare_planned_stop(const faults::PlannedStopWindow & request) override {
+    last_declare_ = request;
+    ++declare_calls_;
+    PlannedStopResult r;
+    r.success = planned_stop_success_;
+    r.error_message = planned_stop_error_;
+    r.failure = planned_stop_failure_;
+    if (planned_stop_success_) {
+      auto stored = request;
+      stored.id = "declared-1";
+      r.stops.push_back(stored);
+    }
+    return r;
+  }
+
+  PlannedStopResult end_planned_stop(const std::string & id) override {
+    last_end_id_ = id;
+    ++end_calls_;
+    PlannedStopResult r;
+    r.success = planned_stop_success_;
+    r.error_message = planned_stop_error_;
+    r.failure = planned_stop_failure_;
+    if (planned_stop_success_) {
+      faults::PlannedStopWindow ended;
+      ended.id = id;
+      ended.ended_early = true;
+      r.stops.push_back(ended);
+    }
+    return r;
+  }
+
+  PlannedStopResult list_planned_stops(bool active_only) override {
+    last_active_only_ = active_only;
+    ++list_stops_calls_;
+    PlannedStopResult r;
+    r.success = planned_stop_success_;
+    r.error_message = planned_stop_error_;
+    r.failure = planned_stop_failure_;
+    if (planned_stop_success_) {
+      r.stops = planned_stops_;
+    }
+    return r;
+  }
+
   bool wait_for_services(std::chrono::duration<double> timeout) override {
     last_wait_timeout_ = timeout.count();
     ++wait_calls_;
@@ -209,6 +254,18 @@ class MockFaultServiceTransport : public FaultServiceTransport {
 
   bool is_available_ = true;
   mutable int availability_calls_ = 0;
+  // Planned-stop state. Kept beside the fault state so a test can make the
+  // planned-stop half fail without disturbing the rest.
+  faults::PlannedStopWindow last_declare_{};
+  std::string last_end_id_;
+  bool last_active_only_{false};
+  std::vector<faults::PlannedStopWindow> planned_stops_;
+  bool planned_stop_success_{true};
+  std::string planned_stop_error_;
+  FaultFailure planned_stop_failure_{FaultFailure::Declined};
+  int declare_calls_{0};
+  int end_calls_{0};
+  int list_stops_calls_{0};
 };
 
 }  // namespace

--- a/src/ros2_medkit_gateway/test/test_fault_manager_routing.cpp
+++ b/src/ros2_medkit_gateway/test/test_fault_manager_routing.cpp
@@ -181,6 +181,10 @@ class MockFaultServiceTransport : public FaultServiceTransport {
     return wait_result_;
   }
 
+  bool planned_stops_available() const override {
+    return planned_stops_ready_;
+  }
+
   bool is_available() const override {
     ++availability_calls_;
     return is_available_;
@@ -261,6 +265,7 @@ class MockFaultServiceTransport : public FaultServiceTransport {
   bool last_active_only_{false};
   std::vector<faults::PlannedStopWindow> planned_stops_;
   bool planned_stop_success_{true};
+  bool planned_stops_ready_{true};
   std::string planned_stop_error_;
   FaultFailure planned_stop_failure_{FaultFailure::Declined};
   int declare_calls_{0};

--- a/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
+++ b/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
@@ -21,18 +21,21 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
 
 #include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
+#include "ros2_medkit_gateway/core/http/http_utils.hpp"
 
 using ros2_medkit_gateway::faults::annotate_fault_with_planned_stop;
 using ros2_medkit_gateway::faults::find_covering_window;
 using ros2_medkit_gateway::faults::floor_to_ms_ns;
 using ros2_medkit_gateway::faults::parse_iso8601_utc_ns;
 using ros2_medkit_gateway::faults::PlannedStopCache;
+using ros2_medkit_gateway::faults::PlannedStopKnowledge;
 using ros2_medkit_gateway::faults::PlannedStopWindow;
 using ros2_medkit_gateway::faults::seconds_to_ns;
 using ros2_medkit_gateway::faults::window_for_fault;
@@ -180,6 +183,23 @@ TEST(PlannedStopTimeParsing, RefusesAYearWhoseNanosecondCountCannotBeCounted) {
   EXPECT_GT(*in_2100, ros2_medkit_gateway::faults::kMaxRepresentableNs);
 }
 
+TEST(PlannedStopTimeParsing, TheOverflowBoundIncludesTheFraction) {
+  // 2262-04-11T23:47:16Z is exactly INT64_MAX / 1e9 seconds. Bounding the
+  // seconds alone and adding the fraction afterwards overflowed int64 - undefined
+  // behaviour on a route whose contract is a 400.
+  const auto last_second = parse_iso8601_utc_ns("2262-04-11T23:47:16Z");
+  ASSERT_TRUE(last_second.has_value());
+
+  const auto last_ms = parse_iso8601_utc_ns("2262-04-11T23:47:16.854Z");
+  ASSERT_TRUE(last_ms.has_value()) << "the last representable millisecond must still parse";
+  EXPECT_EQ(*last_ms, 9223372036854000000LL);
+
+  for (const char * past_the_end :
+       {"2262-04-11T23:47:16.855Z", "2262-04-11T23:47:16.9Z", "2262-04-11T23:47:16.999999999Z"}) {
+    EXPECT_FALSE(parse_iso8601_utc_ns(past_the_end).has_value()) << "accepted: " << past_the_end;
+  }
+}
+
 TEST(PlannedStopTimeParsing, RefusesAnInstantAtOrBeforeTheEpoch) {
   // The epoch is not a sentinel for "now" anywhere in this API, so it cannot be
   // a legal window bound either.
@@ -228,7 +248,7 @@ TEST(PlannedStopAnnotation, MarksAFaultWhoseCycleStartedInsideAWindow) {
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
   nlohmann::json fault{{"fault_code", "MOTOR_STALL"}, {"first_occurred", 15.0}, {"status", "CONFIRMED"}};
 
-  EXPECT_TRUE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_TRUE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_TRUE(fault["x-medkit"]["expected"].get<bool>());
   EXPECT_EQ(fault["x-medkit"]["planned_stop_id"].get<std::string>(), "w");
 }
@@ -237,7 +257,7 @@ TEST(PlannedStopAnnotation, LeavesAFaultOutsideEveryWindowUnexpectedAndUnattribu
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
   nlohmann::json fault{{"fault_code", "MOTOR_STALL"}, {"first_occurred", 25.0}};
 
-  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_FALSE(fault["x-medkit"]["expected"].get<bool>());
   EXPECT_FALSE(fault["x-medkit"].contains("planned_stop_id"))
       << "naming a window that does not cover the fault would be worse than naming none";
@@ -247,7 +267,7 @@ TEST(PlannedStopAnnotation, KeepsVendorKeysTheItemAlreadyCarried) {
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
   nlohmann::json fault{{"first_occurred", 15.0}, {"x-medkit", {{"captured_at", "2026-09-06T00:00:00.000Z"}}}};
 
-  ASSERT_TRUE(annotate_fault_with_planned_stop(fault, windows));
+  ASSERT_TRUE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_EQ(fault["x-medkit"]["captured_at"].get<std::string>(), "2026-09-06T00:00:00.000Z");
   EXPECT_TRUE(fault["x-medkit"]["expected"].get<bool>());
 }
@@ -256,7 +276,7 @@ TEST(PlannedStopAnnotation, ReAnnotatingClearsAStaleAttribution) {
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
   nlohmann::json fault{{"first_occurred", 25.0}, {"x-medkit", {{"expected", true}, {"planned_stop_id", "gone"}}}};
 
-  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_FALSE(fault["x-medkit"]["expected"].get<bool>());
   EXPECT_FALSE(fault["x-medkit"].contains("planned_stop_id"))
       << "a window that no longer covers the fault must not stay named on it";
@@ -266,21 +286,21 @@ TEST(PlannedStopAnnotation, AFaultThatCannotBeDatedIsNeverExpected) {
   const std::vector<PlannedStopWindow> windows{window("w", 0, 4'000'000'000LL * kSec)};
 
   nlohmann::json missing{{"fault_code", "NO_TIME"}};
-  EXPECT_FALSE(annotate_fault_with_planned_stop(missing, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(missing, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_FALSE(missing["x-medkit"]["expected"].get<bool>());
 
   nlohmann::json wrong_type{{"first_occurred", "not a number"}};
-  EXPECT_FALSE(annotate_fault_with_planned_stop(wrong_type, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(wrong_type, PlannedStopKnowledge{true, windows}).value_or(false));
 
   nlohmann::json null_value{{"first_occurred", nullptr}};
-  EXPECT_FALSE(annotate_fault_with_planned_stop(null_value, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(null_value, PlannedStopKnowledge{true, windows}).value_or(false));
 }
 
 TEST(PlannedStopAnnotation, ANonObjectItemIsLeftAlone) {
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
   nlohmann::json not_an_object = nlohmann::json::array({1, 2, 3});
 
-  EXPECT_FALSE(annotate_fault_with_planned_stop(not_an_object, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(not_an_object, PlannedStopKnowledge{true, windows}).value_or(false));
   EXPECT_TRUE(not_an_object.is_array()) << "a malformed peer item must pass through, not be rewritten";
 }
 
@@ -346,15 +366,58 @@ TEST(PlannedStopCoverage, TheBoundaryIsAMillisecondWide) {
       << "the millisecond before the start is outside it, whole";
 }
 
-TEST(PlannedStopAnnotation, TheFaultSideOfTheComparisonIsFlooredTheSameWay) {
+TEST(PlannedStopAnnotation, TheFaultSideRoundsToTheNearestMillisecond) {
   const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
 
-  // first_occurred arrives as a double. 20.0009 s lands inside the closing
-  // millisecond of the window; 20.0011 s does not.
-  nlohmann::json inside{{"first_occurred", 20.0009}};
-  nlohmann::json outside{{"first_occurred", 20.0011}};
-  EXPECT_TRUE(annotate_fault_with_planned_stop(inside, windows));
-  EXPECT_FALSE(annotate_fault_with_planned_stop(outside, windows));
+  // first_occurred arrives as a double and is rounded to the nearest
+  // millisecond, so the bleed past a bound is half a millisecond, not a whole
+  // one. 20.0004 s rounds onto the closing millisecond; 20.0006 s rounds past it.
+  nlohmann::json inside{{"first_occurred", 20.0004}};
+  nlohmann::json outside{{"first_occurred", 20.0006}};
+  EXPECT_TRUE(annotate_fault_with_planned_stop(inside, PlannedStopKnowledge{true, windows}).value_or(false));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(outside, PlannedStopKnowledge{true, windows}).value_or(false));
+
+  // And symmetrically below the opening bound.
+  nlohmann::json just_before{{"first_occurred", 9.9994}};
+  nlohmann::json on_the_edge{{"first_occurred", 9.9996}};
+  EXPECT_FALSE(annotate_fault_with_planned_stop(just_before, PlannedStopKnowledge{true, windows}).value_or(false));
+  EXPECT_TRUE(annotate_fault_with_planned_stop(on_the_edge, PlannedStopKnowledge{true, windows}).value_or(false));
+}
+
+// The unit boundary cases above use 10/15/20 s, where the seconds-as-a-double
+// round trip happens to be exact. At a real epoch it is not: 1788724271.001 is
+// stored as 1788724271000999936, and flooring THAT to a millisecond lands on the
+// previous one. The sweep below is the instrument the round-figure cases could
+// not be.
+TEST(PlannedStopCoverage, TheBoundaryIsExactAtARealEpoch) {
+  constexpr int64_t kEpochSec = 1788724271;
+  constexpr int64_t kMs = 1'000'000;
+  const int64_t from_ns = kEpochSec * kSec + 250 * kMs;
+  const int64_t to_ns = kEpochSec * kSec + 750 * kMs;
+  const std::vector<PlannedStopWindow> windows{window("w", from_ns, to_ns)};
+
+  for (int64_t ms = 0; ms < 1000; ++ms) {
+    // Exactly how a fault arrives: an exact nanosecond instant turned into
+    // seconds-as-a-double by fault_to_json, then read back here.
+    const double first_occurred = static_cast<double>(kEpochSec) + static_cast<double>(ms) / 1000.0;
+    nlohmann::json fault{{"first_occurred", first_occurred}};
+    const bool expected = annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false);
+    const bool should_be = ms >= 250 && ms <= 750;
+    EXPECT_EQ(expected, should_be) << "millisecond offset " << ms << " of second " << kEpochSec;
+  }
+}
+
+TEST(PlannedStopCoverage, AFaultThatCannotBeDatedSafelyIsNeverExpected) {
+  const std::vector<PlannedStopWindow> windows{window("w", 0, 4'000'000'000LL * kSec)};
+
+  // Finite, but far outside any instant a nanosecond count can hold. Rounding it
+  // is undefined behaviour, so it has to be refused before the conversion.
+  for (double absurd : {1e20, -1e20, 1e300, -1e300}) {
+    nlohmann::json fault{{"first_occurred", absurd}};
+    EXPECT_FALSE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, windows}).value_or(false))
+        << "first_occurred " << absurd;
+    EXPECT_FALSE(fault["x-medkit"].contains("planned_stop_id"));
+  }
 }
 
 // --- what a builtin_interfaces/Time can carry --------------------------------
@@ -419,6 +482,54 @@ TEST(PlannedStopExpectedCount, LeavesANonObjectCollectionAlone) {
   EXPECT_TRUE(not_a_collection.is_array());
 }
 
+// R13 is not a stream rule: when the window set is unknown, NO surface may say
+// `expected`. "This gateway could not read the windows" and "no window covers
+// this fault" are different answers, and only one of them is a fact.
+TEST(PlannedStopAnnotation, AnUnknownWindowSetWritesNoFlagAtAll) {
+  nlohmann::json fault{{"fault_code", "MOTOR_STALL"}, {"first_occurred", 15.0}};
+
+  const auto expected = annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{});
+  EXPECT_FALSE(expected.has_value()) << "unknown, not false";
+  EXPECT_FALSE(fault.contains("x-medkit") && fault["x-medkit"].contains("expected"))
+      << "an unreachable fault manager must not read as 'nothing was expected'";
+  EXPECT_FALSE(fault.contains("x-medkit") && fault["x-medkit"].contains("planned_stop_id"));
+}
+
+TEST(PlannedStopAnnotation, AnUnknownWindowSetLeavesAnExistingExtensionAlone) {
+  nlohmann::json fault{{"first_occurred", 15.0}, {"x-medkit", {{"captured_at", "2026-09-06T00:00:00.000Z"}}}};
+
+  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{}).has_value());
+  EXPECT_EQ(fault["x-medkit"]["captured_at"].get<std::string>(), "2026-09-06T00:00:00.000Z");
+  EXPECT_FALSE(fault["x-medkit"].contains("expected"));
+}
+
+TEST(PlannedStopAnnotation, AKnownButEmptyWindowSetSaysFalse) {
+  nlohmann::json fault{{"first_occurred", 15.0}};
+
+  const auto expected = annotate_fault_with_planned_stop(fault, PlannedStopKnowledge{true, {}});
+  ASSERT_TRUE(expected.has_value()) << "an empty answer IS an answer";
+  EXPECT_FALSE(*expected);
+  EXPECT_FALSE(fault["x-medkit"]["expected"].get<bool>());
+}
+
+// --- formatting an instant back out ------------------------------------------
+
+TEST(PlannedStopFormatting, ANegativeInstantNeverProducesAMalformedFraction) {
+  // A row written by an earlier build could hold one. printf("%03d", -500) emits
+  // "-500", which turns 1969-12-31T23:59:59 into "...59.-500Z" - not a timestamp
+  // any reader can parse, and worse than a wrong one because it looks like data.
+  for (int64_t ns : {int64_t{-1}, int64_t{-1'500'000'000}, int64_t{-999'999'999}}) {
+    const std::string formatted = ros2_medkit_gateway::format_timestamp_ns(ns);
+    EXPECT_EQ(formatted.find(".-"), std::string::npos) << ns << " -> " << formatted;
+    EXPECT_EQ(formatted.size(), 24u) << ns << " -> " << formatted;
+    EXPECT_EQ(formatted.back(), 'Z');
+  }
+  // -1 ns is one nanosecond before the epoch: the last millisecond of 1969.
+  EXPECT_EQ(ros2_medkit_gateway::format_timestamp_ns(-1), "1969-12-31T23:59:59.999Z");
+  EXPECT_EQ(ros2_medkit_gateway::format_timestamp_ns(-1'500'000'000), "1969-12-31T23:59:58.500Z");
+  EXPECT_EQ(ros2_medkit_gateway::format_timestamp_ns(0), "1970-01-01T00:00:00.000Z");
+}
+
 // --- the cache the event path reads -----------------------------------------
 
 TEST(PlannedStopCacheTest, StartsEmptyAndDueForARefresh) {
@@ -474,19 +585,66 @@ TEST(PlannedStopCacheTest, ASuccessfulRefreshClearsTheFailureFlag) {
 // an outage of the fault manager as "nothing is expected".
 TEST(PlannedStopCacheTest, KnowsWhetherItHasEverSeenAWindowSet) {
   PlannedStopCache cache;
-  EXPECT_FALSE(cache.has_knowledge()) << "nothing has been read yet";
+  EXPECT_FALSE(cache.has_knowledge(std::chrono::seconds(60))) << "nothing has been read yet";
 
   cache.note_failed_refresh();
-  EXPECT_FALSE(cache.has_knowledge()) << "a read that got no answer taught it nothing";
+  EXPECT_FALSE(cache.has_knowledge(std::chrono::seconds(60))) << "a read that got no answer taught it nothing";
 
   cache.store({});
-  EXPECT_TRUE(cache.has_knowledge()) << "an empty answer IS an answer: no windows are declared";
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60))) << "an empty answer IS an answer: no windows are declared";
 
   cache.note_failed_refresh();
-  EXPECT_TRUE(cache.has_knowledge()) << "a later outage does not unlearn what was read";
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60))) << "a later outage does not unlearn what was read";
 
   cache.invalidate();
-  EXPECT_TRUE(cache.has_knowledge()) << "invalidate asks for a re-read; it does not forget";
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60))) << "invalidate asks for a re-read; it does not forget";
+}
+
+// R22: knowledge expires. A gateway that read a window set once used to serve it
+// for the life of the process - replace the fault manager and one endpoint says
+// it cannot name the windows while another keeps naming one that is gone.
+TEST(PlannedStopCacheTest, KnowledgeGoesQuietOnceItIsTooOldToTrust) {
+  PlannedStopCache cache;
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60))) << "just read";
+  EXPECT_FALSE(cache.has_knowledge(std::chrono::nanoseconds(0))) << "a zero budget means nothing is fresh enough";
+
+  // A failed refresh does not renew it: only a successful read does.
+  cache.note_failed_refresh();
+  EXPECT_FALSE(cache.has_knowledge(std::chrono::nanoseconds(0)));
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60)))
+      << "and it does not blank the set the moment one read fails either";
+
+  cache.store({window("w2", 30 * kSec, 40 * kSec)});
+  EXPECT_TRUE(cache.has_knowledge(std::chrono::seconds(60)));
+  ASSERT_EQ(cache.snapshot().size(), 1u);
+  EXPECT_EQ(cache.snapshot()[0].id, "w2");
+}
+
+TEST(PlannedStopExpectedCount, CountsDistinctExpectedCodesOnly) {
+  // An aggregating gateway serves a code raised on two gateways twice; the plant
+  // still had one stop's worth of it.
+  const nlohmann::json items = nlohmann::json::array({
+      {{"fault_code", "SHARED"}, {"x-medkit", {{"expected", true}}}},
+      {{"fault_code", "SHARED"}, {"x-medkit", {{"expected", true}}}},
+      {{"fault_code", "LOCAL"}, {"x-medkit", {{"expected", true}}}},
+      {{"fault_code", "PLAIN"}, {"x-medkit", {{"expected", false}}}},
+      {{"fault_code", "UNKNOWN_FLAG"}},
+      {{"fault_code", "EMPTY_EXT"}, {"x-medkit", nlohmann::json::object()}},
+  });
+  EXPECT_EQ(ros2_medkit_gateway::faults::count_expected_items(items), 2);
+}
+
+TEST(PlannedStopExpectedCount, AnItemWithNoFlagIsCountedByNeitherSide) {
+  const nlohmann::json unknown_only = nlohmann::json::array({
+      {{"fault_code", "A"}},
+      {{"fault_code", "B"}, {"x-medkit", {{"entity_id", "app"}}}},
+  });
+  EXPECT_EQ(ros2_medkit_gateway::faults::count_expected_items(unknown_only), 0)
+      << "unknown is not expected, and it is not unexpected either";
+  EXPECT_EQ(ros2_medkit_gateway::faults::count_expected_items(nlohmann::json::array()), 0);
+  EXPECT_EQ(ros2_medkit_gateway::faults::count_expected_items(nlohmann::json::object()), 0);
 }
 
 TEST(PlannedStopCacheTest, InvalidateForcesTheNextReadToRefresh) {

--- a/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
+++ b/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
@@ -383,6 +383,42 @@ TEST(PlannedStopRepresentableInstant, AcceptsTheWholeInt32SecondRange) {
   EXPECT_FALSE(is_representable_instant(*before_the_epoch));
 }
 
+// --- the collection-level tally ---------------------------------------------
+
+TEST(PlannedStopExpectedCount, CreatesTheExtensionWhenTheEmitterDidNot) {
+  // A plugin's fault list need not carry an `x-medkit` object at all. Writing
+  // through `collection["x-medkit"]["expected_count"]` without creating it left
+  // the collection answering `"x-medkit": null`, which is neither the count nor
+  // the absence of one.
+  nlohmann::json collection{{"items", nlohmann::json::array()}};
+  ros2_medkit_gateway::faults::set_expected_count(collection, 3);
+
+  ASSERT_TRUE(collection["x-medkit"].is_object()) << "x-medkit must be an object, never null";
+  EXPECT_EQ(collection["x-medkit"]["expected_count"].get<int64_t>(), 3);
+}
+
+TEST(PlannedStopExpectedCount, KeepsWhatTheExtensionAlreadyCarried) {
+  nlohmann::json collection{{"items", nlohmann::json::array()}, {"x-medkit", {{"count", 7}}}};
+  ros2_medkit_gateway::faults::set_expected_count(collection, 2);
+
+  EXPECT_EQ(collection["x-medkit"]["count"].get<int64_t>(), 7);
+  EXPECT_EQ(collection["x-medkit"]["expected_count"].get<int64_t>(), 2);
+}
+
+TEST(PlannedStopExpectedCount, ReplacesANullExtensionRatherThanWritingThroughIt) {
+  nlohmann::json collection{{"items", nlohmann::json::array()}, {"x-medkit", nullptr}};
+  ros2_medkit_gateway::faults::set_expected_count(collection, 0);
+
+  ASSERT_TRUE(collection["x-medkit"].is_object());
+  EXPECT_EQ(collection["x-medkit"]["expected_count"].get<int64_t>(), 0);
+}
+
+TEST(PlannedStopExpectedCount, LeavesANonObjectCollectionAlone) {
+  nlohmann::json not_a_collection = nlohmann::json::array({1, 2});
+  ros2_medkit_gateway::faults::set_expected_count(not_a_collection, 1);
+  EXPECT_TRUE(not_a_collection.is_array());
+}
+
 // --- the cache the event path reads -----------------------------------------
 
 TEST(PlannedStopCacheTest, StartsEmptyAndDueForARefresh) {
@@ -432,6 +468,25 @@ TEST(PlannedStopCacheTest, ASuccessfulRefreshClearsTheFailureFlag) {
 
   cache.store({window("w", 10 * kSec, 20 * kSec)});
   EXPECT_FALSE(cache.last_refresh_failed());
+}
+
+// R13: on the event stream, "unknown" is not "false". A consumer must not read
+// an outage of the fault manager as "nothing is expected".
+TEST(PlannedStopCacheTest, KnowsWhetherItHasEverSeenAWindowSet) {
+  PlannedStopCache cache;
+  EXPECT_FALSE(cache.has_knowledge()) << "nothing has been read yet";
+
+  cache.note_failed_refresh();
+  EXPECT_FALSE(cache.has_knowledge()) << "a read that got no answer taught it nothing";
+
+  cache.store({});
+  EXPECT_TRUE(cache.has_knowledge()) << "an empty answer IS an answer: no windows are declared";
+
+  cache.note_failed_refresh();
+  EXPECT_TRUE(cache.has_knowledge()) << "a later outage does not unlearn what was read";
+
+  cache.invalidate();
+  EXPECT_TRUE(cache.has_knowledge()) << "invalidate asks for a re-read; it does not forget";
 }
 
 TEST(PlannedStopCacheTest, InvalidateForcesTheNextReadToRefresh) {

--- a/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
+++ b/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
@@ -1,0 +1,329 @@
+// Copyright 2026 bburda
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// The pure half of the planned-stop feature: which window covers a fault, and
+/// how an ISO 8601 instant on the wire becomes a nanosecond count.
+///
+/// Both are total functions over their input, which is why they are tested here
+/// at nanosecond resolution instead of through HTTP - a boundary one nanosecond
+/// wide cannot be driven through a JSON body that carries milliseconds.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "ros2_medkit_gateway/core/faults/planned_stop.hpp"
+
+using ros2_medkit_gateway::faults::annotate_fault_with_planned_stop;
+using ros2_medkit_gateway::faults::find_covering_window;
+using ros2_medkit_gateway::faults::parse_iso8601_utc_ns;
+using ros2_medkit_gateway::faults::PlannedStopCache;
+using ros2_medkit_gateway::faults::PlannedStopWindow;
+using ros2_medkit_gateway::faults::seconds_to_ns;
+using ros2_medkit_gateway::faults::window_for_fault;
+
+namespace {
+
+constexpr int64_t kSec = 1'000'000'000;
+
+PlannedStopWindow window(const std::string & id, int64_t from_ns, int64_t to_ns) {
+  PlannedStopWindow w;
+  w.id = id;
+  w.from_ns = from_ns;
+  w.to_ns = to_ns;
+  w.reason = "changeover";
+  w.declared_by = "operator";
+  w.declared_at_ns = from_ns;
+  return w;
+}
+
+}  // namespace
+
+// --- the covering predicate -------------------------------------------------
+
+TEST(PlannedStopCoverage, NoWindowsCoverNothing) {
+  const std::vector<PlannedStopWindow> none;
+  EXPECT_EQ(find_covering_window(none, 42 * kSec), nullptr);
+}
+
+TEST(PlannedStopCoverage, TheIntervalIsClosedAtBothEnds) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+
+  ASSERT_NE(find_covering_window(windows, 10 * kSec), nullptr) << "exactly at from";
+  ASSERT_NE(find_covering_window(windows, 20 * kSec), nullptr) << "exactly at to";
+  ASSERT_NE(find_covering_window(windows, 15 * kSec), nullptr);
+  EXPECT_EQ(find_covering_window(windows, 10 * kSec - 1), nullptr) << "one nanosecond before from";
+  EXPECT_EQ(find_covering_window(windows, 20 * kSec + 1), nullptr) << "one nanosecond after to";
+}
+
+TEST(PlannedStopCoverage, OverlappingWindowsPickTheEarliestStarting) {
+  // Deliberately stored newest-first, which is the order the fault manager lists
+  // them in: the choice must come from `from_ns`, not from position.
+  const std::vector<PlannedStopWindow> windows{
+      window("late", 12 * kSec, 40 * kSec),
+      window("early", 8 * kSec, 30 * kSec),
+      window("middle", 10 * kSec, 25 * kSec),
+  };
+
+  const auto * covering = find_covering_window(windows, 15 * kSec);
+  ASSERT_NE(covering, nullptr);
+  EXPECT_EQ(covering->id, "early");
+}
+
+TEST(PlannedStopCoverage, TwoWindowsStartingTogetherResolveDeterministically) {
+  const std::vector<PlannedStopWindow> windows{
+      window("bbb", 10 * kSec, 40 * kSec),
+      window("aaa", 10 * kSec, 20 * kSec),
+  };
+
+  const auto * first = find_covering_window(windows, 15 * kSec);
+  const auto * second = find_covering_window(windows, 15 * kSec);
+  ASSERT_NE(first, nullptr);
+  ASSERT_NE(second, nullptr);
+  EXPECT_EQ(first->id, second->id) << "the same input must not answer two ways";
+  EXPECT_EQ(first->id, "aaa") << "the tie is broken by id so two gateways agree";
+}
+
+TEST(PlannedStopCoverage, AWindowThatEndedEarlyStopsCoveringWhatCameAfter) {
+  auto ended = window("w", 10 * kSec, 100 * kSec);
+  ended.to_ns = 30 * kSec;
+  ended.ended_early = true;
+  const std::vector<PlannedStopWindow> windows{ended};
+
+  EXPECT_NE(find_covering_window(windows, 20 * kSec), nullptr);
+  EXPECT_EQ(find_covering_window(windows, 40 * kSec), nullptr);
+}
+
+TEST(PlannedStopCoverage, AWindowWhollyInThePastStillMarksWhatItCovers) {
+  const std::vector<PlannedStopWindow> windows{window("historic", 1 * kSec, 2 * kSec)};
+  EXPECT_NE(find_covering_window(windows, 1 * kSec + 500'000'000), nullptr)
+      << "a stop declared after the fact must still mark the faults it covers";
+}
+
+// --- the wire representation of an instant ----------------------------------
+
+TEST(PlannedStopTimeParsing, AcceptsIso8601Utc) {
+  auto parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 0);
+
+  parsed = parse_iso8601_utc_ns("1970-01-01T00:00:01Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, kSec);
+
+  parsed = parse_iso8601_utc_ns("2026-09-06T12:34:56Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 1788698096LL * kSec);
+}
+
+TEST(PlannedStopTimeParsing, KeepsFractionalSecondsToNanosecondResolution) {
+  auto parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.5Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 500'000'000);
+
+  parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.123Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 123'000'000);
+
+  parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.000000001Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 1) << "one nanosecond must survive the parse";
+
+  // More digits than nanoseconds can hold are truncated, not rejected: the
+  // instant is still unambiguous.
+  parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.1234567891Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 123'456'789);
+}
+
+TEST(PlannedStopTimeParsing, AcceptsAnExplicitZeroOffset) {
+  const auto z = parse_iso8601_utc_ns("2026-09-06T12:34:56Z");
+  const auto plus = parse_iso8601_utc_ns("2026-09-06T12:34:56+00:00");
+  const auto minus = parse_iso8601_utc_ns("2026-09-06T12:34:56-00:00");
+  ASSERT_TRUE(z.has_value());
+  ASSERT_TRUE(plus.has_value());
+  ASSERT_TRUE(minus.has_value());
+  EXPECT_EQ(*plus, *z);
+  EXPECT_EQ(*minus, *z);
+}
+
+TEST(PlannedStopTimeParsing, RefusesWhatItCannotReadAsAnInstantInUtc) {
+  const char * unparsable[] = {
+      "",
+      "not a time",
+      "2026-09-06",                 // date only: no instant
+      "2026-09-06T12:34:56",        // no zone: the instant depends on the reader
+      "2026-09-06T12:34:56+02:00",  // a real offset, which this route does not take
+      "2026-09-06 12:34:56Z",       // space instead of T
+      "2026-13-06T12:34:56Z",       // month 13
+      "2026-09-32T12:34:56Z",       // day 32
+      "2026-09-06T25:34:56Z",       // hour 25
+      "2026-09-06T12:60:56Z",       // minute 60
+      "2026-09-06T12:34:61Z",       // second 61
+      "2026-09-06T12:34:56.Z",      // a dot with no fraction
+      "2026-09-06T12:34:56Zjunk",   // trailing junk
+      "  2026-09-06T12:34:56Z",     // leading space
+  };
+  for (const char * text : unparsable) {
+    EXPECT_FALSE(parse_iso8601_utc_ns(text).has_value()) << "accepted: '" << text << "'";
+  }
+}
+
+TEST(PlannedStopTimeParsing, SecondsWithAFractionBecomeNanoseconds) {
+  EXPECT_EQ(seconds_to_ns(0.0), 0);
+  EXPECT_EQ(seconds_to_ns(1.0), kSec);
+  EXPECT_EQ(seconds_to_ns(1.5), kSec + 500'000'000);
+  // The fault list carries first_occurred as a double; a value big enough to be
+  // a real timestamp must not lose whole seconds on the way in.
+  EXPECT_EQ(seconds_to_ns(1788698096.0), 1788698096LL * kSec);
+}
+
+// --- deriving the flag from a fault as it appears on the wire ----------------
+
+TEST(PlannedStopAnnotation, MarksAFaultWhoseCycleStartedInsideAWindow) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+  nlohmann::json fault{{"fault_code", "MOTOR_STALL"}, {"first_occurred", 15.0}, {"status", "CONFIRMED"}};
+
+  EXPECT_TRUE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_TRUE(fault["x-medkit"]["expected"].get<bool>());
+  EXPECT_EQ(fault["x-medkit"]["planned_stop_id"].get<std::string>(), "w");
+}
+
+TEST(PlannedStopAnnotation, LeavesAFaultOutsideEveryWindowUnexpectedAndUnattributed) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+  nlohmann::json fault{{"fault_code", "MOTOR_STALL"}, {"first_occurred", 25.0}};
+
+  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_FALSE(fault["x-medkit"]["expected"].get<bool>());
+  EXPECT_FALSE(fault["x-medkit"].contains("planned_stop_id"))
+      << "naming a window that does not cover the fault would be worse than naming none";
+}
+
+TEST(PlannedStopAnnotation, KeepsVendorKeysTheItemAlreadyCarried) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+  nlohmann::json fault{{"first_occurred", 15.0}, {"x-medkit", {{"captured_at", "2026-09-06T00:00:00.000Z"}}}};
+
+  ASSERT_TRUE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_EQ(fault["x-medkit"]["captured_at"].get<std::string>(), "2026-09-06T00:00:00.000Z");
+  EXPECT_TRUE(fault["x-medkit"]["expected"].get<bool>());
+}
+
+TEST(PlannedStopAnnotation, ReAnnotatingClearsAStaleAttribution) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+  nlohmann::json fault{{"first_occurred", 25.0}, {"x-medkit", {{"expected", true}, {"planned_stop_id", "gone"}}}};
+
+  EXPECT_FALSE(annotate_fault_with_planned_stop(fault, windows));
+  EXPECT_FALSE(fault["x-medkit"]["expected"].get<bool>());
+  EXPECT_FALSE(fault["x-medkit"].contains("planned_stop_id"))
+      << "a window that no longer covers the fault must not stay named on it";
+}
+
+TEST(PlannedStopAnnotation, AFaultThatCannotBeDatedIsNeverExpected) {
+  const std::vector<PlannedStopWindow> windows{window("w", 0, 4'000'000'000LL * kSec)};
+
+  nlohmann::json missing{{"fault_code", "NO_TIME"}};
+  EXPECT_FALSE(annotate_fault_with_planned_stop(missing, windows));
+  EXPECT_FALSE(missing["x-medkit"]["expected"].get<bool>());
+
+  nlohmann::json wrong_type{{"first_occurred", "not a number"}};
+  EXPECT_FALSE(annotate_fault_with_planned_stop(wrong_type, windows));
+
+  nlohmann::json null_value{{"first_occurred", nullptr}};
+  EXPECT_FALSE(annotate_fault_with_planned_stop(null_value, windows));
+}
+
+TEST(PlannedStopAnnotation, ANonObjectItemIsLeftAlone) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+  nlohmann::json not_an_object = nlohmann::json::array({1, 2, 3});
+
+  EXPECT_FALSE(annotate_fault_with_planned_stop(not_an_object, windows));
+  EXPECT_TRUE(not_an_object.is_array()) << "a malformed peer item must pass through, not be rewritten";
+}
+
+TEST(PlannedStopAnnotation, WindowForFaultAgreesWithTheAnnotationAtTheBoundary) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+
+  nlohmann::json at_start{{"first_occurred", 10.0}};
+  nlohmann::json at_end{{"first_occurred", 20.0}};
+  nlohmann::json just_after{{"first_occurred", 20.001}};
+
+  EXPECT_NE(window_for_fault(windows, at_start), nullptr);
+  EXPECT_NE(window_for_fault(windows, at_end), nullptr);
+  EXPECT_EQ(window_for_fault(windows, just_after), nullptr);
+}
+
+// --- the cache the event path reads -----------------------------------------
+
+TEST(PlannedStopCacheTest, StartsEmptyAndDueForARefresh) {
+  PlannedStopCache cache;
+  EXPECT_TRUE(cache.snapshot().empty());
+  EXPECT_TRUE(cache.is_stale(std::chrono::seconds(2)));
+  EXPECT_FALSE(cache.last_refresh_failed()) << "nothing has failed yet";
+}
+
+TEST(PlannedStopCacheTest, StoringWindowsMakesThemReadableAndFreshAgain) {
+  PlannedStopCache cache;
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+
+  const auto snapshot = cache.snapshot();
+  ASSERT_EQ(snapshot.size(), 1u);
+  EXPECT_EQ(snapshot[0].id, "w");
+  EXPECT_FALSE(cache.is_stale(std::chrono::seconds(2))) << "a store that just happened cannot already be stale";
+  EXPECT_TRUE(cache.is_stale(std::chrono::seconds(0))) << "a zero time-to-live means every read refreshes";
+}
+
+TEST(PlannedStopCacheTest, StoringAnEmptyListIsARealAnswerNotAMiss) {
+  PlannedStopCache cache;
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+  cache.store({});
+
+  EXPECT_TRUE(cache.snapshot().empty()) << "every window was ended; the cache must say so";
+  EXPECT_FALSE(cache.is_stale(std::chrono::seconds(2)));
+}
+
+TEST(PlannedStopCacheTest, AFailedRefreshCountsAgainstTheTimeToLive) {
+  PlannedStopCache cache;
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+  cache.note_failed_refresh();
+
+  EXPECT_TRUE(cache.last_refresh_failed());
+  EXPECT_FALSE(cache.is_stale(std::chrono::seconds(2)))
+      << "an attempt that just failed must not invite an immediate retry - finding out costs a transport timeout";
+  ASSERT_EQ(cache.snapshot().size(), 1u)
+      << "a failed refresh must not blank the windows; a fault losing its flag reads as a surprise";
+  EXPECT_EQ(cache.snapshot()[0].id, "w");
+}
+
+TEST(PlannedStopCacheTest, ASuccessfulRefreshClearsTheFailureFlag) {
+  PlannedStopCache cache;
+  cache.note_failed_refresh();
+  ASSERT_TRUE(cache.last_refresh_failed());
+
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+  EXPECT_FALSE(cache.last_refresh_failed());
+}
+
+TEST(PlannedStopCacheTest, InvalidateForcesTheNextReadToRefresh) {
+  PlannedStopCache cache;
+  cache.store({window("w", 10 * kSec, 20 * kSec)});
+  ASSERT_FALSE(cache.is_stale(std::chrono::seconds(60)));
+
+  cache.invalidate();
+  EXPECT_TRUE(cache.is_stale(std::chrono::seconds(60)))
+      << "a window declared through this gateway must not wait out the cache";
+  EXPECT_EQ(cache.snapshot().size(), 1u) << "invalidating asks for a refresh; it does not throw away what is known";
+}

--- a/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
+++ b/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
@@ -30,6 +30,7 @@
 
 using ros2_medkit_gateway::faults::annotate_fault_with_planned_stop;
 using ros2_medkit_gateway::faults::find_covering_window;
+using ros2_medkit_gateway::faults::floor_to_ms_ns;
 using ros2_medkit_gateway::faults::parse_iso8601_utc_ns;
 using ros2_medkit_gateway::faults::PlannedStopCache;
 using ros2_medkit_gateway::faults::PlannedStopWindow;
@@ -66,8 +67,9 @@ TEST(PlannedStopCoverage, TheIntervalIsClosedAtBothEnds) {
   ASSERT_NE(find_covering_window(windows, 10 * kSec), nullptr) << "exactly at from";
   ASSERT_NE(find_covering_window(windows, 20 * kSec), nullptr) << "exactly at to";
   ASSERT_NE(find_covering_window(windows, 15 * kSec), nullptr);
-  EXPECT_EQ(find_covering_window(windows, 10 * kSec - 1), nullptr) << "one nanosecond before from";
-  EXPECT_EQ(find_covering_window(windows, 20 * kSec + 1), nullptr) << "one nanosecond after to";
+  // A millisecond, not a nanosecond: see PlannedStopCoverage.TheBoundaryIsAMillisecondWide.
+  EXPECT_EQ(find_covering_window(windows, 10 * kSec - 1'000'000), nullptr) << "one millisecond before from";
+  EXPECT_EQ(find_covering_window(windows, 20 * kSec + 1'000'000), nullptr) << "one millisecond after to";
 }
 
 TEST(PlannedStopCoverage, OverlappingWindowsPickTheEarliestStarting) {
@@ -141,13 +143,13 @@ TEST(PlannedStopTimeParsing, KeepsFractionalSecondsToNanosecondResolution) {
 
   parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.000000001Z");
   ASSERT_TRUE(parsed.has_value());
-  EXPECT_EQ(*parsed, 1) << "one nanosecond must survive the parse";
+  EXPECT_EQ(*parsed, 0) << "a fraction finer than a millisecond floors to the millisecond";
 
-  // More digits than nanoseconds can hold are truncated, not rejected: the
-  // instant is still unambiguous.
+  // More digits than the API carries are truncated, not rejected: the instant is
+  // still unambiguous.
   parsed = parse_iso8601_utc_ns("1970-01-01T00:00:00.1234567891Z");
   ASSERT_TRUE(parsed.has_value());
-  EXPECT_EQ(*parsed, 123'456'789);
+  EXPECT_EQ(*parsed, 123'000'000);
 }
 
 TEST(PlannedStopTimeParsing, AcceptsAnExplicitZeroOffset) {
@@ -159,6 +161,34 @@ TEST(PlannedStopTimeParsing, AcceptsAnExplicitZeroOffset) {
   ASSERT_TRUE(minus.has_value());
   EXPECT_EQ(*plus, *z);
   EXPECT_EQ(*minus, *z);
+}
+
+TEST(PlannedStopTimeParsing, RefusesAYearWhoseNanosecondCountCannotBeCounted) {
+  // int64 nanoseconds run out in April 2262. Multiplying first wrapped a year
+  // past that back INTO the accepted range, so a stop declared for 2600 was
+  // stored as one in 2015 and answered 201.
+  for (const char * text :
+       {"2262-04-12T00:00:00Z", "2555-01-01T00:00:00Z", "2600-01-01T00:00:00Z", "9999-12-31T23:59:59Z"}) {
+    EXPECT_FALSE(parse_iso8601_utc_ns(text).has_value()) << "accepted: " << text;
+  }
+
+  // A year between the int32-second limit and the int64-nanosecond one parses
+  // to a REAL value, which the representable-instant guard then refuses. That is
+  // the split the fix depends on: the parser must not be the thing that hides it.
+  const auto in_2100 = parse_iso8601_utc_ns("2100-01-01T00:00:00Z");
+  ASSERT_TRUE(in_2100.has_value());
+  EXPECT_GT(*in_2100, ros2_medkit_gateway::faults::kMaxRepresentableNs);
+}
+
+TEST(PlannedStopTimeParsing, RefusesAnInstantAtOrBeforeTheEpoch) {
+  // The epoch is not a sentinel for "now" anywhere in this API, so it cannot be
+  // a legal window bound either.
+  const auto epoch = parse_iso8601_utc_ns("1970-01-01T00:00:00Z");
+  ASSERT_TRUE(epoch.has_value()) << "the text is a valid instant; it is the value that is refused";
+  EXPECT_EQ(*epoch, 0);
+  EXPECT_FALSE(ros2_medkit_gateway::faults::is_representable_instant(*epoch));
+  EXPECT_TRUE(ros2_medkit_gateway::faults::is_representable_instant(1'000'000))
+      << "one millisecond after the epoch is a real instant";
 }
 
 TEST(PlannedStopTimeParsing, RefusesWhatItCannotReadAsAnInstantInUtc) {
@@ -266,6 +296,67 @@ TEST(PlannedStopAnnotation, WindowForFaultAgreesWithTheAnnotationAtTheBoundary) 
   EXPECT_EQ(window_for_fault(windows, just_after), nullptr);
 }
 
+// --- the resolution the API works at ----------------------------------------
+//
+// One millisecond, end to end (parse, storage, comparison, formatting). The
+// reason is in the header: an operator declares a stop at minute or second
+// precision, and the REST fault item carries first_occurred as a double whose
+// resolution at today's epoch is about a quarter of a microsecond, so a boundary
+// defined more finely than the data can express is a boundary nobody can rely
+// on.
+
+TEST(PlannedStopResolution, FloorToMillisecondIsATrueFloor) {
+  EXPECT_EQ(floor_to_ms_ns(0), 0);
+  EXPECT_EQ(floor_to_ms_ns(999'999), 0);
+  EXPECT_EQ(floor_to_ms_ns(1'000'000), 1'000'000);
+  EXPECT_EQ(floor_to_ms_ns(1'999'999), 1'000'000);
+  EXPECT_EQ(floor_to_ms_ns(kSec + 123'456'789), kSec + 123'000'000);
+  // Negative instants are refused by the API, but the helper is used on values
+  // that arrive from outside it, so it must not round towards zero there.
+  EXPECT_EQ(floor_to_ms_ns(-1), -1'000'000);
+  EXPECT_EQ(floor_to_ms_ns(-1'000'000), -1'000'000);
+  EXPECT_EQ(floor_to_ms_ns(-1'000'001), -2'000'000);
+}
+
+TEST(PlannedStopTimeParsing, RoundsAFinerFractionDownToTheMillisecond) {
+  auto parsed = parse_iso8601_utc_ns("2026-09-06T12:34:56.123456789Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed % 1'000'000, 0) << "the parse must not keep what the API cannot carry";
+  EXPECT_EQ(*parsed, 1788698096LL * kSec + 123'000'000);
+
+  parsed = parse_iso8601_utc_ns("2026-09-06T12:34:56.999999Z");
+  ASSERT_TRUE(parsed.has_value());
+  EXPECT_EQ(*parsed, 1788698096LL * kSec + 999'000'000) << "down, never to the nearest";
+}
+
+TEST(PlannedStopCoverage, TheBoundaryIsAMillisecondWide) {
+  const int64_t from_ns = 10 * kSec;
+  const int64_t to_ns = 20 * kSec;
+  const std::vector<PlannedStopWindow> windows{window("w", from_ns, to_ns)};
+
+  // Exactly at the end, and anywhere inside that same millisecond, is covered.
+  EXPECT_NE(find_covering_window(windows, to_ns), nullptr);
+  EXPECT_NE(find_covering_window(windows, to_ns + 999'999), nullptr)
+      << "a fault inside the closing millisecond is inside the window";
+  EXPECT_EQ(find_covering_window(windows, to_ns + 1'000'000), nullptr) << "one millisecond after the end";
+
+  EXPECT_NE(find_covering_window(windows, from_ns), nullptr);
+  EXPECT_EQ(find_covering_window(windows, from_ns - 1'000'000), nullptr) << "one millisecond before the start";
+  EXPECT_EQ(find_covering_window(windows, from_ns - 1), nullptr)
+      << "the millisecond before the start is outside it, whole";
+}
+
+TEST(PlannedStopAnnotation, TheFaultSideOfTheComparisonIsFlooredTheSameWay) {
+  const std::vector<PlannedStopWindow> windows{window("w", 10 * kSec, 20 * kSec)};
+
+  // first_occurred arrives as a double. 20.0009 s lands inside the closing
+  // millisecond of the window; 20.0011 s does not.
+  nlohmann::json inside{{"first_occurred", 20.0009}};
+  nlohmann::json outside{{"first_occurred", 20.0011}};
+  EXPECT_TRUE(annotate_fault_with_planned_stop(inside, windows));
+  EXPECT_FALSE(annotate_fault_with_planned_stop(outside, windows));
+}
+
 // --- what a builtin_interfaces/Time can carry --------------------------------
 
 TEST(PlannedStopRepresentableInstant, AcceptsTheWholeInt32SecondRange) {
@@ -277,7 +368,8 @@ TEST(PlannedStopRepresentableInstant, AcceptsTheWholeInt32SecondRange) {
   EXPECT_TRUE(is_representable_instant(kMaxRepresentableNs));
   EXPECT_TRUE(is_representable_instant(1788698096LL * kSec));
 
-  EXPECT_FALSE(is_representable_instant(kMinRepresentableNs - 1)) << "one nanosecond before the epoch";
+  EXPECT_FALSE(is_representable_instant(kMinRepresentableNs - 1)) << "the epoch itself is not a window bound";
+  EXPECT_FALSE(is_representable_instant(0));
   EXPECT_FALSE(is_representable_instant(kMaxRepresentableNs + 1)) << "one nanosecond past the int32 second limit";
 
   // A window asked for in 2099. Its second count does not fit an int32, so the

--- a/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
+++ b/src/ros2_medkit_gateway/test/test_planned_stop_window.cpp
@@ -266,6 +266,31 @@ TEST(PlannedStopAnnotation, WindowForFaultAgreesWithTheAnnotationAtTheBoundary) 
   EXPECT_EQ(window_for_fault(windows, just_after), nullptr);
 }
 
+// --- what a builtin_interfaces/Time can carry --------------------------------
+
+TEST(PlannedStopRepresentableInstant, AcceptsTheWholeInt32SecondRange) {
+  using ros2_medkit_gateway::faults::is_representable_instant;
+  using ros2_medkit_gateway::faults::kMaxRepresentableNs;
+  using ros2_medkit_gateway::faults::kMinRepresentableNs;
+
+  EXPECT_TRUE(is_representable_instant(kMinRepresentableNs));
+  EXPECT_TRUE(is_representable_instant(kMaxRepresentableNs));
+  EXPECT_TRUE(is_representable_instant(1788698096LL * kSec));
+
+  EXPECT_FALSE(is_representable_instant(kMinRepresentableNs - 1)) << "one nanosecond before the epoch";
+  EXPECT_FALSE(is_representable_instant(kMaxRepresentableNs + 1)) << "one nanosecond past the int32 second limit";
+
+  // A window asked for in 2099. Its second count does not fit an int32, so the
+  // narrowing would wrap it negative and hand back a window covering nothing.
+  const auto in_2099 = parse_iso8601_utc_ns("2099-01-01T00:00:00Z");
+  ASSERT_TRUE(in_2099.has_value()) << "the parse is fine; it is the storage that cannot hold it";
+  EXPECT_FALSE(is_representable_instant(*in_2099));
+
+  const auto before_the_epoch = parse_iso8601_utc_ns("1960-01-01T00:00:00Z");
+  ASSERT_TRUE(before_the_epoch.has_value());
+  EXPECT_FALSE(is_representable_instant(*before_the_epoch));
+}
+
 // --- the cache the event path reads -----------------------------------------
 
 TEST(PlannedStopCacheTest, StartsEmptyAndDueForARefresh) {

--- a/src/ros2_medkit_gateway/test/test_plugin_context_aggregation.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_context_aggregation.cpp
@@ -165,6 +165,10 @@ class FakeFaultTransport : public ros2_medkit_gateway::FaultServiceTransport {
     return true;
   }
 
+  bool planned_stops_available() const override {
+    return true;
+  }
+
   // Unused by these tests - return benign failures.
   ros2_medkit_gateway::FaultResult report_fault(const std::string & /*fault_code*/, uint8_t /*severity*/,
                                                 const std::string & /*description*/,

--- a/src/ros2_medkit_gateway/test/test_plugin_context_aggregation.cpp
+++ b/src/ros2_medkit_gateway/test/test_plugin_context_aggregation.cpp
@@ -193,6 +193,21 @@ class FakeFaultTransport : public ros2_medkit_gateway::FaultServiceTransport {
   ros2_medkit_gateway::FaultResult list_rosbags(const std::string & /*entity_fqn*/) override {
     return {false, json::object(), "not implemented"};
   }
+  ros2_medkit_gateway::PlannedStopResult
+  declare_planned_stop(const ros2_medkit_gateway::faults::PlannedStopWindow & /*request*/) override {
+    return {};
+  }
+  ros2_medkit_gateway::PlannedStopResult end_planned_stop(const std::string & /*id*/) override {
+    return {};
+  }
+  /// Succeeds with no windows, so a fault list built through this fake carries
+  /// `expected: false` rather than no flag at all - the shape a gateway with a
+  /// reachable fault manager and nothing declared actually serves.
+  ros2_medkit_gateway::PlannedStopResult list_planned_stops(bool /*active_only*/) override {
+    ros2_medkit_gateway::PlannedStopResult r;
+    r.success = true;
+    return r;
+  }
   bool wait_for_services(std::chrono::duration<double> /*timeout*/) override {
     return true;
   }

--- a/src/ros2_medkit_gateway/test/test_route_registry.cpp
+++ b/src/ros2_medkit_gateway/test/test_route_registry.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <functional>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -203,8 +204,8 @@ TEST_F(RouteRegistryTest, TypedQueryDeclaresParametersFromDto) {
     }
   }
 
-  // status + include_muted + include_clusters.
-  EXPECT_EQ(query_count, 3u);
+  // status + include_muted + include_clusters + expected.
+  EXPECT_EQ(query_count, 4u);
   ASSERT_NE(status, nullptr);
   EXPECT_EQ((*status)["in"], "query");
   EXPECT_FALSE((*status)["required"].get<bool>());  // optional<std::string> -> not required
@@ -215,11 +216,13 @@ TEST_F(RouteRegistryTest, TypedQueryDeclaresParametersFromDto) {
 }
 
 // @verifies REQ_INTEROP_002
-TEST_F(RouteRegistryTest, PerEntityFaultsQueryAdvertisesStatusOnly) {
+TEST_F(RouteRegistryTest, PerEntityFaultsQueryOmitsTheCorrelationFlags) {
   // The per-entity /faults route uses the narrower FaultEntityListQuery so the
-  // spec advertises exactly what the handler reads: status only. The
-  // correlation flags (include_muted / include_clusters) are global-only, so
-  // they must NOT appear on the per-entity route.
+  // spec advertises exactly what the handler reads. The correlation flags
+  // (include_muted / include_clusters) are global-only, because their metadata
+  // is computed across the whole fault manager and a scoped response carrying it
+  // would leak cross-entity data, so they must NOT appear here. `expected` is
+  // not in that class - the flag is derived per fault - so it does appear.
   seed_get(registry_, "/apps/{app_id}/faults").tag("Faults").query<FaultEntityListQuery>();
 
   auto paths = registry_.to_openapi_paths();
@@ -234,8 +237,8 @@ TEST_F(RouteRegistryTest, PerEntityFaultsQueryAdvertisesStatusOnly) {
     }
   }
 
-  ASSERT_EQ(query_names.size(), 1u);
-  EXPECT_EQ(query_names[0], "status");
+  std::sort(query_names.begin(), query_names.end());
+  EXPECT_EQ(query_names, (std::vector<std::string>{"expected", "status"}));
 }
 
 // =============================================================================

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -600,11 +600,12 @@ TEST_F(SSEFaultHandlerTest, NonPositiveKeepaliveOverrideLogsWarning) {
   EXPECT_NE(logs.find("Non-positive SSE keepalive override"), std::string::npos);
 }
 
-TEST_F(SSEFaultHandlerTest, StreamOmitsXMedkitWhenNoMatchingApp) {
+TEST_F(SSEFaultHandlerTest, StreamOmitsTheEntityHintWhenNoMatchingApp) {
   // Empty cache: reporting source ("/apps/temp_sensor") has no manifest mapping
-  // and no App with id "temp_sensor" exists in runtime cache, so the
-  // ``x-medkit`` payload extension is not emitted (consumer falls back to
-  // discovery).
+  // and no App with id "temp_sensor" exists in the runtime cache, so the entity
+  // hint is not emitted and a consumer falls back to discovery. The ``x-medkit``
+  // object itself IS emitted: it also carries the planned-stop flag, which is a
+  // property of the fault rather than of any entity.
   enqueue_event(make_fault_event(FaultEvent::EVENT_CONFIRMED, "NO_OWNER", 10));
 
   auto req = make_stream_request("127.0.0.1");
@@ -614,7 +615,12 @@ TEST_F(SSEFaultHandlerTest, StreamOmitsXMedkitWhenNoMatchingApp) {
   auto output = read_stream_once(res, 1);
   auto payload = parse_sse_payload(output);
 
-  EXPECT_FALSE(payload.contains("x-medkit"));
+  ASSERT_TRUE(payload.contains("x-medkit"));
+  EXPECT_FALSE(payload["x-medkit"].contains("entity_type"));
+  EXPECT_FALSE(payload["x-medkit"].contains("entity_id"));
+  EXPECT_TRUE(payload["x-medkit"].contains("expected"));
+  EXPECT_FALSE(payload["x-medkit"]["expected"].get<bool>())
+      << "no fault manager answers in this fixture, so no window can cover the fault";
 
   release_stream(res);
 }
@@ -816,7 +822,7 @@ TEST_F(SSEFaultHandlerTest, StreamResolvesRuntimeCollisionRenamedApp) {
   release_stream(res);
 }
 
-TEST_F(SSEFaultHandlerTest, StreamOmitsXMedkitWhenReportingSourcesEmpty) {
+TEST_F(SSEFaultHandlerTest, StreamOmitsTheEntityHintWhenReportingSourcesEmpty) {
   auto event = make_fault_event(FaultEvent::EVENT_CONFIRMED, "ORPHAN", 40);
   event.fault.reporting_sources.clear();
   enqueue_event(event);
@@ -828,7 +834,12 @@ TEST_F(SSEFaultHandlerTest, StreamOmitsXMedkitWhenReportingSourcesEmpty) {
   auto output = read_stream_once(res, 1);
   auto payload = parse_sse_payload(output);
 
-  EXPECT_FALSE(payload.contains("x-medkit"));
+  // A fault with no reporting source resolves to no entity, but it is still a
+  // fault, and a stream consumer still has to be told whether it was expected.
+  ASSERT_TRUE(payload.contains("x-medkit"));
+  EXPECT_FALSE(payload["x-medkit"].contains("entity_id"));
+  EXPECT_FALSE(payload["x-medkit"]["expected"].get<bool>());
+  EXPECT_FALSE(payload["x-medkit"].contains("planned_stop_id"));
 
   release_stream(res);
 }

--- a/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
+++ b/src/ros2_medkit_gateway/test/test_sse_fault_handler.cpp
@@ -615,12 +615,11 @@ TEST_F(SSEFaultHandlerTest, StreamOmitsTheEntityHintWhenNoMatchingApp) {
   auto output = read_stream_once(res, 1);
   auto payload = parse_sse_payload(output);
 
-  ASSERT_TRUE(payload.contains("x-medkit"));
-  EXPECT_FALSE(payload["x-medkit"].contains("entity_type"));
-  EXPECT_FALSE(payload["x-medkit"].contains("entity_id"));
-  EXPECT_TRUE(payload["x-medkit"].contains("expected"));
-  EXPECT_FALSE(payload["x-medkit"]["expected"].get<bool>())
-      << "no fault manager answers in this fixture, so no window can cover the fault";
+  // Nothing to put in it: the reporting source resolves to no entity, and this
+  // fixture has no fault manager, so the gateway has never read a window set and
+  // must not claim the fault was unexpected. Both halves absent means the object
+  // itself is absent.
+  EXPECT_FALSE(payload.contains("x-medkit"));
 
   release_stream(res);
 }
@@ -834,12 +833,13 @@ TEST_F(SSEFaultHandlerTest, StreamOmitsTheEntityHintWhenReportingSourcesEmpty) {
   auto output = read_stream_once(res, 1);
   auto payload = parse_sse_payload(output);
 
-  // A fault with no reporting source resolves to no entity, but it is still a
-  // fault, and a stream consumer still has to be told whether it was expected.
-  ASSERT_TRUE(payload.contains("x-medkit"));
-  EXPECT_FALSE(payload["x-medkit"].contains("entity_id"));
-  EXPECT_FALSE(payload["x-medkit"]["expected"].get<bool>());
-  EXPECT_FALSE(payload["x-medkit"].contains("planned_stop_id"));
+  // "Unknown" is not "false". No fault manager has ever answered here, so the
+  // frame says nothing about whether the fault was expected rather than saying
+  // it was not - a consumer must not read an outage as "nothing is planned".
+  if (payload.contains("x-medkit")) {
+    EXPECT_FALSE(payload["x-medkit"].contains("expected"));
+    EXPECT_FALSE(payload["x-medkit"].contains("planned_stop_id"));
+  }
 
   release_stream(res);
 }

--- a/src/ros2_medkit_integration_tests/CMakeLists.txt
+++ b/src/ros2_medkit_integration_tests/CMakeLists.txt
@@ -275,7 +275,8 @@ if(BUILD_TESTING)
   set(_TWO_GATEWAY_TESTS
     test_peer_recovery
     test_triggers_restore_before_discovery
-    test_aggregator_fault_stream)
+    test_aggregator_fault_stream
+    test_planned_stops_aggregation)
   set(_TWO_GATEWAY_DOMAINS 2)
 
   # Tests whose polling budgets do not fit the glob's default timeout. Keyed by

--- a/src/ros2_medkit_integration_tests/test/features/slow_planned_stop_manager.py
+++ b/src/ros2_medkit_integration_tests/test/features/slow_planned_stop_manager.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A stand-in fault manager whose planned-stop service misbehaves on purpose.
+
+The absent case proves nothing about timeouts: with no service advertised the
+gateway short-circuits and answers in microseconds. The case that costs anything
+is a fault manager that IS on the graph and takes its time, and that is what this
+stands in for. It advertises the four core fault services so the gateway
+considers it available, answers them immediately, and sleeps inside
+list_planned_stops.
+
+Named `fault_manager` inside the namespace the gateway is pointed at, because
+the gateway addresses its fault manager as `<namespace>/fault_manager`.
+
+Three shapes, chosen by argument:
+
+``--delay SEC``       how long ~/list_planned_stops sleeps before answering.
+``--window``          answer with one window covering the next hour, so a fault
+                      reads as expected until the service goes away.
+``--drop-after SEC``  destroy the planned-stop services after SEC, leaving a
+                      fault manager that still serves faults - a pre-planned-stop
+                      release, or one that was replaced under the gateway.
+"""
+
+import argparse
+import sys
+import time
+
+import rclpy
+from rclpy.callback_groups import ReentrantCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from ros2_medkit_msgs.msg import FaultEvent, PlannedStop
+from ros2_medkit_msgs.srv import (
+    ClearFault,
+    DeclarePlannedStop,
+    EndPlannedStop,
+    GetFault,
+    ListFaults,
+    ListPlannedStops,
+    ReportFault,
+)
+
+# Long enough that a formatting pass paying it under the queue lock is
+# unmistakable next to the assertion's budget, short enough to stay inside the
+# gateway's 5 s service timeout so the call SUCCEEDS - a failure would trip the
+# 30 s back-off and the slowness would stop happening after the first frame.
+LIST_PLANNED_STOPS_DELAY_SEC = 3.0
+
+
+class SlowPlannedStopManager(Node):
+
+    def __init__(self, delay, serve_window, drop_after):
+        super().__init__('fault_manager', namespace='slow')
+        self._delay = delay
+        self._serve_window = serve_window
+        group = ReentrantCallbackGroup()
+
+        self._planned_stop_services = [
+            self.create_service(ListPlannedStops, '~/list_planned_stops',
+                                self._slow_list_planned_stops, callback_group=group),
+        ]
+        self.create_service(ListFaults, '~/list_faults',
+                            self._empty_fault_list, callback_group=group)
+        self.create_service(ReportFault, '~/report_fault',
+                            self._accept_report, callback_group=group)
+        self.create_service(GetFault, '~/get_fault',
+                            self._no_such_fault, callback_group=group)
+        self.create_service(ClearFault, '~/clear_fault',
+                            self._no_such_fault, callback_group=group)
+        self._planned_stop_services.append(
+            self.create_service(DeclarePlannedStop, '~/declare_planned_stop',
+                                self._refuse_declare, callback_group=group))
+        self._planned_stop_services.append(
+            self.create_service(EndPlannedStop, '~/end_planned_stop',
+                                self._no_such_fault, callback_group=group))
+
+        if drop_after is not None:
+            self.create_timer(drop_after, self._drop_planned_stop_services,
+                              callback_group=group)
+
+        self._events = self.create_publisher(FaultEvent, '~/events', 10)
+        self.get_logger().info('slow planned-stop manager up')
+
+    def _drop_planned_stop_services(self):
+        if not self._planned_stop_services:
+            return
+        for service in self._planned_stop_services:
+            self.destroy_service(service)
+        self._planned_stop_services = []
+        self.get_logger().info('planned-stop services dropped')
+
+    def _slow_list_planned_stops(self, _request, response):
+        if self._delay > 0.0:
+            self.get_logger().info('list_planned_stops: sleeping')
+            time.sleep(self._delay)
+            self.get_logger().info('list_planned_stops: answering')
+        if self._serve_window:
+            window = PlannedStop()
+            window.id = 'stub-window'
+            window.starts_at.sec = int(time.time()) - 60
+            window.ends_at.sec = int(time.time()) + 3600
+            window.reason = 'served by the stub'
+            window.declared_by = 'stub'
+            window.declared_at.sec = window.starts_at.sec
+            response.stops = [window]
+        return response
+
+    @staticmethod
+    def _empty_fault_list(_request, response):
+        return response
+
+    @staticmethod
+    def _accept_report(_request, response):
+        response.accepted = True
+        return response
+
+    @staticmethod
+    def _no_such_fault(_request, response):
+        response.success = False
+        response.message = 'stub'
+        return response
+
+    @staticmethod
+    def _refuse_declare(_request, response):
+        response.success = False
+        response.message = 'stub'
+        return response
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--delay', type=float, default=LIST_PLANNED_STOPS_DELAY_SEC)
+    parser.add_argument('--window', action='store_true')
+    parser.add_argument('--drop-after', type=float, default=None)
+    args, _ = parser.parse_known_args()
+
+    rclpy.init()
+    node = SlowPlannedStopManager(args.delay, args.window, args.drop_after)
+    # Multi-threaded so the sleep in one call does not also stall the services
+    # the gateway checks for readiness - the point is a slow ANSWER, not a node
+    # that has stopped serving.
+    executor = MultiThreadedExecutor(num_threads=4)
+    executor.add_node(node)
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        executor.remove_node(node)
+        node.destroy_node()
+        rclpy.shutdown()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/ros2_medkit_integration_tests/test/features/test_openapi_error_coverage.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_openapi_error_coverage.test.py
@@ -91,6 +91,20 @@ SKIPPED_BY_DESIGN = {
     ('post', '/updates'),
 }
 
+# Parameterless write operations the sweep DOES call. The blanket rule above -
+# "a POST or DELETE on a parameterless path acts on real state" - is not true of
+# every such route: a POST whose body is required and invalid is refused before
+# anything is created, so the error branch is reachable without touching gateway
+# state. Listed as a literal for the same reason SKIPPED_BY_DESIGN is: deriving
+# it by shape would silently start poking a future write route that does change
+# state on an empty body.
+#
+# Each entry is called once with `{}`, which is a valid JSON document and an
+# invalid body for every route that takes one.
+PROBED_PARAMETERLESS_WRITES = {
+    ('post', '/x-medkit-planned-stops'),
+}
+
 # Floor on the number of `make_error` sites a run must reach. The fixture
 # reaches 39 of the 281 sites in the tree; the floor sits below that so
 # ordinary churn in the handlers does not need this number edited, while a
@@ -233,9 +247,12 @@ class TestOpenApiErrorCoverage(GatewayTestCase):
         for path, item in TestOpenApiErrorCoverage._spec['paths'].items():
             params = path_params(path)
             if not params:
-                # Nothing to poison here, so only the read-only verb is safe:
-                # a POST or DELETE on a parameterless path acts on real state
-                # (`DELETE /faults` clears them, `POST /updates` starts one).
+                # Nothing to poison here, so the read-only verb is always safe:
+                # a POST or DELETE on a parameterless path usually acts on real
+                # state (`DELETE /faults` clears them, `POST /updates` starts
+                # one). The exceptions are listed in
+                # PROBED_PARAMETERLESS_WRITES, where an invalid body is refused
+                # before anything changes.
                 if 'get' in item:
                     try:
                         resp = requests.get(
@@ -244,6 +261,18 @@ class TestOpenApiErrorCoverage(GatewayTestCase):
                         swept += 1
                     except requests.exceptions.RequestException as exc:
                         print(f'sweep: GET {path} raised {exc}')
+                for method in sorted(item):
+                    if method not in HTTP_METHODS:
+                        continue
+                    if (method, path) not in PROBED_PARAMETERLESS_WRITES:
+                        continue
+                    try:
+                        resp = requests.request(
+                            method, f'{cls.BASE_URL}{path}', json={}, timeout=10, stream=True)
+                        resp.close()
+                        swept += 1
+                    except requests.exceptions.RequestException as exc:
+                        print(f'sweep: {method.upper()} {path} raised {exc}')
                 continue
             substitutions = [[ABSENT_ID], [INVALID_ID]]
             collection = path.strip('/').split('/')[0]
@@ -391,6 +420,22 @@ class TestOpenApiErrorCoverage(GatewayTestCase):
                 f'{method} {path} has a path parameter, so the sweep can reach it')
             self.assertNotEqual(
                 method, 'get', f'{method} {path} is read-only, so the sweep can reach it')
+        # The probe list is the mirror of the pin: every entry must be a
+        # documented, parameterless, non-GET operation the sweep DID reach.
+        # Without this an entry could sit here excusing nothing while the route
+        # it names went unreached.
+        self.assertEqual(
+            sorted(PROBED_PARAMETERLESS_WRITES & SKIPPED_BY_DESIGN), [],
+            'an operation cannot be both probed and skipped by design')
+        for method, path in sorted(PROBED_PARAMETERLESS_WRITES):
+            self.assertIn((method, path), documented, f'{method} {path} is not documented')
+            self.assertFalse(
+                path_params(path),
+                f'{method} {path} has a path parameter, so the ordinary sweep already reaches it')
+            self.assertNotEqual(method, 'get', f'{method} {path} is read-only')
+            self.assertIn(
+                (method, path), observed,
+                f'{method} {path} is listed as probed but the sweep never reached it')
         self.assertEqual(
             sorted(documented - observed), sorted(SKIPPED_BY_DESIGN),
             'unreached operations differ from the pinned set')

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
@@ -518,6 +518,72 @@ class TestPlannedStops(GatewayTestCase):
         )
         self.assertEqual(response.status_code, 400, response.text)
 
+    def test_10b_the_epoch_is_not_a_stand_in_for_now(self):
+        """R14: zero is what an unset time reads as, so it cannot also be legal."""
+        self._declare({'from': '1970-01-01T00:00:00Z', 'to': self._iso(600), 'reason': 'epoch'},
+                      expected_status=400)
+
+        response = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}',
+            json={'from': '1970-01-01T00:00:00Z', 'to': self._iso(600), 'reason': 'epoch'},
+            timeout=10,
+        )
+        self.assertEqual(response.json()['parameters']['parameter'], 'from')
+        self.assertIn('1970-01-01T00:00:00Z', response.json()['message'])
+
+    def test_10c_a_year_past_the_nanosecond_count_is_refused_not_wrapped(self):
+        """A year past 2262 used to wrap back INTO the accepted range."""
+        for far in ('2262-04-12T00:00:00Z', '2555-01-01T00:00:00Z', '2600-01-01T00:00:00Z',
+                    '9999-12-31T23:59:59Z'):
+            self._declare({'to': far, 'reason': 'far future'}, expected_status=400)
+
+        # The last representable instant is accepted; one second past it is not.
+        edge = self._declare({'to': '2038-01-19T03:14:07Z', 'reason': 'the very edge'})
+        self.assertTrue(edge['to'].startswith('2038-01-19T03:14:07'))
+        self._declare({'to': '2038-01-19T03:14:08Z', 'reason': 'one second too far'},
+                      expected_status=400)
+
+        # Nothing wrapped: no window in the store starts before this decade.
+        for window in self.get_json(PLANNED_STOPS)['items']:
+            self.assertGreater(window['from'], '2020-01-01', f'window {window["id"]} wrapped')
+
+    def test_10d_times_are_carried_to_the_millisecond_and_come_back_unchanged(self):
+        """R11: what a GET returns is what the POST sent, floored to the ms."""
+        window = self._declare({
+            'from': '2030-03-04T05:06:07.123456789Z',
+            'to': '2030-03-04T06:06:07.987654321Z',
+            'reason': 'sub-millisecond input',
+        })
+        self.assertEqual(window['from'], '2030-03-04T05:06:07.123Z')
+        self.assertEqual(window['to'], '2030-03-04T06:06:07.987Z')
+
+        fetched = self.get_json(f'{PLANNED_STOPS}/{window["id"]}')
+        self.assertEqual(fetched['from'], window['from'], 'a GET must equal the POST that made it')
+        self.assertEqual(fetched['to'], window['to'])
+
+    def test_10e_a_window_that_never_started_is_cancelled_not_ended(self):
+        """R12: it marked nothing, so DELETE removes it instead of inverting it."""
+        window = self._declare({
+            'from': self._iso(3600), 'to': self._iso(7200), 'reason': 'next shift',
+        })
+        self.assertFalse(window['cancelled'])
+
+        response = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        body = response.json()
+        self.assertTrue(body['cancelled'], 'a window stopped before it started is cancelled')
+        self.assertFalse(body['ended_early'], 'it never ran, so it did not end early')
+        self.assertGreater(body['to'], body['from'], 'the interval must never come back inverted')
+
+        gone = requests.get(f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10)
+        self.assertEqual(gone.status_code, 404, 'a cancelled window is gone, not stored')
+
+        self.assertNotIn(
+            window['id'], [w['id'] for w in self.get_json(PLANNED_STOPS)['items']]
+        )
+
     def test_11_an_absent_from_means_now(self):
         before = time.time()
         window = self._declare({'to': self._iso(3600), 'reason': 'starts now'})
@@ -526,6 +592,7 @@ class TestPlannedStops(GatewayTestCase):
         started = calendar.timegm(
             time.strptime(window['from'][:19], '%Y-%m-%dT%H:%M:%S')
         )
+        self.assertNotEqual(started, 0, 'an omitted from must be filled with now, never the epoch')
         # Two seconds of slack: the gateway stamps the window from the fault
         # manager's clock, and the assertion is that it is "now", not that the
         # two machines agree to the millisecond.

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
@@ -108,9 +108,11 @@ class TestPlannedStops(GatewayTestCase):
         except AssertionError:
             return
         for window in active.get('items', []):
-            requests.delete(
+            response = requests.delete(
                 f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
             )
+            if response.status_code == 200 and response.json().get('ended_early'):
+                self._wait_until_past(self._epoch(response.json()['to']))
 
     # --- driving the real fault pipeline -----------------------------------
 
@@ -176,6 +178,52 @@ class TestPlannedStops(GatewayTestCase):
             f'POST {PLANNED_STOPS} {body} -> {response.status_code}: {response.text}'
         )
         return response.json()
+
+    @staticmethod
+    def _epoch(iso_instant):
+        """ISO 8601 in UTC, as the API renders it, back to epoch seconds."""
+        whole = calendar.timegm(time.strptime(iso_instant[:19], '%Y-%m-%dT%H:%M:%S'))
+        fraction = 0.0
+        if len(iso_instant) > 20 and iso_instant[19] == '.':
+            fraction = float('0' + iso_instant[19:-1])
+        return whole + fraction
+
+    def _end_window(self, window_id, expected_status=200):
+        """End a window and wait until the clock is provably past its new end.
+
+        The boundary is a millisecond wide and closed, so a fault raised in the
+        same millisecond the window ended is still inside it. Reporting
+        immediately after the DELETE is therefore a race with the machine's
+        speed, not a test of anything - and it is the race that made this file
+        fail on one distro and pass on four.
+        """
+        response = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window_id}', timeout=10
+        )
+        self.assertEqual(response.status_code, expected_status, response.text)
+        if response.status_code != 200:
+            return response
+        # Only an early END moves `to` to now and needs the clock to move past
+        # it. A CANCELLED window is gone and its `to` is still in the future -
+        # waiting for that would be waiting for the window nobody kept.
+        if response.json().get('ended_early'):
+            self._wait_until_past(self._epoch(response.json()['to']))
+        return response
+
+    @staticmethod
+    def _wait_until_past(epoch_instant, margin=0.05):
+        """Block until the local clock is `margin` seconds past `epoch_instant`.
+
+        The gateway, the fault manager and this process share one wall clock, so
+        this is the same instant all three compare against.
+        """
+        deadline = time.monotonic() + 5.0
+        while time.time() <= epoch_instant + margin and time.monotonic() < deadline:
+            time.sleep(0.005)
+        assert time.time() > epoch_instant + margin, (
+            f'clock never reached {epoch_instant} + {margin}s; the instant is not one '
+            'a window can have ended at'
+        )
 
     @staticmethod
     def _iso(offset_sec):
@@ -330,10 +378,7 @@ class TestPlannedStops(GatewayTestCase):
 
             # End the window, then raise the second fault: same stream, same
             # gateway, opposite answer.
-            ended = requests.delete(
-                f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
-            )
-            self.assertEqual(ended.status_code, 200, ended.text)
+            ended = self._end_window(window['id'])
             self.assertTrue(ended.json()['ended_early'])
 
             self._report('PS_STREAM_OUTSIDE')
@@ -368,10 +413,7 @@ class TestPlannedStops(GatewayTestCase):
         before = self._wait_for_fault_in_list('PS_BEFORE_EARLY_END')
         self.assertTrue(before['x-medkit']['expected'])
 
-        ended = requests.delete(
-            f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
-        )
-        self.assertEqual(ended.status_code, 200, ended.text)
+        ended = self._end_window(window['id'])
         self.assertTrue(ended.json()['ended_early'])
         self.assertLess(ended.json()['to'], window['to'])
 
@@ -446,7 +488,10 @@ class TestPlannedStops(GatewayTestCase):
         self.assertEqual(first['occurrence_count'], 1)
 
         self._clear('PS_CYCLE')
-        requests.delete(f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10)
+        # _end_window blocks until the clock is provably past the new `to`, so
+        # the second cycle cannot start inside the window's closing millisecond.
+        ended = self._end_window(window['id'])
+        window_end = self._epoch(ended.json()['to'])
 
         # Cycle two, with no window open.
         self._report('PS_CYCLE')
@@ -454,6 +499,11 @@ class TestPlannedStops(GatewayTestCase):
         while time.monotonic() < deadline:
             item = self._find(self.get_json('/faults?status=all'), 'PS_CYCLE')
             if item is not None and item.get('occurrence_count') == 2:
+                self.assertGreater(
+                    item['first_occurred'], window_end,
+                    'the re-raise must be dated after the window ended, or the case '
+                    'is not about the second cycle at all'
+                )
                 self.assertFalse(
                     item['x-medkit']['expected'],
                     'the second cycle started outside every window'

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops.test.py
@@ -1,0 +1,624 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end acceptance for planned-stop windows: real gateway, real fault manager.
+
+An operator declares a window over REST, faults are reported inside and outside
+it through the real ReportFault service, and the flag has to come back the same
+way on three surfaces: the global fault list, the per-entity list, and the live
+event stream. The filter has to hide exactly one of the two faults each way, and
+the count beside the list has to agree with the flags on the items.
+
+Every assertion below reads the flag off the ITEM or off the FRAME for a named
+fault code. Asserting on a count, or on "some event in the stream", would pass
+against a gateway that flagged the wrong fault.
+"""
+
+import calendar
+import json
+import threading
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ClearFault, ReportFault
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES, FAULT_TIMEOUT
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+PLANNED_STOPS = '/x-medkit-planned-stops'
+SOURCE_ID = '/powertrain/engine/temp_sensor'
+APP_ID = 'temp_sensor'
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor'],
+        fault_manager=True,
+        lidar_faulty=False,
+        fault_manager_params={
+            'storage_type': 'memory',
+            # One FAILED confirms; two PASSED heal. Keeps every case a single
+            # report away from the transition it is about.
+            'confirmation_threshold': -1,
+            'healing_enabled': True,
+            'healing_threshold': 1,
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+
+class TestPlannedStops(GatewayTestCase):
+    """Declaring a window changes what the gateway REPORTS, never what it does."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {APP_ID}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        rclpy.init()
+        cls._reporter = Node('planned_stop_reporter')
+        cls._report_client = cls._reporter.create_client(
+            ReportFault, '/fault_manager/report_fault'
+        )
+        cls._clear_client = cls._reporter.create_client(
+            ClearFault, '/fault_manager/clear_fault'
+        )
+        assert cls._report_client.wait_for_service(timeout_sec=30.0), \
+            'report_fault service not available'
+        assert cls._clear_client.wait_for_service(timeout_sec=30.0), \
+            'clear_fault service not available'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    def tearDown(self):
+        """End every window this case left open.
+
+        The cases share one gateway and one fault manager, so a window left
+        running would make the NEXT case's faults expected for a reason that case
+        never declared. That is not hypothetical: it is how the first version of
+        this file turned seven honest assertions red at once. Ended windows are
+        left alone on purpose - they are still the reason the faults they already
+        covered read as expected, which several cases below check.
+        """
+        try:
+            active = self.get_json(f'{PLANNED_STOPS}?active=true')
+        except AssertionError:
+            return
+        for window in active.get('items', []):
+            requests.delete(
+                f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
+            )
+
+    # --- driving the real fault pipeline -----------------------------------
+
+    def _report(self, fault_code, event_type=None):
+        request = ReportFault.Request()
+        request.fault_code = fault_code
+        request.event_type = (
+            ReportFault.Request.EVENT_FAILED if event_type is None else event_type
+        )
+        request.severity = Fault.SEVERITY_ERROR
+        request.description = 'planned stop e2e fault'
+        request.source_id = SOURCE_ID
+        future = self._report_client.call_async(request)
+        deadline = time.monotonic() + 10.0
+        while not future.done() and time.monotonic() < deadline:
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+        self.assertTrue(future.done(), f'report_fault({fault_code}) timed out')
+        self.assertTrue(future.result().accepted)
+
+    def _clear(self, fault_code):
+        request = ClearFault.Request()
+        request.fault_code = fault_code
+        future = self._clear_client.call_async(request)
+        deadline = time.monotonic() + 10.0
+        while not future.done() and time.monotonic() < deadline:
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+        self.assertTrue(future.done(), f'clear_fault({fault_code}) timed out')
+
+    # --- reading the gateway ------------------------------------------------
+
+    def _wait_for_fault_in_list(self, fault_code, timeout=None):
+        """Poll GET /faults until the code shows up, and return its item."""
+        limit = timeout if timeout is not None else FAULT_TIMEOUT
+        deadline = time.monotonic() + limit
+        last = None
+        while time.monotonic() < deadline:
+            last = self._items(self.get_json('/faults?status=all'))
+            for item in last:
+                if item.get('fault_code') == fault_code:
+                    return item
+            time.sleep(0.3)
+        raise AssertionError(
+            f'{fault_code} never reached GET /faults; saw '
+            f'{[i.get("fault_code") for i in (last or [])]}'
+        )
+
+    @staticmethod
+    def _items(payload):
+        return payload.get('items', [])
+
+    def _find(self, payload, fault_code):
+        for item in self._items(payload):
+            if item.get('fault_code') == fault_code:
+                return item
+        return None
+
+    def _declare(self, body, expected_status=201):
+        response = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}', json=body, timeout=10
+        )
+        self.assertEqual(
+            response.status_code, expected_status,
+            f'POST {PLANNED_STOPS} {body} -> {response.status_code}: {response.text}'
+        )
+        return response.json()
+
+    @staticmethod
+    def _iso(offset_sec):
+        return time.strftime(
+            '%Y-%m-%dT%H:%M:%SZ', time.gmtime(time.time() + offset_sec)
+        )
+
+    # --- the acceptance -----------------------------------------------------
+
+    def test_01_declared_window_marks_only_the_fault_it_covers(self):
+        """One fault inside a window, one outside: list, flag, id, count, filter."""
+        window = self._declare({
+            'from': self._iso(-60),
+            'to': self._iso(3600),
+            'reason': 'line changeover',
+        })
+        for key in ('id', 'from', 'to', 'reason', 'declared_by', 'declared_at',
+                    'ended_early'):
+            self.assertIn(key, window, f'POST response is missing {key}')
+        self.assertFalse(window['ended_early'])
+        self.assertEqual(window['reason'], 'line changeover')
+        window_id = window['id']
+
+        # Both faults are raised while the window is open, but only one is
+        # reported under a code the window covers - the other one's cycle is
+        # started AFTER the window is ended, further down. Here both are inside.
+        self._report('PS_INSIDE_WINDOW')
+        inside = self._wait_for_fault_in_list('PS_INSIDE_WINDOW')
+
+        self.assertIn('x-medkit', inside, 'the list item carries no vendor extension')
+        self.assertTrue(
+            inside['x-medkit']['expected'],
+            'a fault raised inside a declared window must be reported as expected'
+        )
+        self.assertEqual(inside['x-medkit']['planned_stop_id'], window_id)
+
+        listing = self.get_json('/faults?status=all')
+        self.assertGreaterEqual(listing['x-medkit']['expected_count'], 1)
+
+        # The item's own flag and the count must agree - the count is derived
+        # from the same pass, and a count that drifted from the items would make
+        # every "N faults, M of them planned" summary wrong.
+        flagged = [i for i in self._items(listing)
+                   if i.get('x-medkit', {}).get('expected')]
+        self.assertEqual(listing['x-medkit']['expected_count'], len(flagged))
+
+    def test_02_a_fault_outside_every_window_is_not_expected(self):
+        """The other half of the pair, and the filter in both directions."""
+        # A window that closed before this fault's cycle starts.
+        self._declare({
+            'from': self._iso(-7200),
+            'to': self._iso(-3600),
+            'reason': 'last week',
+        })
+        self._report('PS_OUTSIDE_WINDOW')
+        outside = self._wait_for_fault_in_list('PS_OUTSIDE_WINDOW')
+        self.assertFalse(
+            outside['x-medkit']['expected'],
+            'a fault whose cycle started after every window closed is a surprise'
+        )
+        self.assertNotIn(
+            'planned_stop_id', outside['x-medkit'],
+            'an unexpected fault must not name a window'
+        )
+
+        only_expected = self.get_json('/faults?status=all&expected=true')
+        codes = [i['fault_code'] for i in self._items(only_expected)]
+        self.assertIn('PS_INSIDE_WINDOW', codes)
+        self.assertNotIn('PS_OUTSIDE_WINDOW', codes)
+        for item in self._items(only_expected):
+            self.assertTrue(item['x-medkit']['expected'])
+
+        only_unexpected = self.get_json('/faults?status=all&expected=false')
+        codes = [i['fault_code'] for i in self._items(only_unexpected)]
+        self.assertIn('PS_OUTSIDE_WINDOW', codes)
+        self.assertNotIn('PS_INSIDE_WINDOW', codes)
+        for item in self._items(only_unexpected):
+            self.assertFalse(item['x-medkit']['expected'])
+
+        both = self.get_json('/faults?status=all&expected=all')
+        codes = [i['fault_code'] for i in self._items(both)]
+        self.assertIn('PS_INSIDE_WINDOW', codes)
+        self.assertIn('PS_OUTSIDE_WINDOW', codes)
+
+        unfiltered = self.get_json('/faults?status=all')
+        self.assertEqual(
+            sorted(i['fault_code'] for i in self._items(unfiltered)),
+            sorted(codes),
+            'omitting the parameter must mean "all", not a default filter'
+        )
+
+    def test_03_per_entity_list_agrees_with_the_global_one(self):
+        """A scoped list must not answer differently about the same fault."""
+        per_entity = self.get_json(f'/apps/{APP_ID}/faults?status=all')
+        inside = self._find(per_entity, 'PS_INSIDE_WINDOW')
+        outside = self._find(per_entity, 'PS_OUTSIDE_WINDOW')
+        self.assertIsNotNone(inside, 'the per-entity list lost the expected fault')
+        self.assertIsNotNone(outside)
+        self.assertTrue(inside['x-medkit']['expected'])
+        self.assertFalse(outside['x-medkit']['expected'])
+        self.assertIn('expected_count', per_entity['x-medkit'])
+
+        scoped_expected = self.get_json(f'/apps/{APP_ID}/faults?status=all&expected=true')
+        codes = [i['fault_code'] for i in self._items(scoped_expected)]
+        self.assertIn('PS_INSIDE_WINDOW', codes)
+        self.assertNotIn('PS_OUTSIDE_WINDOW', codes)
+
+    def test_04_fault_detail_carries_the_same_flag(self):
+        """A UI that opens a flagged row must not find the flag gone."""
+        detail = self.get_json(f'/apps/{APP_ID}/faults/PS_INSIDE_WINDOW')
+        self.assertTrue(detail['x-medkit']['expected'])
+        self.assertIn('planned_stop_id', detail['x-medkit'])
+
+        plain = self.get_json(f'/apps/{APP_ID}/faults/PS_OUTSIDE_WINDOW')
+        self.assertFalse(plain['x-medkit']['expected'])
+
+    def test_05_event_stream_carries_the_flag_per_fault(self):
+        """The stream and the list must tell a consumer the same thing."""
+        frames = []
+        stop_event = threading.Event()
+        response = requests.get(
+            f'{self.BASE_URL}/faults/stream', stream=True, timeout=(5, 60)
+        )
+        self.assertEqual(response.status_code, 200)
+        pump = threading.Thread(
+            target=self._pump_stream, args=(response, frames, stop_event),
+            daemon=True,
+        )
+        pump.start()
+        try:
+            self._prime_stream(frames)
+
+            # A window covering only what is raised from here on.
+            window = self._declare({
+                'to': self._iso(3600),
+                'reason': 'stream changeover',
+            })
+            self.assertEqual(
+                window['declared_by'], 'anonymous',
+                'with auth off there is nobody to attribute the declaration to'
+            )
+
+            self._report('PS_STREAM_INSIDE')
+            inside_payload = self._wait_for_frame(frames, 'PS_STREAM_INSIDE')
+            self.assertTrue(
+                inside_payload['x-medkit']['expected'],
+                'the frame for the fault raised inside the window must be flagged'
+            )
+            self.assertEqual(
+                inside_payload['x-medkit']['planned_stop_id'], window['id']
+            )
+
+            # End the window, then raise the second fault: same stream, same
+            # gateway, opposite answer.
+            ended = requests.delete(
+                f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
+            )
+            self.assertEqual(ended.status_code, 200, ended.text)
+            self.assertTrue(ended.json()['ended_early'])
+
+            self._report('PS_STREAM_OUTSIDE')
+            outside_payload = self._wait_for_frame(frames, 'PS_STREAM_OUTSIDE')
+            self.assertFalse(
+                outside_payload['x-medkit']['expected'],
+                'a fault raised after the window was ended must not be flagged'
+            )
+            self.assertNotIn('planned_stop_id', outside_payload['x-medkit'])
+
+            # Counting frames per code proves the two assertions above were made
+            # about two different faults, not twice about one.
+            per_code = {}
+            for frame in list(frames):
+                data = frame.get('data')
+                if not data:
+                    continue
+                code = json.loads(data).get('fault', {}).get('fault_code')
+                if code in ('PS_STREAM_INSIDE', 'PS_STREAM_OUTSIDE'):
+                    per_code[code] = per_code.get(code, 0) + 1
+            self.assertGreaterEqual(per_code.get('PS_STREAM_INSIDE', 0), 1)
+            self.assertGreaterEqual(per_code.get('PS_STREAM_OUTSIDE', 0), 1)
+        finally:
+            stop_event.set()
+            response.close()
+            pump.join(timeout=5)
+
+    def test_06_ending_a_window_keeps_marking_what_came_before_it(self):
+        """CHANGE: the boundary moves, and only forward."""
+        window = self._declare({'to': self._iso(3600), 'reason': 'cut short'})
+        self._report('PS_BEFORE_EARLY_END')
+        before = self._wait_for_fault_in_list('PS_BEFORE_EARLY_END')
+        self.assertTrue(before['x-medkit']['expected'])
+
+        ended = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
+        )
+        self.assertEqual(ended.status_code, 200, ended.text)
+        self.assertTrue(ended.json()['ended_early'])
+        self.assertLess(ended.json()['to'], window['to'])
+
+        self._report('PS_AFTER_EARLY_END')
+        after = self._wait_for_fault_in_list('PS_AFTER_EARLY_END')
+        self.assertFalse(
+            after['x-medkit']['expected'],
+            'ending a window must stop it marking faults raised afterwards'
+        )
+
+        still_flagged = self._find(
+            self.get_json('/faults?status=all'), 'PS_BEFORE_EARLY_END'
+        )
+        self.assertTrue(
+            still_flagged['x-medkit']['expected'],
+            'ending a window must not un-mark the faults it already covered'
+        )
+        self.assertEqual(
+            still_flagged['x-medkit']['planned_stop_id'], window['id']
+        )
+
+        second_end = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10
+        )
+        self.assertEqual(second_end.status_code, 400, second_end.text)
+        # Vendor codes travel in `vendor_code` under the SOVD `vendor-error`
+        # envelope, which is what a generic client keys on.
+        self.assertEqual(second_end.json()['error_code'], 'vendor-error')
+        self.assertEqual(
+            second_end.json()['vendor_code'], 'x-medkit-planned-stop-ended'
+        )
+
+    def test_07_a_window_declared_after_the_fault_marks_it(self):
+        """CHANGE: a stop is a fact about the plant, not about typing speed."""
+        self._report('PS_DECLARED_LATE')
+        late = self._wait_for_fault_in_list('PS_DECLARED_LATE')
+        self.assertFalse(
+            late['x-medkit']['expected'],
+            'nothing covers it yet'
+        )
+        first_occurred = late['first_occurred']
+
+        window = self._declare({
+            'from': self._iso(-300),
+            'to': self._iso(300),
+            'reason': 'declared after the fact',
+        })
+
+        # The cache behind the flag re-reads on a short time to live; a write
+        # through this gateway invalidates it, so the next read already sees it.
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            item = self._find(self.get_json('/faults?status=all'), 'PS_DECLARED_LATE')
+            if item is not None and item['x-medkit']['expected']:
+                self.assertEqual(item['x-medkit']['planned_stop_id'], window['id'])
+                self.assertEqual(item['first_occurred'], first_occurred,
+                                 'declaring a window must not touch the fault')
+                return
+            time.sleep(0.3)
+        raise AssertionError(
+            'a window declared after the fault did not mark it within '
+            f'{FAULT_TIMEOUT}s'
+        )
+
+    def test_08_a_new_cycle_after_a_clear_is_judged_on_its_own(self):
+        """first_occurred moves with the cycle, and so must the flag."""
+        # Cycle one, inside a window.
+        window = self._declare({'to': self._iso(3600), 'reason': 'cycle one'})
+        self._report('PS_CYCLE')
+        first = self._wait_for_fault_in_list('PS_CYCLE')
+        self.assertTrue(first['x-medkit']['expected'])
+        self.assertEqual(first['occurrence_count'], 1)
+
+        self._clear('PS_CYCLE')
+        requests.delete(f'{self.BASE_URL}{PLANNED_STOPS}/{window["id"]}', timeout=10)
+
+        # Cycle two, with no window open.
+        self._report('PS_CYCLE')
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            item = self._find(self.get_json('/faults?status=all'), 'PS_CYCLE')
+            if item is not None and item.get('occurrence_count') == 2:
+                self.assertFalse(
+                    item['x-medkit']['expected'],
+                    'the second cycle started outside every window'
+                )
+                return
+            time.sleep(0.3)
+        raise AssertionError('PS_CYCLE never reached a second occurrence')
+
+    # --- the REST surface itself -------------------------------------------
+
+    def test_09_windows_are_listed_read_back_and_filterable_by_active(self):
+        active = self._declare({'to': self._iso(3600), 'reason': 'still running'})
+        past = self._declare({
+            'from': self._iso(-7200), 'to': self._iso(-3600), 'reason': 'finished',
+        })
+
+        listing = self.get_json(PLANNED_STOPS)
+        ids = [w['id'] for w in listing['items']]
+        self.assertIn(active['id'], ids)
+        self.assertIn(past['id'], ids, 'an ended window is why old faults read as expected')
+
+        only_active = self.get_json(f'{PLANNED_STOPS}?active=true')
+        active_ids = [w['id'] for w in only_active['items']]
+        self.assertIn(active['id'], active_ids)
+        self.assertNotIn(past['id'], active_ids)
+
+        one = self.get_json(f'{PLANNED_STOPS}/{active["id"]}')
+        self.assertEqual(one['id'], active['id'])
+        self.assertEqual(one['reason'], 'still running')
+
+        missing = requests.get(f'{self.BASE_URL}{PLANNED_STOPS}/no_such_window', timeout=10)
+        self.assertEqual(missing.status_code, 404)
+
+        gone = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/no_such_window', timeout=10
+        )
+        self.assertEqual(gone.status_code, 404)
+
+    def test_10_a_window_that_is_not_an_interval_is_refused(self):
+        now = self._iso(0)
+        self._declare({'to': now, 'from': now, 'reason': 'zero length'},
+                      expected_status=400)
+        self._declare({'from': self._iso(600), 'to': self._iso(60), 'reason': 'reversed'},
+                      expected_status=400)
+        self._declare({'to': 'yesterday afternoon', 'reason': 'unparsable'},
+                      expected_status=400)
+        self._declare({'to': '2026-09-06T12:00:00+02:00', 'reason': 'not utc'},
+                      expected_status=400)
+        self._declare({'from': 'nonsense', 'to': self._iso(600), 'reason': 'bad from'},
+                      expected_status=400)
+
+        # builtin_interfaces/Time carries its seconds in an int32, so a window
+        # past January 2038 has no representation. Refused rather than wrapped:
+        # the narrowing would hand back a window with a negative end, covering
+        # nothing, while telling the operator it was accepted.
+        self._declare({'to': '2099-01-01T00:00:00Z', 'reason': 'past 2038'},
+                      expected_status=400)
+
+        # A missing `to` is the request DTO's business, and it must still be 400.
+        response = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}', json={'reason': 'no end'}, timeout=10
+        )
+        self.assertEqual(response.status_code, 400, response.text)
+
+    def test_11_an_absent_from_means_now(self):
+        before = time.time()
+        window = self._declare({'to': self._iso(3600), 'reason': 'starts now'})
+        after = time.time()
+
+        started = calendar.timegm(
+            time.strptime(window['from'][:19], '%Y-%m-%dT%H:%M:%S')
+        )
+        # Two seconds of slack: the gateway stamps the window from the fault
+        # manager's clock, and the assertion is that it is "now", not that the
+        # two machines agree to the millisecond.
+        self.assertGreaterEqual(started, before - 2.0)
+        self.assertLessEqual(started, after + 2.0)
+
+    def test_12_the_expected_filter_refuses_a_value_it_does_not_define(self):
+        response = requests.get(
+            f'{self.BASE_URL}/faults?status=all&expected=maybe', timeout=10
+        )
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertEqual(response.json()['parameters']['parameter'], 'expected')
+
+        scoped = requests.get(
+            f'{self.BASE_URL}/apps/{APP_ID}/faults?expected=perhaps', timeout=10
+        )
+        self.assertEqual(scoped.status_code, 400, scoped.text)
+
+    def test_13_root_endpoint_advertises_the_routes(self):
+        data = self.get_json('/')
+        self.assertIn(f'POST /api/v1{PLANNED_STOPS}', data['endpoints'])
+        self.assertIn(f'GET /api/v1{PLANNED_STOPS}', data['endpoints'])
+        self.assertIn(
+            f'GET /api/v1{PLANNED_STOPS}/{{planned_stop_id}}', data['endpoints']
+        )
+        self.assertIn(
+            f'DELETE /api/v1{PLANNED_STOPS}/{{planned_stop_id}}', data['endpoints']
+        )
+
+    # --- stream plumbing ----------------------------------------------------
+
+    @staticmethod
+    def _pump_stream(response, frames, stop_event):
+        current = {}
+        try:
+            for line in response.iter_lines(decode_unicode=True):
+                if stop_event.is_set():
+                    break
+                if line is None:
+                    continue
+                if line == '':
+                    if current:
+                        frames.append(current)
+                        current = {}
+                    continue
+                if line.startswith(':'):
+                    continue  # keepalive comment
+                key, _, value = line.partition(':')
+                current[key.strip()] = value.strip()
+        except Exception:  # noqa: BLE001 - closed socket on test teardown
+            pass
+
+    def _prime_stream(self, frames):
+        """Block until the event pipeline demonstrably reaches the stream.
+
+        /fault_manager/events is reliable but volatile: an event published before
+        the gateway's subscription has matched is lost outright. Repeating a
+        sacrificial fault until one of its frames arrives proves the whole chain
+        is live before anything is asserted on it.
+        """
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            self._report('PS_STREAM_PRIME')
+            settle = min(time.monotonic() + 1.0, deadline)
+            while time.monotonic() < settle:
+                for frame in list(frames):
+                    data = frame.get('data')
+                    if data and json.loads(data).get(
+                            'fault', {}).get('fault_code') == 'PS_STREAM_PRIME':
+                        return
+                time.sleep(0.1)
+        raise AssertionError('the fault event pipeline never reached the stream')
+
+    def _wait_for_frame(self, frames, fault_code):
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            for frame in list(frames):
+                data = frame.get('data')
+                if not data:
+                    continue
+                payload = json.loads(data)
+                if payload.get('fault', {}).get('fault_code') == fault_code:
+                    return payload
+            time.sleep(0.2)
+        raise AssertionError(
+            f'no frame for {fault_code} on /faults/stream within {FAULT_TIMEOUT}s'
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsShutdown(unittest.TestCase):
+
+    def test_gateway_exits_cleanly(self, proc_info, gateway_node):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=gateway_node, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_aggregation.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_aggregation.test.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The planned-stop flag through an aggregating gateway.
+
+Windows are per fault manager: the peer's gateway derives the flag for the
+peer's faults from the peer's own windows, and the aggregator relays what the
+peer said. Two things have to hold through that relay, and neither is visible
+from a single gateway.
+
+A1  ``?expected=`` reaches the peer and is applied to what comes back. Asserting
+    only that the aggregator returns SOMETHING would pass against a gateway that
+    forwarded a path with no query on it - which is what it did: the peer
+    answered its whole list and every item came through, flag and all.
+A2  ``expected_count`` counts the list that was served, peer items included.
+    A count taken before the merge describes the local half and nothing else.
+A3  The whole query reaches the peer, not just ``expected``. ``?status=`` was
+    dropped by the same line, and unlike ``expected`` the aggregator has no
+    second chance at it: a peer asked nothing answers its DEFAULT status set, so
+    a request for cleared faults came back carrying the peer's confirmed ones and
+    missing its cleared one. This is the assertion the forwarding has to satisfy
+    on its own - filtering peer items locally, which A1 also allows, cannot.
+
+The aggregator runs a fault manager of its own - ``GET /faults`` answers 503
+without one - but nothing ever reports to it, and it sits on a domain of its
+own, so every fault in the merged list demonstrably came from the peer.
+"""
+
+import os
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import TimerAction
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault
+from ros2_medkit_msgs.srv import ClearFault, ReportFault
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    FAULT_TIMEOUT,
+    GATEWAY_STARTUP_TIMEOUT,
+    get_test_domain_id,
+    get_test_port,
+)
+from ros2_medkit_test_utils.launch_helpers import (
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+AGG_PORT = get_test_port(0)
+PEER_PORT = get_test_port(1)
+AGG_URL = f'http://localhost:{AGG_PORT}{API_BASE_PATH}'
+PEER_URL = f'http://localhost:{PEER_PORT}{API_BASE_PATH}'
+
+# The launch default domain is the PEER's: the test process has to reach the
+# peer's fault_manager over ROS to raise anything at all. The aggregator is
+# pushed onto a domain of its own, which is also the deployment being described.
+PEER_DOMAIN_ID = get_test_domain_id(0)
+AGG_DOMAIN_ID = get_test_domain_id(1)
+
+PLANNED_STOPS = '/x-medkit-planned-stops'
+PEER_NAME = 'remote_gateway'
+INSIDE_CODE = 'PS_PEER_INSIDE_WINDOW'
+OUTSIDE_CODE = 'PS_PEER_OUTSIDE_WINDOW'
+SOURCE_ID = '/powertrain/engine/temp_sensor'
+
+
+def generate_test_description():
+    aggregator = create_gateway_node(
+        name='aggregating_gateway_node',
+        port=AGG_PORT,
+        extra_params={
+            'aggregation.enabled': True,
+            'aggregation.timeout_ms': 5000,
+            'aggregation.announce': False,
+            'aggregation.discover': False,
+            'aggregation.peer_urls': [f'http://localhost:{PEER_PORT}'],
+            'aggregation.peer_names': [PEER_NAME],
+            'server.http_thread_pool_size': 16,
+        },
+        extra_env={'ROS_DOMAIN_ID': str(AGG_DOMAIN_ID)},
+    )
+
+    peer_gateway = create_gateway_node(
+        name='remote_gateway_node',
+        port=PEER_PORT,
+        extra_params={'server.http_thread_pool_size': 16},
+    )
+
+    # The aggregator needs a fault manager to answer /faults at all; nothing
+    # reports to it, and it is on the aggregator's own domain, so the merged
+    # list is exactly what the peer contributed.
+    # Default node name on purpose: the gateway addresses its fault manager by
+    # the /fault_manager service namespace, which the node name sets. The two
+    # managers are on different DDS domains, so the shared name collides with
+    # nothing.
+    aggregator_fault_manager = create_fault_manager_node(
+        storage_type='memory',
+        rosbag_enabled=False,
+        extra_params={'snapshots.rosbag.enabled': False},
+        extra_env={'ROS_DOMAIN_ID': str(AGG_DOMAIN_ID)},
+    )
+
+    peer_fault_manager = create_fault_manager_node(
+        storage_type='memory',
+        rosbag_enabled=False,
+        extra_params={
+            # One FAILED confirms, so a fault is in the list one call after it
+            # is raised.
+            'confirmation_threshold': -1,
+            'healing_enabled': False,
+            'snapshots.rosbag.enabled': False,
+        },
+    )
+
+    launch_description = LaunchDescription([
+        peer_gateway,
+        peer_fault_manager,
+        TimerAction(period=1.0, actions=[aggregator, aggregator_fault_manager]),
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+    return (
+        launch_description,
+        {'gateway_node': aggregator, 'peer_gateway': peer_gateway},
+    )
+
+
+class TestPlannedStopsAggregation(unittest.TestCase):
+    """The flag and the filter have to survive the relay."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls._wait_for(AGG_URL)
+        cls._wait_for(PEER_URL)
+
+        # Pinned rather than inherited: this node has to land on the PEER's
+        # domain, where the fault_manager it reports to lives.
+        previous_domain = os.environ.get('ROS_DOMAIN_ID')
+        os.environ['ROS_DOMAIN_ID'] = str(PEER_DOMAIN_ID)
+        try:
+            rclpy.init()
+            cls._reporter = Node('planned_stop_agg_reporter')
+        finally:
+            if previous_domain is None:
+                os.environ.pop('ROS_DOMAIN_ID', None)
+            else:
+                os.environ['ROS_DOMAIN_ID'] = previous_domain
+
+        cls._report_client = cls._reporter.create_client(
+            ReportFault, '/fault_manager/report_fault'
+        )
+        cls._clear_client = cls._reporter.create_client(
+            ClearFault, '/fault_manager/clear_fault'
+        )
+        assert cls._report_client.wait_for_service(timeout_sec=30.0), \
+            'peer report_fault service not available'
+        assert cls._clear_client.wait_for_service(timeout_sec=30.0), \
+            'peer clear_fault service not available'
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._reporter.destroy_node()
+        rclpy.shutdown()
+
+    @staticmethod
+    def _wait_for(base_url):
+        deadline = time.monotonic() + GATEWAY_STARTUP_TIMEOUT
+        while time.monotonic() < deadline:
+            try:
+                if requests.get(f'{base_url}/health', timeout=2).status_code == 200:
+                    return
+            except requests.RequestException:
+                pass
+            time.sleep(0.5)
+        raise AssertionError(f'{base_url} never became healthy')
+
+    def _report(self, fault_code):
+        request = ReportFault.Request()
+        request.fault_code = fault_code
+        request.event_type = ReportFault.Request.EVENT_FAILED
+        request.severity = Fault.SEVERITY_ERROR
+        request.description = 'peer fault for the aggregated planned-stop flag'
+        request.source_id = SOURCE_ID
+        future = self._report_client.call_async(request)
+        deadline = time.monotonic() + 10.0
+        while not future.done() and time.monotonic() < deadline:
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+        self.assertTrue(future.done(), f'report_fault({fault_code}) timed out')
+        self.assertTrue(future.result().accepted)
+
+    @staticmethod
+    def _items(url):
+        response = requests.get(url, timeout=15)
+        assert response.status_code == 200, f'{url} -> {response.status_code}: {response.text}'
+        return response.json()
+
+    def _wait_for_code(self, url, fault_code):
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            payload = self._items(url)
+            for item in payload.get('items', []):
+                if item.get('fault_code') == fault_code:
+                    return payload, item
+            time.sleep(0.5)
+        raise AssertionError(f'{fault_code} never reached {url}')
+
+    def _clear(self, fault_code):
+        request = ClearFault.Request()
+        request.fault_code = fault_code
+        future = self._clear_client.call_async(request)
+        deadline = time.monotonic() + 10.0
+        while not future.done() and time.monotonic() < deadline:
+            rclpy.spin_once(self._reporter, timeout_sec=0.1)
+        self.assertTrue(future.done(), f'clear_fault({fault_code}) timed out')
+        self.assertTrue(future.result().success, future.result().message)
+
+    def test_the_flag_and_the_filter_survive_the_relay(self):
+        # Declared on the PEER, because that is where the fault manager holding
+        # the window and the faults it covers lives.
+        window = requests.post(
+            f'{PEER_URL}{PLANNED_STOPS}',
+            json={'to': time.strftime('%Y-%m-%dT%H:%M:%SZ',
+                                      time.gmtime(time.time() + 3600)),
+                  'reason': 'peer changeover'},
+            timeout=10,
+        )
+        self.assertEqual(window.status_code, 201, window.text)
+        window_id = window.json()['id']
+
+        self._report(INSIDE_CODE)
+        _, inside = self._wait_for_code(f'{PEER_URL}/faults?status=all', INSIDE_CODE)
+        self.assertTrue(
+            inside['x-medkit']['expected'],
+            'the PEER must flag its own fault before the relay can carry it'
+        )
+
+        # A1: the aggregator's merged list carries the peer's flag...
+        payload, relayed = self._wait_for_code(f'{AGG_URL}/faults?status=all', INSIDE_CODE)
+        self.assertTrue(
+            relayed['x-medkit']['expected'],
+            'the aggregator dropped or overwrote the flag the peer derived'
+        )
+        self.assertEqual(relayed['x-medkit']['planned_stop_id'], window_id)
+
+        # A2: ...and the count describes the merged list, not the local half.
+        flagged = [i for i in payload['items'] if i.get('x-medkit', {}).get('expected')]
+        self.assertGreaterEqual(len(flagged), 1)
+        self.assertEqual(
+            payload['x-medkit']['expected_count'], len(flagged),
+            'expected_count must count the list that was served, peer items included'
+        )
+
+        # End the window on the peer, then raise a second fault there: same
+        # aggregator, same route, opposite answer.
+        ended = requests.delete(f'{PEER_URL}{PLANNED_STOPS}/{window_id}', timeout=10)
+        self.assertEqual(ended.status_code, 200, ended.text)
+
+        self._report(OUTSIDE_CODE)
+        self._wait_for_code(f'{AGG_URL}/faults?status=all', OUTSIDE_CODE)
+
+        # A1 again, through the filter this time. Without the query forwarded,
+        # the peer answered its whole list and both codes came through.
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        while time.monotonic() < deadline:
+            only_expected = self._items(f'{AGG_URL}/faults?status=all&expected=true')
+            codes = [i['fault_code'] for i in only_expected['items']]
+            if INSIDE_CODE in codes and OUTSIDE_CODE not in codes:
+                break
+            time.sleep(0.5)
+        self.assertIn(INSIDE_CODE, codes)
+        self.assertNotIn(
+            OUTSIDE_CODE, codes,
+            'a peer fault outside every window must not survive ?expected=true'
+        )
+        for item in only_expected['items']:
+            self.assertTrue(item['x-medkit']['expected'])
+        self.assertEqual(
+            only_expected['x-medkit']['expected_count'], len(only_expected['items'])
+        )
+
+        only_unexpected = self._items(f'{AGG_URL}/faults?status=all&expected=false')
+        codes = [i['fault_code'] for i in only_unexpected['items']]
+        self.assertIn(OUTSIDE_CODE, codes)
+        self.assertNotIn(INSIDE_CODE, codes)
+        self.assertEqual(only_unexpected['x-medkit']['expected_count'], 0)
+
+        # A3: the WHOLE query has to reach the peer. Clear one of the two peer
+        # faults and ask the aggregator for cleared ones only. A peer that was
+        # asked nothing answers its default set - pending and confirmed - so a
+        # gateway that dropped the query returns the fault it was not asked for
+        # and loses the one it was.
+        self._clear(INSIDE_CODE)
+        deadline = time.monotonic() + FAULT_TIMEOUT
+        cleared_codes = []
+        while time.monotonic() < deadline:
+            cleared_only = self._items(f'{AGG_URL}/faults?status=cleared')
+            cleared_codes = [i['fault_code'] for i in cleared_only['items']]
+            if INSIDE_CODE in cleared_codes:
+                break
+            time.sleep(0.5)
+        self.assertIn(
+            INSIDE_CODE, cleared_codes,
+            'the peer was never asked for cleared faults, so it did not send any'
+        )
+        self.assertNotIn(
+            OUTSIDE_CODE, cleared_codes,
+            'the peer answered its default status set instead of the one requested'
+        )
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsAggregationShutdown(unittest.TestCase):
+
+    def test_gateways_exit_cleanly(self, proc_info, gateway_node, peer_gateway):
+        for process in (gateway_node, peer_gateway):
+            launch_testing.asserts.assertExitCodes(
+                proc_info, process=process, allowable_exit_codes=ALLOWED_EXIT_CODES
+            )

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_auth.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_auth.test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Who may declare a planned stop, and whose name ends up on it.
+
+Declaring and ending a window are writes and need OPERATOR; reading needs
+VIEWER. `declared_by` defaults to the authenticated client id, which is the only
+reason the field is worth anything on a machine several people can reach.
+"""
+
+import unittest
+
+import launch
+import launch_testing
+import launch_testing.actions
+import pytest
+import requests
+
+from ros2_medkit_test_utils.constants import (
+    ALLOWED_EXIT_CODES,
+    API_BASE_PATH,
+    get_test_port,
+)
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import (
+    create_fault_manager_node,
+    create_gateway_node,
+)
+
+AUTH_PORT = get_test_port()
+AUTH_BASE_URL = f'http://127.0.0.1:{AUTH_PORT}{API_BASE_PATH}'
+PLANNED_STOPS = '/x-medkit-planned-stops'
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    gateway_node = create_gateway_node(
+        port=AUTH_PORT,
+        extra_params={
+            'server.host': '127.0.0.1',
+            'auth.enabled': True,
+            'auth.jwt_secret': 'planned_stop_auth_secret_key_for_integration_testing_1',
+            'auth.jwt_algorithm': 'HS256',
+            'auth.token_expiry_seconds': 3600,
+            'auth.require_auth_for': 'write',
+            'auth.issuer': 'test_gateway',
+            'auth.clients': [
+                'admin:admin_secret:admin',
+                'operator:operator_secret:operator',
+                'viewer:viewer_secret:viewer',
+            ],
+        },
+    )
+    return launch.LaunchDescription([
+        gateway_node,
+        create_fault_manager_node(storage_type='memory', rosbag_enabled=False),
+        launch_testing.actions.ReadyToTest(),
+    ]), {'gateway_node': gateway_node}
+
+
+class TestPlannedStopsAuth(GatewayTestCase):
+    """Roles on the planned-stop routes, and the identity they record."""
+
+    BASE_URL = AUTH_BASE_URL
+
+    def _token(self, client_id, secret):
+        response = requests.post(
+            f'{self.BASE_URL}/auth/authorize',
+            json={
+                'grant_type': 'client_credentials',
+                'client_id': client_id,
+                'client_secret': secret,
+            },
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()['access_token']
+
+    @staticmethod
+    def _bearer(token):
+        return {'Authorization': f'Bearer {token}'}
+
+    def test_declaring_needs_operator(self):
+        body = {'to': '2037-01-01T00:00:00Z', 'reason': 'role check'}
+
+        viewer = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}', json=body,
+            headers=self._bearer(self._token('viewer', 'viewer_secret')), timeout=10,
+        )
+        self.assertEqual(viewer.status_code, 403, viewer.text)
+
+        operator = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}', json=body,
+            headers=self._bearer(self._token('operator', 'operator_secret')), timeout=10,
+        )
+        self.assertEqual(operator.status_code, 201, operator.text)
+        self.assertEqual(
+            operator.json()['declared_by'], 'operator',
+            'the window must record who actually declared it'
+        )
+
+    def test_a_caller_may_declare_on_somebody_elses_behalf(self):
+        response = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}',
+            json={
+                'to': '2037-01-01T00:00:00Z',
+                'reason': 'declared by the MES',
+                'declared_by': 'mes_line_3',
+            },
+            headers=self._bearer(self._token('operator', 'operator_secret')),
+            timeout=10,
+        )
+        self.assertEqual(response.status_code, 201, response.text)
+        self.assertEqual(response.json()['declared_by'], 'mes_line_3')
+
+    def test_ending_needs_operator_and_reading_needs_viewer(self):
+        created = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}',
+            json={'to': '2037-01-01T00:00:00Z', 'reason': 'end role check'},
+            headers=self._bearer(self._token('admin', 'admin_secret')), timeout=10,
+        )
+        self.assertEqual(created.status_code, 201, created.text)
+        window_id = created.json()['id']
+        self.assertEqual(created.json()['declared_by'], 'admin')
+
+        viewer_headers = self._bearer(self._token('viewer', 'viewer_secret'))
+
+        # A viewer can read the window it may not touch.
+        listing = requests.get(
+            f'{self.BASE_URL}{PLANNED_STOPS}', headers=viewer_headers, timeout=10
+        )
+        self.assertEqual(listing.status_code, 200, listing.text)
+        self.assertIn(window_id, [w['id'] for w in listing.json()['items']])
+
+        one = requests.get(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window_id}',
+            headers=viewer_headers, timeout=10,
+        )
+        self.assertEqual(one.status_code, 200, one.text)
+
+        refused = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window_id}',
+            headers=viewer_headers, timeout=10,
+        )
+        self.assertEqual(refused.status_code, 403, refused.text)
+
+        allowed = requests.delete(
+            f'{self.BASE_URL}{PLANNED_STOPS}/{window_id}',
+            headers=self._bearer(self._token('operator', 'operator_secret')), timeout=10,
+        )
+        self.assertEqual(allowed.status_code, 200, allowed.text)
+        self.assertTrue(allowed.json()['ended_early'])
+
+    def test_an_unauthenticated_write_is_refused(self):
+        # require_auth_for=write, so the read is open and the write is not.
+        # A window nobody may declare is also a window nobody can be blamed for.
+        anonymous = requests.post(
+            f'{self.BASE_URL}{PLANNED_STOPS}',
+            json={'to': '2037-01-01T00:00:00Z', 'reason': 'no token'}, timeout=10,
+        )
+        self.assertEqual(anonymous.status_code, 401, anonymous.text)
+
+        listing = requests.get(f'{self.BASE_URL}{PLANNED_STOPS}', timeout=10)
+        self.assertEqual(listing.status_code, 200, listing.text)
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsAuthShutdown(unittest.TestCase):
+
+    def test_gateway_exits_cleanly(self, proc_info, gateway_node):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=gateway_node, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_slow_manager.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_slow_manager.test.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A fault manager that answers slowly must not stall the gateway.
+
+Deriving the planned-stop flag costs a service call. That call used to happen
+while the SSE handler held its queue mutex - the same mutex the ROS subscription
+callback takes to enqueue an event - so a fault manager that was advertised but
+slow stopped the gateway's executor thread, and every SSE client with it, for as
+long as the call took.
+
+The instrument is `x-medkit-sse.events_received` on `/health`: fault events the
+gateway has ACCEPTED, counted on the executor thread. Measuring frame arrival
+instead would not separate the two paths - the stream's own loop legitimately
+waits for the refresh on its own thread - and measuring with no fault manager at
+all proves nothing, because then the call is skipped and returns in microseconds.
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, TimerAction
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault, FaultEvent
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
+
+# The stub's own delay. Anything the enqueue path pays would be a multiple of
+# this, so the budget below sits well under it.
+MANAGER_DELAY_SEC = 3.0
+
+# What "the enqueue path never blocks" is worth asserting at. Comfortably above
+# DDS delivery on a loaded machine, comfortably below one stalled refresh.
+ENQUEUE_BUDGET_SEC = 1.5
+
+# Enough events, spaced past the cache's time to live, that the window certainly
+# spans one of the stream loop's own refreshes. The FIRST refresh happens in the
+# initial-replay block, which is outside the queue lock either way, so measuring
+# only around it would prove nothing.
+EVENT_COUNT = 10
+
+
+def generate_test_description():
+    manager = ExecuteProcess(
+        cmd=[
+            sys.executable,
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'slow_planned_stop_manager.py'),
+        ],
+        name='slow_planned_stop_manager',
+        output='screen',
+    )
+
+    gateway = create_gateway_node(
+        extra_params={
+            # Points the gateway at the stub, which is `fault_manager` inside
+            # this namespace.
+            'fault_manager.namespace': 'slow',
+            # The stub answers inside this, so the call SUCCEEDS slowly rather
+            # than failing and tripping the failure back-off - a refresh that
+            # fails would stop happening and the slowness with it.
+            'fault_manager.service_timeout_sec': 10.0,
+            'sse.keepalive_interval_sec': 2,
+        },
+    )
+
+    return (
+        LaunchDescription([
+            manager,
+            TimerAction(period=2.0, actions=[gateway]),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {'gateway_node': gateway},
+    )
+
+
+class TestPlannedStopsSlowManager(GatewayTestCase):
+    """The blocking half of the derivation must stay off the executor."""
+
+    # Nothing is discovered here: the fixture is about the fault-manager path, so
+    # MIN_EXPECTED_APPS of 0 skips the discovery wait entirely.
+    MIN_EXPECTED_APPS = 0
+    REQUIRED_APPS = set()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        rclpy.init()
+        cls._publisher_node = Node('slow_manager_event_publisher')
+        cls._event_pub = cls._publisher_node.create_publisher(
+            FaultEvent, '/slow/fault_manager/events', 10
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._publisher_node.destroy_node()
+        rclpy.shutdown()
+
+    def _publish_event(self, fault_code):
+        event = FaultEvent()
+        event.event_type = FaultEvent.EVENT_CONFIRMED
+        event.fault.fault_code = fault_code
+        event.fault.severity = Fault.SEVERITY_ERROR
+        event.fault.status = Fault.STATUS_CONFIRMED
+        event.fault.first_occurred.sec = int(time.time())
+        event.fault.last_occurred.sec = event.fault.first_occurred.sec
+        event.fault.occurrence_count = 1
+        event.fault.reporting_sources = ['/powertrain/engine/temp_sensor']
+        event.timestamp.sec = event.fault.first_occurred.sec
+        self._event_pub.publish(event)
+        rclpy.spin_once(self._publisher_node, timeout_sec=0.05)
+
+    def _events_received(self):
+        sse = self.get_json('/health').get('x-medkit-sse', {})
+        self.assertIn(
+            'events_received', sse,
+            'the counter this case measures with is missing from /health'
+        )
+        return sse['events_received']
+
+    def _wait_for_events(self, target, budget):
+        deadline = time.monotonic() + budget
+        last = None
+        while time.monotonic() < deadline:
+            last = self._events_received()
+            if last >= target:
+                return time.monotonic()
+            time.sleep(0.05)
+        raise AssertionError(
+            f'the gateway accepted {last} of {target} events within {budget}s; '
+            'the thread that accepts them is blocked'
+        )
+
+    @staticmethod
+    def _pump(response, frames, stop_event):
+        current = {}
+        try:
+            for line in response.iter_lines(decode_unicode=True):
+                if stop_event.is_set():
+                    break
+                if line is None:
+                    continue
+                if line == '':
+                    if current:
+                        frames.append(current)
+                        current = {}
+                    continue
+                if line.startswith(':'):
+                    continue
+                key, _, value = line.partition(':')
+                current[key.strip()] = value.strip()
+        except Exception:  # noqa: BLE001 - closed socket on teardown
+            pass
+
+    def test_a_slow_manager_does_not_block_the_event_intake(self):
+        frames = []
+        stop_event = threading.Event()
+        response = requests.get(
+            f'{self.BASE_URL}/faults/stream', stream=True, timeout=(5, 90)
+        )
+        self.assertEqual(response.status_code, 200)
+        pump = threading.Thread(target=self._pump, args=(response, frames, stop_event),
+                                daemon=True)
+        pump.start()
+        try:
+            # Prime. Two things have to happen before anything can be measured:
+            # the gateway's subscription has to match this publisher - an event
+            # published before it does is lost outright, the volatile-topic race
+            # every fault test in this suite primes around - and the stream loop
+            # has to do its first refresh, which is the slow one.
+            baseline = self._events_received()
+            deadline = time.monotonic() + 60.0
+            while time.monotonic() < deadline:
+                self._publish_event('SLOW_PRIME')
+                settle = min(time.monotonic() + 1.0, deadline)
+                while time.monotonic() < settle:
+                    if self._events_received() > baseline:
+                        break
+                    time.sleep(0.1)
+                if self._events_received() > baseline:
+                    break
+            self.assertGreater(
+                self._events_received(), baseline,
+                'no event ever reached the gateway; the fixture never went live'
+            )
+
+            # Let the initial-replay refresh finish and the next one fall due.
+            # That first one runs before the loop is entered and is outside the
+            # queue lock in every variant, so it is not the one under test.
+            time.sleep(MANAGER_DELAY_SEC + 2.0)
+
+            # Now the measurement, one event at a time. The worst SINGLE wait is
+            # what discriminates: a burst measured end to end hides one stalled
+            # refresh inside a generous total, because the events queue in DDS
+            # and all arrive at once when the lock is finally released.
+            #
+            # Spaced past the cache's time to live so at least one refresh
+            # certainly falls inside the measured window.
+            worst = 0.0
+            slowest_event = None
+            for index in range(EVENT_COUNT):
+                before = self._events_received()
+                started = time.monotonic()
+                self._publish_event(f'SLOW_EVENT_{index}')
+                self._wait_for_events(before + 1, budget=MANAGER_DELAY_SEC * 4)
+                elapsed = time.monotonic() - started
+                if elapsed > worst:
+                    worst = elapsed
+                    slowest_event = index
+                time.sleep(0.7)
+            print(f'worst single enqueue wait: {worst:.3f}s (event {slowest_event})')
+            self.assertLess(
+                worst, ENQUEUE_BUDGET_SEC,
+                f'event {slowest_event} waited {worst:.2f}s to be accepted, which is the '
+                f'shape of a {MANAGER_DELAY_SEC}s service call holding the queue mutex'
+            )
+
+            # And the stream is still a stream: the frames arrive, late or not.
+            deadline = time.monotonic() + 60.0
+            seen = set()
+            while time.monotonic() < deadline and len(seen) < EVENT_COUNT:
+                for frame in list(frames):
+                    data = frame.get('data')
+                    if not data:
+                        continue
+                    code = json.loads(data).get('fault', {}).get('fault_code', '')
+                    if code.startswith('SLOW_EVENT_'):
+                        seen.add(code)
+                time.sleep(0.1)
+            self.assertEqual(
+                len(seen), EVENT_COUNT,
+                f'the stream stopped delivering: {sorted(seen)}'
+            )
+        finally:
+            stop_event.set()
+            response.close()
+            pump.join(timeout=5)
+
+    def test_the_gateway_stays_answerable_while_the_manager_is_slow(self):
+        # /health is served by an HTTP worker, but a blocked executor takes the
+        # gateway's discovery and subscription work with it, and the counter
+        # above is read through this route.
+        for _ in range(5):
+            started = time.monotonic()
+            self.get_json('/health')
+            self.assertLess(
+                time.monotonic() - started, ENQUEUE_BUDGET_SEC,
+                '/health must not wait on the fault manager'
+            )
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsSlowManagerShutdown(unittest.TestCase):
+
+    def test_gateway_exits_cleanly(self, proc_info, gateway_node):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=gateway_node, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_stale_windows.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_stale_windows.test.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What the fault list says once the windows stop being readable.
+
+Three claims, all about the same moment: a fault manager that still serves
+faults and no longer serves planned stops.
+
+S1  The flag goes QUIET, not false. `expected: false` there would tell an
+    operator that nothing was planned during a stop the gateway simply cannot
+    read - the same ruling the event stream already follows, applied where a
+    reader actually looks.
+S2  Window knowledge EXPIRES. A gateway that read a set once used to serve it
+    for the life of the process: replace the fault manager and `GET /faults`
+    kept naming a window that existed nowhere, while
+    `GET /x-medkit-planned-stops` answered 503 at the same instant. Two
+    endpoints of one API contradicting each other, indefinitely.
+S3  The list stays FAST. The planned-stop client's readiness is part of the
+    decision to call it, so a manager without the service costs no timeout.
+
+The stub serves one window, then destroys its planned-stop services. Asserting
+only the end state would not show S2: a gateway that never read the window at
+all would pass it.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess, TimerAction
+import launch_testing
+import launch_testing.actions
+import rclpy
+from rclpy.node import Node
+import requests
+from ros2_medkit_msgs.msg import Fault, FaultEvent
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_gateway_node
+
+PLANNED_STOPS = '/x-medkit-planned-stops'
+
+# The stub answers planned-stop reads for this long, then destroys the services.
+DROP_AFTER_SEC = 12.0
+
+# FaultManager::kPlannedStopKnowledgeMaxAge. Past this, a set nothing has
+# refreshed is no longer reported.
+KNOWLEDGE_MAX_AGE_SEC = 6.0
+
+# A list that has to wait out a service timeout takes seconds; one that knows
+# not to ask takes milliseconds. The budget is far below the gateway's own
+# timeout so it cannot pass by accident.
+LIST_BUDGET_SEC = 1.5
+SERVICE_TIMEOUT_SEC = 5.0
+
+
+def generate_test_description():
+    manager = ExecuteProcess(
+        cmd=[
+            sys.executable,
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         'slow_planned_stop_manager.py'),
+            '--delay', '0',
+            '--window',
+            '--drop-after', str(DROP_AFTER_SEC),
+        ],
+        name='vanishing_planned_stop_manager',
+        output='screen',
+    )
+
+    gateway = create_gateway_node(
+        extra_params={
+            'fault_manager.namespace': 'slow',
+            'fault_manager.service_timeout_sec': SERVICE_TIMEOUT_SEC,
+            'sse.keepalive_interval_sec': 2,
+        },
+    )
+
+    return (
+        LaunchDescription([
+            manager,
+            TimerAction(period=2.0, actions=[gateway]),
+            launch_testing.actions.ReadyToTest(),
+        ]),
+        {'gateway_node': gateway},
+    )
+
+
+class TestPlannedStopsStaleWindows(GatewayTestCase):
+    """A window nobody can read must stop being reported."""
+
+    MIN_EXPECTED_APPS = 0
+    REQUIRED_APPS = set()
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        rclpy.init()
+        cls._publisher_node = Node('stale_window_event_publisher')
+        cls._event_pub = cls._publisher_node.create_publisher(
+            FaultEvent, '/slow/fault_manager/events', 10
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._publisher_node.destroy_node()
+        rclpy.shutdown()
+
+    def _publish_event(self, fault_code):
+        event = FaultEvent()
+        event.event_type = FaultEvent.EVENT_CONFIRMED
+        event.fault.fault_code = fault_code
+        event.fault.severity = Fault.SEVERITY_ERROR
+        event.fault.status = Fault.STATUS_CONFIRMED
+        event.fault.first_occurred.sec = int(time.time())
+        event.fault.last_occurred.sec = event.fault.first_occurred.sec
+        event.fault.occurrence_count = 1
+        event.fault.reporting_sources = ['/powertrain/engine/temp_sensor']
+        event.timestamp.sec = event.fault.first_occurred.sec
+        self._event_pub.publish(event)
+        rclpy.spin_once(self._publisher_node, timeout_sec=0.05)
+
+    def _timed_get(self, path):
+        started = time.monotonic()
+        response = requests.get(f'{self.BASE_URL}{path}', timeout=SERVICE_TIMEOUT_SEC * 4)
+        return response, time.monotonic() - started
+
+    def test_the_flag_goes_quiet_when_the_windows_stop_being_readable(self):
+        # S2's first half: the gateway must genuinely READ the window first, or
+        # the end state proves nothing.
+        windows, _ = self._timed_get(PLANNED_STOPS)
+        self.assertEqual(windows.status_code, 200, windows.text)
+        self.assertEqual(
+            [w['id'] for w in windows.json()['items']], ['stub-window'],
+            'the stub must be serving its window while it still has the service'
+        )
+
+        listing, _ = self._timed_get('/faults?status=all')
+        self.assertEqual(listing.status_code, 200, listing.text)
+        self.assertIn(
+            'expected_count', listing.json()['x-medkit'],
+            'while the windows are readable the tally must be stated'
+        )
+
+        # Now let the services go, and the knowledge age out behind them.
+        deadline = time.monotonic() + DROP_AFTER_SEC + KNOWLEDGE_MAX_AGE_SEC + 30.0
+        while time.monotonic() < deadline:
+            listing, elapsed = self._timed_get('/faults?status=all')
+            self.assertEqual(listing.status_code, 200, listing.text)
+            if 'expected_count' not in listing.json()['x-medkit']:
+                break
+            time.sleep(0.5)
+        else:
+            self.fail(
+                'the fault list still reported a planned-stop tally long after the '
+                'windows became unreadable'
+            )
+
+        # S1: quiet, not false - on the items as well as the collection.
+        for item in listing.json()['items']:
+            self.assertNotIn(
+                'expected', item.get('x-medkit', {}),
+                'a fault must not be reported as unexpected on a gateway that '
+                'cannot read the windows'
+            )
+
+        # S2's second half: the two endpoints agree. One saying 503 while the
+        # other names a window is the contradiction this rules out.
+        windows, _ = self._timed_get(PLANNED_STOPS)
+        self.assertEqual(
+            windows.status_code, 503,
+            'the windows endpoint must admit it cannot read them'
+        )
+
+        # S3: and none of that costs a service timeout.
+        for _ in range(3):
+            _, elapsed = self._timed_get('/faults?status=all')
+            self.assertLess(
+                elapsed, LIST_BUDGET_SEC,
+                'the fault list waited out the planned-stop service timeout; the '
+                'client readiness check is not part of the decision to call'
+            )
+
+    def test_a_filtered_list_keeps_nothing_it_cannot_judge(self):
+        # Asking for one half of a set the gateway cannot read has no honest
+        # answer, so neither half is served.
+        for value in ('true', 'false'):
+            response, elapsed = self._timed_get(f'/faults?status=all&expected={value}')
+            self.assertEqual(response.status_code, 200, response.text)
+            self.assertEqual(
+                response.json()['items'], [],
+                f'?expected={value} served items whose flag the gateway does not know'
+            )
+            self.assertLess(elapsed, LIST_BUDGET_SEC)
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsStaleWindowsShutdown(unittest.TestCase):
+
+    def test_gateway_exits_cleanly(self, proc_info, gateway_node):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=gateway_node, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_unreachable.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_unreachable.test.py
@@ -21,12 +21,17 @@ put a declaration and nothing to list. What matters is that the gateway SAYS so
 surfaces keep working without the flag they cannot derive.
 """
 
+import json
+import threading
 import time
 import unittest
 
 import launch_testing
 import launch_testing.actions
+import rclpy
+from rclpy.node import Node
 import requests
+from ros2_medkit_msgs.msg import Fault, FaultEvent
 
 from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
@@ -53,6 +58,39 @@ class TestPlannedStopsWithoutFaultManager(GatewayTestCase):
 
     MIN_EXPECTED_APPS = 1
     REQUIRED_APPS = {'temp_sensor'}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        rclpy.init()
+        cls._publisher_node = Node('planned_stop_unreachable_publisher')
+        # The gateway subscribes to this topic whether or not a fault manager
+        # exists, so a frame can be driven onto the stream with none running -
+        # which is the only way to see what the stream says about a flag it
+        # cannot derive.
+        cls._event_pub = cls._publisher_node.create_publisher(
+            FaultEvent, '/fault_manager/events', 10
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._publisher_node.destroy_node()
+        rclpy.shutdown()
+
+    def _publish_event(self, fault_code):
+        event = FaultEvent()
+        event.event_type = FaultEvent.EVENT_CONFIRMED
+        event.fault.fault_code = fault_code
+        event.fault.severity = Fault.SEVERITY_ERROR
+        event.fault.status = Fault.STATUS_CONFIRMED
+        event.fault.description = 'published with no fault manager running'
+        event.fault.first_occurred.sec = int(time.time())
+        event.fault.last_occurred.sec = event.fault.first_occurred.sec
+        event.fault.occurrence_count = 1
+        event.fault.reporting_sources = ['/powertrain/engine/temp_sensor']
+        event.timestamp.sec = event.fault.first_occurred.sec
+        self._event_pub.publish(event)
+        rclpy.spin_once(self._publisher_node, timeout_sec=0.05)
 
     def _timed(self, method, path, **kwargs):
         started = time.monotonic()
@@ -96,6 +134,66 @@ class TestPlannedStopsWithoutFaultManager(GatewayTestCase):
         )
         self.assertEqual(response.status_code, 400, response.text)
         self.assertEqual(response.json()['parameters']['parameter'], 'to')
+
+    def test_the_stream_says_nothing_rather_than_expected_false(self):
+        """R13: a consumer must not read an outage as "nothing is expected"."""
+        frames = []
+        stop_event = threading.Event()
+        response = requests.get(
+            f'{self.BASE_URL}/faults/stream', stream=True, timeout=(5, 30)
+        )
+        self.assertEqual(response.status_code, 200)
+
+        def pump():
+            current = {}
+            try:
+                for line in response.iter_lines(decode_unicode=True):
+                    if stop_event.is_set():
+                        break
+                    if line is None:
+                        continue
+                    if line == '':
+                        if current:
+                            frames.append(current)
+                            current = {}
+                        continue
+                    if line.startswith(':'):
+                        continue
+                    key, _, value = line.partition(':')
+                    current[key.strip()] = value.strip()
+            except Exception:  # noqa: BLE001 - closed socket on teardown
+                pass
+
+        pump_thread = threading.Thread(target=pump, daemon=True)
+        pump_thread.start()
+        try:
+            payload = None
+            deadline = time.monotonic() + 25.0
+            while payload is None and time.monotonic() < deadline:
+                self._publish_event('PS_NO_MANAGER')
+                settle = min(time.monotonic() + 1.0, deadline)
+                while payload is None and time.monotonic() < settle:
+                    for frame in list(frames):
+                        data = frame.get('data')
+                        if not data:
+                            continue
+                        candidate = json.loads(data)
+                        if candidate.get('fault', {}).get('fault_code') == 'PS_NO_MANAGER':
+                            payload = candidate
+                            break
+                    time.sleep(0.1)
+            self.assertIsNotNone(payload, 'no frame for the published event reached the stream')
+
+            extension = payload.get('x-medkit', {})
+            self.assertNotIn(
+                'expected', extension,
+                'with no window set ever read, the frame must not claim the fault was unexpected'
+            )
+            self.assertNotIn('planned_stop_id', extension)
+        finally:
+            stop_event.set()
+            response.close()
+            pump_thread.join(timeout=5)
 
     def test_the_fault_stream_still_serves_without_the_flag_it_cannot_derive(self):
         # The flag is derived from windows the gateway cannot read. Losing it

--- a/src/ros2_medkit_integration_tests/test/features/test_planned_stops_unreachable.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_planned_stops_unreachable.test.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planned-stop routes with no fault manager on the graph.
+
+The windows live in the fault manager, so with none running there is nowhere to
+put a declaration and nothing to list. What matters is that the gateway SAYS so
+- 503, inside the transport's timeout - rather than hanging, and that the fault
+surfaces keep working without the flag they cannot derive.
+"""
+
+import time
+import unittest
+
+import launch_testing
+import launch_testing.actions
+import requests
+
+from ros2_medkit_test_utils.constants import ALLOWED_EXIT_CODES
+from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
+from ros2_medkit_test_utils.launch_helpers import create_test_launch
+
+PLANNED_STOPS = '/x-medkit-planned-stops'
+
+# The gateway's fault_manager.service_timeout_sec default. A route that answers
+# inside this budget answered rather than hung; the margin is what the assertion
+# is really about.
+SERVICE_TIMEOUT_SEC = 5.0
+
+
+def generate_test_description():
+    return create_test_launch(
+        demo_nodes=['temp_sensor'],
+        fault_manager=False,
+        lidar_faulty=False,
+    )
+
+
+class TestPlannedStopsWithoutFaultManager(GatewayTestCase):
+    """No fault manager: every planned-stop route must fail loudly and quickly."""
+
+    MIN_EXPECTED_APPS = 1
+    REQUIRED_APPS = {'temp_sensor'}
+
+    def _timed(self, method, path, **kwargs):
+        started = time.monotonic()
+        response = requests.request(
+            method, f'{self.BASE_URL}{path}', timeout=SERVICE_TIMEOUT_SEC * 4, **kwargs
+        )
+        return response, time.monotonic() - started
+
+    def test_declaring_answers_503_rather_than_hanging(self):
+        response, elapsed = self._timed(
+            'POST', PLANNED_STOPS,
+            json={'to': '2037-01-01T00:00:00Z', 'reason': 'nobody home'},
+        )
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertEqual(response.json()['error_code'], 'service-unavailable')
+        self.assertLess(
+            elapsed, SERVICE_TIMEOUT_SEC * 3,
+            'the route must give up on the transport timeout, not sit on the request'
+        )
+
+    def test_listing_answers_503(self):
+        response, elapsed = self._timed('GET', PLANNED_STOPS)
+        self.assertEqual(response.status_code, 503, response.text)
+        self.assertLess(elapsed, SERVICE_TIMEOUT_SEC * 3)
+
+    def test_reading_one_answers_503_not_404(self):
+        # 404 would be a claim about the store, and there is no store to make a
+        # claim about.
+        response, _ = self._timed('GET', f'{PLANNED_STOPS}/whatever')
+        self.assertEqual(response.status_code, 503, response.text)
+
+    def test_ending_answers_503_not_404(self):
+        response, _ = self._timed('DELETE', f'{PLANNED_STOPS}/whatever')
+        self.assertEqual(response.status_code, 503, response.text)
+
+    def test_a_bad_request_is_still_a_bad_request(self):
+        # Validation runs before the transport, so the caller is told what is
+        # wrong with the request instead of being told the server is down.
+        response, _ = self._timed(
+            'POST', PLANNED_STOPS, json={'to': 'not a timestamp', 'reason': 'x'}
+        )
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertEqual(response.json()['parameters']['parameter'], 'to')
+
+    def test_the_fault_stream_still_serves_without_the_flag_it_cannot_derive(self):
+        # The flag is derived from windows the gateway cannot read. Losing it
+        # must not cost the stream: a consumer with no fault manager still needs
+        # its connection, and it must not wait a transport timeout per frame.
+        started = time.monotonic()
+        response = requests.get(
+            f'{self.BASE_URL}/faults/stream', stream=True, timeout=(5, 15)
+        )
+        try:
+            self.assertEqual(response.status_code, 200)
+            self.assertLess(time.monotonic() - started, SERVICE_TIMEOUT_SEC * 2)
+        finally:
+            response.close()
+
+
+@launch_testing.post_shutdown_test()
+class TestPlannedStopsUnreachableShutdown(unittest.TestCase):
+
+    def test_gateway_exits_cleanly(self, proc_info, gateway_node):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=gateway_node, allowable_exit_codes=ALLOWED_EXIT_CODES
+        )

--- a/src/ros2_medkit_msgs/CMakeLists.txt
+++ b/src/ros2_medkit_msgs/CMakeLists.txt
@@ -32,6 +32,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/EnvironmentData.msg"
   "msg/MedkitDiscoveryHint.msg"
   "msg/EntityInfo.msg"
+  "msg/PlannedStop.msg"
   "srv/ReportFault.srv"
   "srv/ListFaults.srv"
   "srv/GetFault.srv"
@@ -43,6 +44,9 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListEntities.srv"
   "srv/GetEntityData.srv"
   "srv/GetCapabilities.srv"
+  "srv/DeclarePlannedStop.srv"
+  "srv/EndPlannedStop.srv"
+  "srv/ListPlannedStops.srv"
   DEPENDENCIES builtin_interfaces diagnostic_msgs
 )
 

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -173,11 +173,13 @@ Declare a window during which faults are expected. Windows may overlap and may l
 | `success` | bool | True when the window was stored |
 | `message` | string | Why the declaration was refused; empty on success |
 | `stop` | PlannedStop | The stored window, including its assigned id |
-| `outcome` | uint8 | `OUTCOME_STORED`, `OUTCOME_INVALID_INTERVAL`, `OUTCOME_INVALID_INSTANT`, `OUTCOME_DUPLICATE_ID` or `OUTCOME_NOT_RETAINED`. A caller maps a refusal onto its own answer from this, never from the message prose |
+| `outcome` | uint8 | `OUTCOME_STORED`, `OUTCOME_INVALID_INTERVAL`, `OUTCOME_INVALID_INSTANT`, `OUTCOME_DUPLICATE_ID` or `OUTCOME_NOT_RETAINED` (the retention bound is full of windows that have not ended). A caller maps a refusal onto its own answer from this, never from the message prose |
 
 ### EndPlannedStop.srv
 
-Stop a window. A window still **running** at the given instant is cut short: `ends_at` moves there and `ended_early` becomes true, so faults whose cycle started before it stay expected and faults raised after it do not. A window that has **not started** by then is cancelled - removed, with `cancelled` set on the copy returned - because it marked nothing and storing `ends_at <= starts_at` would contradict the message's own promise. A window that has **already ended** cannot be ended again, and a backdated instant cannot walk its end backwards.
+Stop a window. Whether it is **finished**, **not started** or **running** is decided against the fault manager's own wall clock, never against the `at` sent.
+
+A window still running is cut short: `ends_at` moves to `at` and `ended_early` becomes true, so faults whose cycle started before it stay expected and faults raised after it do not. `at` must fall in `(starts_at, now]` - strictly after the start, because ending at the start would store a zero-length window - and is refused outside that range rather than clamped. A window that has not started is cancelled: removed, with `cancelled` set on the copy returned, because it marked nothing and storing `ends_at <= starts_at` would contradict the message's own promise. A window that has already finished cannot be touched again, backdated instants included.
 
 **Request:**
 | Field | Type | Description |
@@ -191,14 +193,14 @@ Stop a window. A window still **running** at the given instant is cut short: `en
 | `success` | bool | True when the window was ended or cancelled |
 | `message` | string | Why the request was refused |
 | `stop` | PlannedStop | The window after the request: cut short, or as it was for a cancellation |
-| `outcome` | uint8 | `OUTCOME_ENDED`, `OUTCOME_CANCELLED`, `OUTCOME_NOT_FOUND` or `OUTCOME_ALREADY_ENDED` |
+| `outcome` | uint8 | `OUTCOME_ENDED`, `OUTCOME_CANCELLED`, `OUTCOME_NOT_FOUND`, `OUTCOME_ALREADY_ENDED` or `OUTCOME_INVALID_AT` |
 
 ### ListPlannedStops.srv
 
 **Request:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `active_only` | bool | When true, return only the windows containing `now` |
+| `active_only` | bool | When true, return only the windows that have NOT ENDED at `now` - running and not-yet-started alike, the same notion retention uses |
 | `now` | builtin_interfaces/Time | The instant `active_only` is evaluated against; zero means the fault manager's own wall clock |
 
 **Response:**

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -86,8 +86,9 @@ A window of wall-clock time during which faults are expected. An operator declar
 | `declared_by` | string | Authenticated client id, or `anonymous` |
 | `declared_at` | builtin_interfaces/Time | When the declaration was recorded; retention orders by this field |
 | `ended_early` | bool | True when an operator cut the window short |
+| `cancelled` | bool | True on the copy returned when a window was stopped before it ever started, and therefore removed. Never true on a stored window |
 
-A fault is expected when its `first_occurred` lies in `[starts_at, ends_at]`. The fields are named `starts_at` / `ends_at` rather than `from` / `to` because a message field named `from` is a Python keyword and rosidl cannot generate a binding for it; the gateway's REST representation of the same window uses `from` and `to`.
+A fault is expected when its `first_occurred` lies in `[starts_at, ends_at]`, compared at millisecond resolution. The fields are named `starts_at` / `ends_at` rather than `from` / `to` because a message field named `from` is a Python keyword and rosidl cannot generate a binding for it; the gateway's REST representation of the same window uses `from` and `to`.
 
 ## Services
 
@@ -161,7 +162,7 @@ Declare a window during which faults are expected. Windows may overlap and may l
 **Request:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `starts_at` | builtin_interfaces/Time | Start of the window (wall clock, UTC) |
+| `starts_at` | builtin_interfaces/Time | Start of the window (wall clock, UTC). Must be after the Unix epoch: zero is what an unset Time reads as, never a request for "now" |
 | `ends_at` | builtin_interfaces/Time | End of the window; must be strictly after `starts_at` |
 | `reason` | string | Why the plant is stopping |
 | `declared_by` | string | Who is declaring it; empty means the caller did not say |
@@ -172,10 +173,11 @@ Declare a window during which faults are expected. Windows may overlap and may l
 | `success` | bool | True when the window was stored |
 | `message` | string | Why the declaration was refused; empty on success |
 | `stop` | PlannedStop | The stored window, including its assigned id |
+| `outcome` | uint8 | `OUTCOME_STORED`, `OUTCOME_INVALID_INTERVAL`, `OUTCOME_INVALID_INSTANT`, `OUTCOME_DUPLICATE_ID` or `OUTCOME_NOT_RETAINED`. A caller maps a refusal onto its own answer from this, never from the message prose |
 
 ### EndPlannedStop.srv
 
-Cut a window short: `ends_at` moves to the given instant and `ended_early` becomes true. Faults whose cycle started before that instant stay expected; faults raised after it do not. A window whose `ends_at` has already passed cannot be ended again.
+Stop a window. A window still **running** at the given instant is cut short: `ends_at` moves there and `ended_early` becomes true, so faults whose cycle started before it stay expected and faults raised after it do not. A window that has **not started** by then is cancelled - removed, with `cancelled` set on the copy returned - because it marked nothing and storing `ends_at <= starts_at` would contradict the message's own promise. A window that has **already ended** cannot be ended again, and a backdated instant cannot walk its end backwards.
 
 **Request:**
 | Field | Type | Description |
@@ -186,9 +188,10 @@ Cut a window short: `ends_at` moves to the given instant and `ended_early` becom
 **Response:**
 | Field | Type | Description |
 |-------|------|-------------|
-| `success` | bool | True when the window was ended |
-| `message` | string | Why the request was refused; distinguishes an unknown id from an already-ended window |
-| `stop` | PlannedStop | The window as stored after the request |
+| `success` | bool | True when the window was ended or cancelled |
+| `message` | string | Why the request was refused |
+| `stop` | PlannedStop | The window after the request: cut short, or as it was for a cancellation |
+| `outcome` | uint8 | `OUTCOME_ENDED`, `OUTCOME_CANCELLED`, `OUTCOME_NOT_FOUND` or `OUTCOME_ALREADY_ENDED` |
 
 ### ListPlannedStops.srv
 

--- a/src/ros2_medkit_msgs/README.md
+++ b/src/ros2_medkit_msgs/README.md
@@ -73,6 +73,22 @@ Real-time fault event notification for SSE streaming (published on `/fault_manag
 | `EVENT_CLEARED` | Fault ends: CLEARED via ClearFault, or HEALED by PASSED events (`fault.status` tells which) |
 | `EVENT_UPDATED` | Fault data changes without status transition |
 
+### PlannedStop.msg
+
+A window of wall-clock time during which faults are expected. An operator declares the window at runtime; the fault manager stores it and serves it. Nothing in the fault pipeline consults a window - a fault whose cycle starts inside one is confirmed, healed, cleared, captured, published and audited exactly as any other fault. The window only lets a reader tell the two apart.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Server-assigned identifier, unique within one fault manager |
+| `starts_at` | builtin_interfaces/Time | Start of the window (wall clock, UTC) |
+| `ends_at` | builtin_interfaces/Time | End of the window (wall clock, UTC); always strictly after `starts_at` |
+| `reason` | string | Why the plant is stopping |
+| `declared_by` | string | Authenticated client id, or `anonymous` |
+| `declared_at` | builtin_interfaces/Time | When the declaration was recorded; retention orders by this field |
+| `ended_early` | bool | True when an operator cut the window short |
+
+A fault is expected when its `first_occurred` lies in `[starts_at, ends_at]`. The fields are named `starts_at` / `ends_at` rather than `from` / `to` because a message field named `from` is a Python keyword and rosidl cannot generate a binding for it; the gateway's REST representation of the same window uses `from` and `to`.
+
 ## Services
 
 ### ReportFault.srv
@@ -137,6 +153,55 @@ Clear/acknowledge a fault. Cleared faults are retained and queryable with `statu
 | `auto_cleared_codes` | string[] | Symptom fault codes auto-cleared with the root cause (empty when `skip_correlation_auto_clear=true`) |
 
 > **Note:** `skip_correlation_auto_clear` was added in `ros2_medkit_msgs` post-0.4.0. Adding a request field changes the service type hash, so out-of-tree callers that invoke `/fault_manager/clear_fault` directly (via `ros2 service call` or a generated client) must rebuild against the new `ros2_medkit_msgs` release to keep talking to `fault_manager`.
+
+### DeclarePlannedStop.srv
+
+Declare a window during which faults are expected. Windows may overlap and may lie wholly in the past.
+
+**Request:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `starts_at` | builtin_interfaces/Time | Start of the window (wall clock, UTC) |
+| `ends_at` | builtin_interfaces/Time | End of the window; must be strictly after `starts_at` |
+| `reason` | string | Why the plant is stopping |
+| `declared_by` | string | Who is declaring it; empty means the caller did not say |
+
+**Response:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | True when the window was stored |
+| `message` | string | Why the declaration was refused; empty on success |
+| `stop` | PlannedStop | The stored window, including its assigned id |
+
+### EndPlannedStop.srv
+
+Cut a window short: `ends_at` moves to the given instant and `ended_early` becomes true. Faults whose cycle started before that instant stay expected; faults raised after it do not. A window whose `ends_at` has already passed cannot be ended again.
+
+**Request:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Identifier of the window to end |
+| `at` | builtin_interfaces/Time | Instant to end at; zero means the fault manager's own wall clock |
+
+**Response:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `success` | bool | True when the window was ended |
+| `message` | string | Why the request was refused; distinguishes an unknown id from an already-ended window |
+| `stop` | PlannedStop | The window as stored after the request |
+
+### ListPlannedStops.srv
+
+**Request:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `active_only` | bool | When true, return only the windows containing `now` |
+| `now` | builtin_interfaces/Time | The instant `active_only` is evaluated against; zero means the fault manager's own wall clock |
+
+**Response:**
+| Field | Type | Description |
+|-------|------|-------------|
+| `stops` | PlannedStop[] | Every stored window, newest declaration first |
 
 ## Usage
 

--- a/src/ros2_medkit_msgs/msg/PlannedStop.msg
+++ b/src/ros2_medkit_msgs/msg/PlannedStop.msg
@@ -48,3 +48,8 @@ builtin_interfaces/Time declared_at
 # True when an operator cut the window short, which moved ends_at to the moment
 # of that request. False for a window that ran or is running to its declared end.
 bool ended_early
+
+# True on the copy returned when a window was CANCELLED: stopped before it ever
+# started, and therefore removed rather than shortened. Never true on a stored
+# window - a cancelled one is gone - so a listing never carries it.
+bool cancelled

--- a/src/ros2_medkit_msgs/msg/PlannedStop.msg
+++ b/src/ros2_medkit_msgs/msg/PlannedStop.msg
@@ -1,0 +1,50 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# PlannedStop.msg - a window of wall-clock time during which faults are expected.
+#
+# An operator declares the window; the fault manager stores it and serves it.
+# Nothing in the fault pipeline consults a window: a fault whose cycle starts
+# inside one is confirmed, healed, cleared, captured, published and audited
+# exactly as any other fault. The window only lets a reader tell the two apart.
+#
+# Field names are starts_at / ends_at rather than from / to because a message
+# field named "from" is a Python keyword and rosidl cannot generate a binding
+# for it. The REST representation of this same window uses "from" and "to".
+
+# Server-assigned identifier, unique within one fault manager
+string id
+
+# Start of the window (wall clock, UTC). A fault whose first_occurred lies in
+# [starts_at, ends_at] is expected.
+builtin_interfaces/Time starts_at
+
+# End of the window (wall clock, UTC). Always strictly greater than starts_at.
+builtin_interfaces/Time ends_at
+
+# Why the plant is stopping: a changeover, a maintenance weekend, a line move
+string reason
+
+# Who declared it: the authenticated client id, or "anonymous" when the
+# declaration arrived without authentication
+string declared_by
+
+# When the declaration was recorded (wall clock, UTC). Retention orders by this
+# field, not by starts_at, because a window declared after the fact describes a
+# stop that already happened.
+builtin_interfaces/Time declared_at
+
+# True when an operator cut the window short, which moved ends_at to the moment
+# of that request. False for a window that ran or is running to its declared end.
+bool ended_early

--- a/src/ros2_medkit_msgs/srv/DeclarePlannedStop.srv
+++ b/src/ros2_medkit_msgs/srv/DeclarePlannedStop.srv
@@ -18,7 +18,9 @@
 # the plant, not about when someone typed it in. The only refusal is a window
 # that does not describe an interval (ends_at <= starts_at).
 
-# Start of the window (wall clock, UTC)
+# Start of the window (wall clock, UTC). Must be after the Unix epoch: zero is
+# what an unset Time reads as and is not a sentinel for "now", so a caller that
+# wants the current instant sends the current instant.
 builtin_interfaces/Time starts_at
 
 # End of the window (wall clock, UTC); must be strictly after starts_at
@@ -38,3 +40,12 @@ string message
 
 # The stored window, including its assigned id. Meaningful only when success.
 PlannedStop stop
+
+# Which of the refusals this was, so a caller can answer differently without
+# reading the message prose, which this service is free to reword.
+uint8 outcome
+uint8 OUTCOME_STORED = 0
+uint8 OUTCOME_INVALID_INTERVAL = 1
+uint8 OUTCOME_INVALID_INSTANT = 2
+uint8 OUTCOME_DUPLICATE_ID = 3
+uint8 OUTCOME_NOT_RETAINED = 4

--- a/src/ros2_medkit_msgs/srv/DeclarePlannedStop.srv
+++ b/src/ros2_medkit_msgs/srv/DeclarePlannedStop.srv
@@ -1,0 +1,40 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# DeclarePlannedStop.srv - declare a window during which faults are expected.
+#
+# Windows may overlap and may lie wholly in the past: a stop is a fact about
+# the plant, not about when someone typed it in. The only refusal is a window
+# that does not describe an interval (ends_at <= starts_at).
+
+# Start of the window (wall clock, UTC)
+builtin_interfaces/Time starts_at
+
+# End of the window (wall clock, UTC); must be strictly after starts_at
+builtin_interfaces/Time ends_at
+
+# Why the plant is stopping
+string reason
+
+# Who is declaring it; empty means the caller did not say
+string declared_by
+---
+# True when the window was stored
+bool success
+
+# Why the declaration was refused; empty on success
+string message
+
+# The stored window, including its assigned id. Meaningful only when success.
+PlannedStop stop

--- a/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
+++ b/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
@@ -1,0 +1,37 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# EndPlannedStop.srv - cut a planned-stop window short.
+#
+# Ending a window moves its ends_at to the given instant and marks it
+# ended_early. Faults whose cycle started before that instant stay expected;
+# faults raised after it do not. A window whose ends_at has already passed
+# cannot be ended again.
+
+# Identifier of the window to end
+string id
+
+# Instant the window should end at (wall clock, UTC). Zero means "now", which
+# is what an operator pressing stop means.
+builtin_interfaces/Time at
+---
+# True when the window was ended
+bool success
+
+# Why the request was refused; empty on success. Distinguishes an unknown id
+# from a window that has already ended.
+string message
+
+# The window as stored after the request. Meaningful only when success.
+PlannedStop stop

--- a/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
+++ b/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
@@ -14,18 +14,27 @@
 
 # EndPlannedStop.srv - stop a planned-stop window.
 #
-# A window still running at the given instant is CUT SHORT: ends_at moves there
-# and ended_early is set. Faults whose cycle started before that instant stay
-# expected; faults raised after it do not. A window that has not STARTED by then
-# is CANCELLED - removed, with cancelled set on the copy returned - because it
-# marked nothing. A window that has already ended cannot be ended again, and a
-# backdated instant cannot walk its end backwards.
+# A window still running NOW is CUT SHORT: ends_at moves to `at` and ended_early
+# is set. Faults whose cycle started before that instant stay expected; faults
+# raised after it do not. A window that has not STARTED yet is CANCELLED -
+# removed, with cancelled set on the copy returned - because it marked nothing.
+# A window that has already finished, early or on its own, cannot be touched
+# again: when a stop finished is not something a later request gets to rewrite.
+#
+# "Finished", "not started" and "running" are all judged against the fault
+# manager's wall clock. `at` only picks where inside [starts_at, now] a running
+# window ends, and is refused outside that range rather than clamped.
 
 # Identifier of the window to end
 string id
 
-# Instant the window should end at (wall clock, UTC). Zero means "now", which
-# is what an operator pressing stop means.
+# Instant the window should end at (wall clock, UTC). Zero means "now", which is
+# what an operator pressing stop means.
+#
+# This only REFINES the end of a window that is running: it must lie in
+# [starts_at, now]. Which of the three situations the window is in - finished,
+# not started, running - is decided against the fault manager's own clock, never
+# against this field.
 builtin_interfaces/Time at
 ---
 # True when the window was ended
@@ -46,3 +55,4 @@ uint8 OUTCOME_ENDED = 0
 uint8 OUTCOME_CANCELLED = 1
 uint8 OUTCOME_NOT_FOUND = 2
 uint8 OUTCOME_ALREADY_ENDED = 3
+uint8 OUTCOME_INVALID_AT = 4

--- a/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
+++ b/src/ros2_medkit_msgs/srv/EndPlannedStop.srv
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# EndPlannedStop.srv - cut a planned-stop window short.
+# EndPlannedStop.srv - stop a planned-stop window.
 #
-# Ending a window moves its ends_at to the given instant and marks it
-# ended_early. Faults whose cycle started before that instant stay expected;
-# faults raised after it do not. A window whose ends_at has already passed
-# cannot be ended again.
+# A window still running at the given instant is CUT SHORT: ends_at moves there
+# and ended_early is set. Faults whose cycle started before that instant stay
+# expected; faults raised after it do not. A window that has not STARTED by then
+# is CANCELLED - removed, with cancelled set on the copy returned - because it
+# marked nothing. A window that has already ended cannot be ended again, and a
+# backdated instant cannot walk its end backwards.
 
 # Identifier of the window to end
 string id
@@ -33,5 +35,14 @@ bool success
 # from a window that has already ended.
 string message
 
-# The window as stored after the request. Meaningful only when success.
+# The window after the request: cut short, or as it was for a cancellation.
+# Meaningful only when success.
 PlannedStop stop
+
+# Which of the outcomes this was, so a caller can answer differently without
+# reading the message prose, which this service is free to reword.
+uint8 outcome
+uint8 OUTCOME_ENDED = 0
+uint8 OUTCOME_CANCELLED = 1
+uint8 OUTCOME_NOT_FOUND = 2
+uint8 OUTCOME_ALREADY_ENDED = 3

--- a/src/ros2_medkit_msgs/srv/ListPlannedStops.srv
+++ b/src/ros2_medkit_msgs/srv/ListPlannedStops.srv
@@ -14,7 +14,10 @@
 
 # ListPlannedStops.srv - list the declared planned-stop windows.
 
-# When true, return only the windows containing 'now'
+# When true, return only the windows that have NOT ENDED at 'now' - the ones
+# still running and the ones that have yet to start. That is the same notion
+# retention uses, so this lists exactly the windows that cannot be pruned and
+# are therefore holding the planned_stop.max_windows bound.
 bool active_only
 
 # The instant 'active_only' is evaluated against (wall clock, UTC). Zero means

--- a/src/ros2_medkit_msgs/srv/ListPlannedStops.srv
+++ b/src/ros2_medkit_msgs/srv/ListPlannedStops.srv
@@ -1,0 +1,26 @@
+# Copyright 2026 bburda
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ListPlannedStops.srv - list the declared planned-stop windows.
+
+# When true, return only the windows containing 'now'
+bool active_only
+
+# The instant 'active_only' is evaluated against (wall clock, UTC). Zero means
+# the fault manager's own wall clock, which is what a caller without a reason
+# to disagree wants.
+builtin_interfaces/Time now
+---
+# Every stored window, newest declaration first
+PlannedStop[] stops


### PR DESCRIPTION
# Pull Request

## Summary

A plant stops on purpose: a weekend, a changeover, a maintenance slot. Every controller the fault manager watches goes quiet at once, and there was no way to tell it that this was expected. With a debounce set and healing on, every one of those faults confirms and heals, every transition is an audit row, and the first Monday starts with a fault list nobody can read.

**A planned stop is a declared window, not a suppression.** An operator declares `{from, to, reason}` through `POST /api/v1/x-medkit-planned-stops`; the gateway forwards it to a new fault manager service, and the window is stored next to the faults, so a restart inside it keeps it. A fault whose cycle started inside a window (its `first_occurred`, which resets when a cleared fault is raised again) is reported as expected: `x-medkit.expected` and `x-medkit.planned_stop_id` on every fault item, `x-medkit.expected_count` on every fault list including aggregated ones, an `expected=true|false|all` query on all five fault-list routes, and the same flag on the fault event stream. Storage, debounce, healing, capture and the audit log treat the fault exactly as any other; no code path in the fault manager consults the windows to change a transition.

**No released interface changes.** `Fault.msg` and the existing services are untouched; the flag is derived in the gateway from the windows the fault manager serves. What is new is additive: `PlannedStop.msg`, `DeclarePlannedStop.srv`, `EndPlannedStop.srv`, `ListPlannedStops.srv`.

**The rules, each written where the code decides.** Time resolution is one millisecond end to end: the parser floors, storage keeps it, responses return it unchanged, and the covering test floors the fault instant the same way, because the fault item carries `first_occurred` as a double. A window that has not started is cancelled by `DELETE`, never ended early; a running one ends at now or at an instant within its running span; a finished one is immutable, judged against the fault manager's clock and never against an instant a caller sent. An instant at or before the epoch is refused everywhere; omitting `from` on the REST side means now, and the gateway always sends an explicit start. Retention, `planned_stop.max_windows` (default 100, clamped to [1, 10000]), bounds the windows that are no longer active; an active window is never dropped, and a declaration is never pruned by the retention it triggers. On the event stream an event carries no `expected` key until the gateway has read a window set, so an outage of the fault manager cannot read as "nothing is expected". Windows are per fault manager; an aggregating gateway reports what each peer derived and counts what it actually served.

---

## Issue

- closes #656

---

## Type

- [ ] Bug fix
- [x] New feature or tests
- [ ] Breaking change
- [x] Documentation only

The relaxed `required` on `FaultStreamXMedkit` is a schema change without a behaviour break: the object was previously present only when the entity resolved and is now present on every event with the flag; the entity fields are unchanged when they resolve.

---

## Testing

- Gateway end to end, real gateway with fault manager and demo node: declare over REST, report inside and outside, list with each filter value, per-entity list, `expected_count`, the stream flag on the specific event, a window declared after the fault, a window ended early, a second cycle after a clear, a cancel, the auth roles (viewer refused on POST and DELETE), and the no-fault-manager case (503 on POST, no `expected` key on the stream). Two-gateway aggregation: the filter reaches the peer and the count includes what the peer served.
- Fault manager over its services with SQLite: restart inside a window keeps it; an expected and an unexpected fault produce the same rows and transitions; retention at 1, at the default and past the cap; the end and cancel rules against the clock on both backends.
- Unit: the covering predicate at the millisecond boundaries and with overlapping windows, the ISO 8601 parser including the overflow and epoch bounds, the ns to `Time` conversion at negative and extreme values, the retention clamp sweep, and the SSE handler with and without window knowledge.
- Mutations run and recorded: dropping the derivation, freezing the end instant, removing the migration, forwarding the fan-out without the query, restoring the instant-based guards; each reddens the tests that pin it and nothing else.
- Suites: fault manager 579 unit and 113 integration, gateway and msgs unit sweep 3468, the six feature tests above, lint clean, clang-tidy zero findings in changed hunks, Sphinx with no new warnings, OpenAPI differential against main limited to the new routes, schemas, tag and fields.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
