### PR TITLE
integration_tests: bound two timing cases on what they can actually prove

### DIFF
--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -112,12 +112,14 @@ PRE_BACKSTOP_BUDGET_SEC = 50.0
 # See PRE_BACKSTOP_BUDGET_SEC for why this is the reference point.
 _LAUNCH_DESCRIBED_AT = None
 
-# The latency of the graph-event path itself, measured from process spawn. It
-# cannot be sub-second: the gateway coalesces graph events behind
-# discovery.refresh_debounce_ms, 1000 ms by default, and a spawn that arrives
-# mid-window waits for the next one, so detection lands on a multiple of the
-# debounce. Measured on a developer machine with the default settings, the
-# spread is roughly 1 s to 3.6 s. The budget scales with the sanitizer factor.
+# The latency of the graph-event path itself, measured from process spawn. The
+# gateway coalesces graph events behind discovery.refresh_debounce_ms, 1000 ms
+# by default: the first event after a quiet period is serviced at the next
+# 100 ms tick, and every event inside the window that follows waits for the
+# window to end. A node coming up raises several events in a row, so its
+# detection typically lands one window after its first event. Measured on a
+# developer machine with the default settings, the spread is roughly 1 s to
+# 3.6 s. The budget scales with the sanitizer factor.
 GRAPH_EVENT_MAX_LATENCY_SEC = 10.0 * get_time_scale()
 
 # Initial discovery shares the budget with full gateway startup, so it scales

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -91,21 +91,26 @@ LATE_NODE_KEY = 'pressure_sensor'
 # instrumented work, so the budget scales with the sanitizer factor.
 SPAWN_DETECTION_TIMEOUT = 15.0 * get_time_scale()
 
-# How long after the gateway first answered /health the spawn case may still
-# measure. A measurement inside this budget is one no backstop sweep could have
+# How long after the launch description was generated the spawn case may still
+# measure. launch_testing builds the description in this process and only then
+# starts the launch service that forks the gateway, and the gateway arms its
+# backstop timer during its own initialisation, so the timer is armed strictly
+# after that anchor and its first sweep cannot come earlier than
+# BACKSTOP_INTERVAL_MS past it: a wall timer fires late, never early. A
+# detection measured inside this budget is therefore one no sweep could have
 # served, which is what makes the bound below a statement about the graph-event
-# path. The window is derived: the backstop timer is armed during gateway
-# initialisation, ahead of start_rest_server(), whose wait for the REST server
-# to accept connections is bounded at 5 s, and the test base class then polls
-# /health every 0.5 s. So of the 60 s backstop interval about 54 s are still
-# ahead of the first sweep once /health answers, and 50 leaves a margin for
-# scheduling slack.
+# path. The gateway's own startup only widens the window; 50 keeps the
+# assertion 10 s clear of the 60 s edge.
 #
 # This budget deliberately does NOT scale with MEDKIT_TEST_TIME_SCALE. It is
 # bounded by the gateway's own backstop interval, which the scale factor does
 # not stretch; scaling the budget would let the measurement drift past the
 # first sweep, and the assertion would stop being about the graph-event path.
 PRE_BACKSTOP_BUDGET_SEC = 50.0
+
+# Taken when generate_test_description() runs, before launch forks the gateway.
+# See PRE_BACKSTOP_BUDGET_SEC for why this is the reference point.
+_LAUNCH_DESCRIBED_AT = None
 
 # The latency of the graph-event path itself, measured from process spawn. It
 # cannot be sub-second: the gateway coalesces graph events behind
@@ -121,6 +126,9 @@ INITIAL_DETECTION_TIMEOUT = 30.0 * get_time_scale()
 
 
 def generate_test_description():
+    global _LAUNCH_DESCRIBED_AT
+    _LAUNCH_DESCRIBED_AT = time.monotonic()
+
     gateway_node = create_gateway_node(
         extra_params={
             'refresh_interval_ms': BACKSTOP_INTERVAL_MS,
@@ -180,10 +188,6 @@ class TestGraphEventDiscovery(GatewayTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Reference point for PRE_BACKSTOP_BUDGET_SEC: the gateway has answered
-        # /health by the time the base class returns, so initialisation - and
-        # with it the backstop timer - started a moment earlier.
-        cls._health_at = time.monotonic()
         cls._extra_proc = None
 
     @classmethod
@@ -275,10 +279,10 @@ class TestGraphEventDiscovery(GatewayTestCase):
             # Establish what was measured before bounding it. Past this budget
             # a backstop sweep could have served the detection, and then the
             # bound below would be reporting on the wrong mechanism.
-            since_health = time.monotonic() - type(self)._health_at
+            since_launch = time.monotonic() - _LAUNCH_DESCRIBED_AT
             self.assertLess(
-                since_health, PRE_BACKSTOP_BUDGET_SEC,
-                f'detection landed {since_health:.3f}s after the gateway came up, '
+                since_launch, PRE_BACKSTOP_BUDGET_SEC,
+                f'detection landed {since_launch:.3f}s after the launch was described, '
                 f'past the {PRE_BACKSTOP_BUDGET_SEC}s window in which no backstop '
                 f'sweep can have run ({BACKSTOP_INTERVAL_MS}ms backstop), so this '
                 f'run cannot say what triggered the refresh',

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -55,6 +55,7 @@ import launch_testing.actions
 from ros2_medkit_test_utils.constants import (
     ALLOWED_EXIT_CODES,
     DEFAULT_DOMAIN_ID,
+    get_time_scale,
 )
 from ros2_medkit_test_utils.gateway_test_case import GatewayTestCase
 from ros2_medkit_test_utils.launch_helpers import (
@@ -85,26 +86,37 @@ LATE_NODE_KEY = 'pressure_sensor'
 # Spawn detection is bounded by:
 #   process exec + rclcpp init + DDS announce + 100 ms poll + refresh_cache.
 # The poll sits above the latency bound below, so a detection that arrives late
-# reports the time it took instead of a bare timeout.
-SPAWN_DETECTION_TIMEOUT = 15.0
+# reports the time it took instead of a bare timeout. Every term in that sum is
+# instrumented work, so the budget scales with the sanitizer factor.
+SPAWN_DETECTION_TIMEOUT = 15.0 * get_time_scale()
 
 # How long after the gateway first answered /health the spawn case may still
-# measure. The first backstop sweep runs BACKSTOP_INTERVAL_MS after gateway
-# initialisation, which precedes that first answer by well under a second, so a
-# measurement inside this budget is one no sweep could have served. That is what
-# makes the bound below a statement about the graph-event path.
-PRE_BACKSTOP_BUDGET_SEC = 30.0
+# measure. A measurement inside this budget is one no backstop sweep could have
+# served, which is what makes the bound below a statement about the graph-event
+# path. The window is derived: the backstop timer is armed during gateway
+# initialisation, ahead of start_rest_server(), whose wait for the REST server
+# to accept connections is bounded at 5 s, and the test base class then polls
+# /health every 0.5 s. So of the 60 s backstop interval about 54 s are still
+# ahead of the first sweep once /health answers, and 50 leaves a margin for
+# scheduling slack.
+#
+# This budget deliberately does NOT scale with MEDKIT_TEST_TIME_SCALE. It is
+# bounded by the gateway's own backstop interval, which the scale factor does
+# not stretch; scaling the budget would let the measurement drift past the
+# first sweep, and the assertion would stop being about the graph-event path.
+PRE_BACKSTOP_BUDGET_SEC = 50.0
 
 # The latency of the graph-event path itself, measured from process spawn. It
 # cannot be sub-second: the gateway coalesces graph events behind
 # discovery.refresh_debounce_ms, 1000 ms by default, and a spawn that arrives
 # mid-window waits for the next one, so detection lands on a multiple of the
 # debounce. Measured on a developer machine with the default settings, the
-# spread is roughly 1 s to 3.6 s.
-GRAPH_EVENT_MAX_LATENCY_SEC = 10.0
+# spread is roughly 1 s to 3.6 s. The budget scales with the sanitizer factor.
+GRAPH_EVENT_MAX_LATENCY_SEC = 10.0 * get_time_scale()
 
-# Initial discovery shares the budget with full gateway startup.
-INITIAL_DETECTION_TIMEOUT = 30.0
+# Initial discovery shares the budget with full gateway startup, so it scales
+# with the sanitizer factor.
+INITIAL_DETECTION_TIMEOUT = 30.0 * get_time_scale()
 
 
 def generate_test_description():

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -28,9 +28,10 @@ Scope of these tests:
    ``/apps`` quickly - the load-bearing assertion that proves the
    graph-event refactor is working.
 
-The gateway runs with a long ``refresh_interval_ms`` (30 s) so any
-detection well under that window must come from the graph-event poll
-rather than the safety backstop.
+The gateway runs with ``refresh_interval_ms`` at its maximum (60 s), and the
+spawn case checks that it finished inside the window before the first sweep,
+so the detection it observes must come from the graph-event poll rather than
+the safety backstop.
 
 Kill-detection latency is intentionally not asserted: rclcpp's
 graph-event for a departing participant fires only after the executor

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -222,8 +222,29 @@ class TestGraphEventDiscovery(GatewayTestCase):
             stderr=subprocess.DEVNULL,
         )
 
+    def _assert_before_first_sweep(self, what):
+        """Establish what a detection measured, before anything is bounded.
+
+        Past PRE_BACKSTOP_BUDGET_SEC a backstop sweep could have served the
+        detection, and a bound on it would then be reporting on the wrong
+        mechanism.
+        """
+        since_launch = time.monotonic() - _LAUNCH_DESCRIBED_AT
+        self.assertLess(
+            since_launch, PRE_BACKSTOP_BUDGET_SEC,
+            f'{what} landed {since_launch:.3f}s after the launch was described, '
+            f'past the {PRE_BACKSTOP_BUDGET_SEC}s window in which no backstop '
+            f'sweep can have run ({BACKSTOP_INTERVAL_MS}ms backstop), so this '
+            f'run cannot say what triggered the refresh',
+        )
+
     def test_initial_discovery_picks_up_startup_nodes(self):
-        """Both startup demo nodes must be visible in /apps."""
+        """Both startup demo nodes must be visible in /apps.
+
+        The nodes come up after the gateway's own initial discovery, so a
+        refresh has to pick them up. The window check is what makes this a
+        statement about the graph-event path.
+        """
         for key in INITIAL_NODES:
             _, ros_name, _ = DEMO_NODE_REGISTRY[key]
             data = self.poll_endpoint_until(
@@ -235,6 +256,7 @@ class TestGraphEventDiscovery(GatewayTestCase):
                 timeout=INITIAL_DETECTION_TIMEOUT,
                 interval=0.1,
             )
+            self._assert_before_first_sweep(f'startup discovery of {ros_name}')
             app_ids = [app.get('id', '') for app in data.get('items', [])]
             self.assertTrue(
                 any(ros_name in app_id for app_id in app_ids),
@@ -278,17 +300,7 @@ class TestGraphEventDiscovery(GatewayTestCase):
                 interval=0.1,
             )
             elapsed = time.monotonic() - spawn_time
-            # Establish what was measured before bounding it. Past this budget
-            # a backstop sweep could have served the detection, and then the
-            # bound below would be reporting on the wrong mechanism.
-            since_launch = time.monotonic() - _LAUNCH_DESCRIBED_AT
-            self.assertLess(
-                since_launch, PRE_BACKSTOP_BUDGET_SEC,
-                f'detection landed {since_launch:.3f}s after the launch was described, '
-                f'past the {PRE_BACKSTOP_BUDGET_SEC}s window in which no backstop '
-                f'sweep can have run ({BACKSTOP_INTERVAL_MS}ms backstop), so this '
-                f'run cannot say what triggered the refresh',
-            )
+            self._assert_before_first_sweep('spawn detection')
             self.assertLess(
                 elapsed, GRAPH_EVENT_MAX_LATENCY_SEC,
                 f'Spawn detection took {elapsed:.3f}s - expected the '

--- a/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_graph_event_discovery.test.py
@@ -65,8 +65,14 @@ from ros2_medkit_test_utils.launch_helpers import (
 )
 
 
-# Long backstop so any sub-backstop detection must come from graph events.
-BACKSTOP_INTERVAL_MS = 30000
+# The gateway's maximum accepted backstop interval, and it has to be the
+# maximum. The backstop timer is created during gateway initialisation and its
+# phase relative to a mid-run spawn is arbitrary, so a case that only measures
+# elapsed time cannot tell a graph-event refresh from a backstop sweep that
+# happened to land nearby. Pushing the FIRST sweep as far out as the parameter
+# allows lets the spawn case finish inside a window where no sweep has run yet;
+# PRE_BACKSTOP_BUDGET_SEC below is what keeps it inside that window.
+BACKSTOP_INTERVAL_MS = 60000
 
 # Demo nodes launched at startup.
 INITIAL_NODES = ['temp_sensor', 'rpm_sensor']
@@ -78,16 +84,24 @@ LATE_NODE_KEY = 'pressure_sensor'
 #
 # Spawn detection is bounded by:
 #   process exec + rclcpp init + DDS announce + 100 ms poll + refresh_cache.
-# 5 s is comfortable; well under the 30 s backstop, so a pass proves the
-# graph-event poll fired the refresh.
-SPAWN_DETECTION_TIMEOUT = 5.0
+# The poll sits above the latency bound below, so a detection that arrives late
+# reports the time it took instead of a bare timeout.
+SPAWN_DETECTION_TIMEOUT = 15.0
 
-# Graph-event-driven detection should land in under a second; allow
-# generous CI jitter headroom but still well below the backstop. A
-# detection above this bound proves the backstop, not the graph event,
-# triggered the refresh - which is the regression this test exists to
-# catch.
-GRAPH_EVENT_MAX_LATENCY_SEC = 2.0
+# How long after the gateway first answered /health the spawn case may still
+# measure. The first backstop sweep runs BACKSTOP_INTERVAL_MS after gateway
+# initialisation, which precedes that first answer by well under a second, so a
+# measurement inside this budget is one no sweep could have served. That is what
+# makes the bound below a statement about the graph-event path.
+PRE_BACKSTOP_BUDGET_SEC = 30.0
+
+# The latency of the graph-event path itself, measured from process spawn. It
+# cannot be sub-second: the gateway coalesces graph events behind
+# discovery.refresh_debounce_ms, 1000 ms by default, and a spawn that arrives
+# mid-window waits for the next one, so detection lands on a multiple of the
+# debounce. Measured on a developer machine with the default settings, the
+# spread is roughly 1 s to 3.6 s.
+GRAPH_EVENT_MAX_LATENCY_SEC = 10.0
 
 # Initial discovery shares the budget with full gateway startup.
 INITIAL_DETECTION_TIMEOUT = 30.0
@@ -153,6 +167,10 @@ class TestGraphEventDiscovery(GatewayTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        # Reference point for PRE_BACKSTOP_BUDGET_SEC: the gateway has answered
+        # /health by the time the base class returns, so initialisation - and
+        # with it the backstop timer - started a moment earlier.
+        cls._health_at = time.monotonic()
         cls._extra_proc = None
 
     @classmethod
@@ -207,9 +225,10 @@ class TestGraphEventDiscovery(GatewayTestCase):
     def test_new_node_detected_via_graph_event(self):
         """Spawning a node mid-run must propagate within the spawn budget.
 
-        ``BACKSTOP_INTERVAL_MS`` is 30 s; detection within
-        ``SPAWN_DETECTION_TIMEOUT`` (5 s) therefore proves the refresh
-        was triggered by a graph event, not the safety-backstop sweep.
+        The case runs before the first backstop sweep and checks that it did,
+        so the refresh it observes can only have come from a graph event. The
+        measured time starts at process spawn, so it also carries the node's
+        own startup and the gateway's event debounce.
         """
         # Make sure the initial graph is fully settled before spawning.
         for key in INITIAL_NODES:
@@ -240,10 +259,21 @@ class TestGraphEventDiscovery(GatewayTestCase):
                 interval=0.1,
             )
             elapsed = time.monotonic() - spawn_time
+            # Establish what was measured before bounding it. Past this budget
+            # a backstop sweep could have served the detection, and then the
+            # bound below would be reporting on the wrong mechanism.
+            since_health = time.monotonic() - type(self)._health_at
+            self.assertLess(
+                since_health, PRE_BACKSTOP_BUDGET_SEC,
+                f'detection landed {since_health:.3f}s after the gateway came up, '
+                f'past the {PRE_BACKSTOP_BUDGET_SEC}s window in which no backstop '
+                f'sweep can have run ({BACKSTOP_INTERVAL_MS}ms backstop), so this '
+                f'run cannot say what triggered the refresh',
+            )
             self.assertLess(
                 elapsed, GRAPH_EVENT_MAX_LATENCY_SEC,
-                f'Spawn detection took {elapsed:.3f}s - expected sub-second '
-                f'via graph-event poll, not backstop-driven '
+                f'Spawn detection took {elapsed:.3f}s - expected the '
+                f'graph-event poll to serve it, not the backstop sweep '
                 f'({BACKSTOP_INTERVAL_MS}ms backstop configured)',
             )
             app_ids = [app.get('id', '') for app in data.get('items', [])]

--- a/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
@@ -884,10 +884,9 @@ class PeerRecoveryTest(unittest.TestCase):
         # The poll above waits the member's subscription warm, which is what a
         # first read after recovery has to do. Once it is warm a read carries
         # the sample on the spot: the gateway holds the latest one and answers
-        # from it. This is the first read after the one the poll accepted -
-        # the failure path above is the only other reader, and it never runs
-        # here - so an empty body is not a cold-start transient, it is a
-        # member that serves nothing until asked twice.
+        # from it. This read follows one that carried the sample, so an empty
+        # body here is not a cold-start transient, it is a member that goes
+        # back to serving nothing between reads.
         warm = self._aggregate_read_of_peer_topic()
         self.assertEqual(warm.status_code, 200, warm.text)
         warm_body = warm.json()

--- a/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
@@ -841,11 +841,12 @@ class PeerRecoveryTest(unittest.TestCase):
             return answer
 
         response = _poll(served, timeout=RECOVERY_TIMEOUT)
-        self.assertIsNotNone(
-            response,
-            f"a read of {PEER_DECLARED_APP} never carried the member's sample after "
-            f'its peer came back; last answer was {self._aggregate_read_of_peer_topic().text}',
-        )
+        if response is None:
+            last = self._aggregate_read_of_peer_topic()
+            self.fail(
+                f"a read of {PEER_DECLARED_APP} never carried the member's sample after "
+                f'its peer came back; last answer was {last.text}'
+            )
 
         body = response.json()
         self.assertEqual(
@@ -883,8 +884,10 @@ class PeerRecoveryTest(unittest.TestCase):
         # The poll above waits the member's subscription warm, which is what a
         # first read after recovery has to do. Once it is warm a read carries
         # the sample on the spot: the gateway holds the latest one and answers
-        # from it. A read that comes back empty here is not a cold-start
-        # transient, it is a member that serves nothing until asked twice.
+        # from it. This is the first read after the one the poll accepted -
+        # the failure path above is the only other reader, and it never runs
+        # here - so an empty body is not a cold-start transient, it is a
+        # member that serves nothing until asked twice.
         warm = self._aggregate_read_of_peer_topic()
         self.assertEqual(warm.status_code, 200, warm.text)
         warm_body = warm.json()

--- a/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
+++ b/src/ros2_medkit_integration_tests/test/features/test_peer_recovery.test.py
@@ -825,15 +825,26 @@ class PeerRecoveryTest(unittest.TestCase):
             'test_04 must watch this URL fail before test_07 can claim it recovered',
         )
 
+        # A 200 is not yet an answer here. The member re-subscribes when its
+        # peer comes back, and until its first sample arrives the read is a
+        # well-formed 'metadata_only' body with no payload - the same state
+        # case 1 waits through on the healthy peer. The budget below is what
+        # covers the gap; reading once and calling the empty body a failure
+        # makes the case race the publisher.
         def served():
             answer = self._aggregate_read_of_peer_topic()
-            return answer if answer.status_code == 200 else None
+            if answer.status_code != 200:
+                return None
+            payload = answer.json()
+            if payload.get('x-medkit', {}).get('status') != 'data' or not payload.get('data'):
+                return None
+            return answer
 
         response = _poll(served, timeout=RECOVERY_TIMEOUT)
         self.assertIsNotNone(
             response,
-            f'a read of {PEER_DECLARED_APP} never recovered after its peer came back; '
-            f'last answer was {self._aggregate_read_of_peer_topic().text}',
+            f"a read of {PEER_DECLARED_APP} never carried the member's sample after "
+            f'its peer came back; last answer was {self._aggregate_read_of_peer_topic().text}',
         )
 
         body = response.json()
@@ -867,6 +878,23 @@ class PeerRecoveryTest(unittest.TestCase):
             sorted(body['data'].keys()), self._peer_payload_keys,
             f'the recovered payload is not shaped like the one the same read '
             f'returned before the outage: {body}',
+        )
+
+        # The poll above waits the member's subscription warm, which is what a
+        # first read after recovery has to do. Once it is warm a read carries
+        # the sample on the spot: the gateway holds the latest one and answers
+        # from it. A read that comes back empty here is not a cold-start
+        # transient, it is a member that serves nothing until asked twice.
+        warm = self._aggregate_read_of_peer_topic()
+        self.assertEqual(warm.status_code, 200, warm.text)
+        warm_body = warm.json()
+        self.assertEqual(
+            warm_body.get('x-medkit', {}).get('status'), 'data',
+            f'a second read of the recovered member came back without data: {warm_body}',
+        )
+        self.assertTrue(
+            warm_body.get('data'),
+            f'a second read of the recovered member carried an empty payload: {warm_body}',
         )
 
     def test_08_the_retained_declaration_does_not_linger_beside_the_live_copy(self):


### PR DESCRIPTION
# Pull Request

## Summary

`test_peer_recovery` case 7 reads the peer-owned topic through the merged Function after the peer gateway comes back, and it polls until that read answers 200. A 200 is not the answer here. When the peer returns, the member re-subscribes, and until its first sample arrives the read is a well-formed body with `"status": "metadata_only"` and no payload. The case checked the payload after the poll had already stopped, so the first 200 had to carry data or the case failed.

That is a race with the publisher, and it lost on a sanitizer build: `AssertionError: 'metadata_only' != 'data'`, with `subscriber_count: 0` in the reported body.

Case 1 in the same file already waits for the payload, and says why in its own comment. Case 7 now does the same. A read that never carries the sample within the recovery budget still fails the case, with a message that says the sample never came.

Waiting for the payload would on its own accept a gateway whose reads go back to empty between samples, because the poll stops at the first read that carries data. One more read after the poll pins that a read which follows a successful one carries the sample too: once the member's subscription is warm the gateway holds the latest sample and answers from it. This read does not measure how long a cold read waits for its first sample; the test controls no publisher, so it cannot pin that. The failure message of the poll used to make one more read while it was built, on success as well, so the read after the poll was the second one. It now reads the last answer only on the failure path, the way case 4 does.

---

## Issue

- none: a test-side timing fix, no change to the gateway

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

The demo publisher on the peer-owned topic runs at 500 ms, which is fast enough that the first read after recovery usually already carries a sample. To make the window real, the publisher period was raised locally and the case was run in four configurations:

| test version | publisher period | result |
|---|---|---|
| before | 500 ms | passes, case 7 takes 0.41 s |
| before | 15 s | **fails**, `'metadata_only' != 'data'`, same body as CI |
| after | 15 s | passes, case 7 takes 10.0 s |
| after, expected value mutated to one the gateway never reports | 500 ms | **fails** after the full 90 s budget, only case 7, on the new message |

The last row is the check that the new poll can still fail: with the expectation mutated, case 7 spends its whole budget and reports that the sample never came, while the other eight cases stay green.

Full package run with all three changes: `colcon test --packages-select ros2_medkit_integration_tests`, 1244 tests, 0 errors, 0 failures.

## Second case: the graph-event spawn bound

The same package had a second case measuring a quantity it did not control. `test_graph_event_discovery` timed spawn detection from `subprocess.Popen` and required it under 2.0 s. The gateway coalesces graph events behind `discovery.refresh_debounce_ms`, 1000 ms by default and not set by that test. The first event after a quiet period is serviced at the next 100 ms tick, and every event inside the window that follows waits for the window to end. A node coming up raises several events in a row, so its detection typically lands one window after its first event.

Measured by setting the bound to 0 so every run prints its time, eight runs with the default settings:

    3.616  3.619  3.415  3.634  3.523  1.148  1.043  3.623  [s]

Two clusters, and the 2.0 s bound sits in the empty gap between them, so the case passed on which side of the debounce the spawn happened to land. Locally that was 2 passes in 8. With the debounce lowered to 50 ms, six runs gave `1.247 1.244 1.244 1.248 0.210 3.005`, which is what identifies the debounce as the cause.

For reference, spawn to node-visible-in-the-ROS-graph, measured by an independent rclpy node with no gateway involved and a fresh domain per iteration, is 0.43 s to 0.59 s over eight samples. So most of the old 2.0 s budget was never the gateway's to spend.

A bound on elapsed time cannot separate the two mechanisms on its own, whatever value it takes. The backstop timer is created during gateway initialisation, so its phase relative to a mid-run spawn is arbitrary: a sweep landing inside the bound serves the detection even when the graph-event path is dead. At a 30 s backstop that is a 10/30 chance for a 10 s bound and 2/30 for the old 2 s one, so raising the bound alone would have made the case weaker.

So the case now establishes what it measured before bounding it. The backstop runs at 60 s, the longest interval the gateway accepts. Both cases check that the detection they observed landed within 50 s of a time taken in `generate_test_description()`. launch_testing calls that function in the test process and only then starts the launch service that forks the gateway, and the gateway arms the backstop timer during its own initialisation. The timer is therefore armed after that point, and a wall timer fires late, never early, so no sweep can have run inside the window. The gateway's own startup only widens it. The spawn bound is 10 s, above the measured spread, and the poll gives up at 15 s so a late detection reports the time it took. The startup case needs the same check because its poll budget outlives the backstop in the sanitizer jobs.

The three poll and latency budgets multiply by `get_time_scale()`, as the other tests in this directory do, so the ASan and TSan jobs get 30 s, 45 s and 90 s. The 50 s window does not scale: it is bounded by the gateway's backstop interval, which the scale factor does not stretch.

Verified: three runs at scale 1 and three at scale 3 pass with the default settings, spawn detection landing 4.3 s to 4.7 s after the launch was described. Falsification, with the graph-event path disabled by a 60 s debounce:

| scale | startup case | spawn case |
|---|---|---|
| 1 | fails at its 30 s poll | fails at its 15 s poll |
| 3 | served by the backstop at 60.1 s, fails the 50 s window check | fails at its 45 s poll |

The scale 3 row is the reason the startup case checks the window: with a 90 s poll and no check, the backstop would have served it and the case would have passed with the graph-event path dead.

Not identified: with the debounce at 50 ms four runs clustered at 1.244-1.248 s, too tight to be chance, so there is a second quantisation in there; and one run still took 3.005 s. Neither is explained, and neither changes what the bound can prove.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [ ] Docs were updated if behavior or public API changed

