### PR TITLE
ci: retry the network reads our own CI steps make

### DIFF
--- a/.github/actions/ros-apt-source/action.yml
+++ b/.github/actions/ros-apt-source/action.yml
@@ -49,7 +49,13 @@ runs:
         url="https://github.com/ros-infrastructure/ros-apt-source/releases/download/${version}/${deb}"
 
         echo "Installing ${deb} (ros-apt-source ${version}, ${codename})"
-        curl --fail --location --retry 5 --retry-delay 3 -o "/tmp/${deb}" "${url}"
+        # This download has no fallback: the version lookup above can fall back to
+        # a pin, but a 5xx on the release asset itself ends the job. The retry
+        # window is therefore minutes rather than seconds, so a short outage on
+        # the release host is waited out instead of failing every job that starts
+        # during it.
+        curl --fail --location --retry 8 --retry-delay 15 --retry-max-time 180 \
+          -o "/tmp/${deb}" "${url}"
         $SUDO dpkg -i "/tmp/${deb}"
         rm -f "/tmp/${deb}"
         $SUDO apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -68,13 +68,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
           if [ "${{ matrix.ros_distro }}" = "humble" ]; then
             apt-get install -y ros-humble-rmw-cyclonedds-cpp
           fi
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           # Linters (clang-tidy / clang-format) only run in the Jazzy quality
           # job (quality.yml). Multiple package.xml files still list them as
           # <test_depend>, so we skip the rosdep keys here to keep build-and-
@@ -200,7 +200,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -232,13 +232,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
           if [ "${{ matrix.ros_distro }}" = "humble" ] || [ "${{ matrix.ros_distro }}" = "jazzy" ]; then
             apt-get install -y ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp
           fi
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           # Same skip-keys as build-and-test: the linters run only in the Jazzy quality job.
           rosdep install --from-paths src --ignore-src -y \
             --skip-keys "ament_cmake_clang_tidy ament_cmake_clang_format"
@@ -332,7 +332,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -366,12 +366,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y \
             ros-jazzy-test-msgs \
             ros-jazzy-rmw-cyclonedds-cpp
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Build packages
@@ -500,7 +500,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -532,11 +532,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           # gpg is required by codecov/codecov-action@v5 dependency check
           apt-get install -y lcov ros-jazzy-test-msgs gpg
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -r -y
 
       - name: Build packages with coverage
@@ -663,7 +663,7 @@ jobs:
     steps:
       - name: Install tools
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           # gpg and curl are both required by the codecov action's dependency
           # check, which fails the step rather than skipping the upload.
           apt-get install -y git lcov gpg curl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
           if [ "${{ matrix.ros_distro }}" = "humble" ]; then
             apt-get install -y ros-humble-rmw-cyclonedds-cpp
@@ -200,7 +200,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -232,7 +232,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs
           if [ "${{ matrix.ros_distro }}" = "humble" ] || [ "${{ matrix.ros_distro }}" = "jazzy" ]; then
             apt-get install -y ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp
@@ -332,7 +332,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -366,7 +366,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y \
             ros-jazzy-test-msgs \
             ros-jazzy-rmw-cyclonedds-cpp
@@ -500,7 +500,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -532,7 +532,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           # gpg is required by codecov/codecov-action@v5 dependency check
           apt-get install -y lcov ros-jazzy-test-msgs gpg
           source /opt/ros/jazzy/setup.bash
@@ -663,7 +663,7 @@ jobs:
     steps:
       - name: Install tools
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           # gpg and curl are both required by the codecov action's dependency
           # check, which fails the step rather than skipping the upload.
           apt-get install -y git lcov gpg curl

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get update
           sudo apt-get install -y graphviz plantuml doxygen
           pip install -e docs/.[dev]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y graphviz plantuml doxygen
           pip install -e docs/.[dev]
 

--- a/.github/workflows/opcua-plugin.yml
+++ b/.github/workflows/opcua-plugin.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -82,10 +82,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs libyaml-cpp-dev libssl-dev
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           # Skip nav2_msgs (vda5050_agent declares it; not available on all
           # distros) and the linter rosdep keys. Linters only run in the Jazzy
           # quality job, so we don't need them installed here. The upstream
@@ -242,7 +242,7 @@ jobs:
 
       - name: Install jq + asyncua (smoke test prerequisite)
         run: |
-          sudo apt-get update
+          sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get install -y jq python3-pip
           pip3 install --break-system-packages asyncua
 
@@ -276,7 +276,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -303,12 +303,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           # openssl: cert generation. libssl-dev: encryption backend for both
           # the plugin's open62541pp and the fixture's static open62541.
           apt-get install -y ros-jazzy-test-msgs libyaml-cpp-dev libssl-dev openssl
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y \
             --skip-keys='nav2_msgs ament_cmake_clang_format ament_cmake_clang_tidy'
 

--- a/.github/workflows/opcua-plugin.yml
+++ b/.github/workflows/opcua-plugin.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -82,7 +82,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-${{ matrix.ros_distro }}-test-msgs libyaml-cpp-dev libssl-dev
           source /opt/ros/${{ matrix.ros_distro }}/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
@@ -242,7 +242,7 @@ jobs:
 
       - name: Install jq + asyncua (smoke test prerequisite)
         run: |
-          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get update
           sudo apt-get install -y jq python3-pip
           pip3 install --break-system-packages asyncua
 
@@ -276,7 +276,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -303,7 +303,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           # openssl: cert generation. libssl-dev: encryption backend for both
           # the plugin's open62541pp and the fixture's static open62541.
           apt-get install -y ros-jazzy-test-msgs libyaml-cpp-dev libssl-dev openssl

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -49,10 +49,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y clang-format ccache
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Cache ccache
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -160,10 +160,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Build (compile database only, no clang-tidy)
@@ -265,7 +265,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -292,10 +292,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Redirect heavy build output to /mnt
@@ -419,7 +419,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -446,10 +446,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Redirect heavy build output to /mnt
@@ -566,7 +566,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y git
 
       - name: Checkout repository
@@ -598,10 +598,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
+          apt-get -o Acquire::Retries=3 update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
-          rosdep update
+          for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
           rosdep install --from-paths src --ignore-src -y
 
       - name: Redirect heavy build output to /mnt

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y clang-format ccache
           source /opt/ros/jazzy/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
@@ -113,7 +113,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -146,7 +146,7 @@ jobs:
       - name: Install clang-tidy-cache (ctcache)
         run: |
           apt-get install -y python3-pip
-          pip3 install --break-system-packages git+https://github.com/matus-chochlik/ctcache.git@3880541496c7ce0d2e2830d2f525375078fe0b1f
+          for attempt in 1 2 3; do pip3 install --break-system-packages git+https://github.com/matus-chochlik/ctcache.git@3880541496c7ce0d2e2830d2f525375078fe0b1f && break; [ "$attempt" = 3 ] && exit 1; echo "ctcache install attempt $attempt failed, retrying" >&2; sleep 5; done
           printf '#!/bin/sh\nexec clang-tidy-cache /usr/bin/clang-tidy "$@"\n' > /usr/local/bin/ctcache-wrapper
           chmod +x /usr/local/bin/ctcache-wrapper
 
@@ -160,7 +160,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
@@ -265,7 +265,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -292,7 +292,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
@@ -419,7 +419,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -446,7 +446,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done
@@ -566,7 +566,7 @@ jobs:
     steps:
       - name: Install Git
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y git
 
       - name: Checkout repository
@@ -598,7 +598,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get -o Acquire::Retries=3 update
+          apt-get update
           apt-get install -y ros-jazzy-test-msgs
           source /opt/ros/jazzy/setup.bash
           for attempt in 1 2 3; do rosdep update && break; [ "$attempt" = 3 ] && exit 1; echo "rosdep update attempt $attempt failed, retrying" >&2; sleep 5; done


### PR DESCRIPTION
# Pull Request

## Summary

Every CI job reads from the network before anything of ours is built, and `rosdep update` is the one of those reads this branch can wrap: it fetches the distribution index from raw.githubusercontent.com. A reset connection there fails the whole job with an error that has nothing to do with the change under test. Two jobs on two pull requests failed that way within an hour on the day this branch was opened, both on `rosdep update` with `Connection reset by peer`.

`rosdep update` now gets three attempts five seconds apart in every workflow step that calls it (`ci.yml`, `quality.yml`, `opcua-plugin.yml`). The ctcache install in the clang-tidy job gets the same loop: it is a `git+https` URL, so pip runs `git clone` in a subprocess to fetch it, and pip's own `--retries` only covers its HTTP session. A genuine failure still ends the job after the last attempt with its own error text; the loop only names the attempt.

The release-asset download in `.github/actions/ros-apt-source` gets a wider window. It already retried, but only for about 18 seconds, and a job on this branch died when GitHub answered 500 to all six attempts. That download is the one fetch in the action with nothing to fall back to: the version lookup above it can use the pinned value, but a 5xx on the .deb ends the step, and setup-ros then has no apt source, so the build stops at `colcon: command not found`. Measured against a server that answers 500 every time, the old flags make 6 attempts over 18 s and the new ones make 9 over 131 s.

One read stays unprotected, and it runs earlier than any of these. `ros-tooling/setup-ros@v0.7` removes `/etc/ros/rosdep/sources.list.d/20-default.list` and then runs `sudo rosdep init` once, with no retry around it (`src/setup-ros-ubuntu.ts:135-137` in the action). That call fetches `20-default.list` from raw.githubusercontent.com, the same host that fails here, and it happens before the step this branch touches, so a reset there still ends the job. Wrapping it would mean not using the action, which is a larger change than this one.

`apt-get update` is left alone on purpose. apt has defaulted `Acquire::Retries` to 3 since 2.3.2. Measured on the three images this repository builds in, a fetch against a dead endpoint makes the same four attempts with the flag and without it:

| image | apt | no flag | `-o Acquire::Retries=3` | `-o Acquire::Retries=0` |
|---|---|---|---|---|
| ubuntu:jammy | 2.4.14 | 4 attempts | 4 attempts | 1 attempt |
| ubuntu:noble | 2.8.3 | 4 attempts | 4 attempts | 1 attempt |
| ubuntu:resolute | 3.2.0 | 4 attempts | 4 attempts | 1 attempt |

---

## Issue

- none: a CI hardening with no behaviour change in the repository's code

---

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

CI configuration only.

---

## Testing

- Every workflow file still loads as YAML.
- The diff against `main` is the 11 `rosdep update` call sites, the ctcache install, and the curl flags plus their comment in the apt-source action. No other line is touched.
- The loop was exercised the way the workflow runs it. Each step body was read out of the YAML and run under the shell GitHub Actions uses (`bash --noprofile --norc -eo pipefail`), with a stand-in `rosdep` and `pip3` that fail a set number of times. `set -e` does not stop the step on a failed attempt: with zero, one or two failures the step ends at 0 and the following `rosdep install` still runs; with three failures the step ends at 1 and the last error is visible.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed
