### PR TITLE
docs(gateway): define the fault occurrence timestamps in the REST reference

### DIFF
--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1500,7 +1500,10 @@ Query and manage faults.
 
    The ``environment_data.extended_data_records`` object carries the fault's
    occurrence timestamps, which are ``Fault.msg``'s ``first_occurred`` and
-   ``last_occurred`` under their REST names (see :doc:`messages`):
+   ``last_occurred`` (see :doc:`messages`). The list route serves the same
+   instants as ``first_occurred`` and ``last_occurred`` in epoch seconds; only
+   this detail route renames them and formats them as ISO-8601 UTC with
+   millisecond precision:
 
    - ``first_occurrence``: when the current occurrence started, reset when a
      FAILED event reactivates a CLEARED fault, so it moves with

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1496,6 +1496,18 @@ Query and manage faults.
    - ``confirmedDTC``: Confirmed DTC indicator (``0`` or ``1``)
    - ``pendingDTC``: Pending DTC indicator (``0`` or ``1``)
 
+   **Extended Data Records:**
+
+   The ``environment_data.extended_data_records`` object carries the fault's
+   occurrence timestamps, taken from ``Fault.msg`` (see :doc:`messages`):
+
+   - ``first_occurrence``: when the current occurrence started, reset when a
+     FAILED event reactivates a CLEARED fault, so it moves with
+     ``occurrence_count`` instead of marking the fault's first report ever.
+   - ``last_occurrence``: when this fault last occurred, from FAILED events
+     only. A PASSED event is the fault ending, not occurring, and does not
+     touch this field.
+
    **Snapshot Types:**
 
    - ``freeze_frame``: Data captured at fault confirmation. Entity frames for

--- a/docs/api/rest.rst
+++ b/docs/api/rest.rst
@@ -1499,7 +1499,8 @@ Query and manage faults.
    **Extended Data Records:**
 
    The ``environment_data.extended_data_records`` object carries the fault's
-   occurrence timestamps, taken from ``Fault.msg`` (see :doc:`messages`):
+   occurrence timestamps, which are ``Fault.msg``'s ``first_occurred`` and
+   ``last_occurred`` under their REST names (see :doc:`messages`):
 
    - ``first_occurrence``: when the current occurrence started, reset when a
      FAILED event reactivates a CLEARED fault, so it moves with


### PR DESCRIPTION
## Summary

The fault detail in the REST reference showed `first_occurrence` and `last_occurrence` as example values with no definition.

The reference now defines both where the fault object's fields are described. `first_occurrence` is the start of the current occurrence. It is reset when a FAILED event reactivates a CLEARED fault, so it moves with `occurrence_count`. `last_occurrence` advances on FAILED events only. The second commit states the mapping to `Fault.msg`'s `first_occurred` and `last_occurred`.

These are the definitions #618 settled at the message layer. The naming question in #672 stays open.

## Issue

- related #672

## Type

- [ ] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [x] Documentation only

## Testing

Docs only. From `docs/`, both clean:

```
sphinx-build -b linkcheck . _build/linkcheck
sphinx-build -b html . _build/html -W --keep-going
```

`pre-commit` passes.

## Checklist

- [ ] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [ ] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
