### PR TITLE
ci: build write-capable-build on ros-base too

### DIFF
--- a/.github/workflows/opcua-plugin.yml
+++ b/.github/workflows/opcua-plugin.yml
@@ -388,30 +388,19 @@ jobs:
     name: Write-capable build (jazzy)
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:noble
+      image: ros:jazzy-ros-base
     timeout-minutes: 60
     defaults:
       run:
         shell: bash
     steps:
-      - name: Install Git
-        run: |
-          apt-get update
-          apt-get install -y git
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Pre-install ROS 2 apt source
-        uses: ./.github/actions/ros-apt-source
-
-      - name: Set up ROS 2 Jazzy
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: jazzy
-
       - name: Install ccache
-        run: apt-get install -y ccache
+        run: |
+          apt-get update
+          apt-get install -y ccache
 
       - name: Cache ccache
         uses: actions/cache@v4


### PR DESCRIPTION
# Pull Request

## Summary

`opcua-plugin.yml`'s `write-capable-build` job still ran on `ubuntu:noble` with the "Install Git", "Pre-install ROS 2 apt source" and "Set up ROS 2 Jazzy" steps, and the `ros-apt-source` composite action the second step used no longer exists since the other container jobs moved to `ros:<distro>-ros-base`. The job fails at that step on every run of the workflow on `main`, and on every pull request that triggers it.

The job now runs on `ros:jazzy-ros-base` like its siblings, the three steps are gone, and "Install ccache" runs its own `apt-get update` first, because the ros-base images ship without an apt index.

---

## Issue

No issue. This is a one-file repair of a job the ros-base migration on `main` left behind.

---

## Type

- [x] Bug fix
- [ ] New feature or tests
- [ ] Breaking change
- [ ] Documentation only

---

## Testing

- The `write-capable-build` job of the OPC-UA Plugin Integration workflow is the test: it is red on `main` and must be green on this branch.
- Locally: the workflow parses, the job's container image is `ros:jazzy-ros-base`, its step list no longer contains the three removed steps, and no workflow file references `ros-apt-source` or `setup-ros` any more.

---

## Checklist

- [x] Breaking changes are clearly described (and announced in docs / changelog if needed)
- [x] Tests were added or updated if needed
- [x] Docs were updated if behavior or public API changed
